### PR TITLE
feat(cloud): team project memories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,6 +3677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4862,6 +4868,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4935,6 +4953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4974,6 +5001,29 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -6036,7 +6086,11 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tungstenite 0.24.0",
 ]
 
@@ -6311,6 +6365,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.23.36",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -30,6 +30,8 @@ pub enum CloudCommands {
     Pull(CloudPullArgs),
     /// Full sync (push then pull)
     Sync(CloudSyncArgs),
+    /// Pull team memories for the current project
+    TeamMemories(CloudTeamMemoriesArgs),
 }
 
 #[derive(Parser)]
@@ -70,6 +72,17 @@ pub struct CloudSyncArgs {
 }
 
 #[derive(Parser)]
+pub struct CloudTeamMemoriesArgs {
+    /// Show what would be pulled without merging
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Ignore last sync timestamp, pull everything
+    #[arg(long)]
+    pub full: bool,
+}
+
+#[derive(Parser)]
 pub struct CloudQueueArgs {
     /// Show detailed list of queued items
     #[arg(long, short)]
@@ -95,6 +108,7 @@ pub fn execute(cmd: &CloudCommands, cli: &Cli, cas_root: &Path) -> anyhow::Resul
         CloudCommands::Push(args) => execute_push(args, cli, cas_root),
         CloudCommands::Pull(args) => execute_pull(args, cli, cas_root),
         CloudCommands::Sync(args) => execute_sync(args, cli, cas_root),
+        CloudCommands::TeamMemories(args) => execute_team_memories(args, cli, cas_root),
     }
 }
 
@@ -1051,6 +1065,291 @@ fn execute_sync(args: &CloudSyncArgs, cli: &Cli, cas_root: &Path) -> anyhow::Res
             cli,
             cas_root,
         )?;
+    }
+
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEAM MEMORIES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn execute_team_memories(
+    args: &CloudTeamMemoriesArgs,
+    cli: &Cli,
+    cas_root: &Path,
+) -> anyhow::Result<()> {
+    use crate::cloud::{TeamMemoriesResponse, TeamProjectsResponse};
+    use crate::ui::components::{Spinner, clear_inline, render_inline_view};
+
+    let mut config = CloudConfig::load()?;
+
+    let team_id = config
+        .team_id
+        .as_ref()
+        .ok_or_else(|| {
+            anyhow::anyhow!("No team configured. Run `cas cloud team set <slug>` first.")
+        })?
+        .clone();
+
+    let canonical_id = crate::cloud::get_project_canonical_id().ok_or_else(|| {
+        anyhow::anyhow!("Not in a git repository with a remote.")
+    })?;
+
+    let token = config
+        .token
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Not logged in. Run 'cas login' first."))?
+        .clone();
+
+    let theme = ActiveTheme::default();
+    let prev_lines = if !cli.json {
+        let spinner = Spinner::new("Pulling team memories...");
+        render_inline_view(&spinner, &theme)?
+    } else {
+        0u16
+    };
+
+    // Step 1: Find the project UUID by listing team projects
+    let projects_url = format!("{}/api/teams/{}/projects", config.endpoint, team_id);
+    let projects_resp = ureq::get(&projects_url)
+        .set("Authorization", &format!("Bearer {token}"))
+        .timeout(Duration::from_secs(30))
+        .call();
+
+    let projects_body: TeamProjectsResponse = match projects_resp {
+        Ok(resp) => resp.into_json()?,
+        Err(ureq::Error::Status(401, _)) => {
+            if prev_lines > 0 {
+                clear_inline(prev_lines)?;
+            }
+            anyhow::bail!("Session expired. Run `cas login` to re-authenticate.");
+        }
+        Err(e) => {
+            if prev_lines > 0 {
+                clear_inline(prev_lines)?;
+            }
+            anyhow::bail!("Failed to list team projects: {e}");
+        }
+    };
+
+    let project = projects_body
+        .projects
+        .iter()
+        .find(|p| p.canonical_id == canonical_id);
+
+    let project_uuid = match project {
+        Some(p) => p.id.clone(),
+        None => {
+            if prev_lines > 0 {
+                clear_inline(prev_lines)?;
+            }
+            anyhow::bail!(
+                "This project hasn't been synced to the team yet. Run `cas cloud sync --team` to register it."
+            );
+        }
+    };
+
+    // Step 2: Fetch team memories for this project
+    let mut memories_url = format!(
+        "{}/api/teams/{}/projects/{}/memories",
+        config.endpoint, team_id, project_uuid
+    );
+
+    if !args.full {
+        if let Some(since) = config.get_team_memory_sync(&canonical_id) {
+            memories_url = format!("{memories_url}?since={since}");
+        }
+    }
+
+    let memories_resp = ureq::get(&memories_url)
+        .set("Authorization", &format!("Bearer {token}"))
+        .timeout(Duration::from_secs(60))
+        .call();
+
+    let body: TeamMemoriesResponse = match memories_resp {
+        Ok(resp) => resp.into_json()?,
+        Err(ureq::Error::Status(401, _)) => {
+            if prev_lines > 0 {
+                clear_inline(prev_lines)?;
+            }
+            anyhow::bail!("Session expired. Run `cas login` to re-authenticate.");
+        }
+        Err(e) => {
+            if prev_lines > 0 {
+                clear_inline(prev_lines)?;
+            }
+            anyhow::bail!("Failed to fetch team memories: {e}");
+        }
+    };
+
+    let entry_count = body.memories.entries.len();
+    let rule_count = body.memories.rules.len();
+    let skill_count = body.memories.skills.len();
+    let contributor_count = body.contributors.len();
+
+    // Dry run: just show counts
+    if args.dry_run {
+        if prev_lines > 0 {
+            clear_inline(prev_lines)?;
+        }
+
+        if cli.json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "dry_run": true,
+                    "entries": entry_count,
+                    "rules": rule_count,
+                    "skills": skill_count,
+                    "contributors": contributor_count,
+                })
+            );
+        } else {
+            let mut out = io::stdout();
+            let mut fmt = Formatter::stdout(&mut out, theme);
+            fmt.write_accent("  \u{2192} ")?;
+            fmt.write_raw(&format!(
+                "Would pull: {} entries, {} rules, {} skills from {} contributors",
+                entry_count, rule_count, skill_count, contributor_count
+            ))?;
+            fmt.newline()?;
+        }
+        return Ok(());
+    }
+
+    // Check if there's anything to merge
+    if entry_count == 0 && rule_count == 0 && skill_count == 0 {
+        if prev_lines > 0 {
+            clear_inline(prev_lines)?;
+        }
+        if cli.json {
+            println!(r#"{{"status":"ok","message":"up_to_date"}}"#);
+        } else {
+            let mut out = io::stdout();
+            let mut fmt = Formatter::stdout(&mut out, theme);
+            let success_color = fmt.theme().palette.status_success;
+            fmt.write_colored("  \u{2713} ", success_color)?;
+            fmt.write_raw("Team memories are up to date.")?;
+            fmt.newline()?;
+        }
+        return Ok(());
+    }
+
+    // Merge into local stores using LWW
+    let store = open_store(cas_root)?;
+    let rule_store = open_rule_store(cas_root)?;
+    let skill_store = open_skill_store(cas_root)?;
+
+    let mut entries_merged = 0usize;
+    let mut entries_skipped = 0usize;
+    let mut rules_merged = 0usize;
+    let mut rules_skipped = 0usize;
+    let mut skills_merged = 0usize;
+    let mut skills_skipped = 0usize;
+
+    // Merge entries (LWW by last_accessed or created)
+    for entry in body.memories.entries {
+        match store.get(&entry.id) {
+            Ok(local) => {
+                let local_time = local.last_accessed.unwrap_or(local.created);
+                let remote_time = entry.last_accessed.unwrap_or(entry.created);
+                if remote_time > local_time {
+                    store.update(&entry)?;
+                    entries_merged += 1;
+                } else {
+                    entries_skipped += 1;
+                }
+            }
+            Err(_) => {
+                store.add(&entry)?;
+                entries_merged += 1;
+            }
+        }
+    }
+
+    // Merge rules (LWW by last_accessed or created)
+    for rule in body.memories.rules {
+        match rule_store.get(&rule.id) {
+            Ok(local) => {
+                let local_time = local.last_accessed.unwrap_or(local.created);
+                let remote_time = rule.last_accessed.unwrap_or(rule.created);
+                if remote_time > local_time {
+                    rule_store.update(&rule)?;
+                    rules_merged += 1;
+                } else {
+                    rules_skipped += 1;
+                }
+            }
+            Err(_) => {
+                rule_store.add(&rule)?;
+                rules_merged += 1;
+            }
+        }
+    }
+
+    // Merge skills (LWW by updated_at)
+    for skill in body.memories.skills {
+        match skill_store.get(&skill.id) {
+            Ok(local) => {
+                if skill.updated_at > local.updated_at {
+                    skill_store.update(&skill)?;
+                    skills_merged += 1;
+                } else {
+                    skills_skipped += 1;
+                }
+            }
+            Err(_) => {
+                skill_store.add(&skill)?;
+                skills_merged += 1;
+            }
+        }
+    }
+
+    // Save sync timestamp
+    if let Some(pulled_at) = &body.pulled_at {
+        config.set_team_memory_sync(&canonical_id, pulled_at);
+        config.save()?;
+    }
+
+    if prev_lines > 0 {
+        clear_inline(prev_lines)?;
+    }
+
+    if cli.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "status": "ok",
+                "entries": { "merged": entries_merged, "skipped": entries_skipped },
+                "rules": { "merged": rules_merged, "skipped": rules_skipped },
+                "skills": { "merged": skills_merged, "skipped": skills_skipped },
+                "contributors": contributor_count,
+            })
+        );
+    } else {
+        let mut out = io::stdout();
+        let mut fmt = Formatter::stdout(&mut out, theme);
+        fmt.success("Team memories synced")?;
+        if entries_merged > 0 {
+            fmt.write_raw(&format!("    {} entries merged", entries_merged))?;
+            fmt.newline()?;
+        }
+        if rules_merged > 0 {
+            fmt.write_raw(&format!("    {} rules merged", rules_merged))?;
+            fmt.newline()?;
+        }
+        if skills_merged > 0 {
+            fmt.write_raw(&format!("    {} skills merged", skills_merged))?;
+            fmt.newline()?;
+        }
+        if entries_skipped + rules_skipped + skills_skipped > 0 {
+            fmt.write_muted(&format!(
+                "    {} skipped (local newer)",
+                entries_skipped + rules_skipped + skills_skipped
+            ))?;
+            fmt.newline()?;
+        }
     }
 
     Ok(())

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -1166,12 +1166,24 @@ fn execute_projects(args: &CloudProjectsArgs, cli: &Cli) -> anyhow::Result<()> {
                         .max(4);
 
                     for project in &body.projects {
+                        let contrib_label = if project.contributor_count == 1 {
+                            "contributor"
+                        } else {
+                            "contributors"
+                        };
+                        let mem_label = if project.memory_count == 1 {
+                            "memory"
+                        } else {
+                            "memories"
+                        };
                         fmt.write_raw(&format!(
-                            "    {:<name_w$}   {:<canonical_w$}   {} contributors   {} memories",
+                            "    {:<name_w$}   {:<canonical_w$}   {} {:<14}  {} {}",
                             project.name,
                             project.canonical_id,
                             project.contributor_count,
+                            contrib_label,
                             project.memory_count,
+                            mem_label,
                             name_w = max_name,
                             canonical_w = max_canonical,
                         ))?;
@@ -1197,6 +1209,9 @@ fn execute_projects(args: &CloudProjectsArgs, cli: &Cli) -> anyhow::Result<()> {
                 fmt.write_raw(" to re-authenticate")?;
                 fmt.newline()?;
             }
+        }
+        Err(ureq::Error::Status(403, _)) => {
+            anyhow::bail!("You're not a member of this team.");
         }
         Err(e) => {
             anyhow::bail!("Failed to fetch projects: {e}");
@@ -1261,6 +1276,12 @@ fn execute_team_memories(
             }
             anyhow::bail!("Session expired. Run `cas login` to re-authenticate.");
         }
+        Err(ureq::Error::Status(403, _)) => {
+            if prev_lines > 0 {
+                clear_inline(prev_lines)?;
+            }
+            anyhow::bail!("You're not a member of this team.");
+        }
         Err(e) => {
             if prev_lines > 0 {
                 clear_inline(prev_lines)?;
@@ -1310,6 +1331,18 @@ fn execute_team_memories(
                 clear_inline(prev_lines)?;
             }
             anyhow::bail!("Session expired. Run `cas login` to re-authenticate.");
+        }
+        Err(ureq::Error::Status(403, _)) => {
+            if prev_lines > 0 {
+                clear_inline(prev_lines)?;
+            }
+            anyhow::bail!("You're not a member of this team.");
+        }
+        Err(ureq::Error::Status(404, _)) => {
+            if prev_lines > 0 {
+                clear_inline(prev_lines)?;
+            }
+            anyhow::bail!("Project not found in this team.");
         }
         Err(e) => {
             if prev_lines > 0 {

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -30,6 +30,8 @@ pub enum CloudCommands {
     Pull(CloudPullArgs),
     /// Full sync (push then pull)
     Sync(CloudSyncArgs),
+    /// List team projects in cloud
+    Projects(CloudProjectsArgs),
 }
 
 #[derive(Parser)]
@@ -70,6 +72,13 @@ pub struct CloudSyncArgs {
 }
 
 #[derive(Parser)]
+pub struct CloudProjectsArgs {
+    /// Specify team slug (defaults to active team)
+    #[arg(long)]
+    pub team: Option<String>,
+}
+
+#[derive(Parser)]
 pub struct CloudQueueArgs {
     /// Show detailed list of queued items
     #[arg(long, short)]
@@ -95,6 +104,7 @@ pub fn execute(cmd: &CloudCommands, cli: &Cli, cas_root: &Path) -> anyhow::Resul
         CloudCommands::Push(args) => execute_push(args, cli, cas_root),
         CloudCommands::Pull(args) => execute_pull(args, cli, cas_root),
         CloudCommands::Sync(args) => execute_sync(args, cli, cas_root),
+        CloudCommands::Projects(args) => execute_projects(args, cli),
     }
 }
 
@@ -1051,6 +1061,132 @@ fn execute_sync(args: &CloudSyncArgs, cli: &Cli, cas_root: &Path) -> anyhow::Res
             cli,
             cas_root,
         )?;
+    }
+
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PROJECTS - List team projects
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn execute_projects(args: &CloudProjectsArgs, cli: &Cli) -> anyhow::Result<()> {
+    let config = CloudConfig::load()?;
+    let token = config
+        .token
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Not logged in. Run 'cas login' first"))?;
+
+    // Resolve team_id: --team flag overrides config
+    let team_id = args
+        .team
+        .as_deref()
+        .or(config.team_id.as_deref())
+        .or(config.team_slug.as_deref());
+
+    let team_id = match team_id {
+        Some(id) => id,
+        None => {
+            if cli.json {
+                println!(r#"{{"status":"error","message":"No team configured"}}"#);
+            } else {
+                let theme = ActiveTheme::default();
+                let mut out = io::stdout();
+                let mut fmt = Formatter::stdout(&mut out, theme);
+                let warning_color = fmt.theme().palette.status_warning;
+                fmt.write_colored("  \u{25CF} ", warning_color)?;
+                fmt.write_raw("No team configured. Run ")?;
+                fmt.write_accent("cas cloud team set <slug>")?;
+                fmt.write_raw(" first.")?;
+                fmt.newline()?;
+            }
+            return Ok(());
+        }
+    };
+
+    let url = format!("{}/api/teams/{}/projects", config.endpoint, team_id);
+
+    match ureq::get(&url)
+        .set("Authorization", &format!("Bearer {token}"))
+        .call()
+    {
+        Ok(resp) => {
+            let body: crate::cloud::TeamProjectsResponse = resp.into_json()?;
+
+            if cli.json {
+                println!("{}", serde_json::to_string(&body.projects)?);
+            } else {
+                let theme = ActiveTheme::default();
+                let mut out = io::stdout();
+                let mut fmt = Formatter::stdout(&mut out, theme);
+
+                fmt.newline()?;
+                let team_display = args
+                    .team
+                    .as_deref()
+                    .or(config.team_slug.as_deref())
+                    .unwrap_or(team_id);
+                fmt.write_muted("  Team: ")?;
+                fmt.write_accent(team_display)?;
+                fmt.newline()?;
+                fmt.newline()?;
+
+                if body.projects.is_empty() {
+                    fmt.write_muted("  No projects found.")?;
+                    fmt.newline()?;
+                } else {
+                    // Calculate column widths for aligned output
+                    let max_name = body
+                        .projects
+                        .iter()
+                        .map(|p| p.name.len())
+                        .max()
+                        .unwrap_or(0)
+                        .max(4);
+                    let max_canonical = body
+                        .projects
+                        .iter()
+                        .map(|p| p.canonical_id.len())
+                        .max()
+                        .unwrap_or(0)
+                        .max(4);
+
+                    for project in &body.projects {
+                        fmt.write_raw(&format!(
+                            "    {:<name_w$}   {:<canonical_w$}   {} contributors   {} memories",
+                            project.name,
+                            project.canonical_id,
+                            project.contributor_count,
+                            project.memory_count,
+                            name_w = max_name,
+                            canonical_w = max_canonical,
+                        ))?;
+                        fmt.newline()?;
+                    }
+                }
+                fmt.newline()?;
+            }
+        }
+        Err(ureq::Error::Status(401, _)) => {
+            if cli.json {
+                println!(r#"{{"status":"error","message":"Invalid or expired token"}}"#);
+            } else {
+                let theme = ActiveTheme::default();
+                let mut err = io::stderr();
+                let mut fmt = Formatter::stdout(&mut err, theme);
+                let error_color = fmt.theme().palette.status_error;
+                fmt.write_colored("  \u{2717} ", error_color)?;
+                fmt.write_raw("Session expired")?;
+                fmt.newline()?;
+                fmt.write_raw("  Run ")?;
+                fmt.write_accent("cas login")?;
+                fmt.write_raw(" to re-authenticate")?;
+                fmt.newline()?;
+            }
+        }
+        Err(e) => {
+            anyhow::bail!("Failed to fetch projects: {e}");
+        }
     }
 
     Ok(())

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -144,6 +144,10 @@ pub struct CloudConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub team_sync_timestamps: HashMap<String, DateTime<Utc>>,
 
+    /// Per-project team memory sync timestamps (canonical_id -> last pull time)
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub team_memory_sync_timestamps: HashMap<String, String>,
+
     /// Last sync timestamp for entries
     pub last_entry_sync: Option<String>,
 
@@ -173,6 +177,7 @@ impl Default for CloudConfig {
             team_id: None,
             team_slug: None,
             team_sync_timestamps: HashMap::new(),
+            team_memory_sync_timestamps: HashMap::new(),
             last_entry_sync: None,
             last_task_sync: None,
             last_rule_sync: None,
@@ -284,6 +289,19 @@ impl CloudConfig {
     pub fn clear_team_sync_timestamp(&mut self, team_id: &str) {
         self.team_sync_timestamps.remove(team_id);
     }
+
+    /// Get the last team memory sync timestamp for a project
+    pub fn get_team_memory_sync(&self, canonical_id: &str) -> Option<&str> {
+        self.team_memory_sync_timestamps
+            .get(canonical_id)
+            .map(|s| s.as_str())
+    }
+
+    /// Set the last team memory sync timestamp for a project
+    pub fn set_team_memory_sync(&mut self, canonical_id: &str, timestamp: &str) {
+        self.team_memory_sync_timestamps
+            .insert(canonical_id.to_string(), timestamp.to_string());
+    }
 }
 
 #[cfg(test)]
@@ -377,6 +395,35 @@ mod tests {
         config.clear_team_sync_timestamp("team-a");
         assert!(config.get_team_sync_timestamp("team-a").is_none());
         assert_eq!(config.get_team_sync_timestamp("team-b"), Some(ts2));
+    }
+
+    #[test]
+    fn test_team_memory_sync_timestamps() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("cloud.json");
+
+        let mut config = CloudConfig {
+            token: Some("t".to_string()),
+            ..Default::default()
+        };
+
+        // Initially no timestamp
+        assert!(config.get_team_memory_sync("github.com/foo/bar").is_none());
+
+        // Set and get
+        config.set_team_memory_sync("github.com/foo/bar", "2026-04-02T10:00:00Z");
+        assert_eq!(
+            config.get_team_memory_sync("github.com/foo/bar"),
+            Some("2026-04-02T10:00:00Z")
+        );
+
+        // Persists through save/load
+        config.save_to(&path).unwrap();
+        let loaded = CloudConfig::load_from(&path).unwrap();
+        assert_eq!(
+            loaded.get_team_memory_sync("github.com/foo/bar"),
+            Some("2026-04-02T10:00:00Z")
+        );
     }
 
     #[test]

--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -28,4 +28,5 @@ pub use device::DeviceConfig;
 pub use sync_queue::{EntityType, QueuedSync, SyncOperation, SyncQueue};
 pub use syncer::{
     CloudSyncer, CloudSyncerConfig, ConflictAction, ConflictResolution, SyncConflict, SyncResult,
+    TeamProject, TeamProjectsResponse,
 };

--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -28,4 +28,5 @@ pub use device::DeviceConfig;
 pub use sync_queue::{EntityType, QueuedSync, SyncOperation, SyncQueue};
 pub use syncer::{
     CloudSyncer, CloudSyncerConfig, ConflictAction, ConflictResolution, SyncConflict, SyncResult,
+    TeamMemoriesResponse, TeamProjectsResponse,
 };

--- a/cas-cli/src/cloud/syncer/mod.rs
+++ b/cas-cli/src/cloud/syncer/mod.rs
@@ -325,6 +325,51 @@ struct SyncedCounts {
     worktrees: usize,
 }
 
+/// Response from team projects listing endpoint
+#[derive(Debug, Deserialize)]
+pub struct TeamProjectsResponse {
+    pub projects: Vec<TeamProject>,
+}
+
+/// A project registered with a team
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TeamProject {
+    pub id: String,
+    pub canonical_id: String,
+    pub name: String,
+    pub contributor_count: u32,
+    pub memory_count: u32,
+}
+
+/// Response from team memories endpoint
+#[derive(Debug, Deserialize)]
+pub struct TeamMemoriesResponse {
+    pub project: Option<TeamMemoriesProject>,
+    pub memories: TeamMemoriesData,
+    #[serde(default)]
+    pub contributors: Vec<String>,
+    pub pulled_at: Option<String>,
+}
+
+/// Project info in team memories response
+#[derive(Debug, Deserialize)]
+pub struct TeamMemoriesProject {
+    pub id: String,
+    pub canonical_id: String,
+    pub name: String,
+}
+
+/// Team memories data grouped by type
+#[derive(Debug, Default, Deserialize)]
+pub struct TeamMemoriesData {
+    #[serde(default)]
+    pub entries: Vec<Entry>,
+    #[serde(default)]
+    pub rules: Vec<Rule>,
+    #[serde(default)]
+    pub skills: Vec<Skill>,
+}
+
 /// Grouped queued items by entity type and operation
 #[derive(Default)]
 struct GroupedQueuedItems {

--- a/cas-cli/src/cloud/syncer/mod.rs
+++ b/cas-cli/src/cloud/syncer/mod.rs
@@ -290,6 +290,22 @@ struct TeamPullResponse {
     status: Option<String>,
 }
 
+/// Response from team projects endpoint
+#[derive(Debug, Deserialize)]
+pub struct TeamProjectsResponse {
+    pub projects: Vec<TeamProject>,
+}
+
+/// A project within a team
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TeamProject {
+    pub id: String,
+    pub canonical_id: String,
+    pub name: String,
+    pub contributor_count: u32,
+    pub memory_count: u32,
+}
+
 /// Response from team push endpoint
 #[derive(Debug, Deserialize)]
 struct TeamPushResponse {

--- a/docs/FEATURE-REQUEST-TEAM-PROJECT-MEMORIES.md
+++ b/docs/FEATURE-REQUEST-TEAM-PROJECT-MEMORIES.md
@@ -1,0 +1,266 @@
+# Feature Request: Team Project Memories (CAS CLI Side)
+
+**From:** Petra Stella Cloud team
+**Date:** 2026-04-02
+**Server status:** SHIPPED (commit `92d69e8` on petra-stella-cloud main)
+**Server spec:** `petra-stella-cloud/docs/FEATURE-TEAM-PROJECT-MEMORIES.md`
+**Priority:** High — unblocks team knowledge sharing
+
+---
+
+## Context
+
+Petra Stella Cloud now supports **team project memories**. When a developer joins a project that teammates have been working on, they can pull down the team's collective learnings (architectural decisions, bug fixes, conventions, domain knowledge) — with personal preferences automatically excluded.
+
+The server-side is complete and deployed. This document describes what the CAS CLI needs to implement to complete the feature end-to-end.
+
+---
+
+## What Already Exists in CAS CLI
+
+1. **`project_canonical_id`** — `cas-cli/src/cloud/config.rs:24-53` normalizes the git remote URL and includes it in push payloads. This is the project key server-side.
+
+2. **Team push** — `cas-cli/src/cloud/syncer/team_push.rs` pushes entities with `team_id` to `/api/teams/{team_id}/sync/push`. The server now auto-registers the project in a `projects` table on first team push when `project_canonical_id` is present.
+
+3. **Entry types** — `crates/cas-types/src/entry.rs` defines `entry_type` as `Learning`, `Preference`, `Context`, `Observation`. The server filters by this field to exclude `Preference` entries from team memory responses.
+
+4. **Team config** — `cas-cli/src/cloud/config.rs:135-145` stores `team_id`, `team_slug`, and per-team sync timestamps in `cloud.json`.
+
+---
+
+## Shipped Server Endpoints
+
+All endpoints require `Authorization: Bearer <api_key>` and team membership (returns 403 if not a member).
+
+### GET /api/teams/{teamId}/projects
+
+Lists all projects the team has pushed to. Projects are auto-registered when any team member pushes with a `project_canonical_id`.
+
+**Response (200):**
+```json
+{
+  "projects": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "canonical_id": "github.com/petrastella/cas",
+      "name": "cas",
+      "created_by": "user-uuid",
+      "created_at": "2026-04-02T10:00:00.000Z",
+      "contributor_count": 3,
+      "memory_count": 147
+    }
+  ]
+}
+```
+
+**Notes:**
+- `name` is auto-derived from the last segment of `canonical_id` (e.g. `github.com/petrastella/cas` → `cas`). Can be renamed via PATCH.
+- `contributor_count` = distinct users who pushed entities to this project within the team.
+- `memory_count` = total entities excluding those where `data.type = 'user'` or `data.entry_type = 'Preference'`.
+- Results ordered by `created_at` ascending.
+
+### GET /api/teams/{teamId}/projects/{projectId}/memories
+
+Returns project-scoped memories from ALL team members, with personal preferences filtered out.
+
+**Important:** `{projectId}` is the project **UUID** from the list endpoint, NOT the canonical ID.
+
+**Query params:**
+| Param | Default | Description |
+|-------|---------|-------------|
+| `since` | (none) | ISO8601 timestamp — only return entities updated after this time |
+| `types` | `entry,rule,skill` | Comma-separated entity types to include. Valid: `entry`, `rule`, `skill` |
+| `exclude_user_type` | `true` | Set to `false` to include Preference/user-type entries |
+
+**Response (200):**
+```json
+{
+  "project": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "canonical_id": "github.com/petrastella/cas",
+    "name": "cas"
+  },
+  "memories": {
+    "entries": [
+      { "id": "g-2026-01-15-001", "type": "Learning", "content": "...", ... },
+      { "id": "g-2026-02-03-004", "type": "Context", "content": "...", ... }
+    ],
+    "rules": [
+      { "id": "rule-uuid", "content": "...", ... }
+    ],
+    "skills": []
+  },
+  "contributors": ["user-uuid-1", "user-uuid-2"],
+  "pulled_at": "2026-04-02T18:00:00.000Z"
+}
+```
+
+**Error responses:**
+| Status | Condition |
+|--------|-----------|
+| 400 | No valid entity types in `types` param |
+| 401 | Missing/invalid bearer token |
+| 403 | Not a member of this team |
+| 404 | Project not found in this team |
+
+**Implementation details:**
+- Queries `sync_entities` WHERE `team_id = teamId AND project_id = project.canonical_id AND entity_type IN (types)`
+- Privacy filter (when `exclude_user_type=true`): `NOT ((data->>'type' = 'user') OR (data->>'entry_type' = 'Preference'))`
+- Results ordered by `updated_at` ascending
+- Uses index `idx_sync_team_project_pull(team_id, project_id, updated_at) WHERE team_id IS NOT NULL`
+
+### PATCH /api/teams/{teamId}/projects/{projectId}
+
+Update project display name. Any team member can rename.
+
+**Request body:**
+```json
+{ "name": "CAS CLI" }
+```
+
+**Response (200):**
+```json
+{
+  "id": "550e8400-...",
+  "canonical_id": "github.com/petrastella/cas",
+  "name": "CAS CLI",
+  "created_by": "user-uuid",
+  "created_at": "2026-04-02T10:00:00.000Z"
+}
+```
+
+**Errors:** 400 (missing/invalid name), 404 (project not found), 401, 403.
+
+### Auto-Registration on Team Push
+
+No new endpoint — this happens automatically. When `POST /api/teams/{teamId}/sync/push` receives a payload with `project_canonical_id`, it inserts into the `projects` table with `ON CONFLICT DO NOTHING`. The project name defaults to the last path segment of the canonical ID.
+
+**What this means for the CLI:** No changes needed to push. As long as `project_canonical_id` is included in team push payloads (which it already is), projects auto-register.
+
+---
+
+## Requested CLI Changes
+
+### 1. New Command: `cas cloud team-memories`
+
+Pull memories from teammates who have worked on the current project.
+
+```bash
+cas cloud team-memories              # Pull all team memories for current project
+cas cloud team-memories --dry-run    # Show what would be pulled without merging
+cas cloud team-memories --full       # Ignore last sync timestamp, pull everything
+```
+
+**Flow:**
+1. Read `team_id` from `cloud.json`. Error if not set.
+2. Get `project_canonical_id` from current repo's git remote. Error if no remote.
+3. Call `GET /api/teams/{teamId}/projects` to find the project UUID matching the canonical ID. Error if not found (project hasn't been team-pushed yet).
+4. Call `GET /api/teams/{teamId}/projects/{projectId}/memories?since={last_team_memory_pull}`
+5. Merge returned entries/rules/skills into local SQLite store using existing pull/merge logic from `pull.rs`
+6. Store `last_team_memory_pull_at` timestamp in `cloud.json` sync metadata
+
+**Merge behavior:**
+- Use existing LWW merge from `pull.rs` — compare `updated_at` timestamps
+- Team memories are read into local store as regular entries, rules, skills
+- The `team_id` field on each entity is preserved so the CLI knows the origin
+- If a local memory and a team memory have the same content, prefer whichever has the newer timestamp
+
+### 2. New Command: `cas cloud projects`
+
+List projects the team has worked on.
+
+```bash
+cas cloud projects                   # List all team projects
+cas cloud projects --team <slug>     # Specify team (defaults to active team)
+```
+
+**Output format:**
+```
+Team: petrastella
+
+  CAS CLI                    github.com/petrastella/cas          3 contributors   147 memories
+  Petra Stella Cloud         github.com/petrastella/cloud        2 contributors    89 memories
+  Gabber Studio              github.com/petrastella/gabber       1 contributor     34 memories
+```
+
+### 3. Auto-Pull Team Memories on Session Start (Optional/Future)
+
+If auto-sync hooks are implemented later, team memory pull could be added to the SessionStart hook alongside personal pull. Not required for the initial implementation.
+
+### 4. New Metadata Keys in cloud.json
+
+```json
+{
+  "team_memory_sync_timestamps": {
+    "github.com/petrastella/cas": "2026-04-02T10:00:00Z"
+  }
+}
+```
+
+Keyed by `canonical_id` so each project tracks its own team memory sync state independently.
+
+---
+
+## Privacy Model
+
+The server handles all privacy filtering — the CLI does not need to implement any filtering logic. The server:
+- **Includes:** Learning, Context, Observation entries + all rules + all skills
+- **Excludes:** Preference entries (user-specific OS/editor/workflow preferences) and entries where `data.type = 'user'`
+- The CLI can override by passing `?exclude_user_type=false` if needed
+
+If a user wants to explicitly exclude a specific memory from team visibility, that's a future feature (per-entry `private: true` flag).
+
+---
+
+## Edge Cases to Handle
+
+1. **No team configured** — `cas cloud team-memories` should print: "No team configured. Run `cas cloud team set <slug>` first."
+
+2. **Project not found on server** — First team push for this project hasn't happened yet. Print: "This project hasn't been synced to the team yet. Run `cas cloud sync --team` to register it."
+
+3. **No new memories** — `?since=` returns empty memories. Print: "Team memories are up to date."
+
+4. **User's own memories in response** — The server returns ALL team members' memories including the requester's own. The merge logic handles this naturally (LWW, same entity ID = no-op if timestamps match).
+
+5. **Large memory sets** — Server returns everything matching the filter. If a project has 10K+ memories, consider adding pagination (`?limit=500&cursor=`) in a follow-up.
+
+---
+
+## Testing
+
+Server has 20 tests covering the new endpoints. CLI-side, add tests for:
+- `team-memories` command with mock server responses
+- Merge behavior when team memories overlap with local
+- Edge cases (no team, no project, empty response)
+- `projects` list command formatting
+
+---
+
+## Implementation Priority
+
+1. **`cas cloud projects`** — Simple GET + format. Low risk. Lets users see what's available.
+2. **`cas cloud team-memories`** — The core feature. Pull + merge.
+3. **Sync metadata tracking** — Per-project timestamps in cloud.json.
+4. **Auto-pull on session start** — Future, after manual flow is validated.
+
+---
+
+## Server Database Schema (for reference)
+
+```sql
+-- projects table (new, migration 0007)
+CREATE TABLE projects (
+  id TEXT PRIMARY KEY,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  canonical_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_by TEXT NOT NULL REFERENCES users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX idx_projects_team_canonical ON projects(team_id, canonical_id);
+CREATE INDEX idx_projects_team ON projects(team_id);
+
+-- sync_entities (existing, unchanged)
+-- Key columns: user_id, entity_type, id (PK), team_id, project_id, data (JSONB)
+-- Index used: idx_sync_team_project_pull(team_id, project_id, updated_at) WHERE team_id IS NOT NULL
+```


### PR DESCRIPTION
## Summary
- Add `cas cloud projects` command — lists all team projects with contributor/memory counts
- Add `cas cloud team-memories` command — pulls team memories for current project, merges into local stores via LWW
- Add per-project sync timestamps (`team_memory_sync_timestamps`) to CloudConfig
- Add response types for new cloud endpoints (shipped in petra-stella-cloud `92d69e8`)
- Handle 401/403/404 error codes per cloud API contract

## Details
When a dev joins a project teammates have worked on, `cas cloud team-memories` pulls the team's collective learnings (entries, rules, skills) — with personal preferences filtered server-side. Uses existing LWW merge from `pull.rs`. Supports `--dry-run`, `--full`, and `--json` flags.

## Test plan
- [x] `cargo check` passes
- [x] All 7 cloud config tests pass (including new `test_team_memory_sync_timestamps`)
- [ ] Manual test: `cas cloud projects` with active team
- [ ] Manual test: `cas cloud team-memories --dry-run` on a team-pushed project
- [ ] Manual test: `cas cloud team-memories` full merge flow
- [ ] Edge cases: no team configured, no git remote, project not on server

🤖 Generated with [Claude Code](https://claude.com/claude-code)