### PR TITLE
EPIC cas-9508: Factory session friction + build infra (7/11 closed)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,4 +9,4 @@ jobs = 16
 
 [target.x86_64-unknown-linux-gnu]
 linker = "gcc"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/cas-cli/src/builtins/skills/cas-supervisor-checklist.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor-checklist.md
@@ -24,14 +24,19 @@ managed_by: cas
    - If it exists but is stale (structural changes since last update) → run `/codemap` to refresh.
    - Workers reference CODEMAP for codebase orientation — ensure it's current before spawning them.
 5. Check worker availability: `mcp__cas__coordination action=worker_status`
-6. **Session hygiene triage** — check for leftover WIP from prior factory sessions:
+6. **Session hygiene triage** — the SessionStart hook prepends a "⚠ Prior-factory
+   WIP detected" banner to the supervisor context when the main worktree has
+   uncommitted changes, with per-file attribution (last `cas-xxxx` commit)
+   where git history permits. If you see that banner, decide salvage / commit /
+   discard **before** spawning workers — otherwise a cherry-pick into `develop`
+   will abort later.
+
+   For a full on-demand report (including stale agents and orphan worktrees):
    ```
    mcp__cas__coordination action=gc_report
    ```
-   The report's "Prior-factory WIP candidates" section lists uncommitted files
-   in the main worktree. Files often survive when a prior session died mid-task
-   without committing. Decide salvage / commit / discard **before** spawning
-   workers — otherwise a cherry-pick into `develop` will abort later.
+   The report's "Prior-factory WIP candidates" section mirrors the banner and
+   is safe to re-run at any time; it never auto-deletes.
 
    For the full history of what prior sessions left behind, see
    `.cas/logs/factory-session-{YYYY-MM-DD}.log` (written automatically on

--- a/cas-cli/src/builtins/skills/cas-supervisor-checklist.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor-checklist.md
@@ -24,6 +24,19 @@ managed_by: cas
    - If it exists but is stale (structural changes since last update) → run `/codemap` to refresh.
    - Workers reference CODEMAP for codebase orientation — ensure it's current before spawning them.
 5. Check worker availability: `mcp__cas__coordination action=worker_status`
+6. **Session hygiene triage** — check for leftover WIP from prior factory sessions:
+   ```
+   mcp__cas__coordination action=gc_report
+   ```
+   The report's "Prior-factory WIP candidates" section lists uncommitted files
+   in the main worktree. Files often survive when a prior session died mid-task
+   without committing. Decide salvage / commit / discard **before** spawning
+   workers — otherwise a cherry-pick into `develop` will abort later.
+
+   For the full history of what prior sessions left behind, see
+   `.cas/logs/factory-session-{YYYY-MM-DD}.log` (written automatically on
+   `SessionEnd`; each block records session id, agent, worktree, and a
+   `git status --porcelain` snapshot).
 
 ## Intake Gate (Before Planning)
 

--- a/cas-cli/src/hooks/handlers.rs
+++ b/cas-cli/src/hooks/handlers.rs
@@ -242,6 +242,7 @@ pub(crate) fn truncate_display(s: &str, max_len: usize) -> String {
 
 mod handlers_session;
 mod handlers_state;
+pub(crate) mod session_hygiene;
 
 #[cfg(test)]
 pub(crate) use handlers_session::estimate_tokens;

--- a/cas-cli/src/hooks/handlers/handlers_session.rs
+++ b/cas-cli/src/hooks/handlers/handlers_session.rs
@@ -292,6 +292,26 @@ pub fn handle_session_end(
     // Clean up agent leases and reset task status - ALWAYS do this regardless of observation count
     cleanup_agent_leases(cas_root, &input.session_id);
 
+    // Factory session hygiene (task cas-a9ab): append a durable manifest of
+    // the main worktree's uncommitted state so the next supervisor can see
+    // what was left behind if this session died mid-task. Best-effort —
+    // never let hygiene logging break session-end.
+    {
+        let agent_name = std::env::var("CAS_AGENT_NAME").ok();
+        let agent_role = std::env::var("CAS_AGENT_ROLE").ok();
+        if let Some(path) = crate::hooks::handlers::session_hygiene::write_session_end_manifest(
+            cas_root,
+            &input.session_id,
+            agent_name.as_deref(),
+            agent_role.as_deref(),
+        ) {
+            eprintln!(
+                "cas: Wrote session-end manifest to {}",
+                path.display()
+            );
+        }
+    }
+
     // Notify daemon via socket that session ended
     #[cfg(feature = "mcp-server")]
     {

--- a/cas-cli/src/hooks/handlers/handlers_session.rs
+++ b/cas-cli/src/hooks/handlers/handlers_session.rs
@@ -221,15 +221,20 @@ pub fn handle_session_start(
     };
 
     // Factory session-start hygiene triage (task cas-aeec): for supervisor
-    // sessions, prepend a banner listing uncommitted files in the main
+    // sessions, append a banner listing uncommitted files in the main
     // worktree with per-file last-touching-task-id attribution. Visibility
     // only — the supervisor decides salvage / commit / discard before
     // spawning workers. Best-effort: git failures, non-supervisor roles,
     // and clean trees all fall through silently.
+    //
+    // Appended (not prepended) so codemap and project-overview retain the
+    // preview top slot they are explicitly engineered to land in (see
+    // comments above). The banner is not severity-ranked against those
+    // modules, so it sits below them in the supervisor's initial view.
     let context = if is_supervisor {
         match crate::hooks::handlers::session_hygiene::build_session_start_wip_banner(cas_root) {
             Some(banner) if context.is_empty() => banner,
-            Some(banner) => format!("{banner}\n{context}"),
+            Some(banner) => format!("{context}\n{banner}"),
             None => context,
         }
     } else {

--- a/cas-cli/src/hooks/handlers/handlers_session.rs
+++ b/cas-cli/src/hooks/handlers/handlers_session.rs
@@ -220,6 +220,22 @@ pub fn handle_session_start(
         context
     };
 
+    // Factory session-start hygiene triage (task cas-aeec): for supervisor
+    // sessions, prepend a banner listing uncommitted files in the main
+    // worktree with per-file last-touching-task-id attribution. Visibility
+    // only — the supervisor decides salvage / commit / discard before
+    // spawning workers. Best-effort: git failures, non-supervisor roles,
+    // and clean trees all fall through silently.
+    let context = if is_supervisor {
+        match crate::hooks::handlers::session_hygiene::build_session_start_wip_banner(cas_root) {
+            Some(banner) if context.is_empty() => banner,
+            Some(banner) => format!("{banner}\n{context}"),
+            None => context,
+        }
+    } else {
+        context
+    };
+
     let output = if context.is_empty() {
         HookOutput::empty()
     } else {

--- a/cas-cli/src/hooks/handlers/session_hygiene.rs
+++ b/cas-cli/src/hooks/handlers/session_hygiene.rs
@@ -1,0 +1,291 @@
+//! Factory session hygiene — surface and record the main worktree's state
+//! around session boundaries so supervisors can attribute leftover
+//! uncommitted work from crashed/interrupted prior factory sessions.
+//!
+//! Two features live here:
+//!
+//! 1. A **session-end manifest** appended to
+//!    `.cas/logs/factory-session-{YYYY-MM-DD}.log`, capturing
+//!    `git status --porcelain` of the main worktree when a session ends.
+//!    This gives the next supervisor a durable record of what was left
+//!    behind (see task cas-a9ab, report §3).
+//!
+//! 2. A **WIP candidates** helper used by `coordination action=gc_report`
+//!    (and consumable by `SessionStart` triage for task cas-aeec) that
+//!    lists uncommitted entries in the main worktree so they can be
+//!    surfaced — never auto-deleted.
+//!
+//! The module is best-effort: I/O and git failures are swallowed because
+//! hygiene instrumentation must never break a session-end hook.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Single `git status --porcelain` entry.
+///
+/// `status` is the raw two-char porcelain code (e.g. `"??"`, `" M"`, `"M "`,
+/// `"A "`). `path` is the file path relative to the worktree root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PorcelainEntry {
+    pub status: String,
+    pub path: String,
+}
+
+impl PorcelainEntry {
+    /// True if this is an untracked file (`??` status).
+    pub fn is_untracked(&self) -> bool {
+        self.status.starts_with("??")
+    }
+
+    /// Short human label for the entry's state.
+    pub fn label(&self) -> &'static str {
+        match self.status.as_str() {
+            "??" => "untracked",
+            " M" => "modified",
+            "M " | "MM" | "AM" => "modified-staged",
+            "A " => "added",
+            "D " | " D" => "deleted",
+            _ => "changed",
+        }
+    }
+}
+
+/// Resolve the main repo root for this CAS installation.
+///
+/// By convention, the CAS root sits at `<repo>/.cas`, so the main
+/// worktree is its parent directory. Returns `None` if the layout is
+/// unexpected.
+pub fn main_worktree_path(cas_root: &Path) -> Option<PathBuf> {
+    cas_root.parent().map(PathBuf::from)
+}
+
+/// Run `git status --porcelain=v1` in `repo` and parse the output.
+///
+/// Returns `None` if git is unavailable, the directory is not a repo,
+/// or the command fails. On success, returns an empty vec for a clean
+/// tree.
+pub fn porcelain_status(repo: &Path) -> Option<Vec<PorcelainEntry>> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["status", "--porcelain=v1"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut entries = Vec::new();
+    for line in text.lines() {
+        if line.len() < 3 {
+            continue;
+        }
+        // Porcelain v1: "XY path", where XY are exactly 2 chars and then a space.
+        let (status, rest) = line.split_at(2);
+        // `rest` starts with a space; strip it.
+        let path = rest.trim_start().to_string();
+        entries.push(PorcelainEntry {
+            status: status.to_string(),
+            path,
+        });
+    }
+    Some(entries)
+}
+
+/// Append a session-end manifest entry to
+/// `<cas_root>/logs/factory-session-{YYYY-MM-DD}.log`.
+///
+/// The manifest is human-readable YAML-ish text, one block per session end,
+/// separated by `---`. The block always includes the session id, the agent
+/// (if known), the worktree path, and a porcelain status dump. A clean
+/// worktree is recorded as `git_status: (clean)` for later auditing.
+///
+/// Returns the log path on success, or `None` if the worktree could not be
+/// resolved or the git probe failed. I/O errors are swallowed by design.
+pub fn write_session_end_manifest(
+    cas_root: &Path,
+    session_id: &str,
+    agent_name: Option<&str>,
+    agent_role: Option<&str>,
+) -> Option<PathBuf> {
+    let repo = main_worktree_path(cas_root)?;
+    let entries = porcelain_status(&repo)?;
+
+    let now = chrono::Utc::now();
+    let log_dir = cas_root.join("logs");
+    std::fs::create_dir_all(&log_dir).ok()?;
+    let log_path = log_dir.join(format!("factory-session-{}.log", now.format("%Y-%m-%d")));
+
+    let mut body = String::new();
+    body.push_str("---\n");
+    body.push_str(&format!("session_end: {}\n", now.to_rfc3339()));
+    body.push_str(&format!("session_id: {session_id}\n"));
+    body.push_str(&format!(
+        "agent: {} ({})\n",
+        agent_name.unwrap_or("unknown"),
+        agent_role.unwrap_or("unknown"),
+    ));
+    body.push_str(&format!("worktree: {}\n", repo.display()));
+    if entries.is_empty() {
+        body.push_str("git_status: (clean)\n");
+    } else {
+        body.push_str(&format!("git_status: {} entries\n", entries.len()));
+        for e in &entries {
+            body.push_str(&format!("  {} {}\n", e.status, e.path));
+        }
+    }
+
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .ok()?;
+    f.write_all(body.as_bytes()).ok()?;
+    Some(log_path)
+}
+
+/// Summary of WIP candidates in the main worktree.
+///
+/// Returned by [`wip_candidates`] so callers can render a concise report
+/// without re-running git. `entries` preserves the porcelain output order.
+#[derive(Debug, Clone, Default)]
+pub struct WipSummary {
+    pub worktree: PathBuf,
+    pub entries: Vec<PorcelainEntry>,
+}
+
+impl WipSummary {
+    pub fn is_clean(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn untracked_count(&self) -> usize {
+        self.entries.iter().filter(|e| e.is_untracked()).count()
+    }
+
+    pub fn modified_count(&self) -> usize {
+        self.entries.iter().filter(|e| !e.is_untracked()).count()
+    }
+}
+
+/// Inspect the main worktree and return a [`WipSummary`].
+///
+/// Returns `None` if the worktree path can't be resolved or git is
+/// unavailable. Clean trees return `Some(WipSummary { entries: [] })`
+/// so callers can still report "clean".
+pub fn wip_candidates(cas_root: &Path) -> Option<WipSummary> {
+    let repo = main_worktree_path(cas_root)?;
+    let entries = porcelain_status(&repo)?;
+    Some(WipSummary {
+        worktree: repo,
+        entries,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn init_repo(dir: &Path) {
+        let _ = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["init", "-q", "-b", "main"])
+            .status();
+        // Minimal identity so commits don't fail.
+        let _ = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["config", "user.email", "test@example.com"])
+            .status();
+        let _ = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["config", "user.name", "test"])
+            .status();
+    }
+
+    #[test]
+    fn porcelain_clean_tree_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+        // Empty repo has no changes.
+        let entries = porcelain_status(tmp.path()).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn porcelain_reports_untracked_and_modified() {
+        let tmp = tempfile::tempdir().unwrap();
+        init_repo(tmp.path());
+
+        // Commit an initial file.
+        fs::write(tmp.path().join("a.txt"), "hello").unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .args(["add", "a.txt"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .args(["commit", "-q", "-m", "init"])
+            .status()
+            .unwrap();
+
+        // Modify committed file and drop an untracked one.
+        fs::write(tmp.path().join("a.txt"), "changed").unwrap();
+        fs::write(tmp.path().join("b.txt"), "new").unwrap();
+
+        let entries = porcelain_status(tmp.path()).unwrap();
+        let untracked = entries.iter().filter(|e| e.is_untracked()).count();
+        let modified = entries.iter().filter(|e| !e.is_untracked()).count();
+        assert_eq!(untracked, 1);
+        assert_eq!(modified, 1);
+    }
+
+    #[test]
+    fn write_session_end_manifest_appends_to_daily_log() {
+        let tmp = tempfile::tempdir().unwrap();
+        // cas_root lives *inside* the repo, so repo == cas_root.parent().
+        let repo = tmp.path();
+        init_repo(repo);
+        fs::write(repo.join("leftover.txt"), "oops").unwrap();
+
+        let cas_root = repo.join(".cas");
+        fs::create_dir_all(&cas_root).unwrap();
+
+        let path = write_session_end_manifest(
+            &cas_root,
+            "session-abc",
+            Some("lively-pelican-94"),
+            Some("worker"),
+        )
+        .expect("manifest written");
+
+        assert!(path.exists());
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("session_id: session-abc"));
+        assert!(contents.contains("lively-pelican-94"));
+        assert!(contents.contains("leftover.txt"));
+    }
+
+    #[test]
+    fn wip_candidates_surfaces_untracked() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_repo(repo);
+        fs::write(repo.join("wip.rs"), "// todo").unwrap();
+
+        let cas_root = repo.join(".cas");
+        fs::create_dir_all(&cas_root).unwrap();
+
+        let summary = wip_candidates(&cas_root).expect("summary");
+        assert!(!summary.is_clean());
+        assert_eq!(summary.untracked_count(), 1);
+        assert_eq!(summary.modified_count(), 0);
+    }
+}

--- a/cas-cli/src/hooks/handlers/session_hygiene.rs
+++ b/cas-cli/src/hooks/handlers/session_hygiene.rs
@@ -212,6 +212,128 @@ pub fn wip_candidates(cas_root: &Path) -> Option<WipSummary> {
     })
 }
 
+/// Extract the first `cas-xxxx` task id from `text`, if any.
+///
+/// Task ids in commit messages follow the canonical 4-char hex form used
+/// throughout the codebase (e.g. `cas-4181`, `cas-a9ab`). Anything past 4
+/// lowercase hex chars is rejected so arbitrary strings like `cas-foo`
+/// are not falsely matched.
+pub(crate) fn extract_task_id(text: &str) -> Option<String> {
+    // Tiny hand-rolled scanner to avoid pulling in a regex dep just for one
+    // match. Finds `cas-` then up to 4 hex chars followed by a non-hex
+    // boundary (whitespace, punctuation, end-of-string).
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    let eq_ci = |a: u8, b: u8| a.eq_ignore_ascii_case(&b);
+    while i + 8 <= bytes.len() {
+        if eq_ci(bytes[i], b'c')
+            && eq_ci(bytes[i + 1], b'a')
+            && eq_ci(bytes[i + 2], b's')
+            && bytes[i + 3] == b'-'
+        {
+            let start = i + 4;
+            let mut end = start;
+            while end < bytes.len() && end - start < 4 {
+                let c = bytes[end];
+                let is_hex =
+                    c.is_ascii_digit() || (b'a'..=b'f').contains(&c) || (b'A'..=b'F').contains(&c);
+                if !is_hex {
+                    break;
+                }
+                end += 1;
+            }
+            if end - start == 4 {
+                // Boundary check: next byte must be a non-hex, non-alnum
+                // delimiter (or end of string).
+                let terminates = end == bytes.len() || {
+                    let c = bytes[end];
+                    !(c.is_ascii_digit()
+                        || (b'a'..=b'z').contains(&c)
+                        || (b'A'..=b'Z').contains(&c))
+                };
+                if terminates {
+                    let id = std::str::from_utf8(&bytes[i..end]).ok()?.to_ascii_lowercase();
+                    return Some(id);
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Ask git for the most recent commit that touched `file` and return the
+/// first `cas-xxxx` task id from its subject+body, if any. Used to
+/// attribute a modified WIP file to the task that most likely left it
+/// behind. Returns `None` for untracked files, missing history, or when
+/// the last commit message carries no task id.
+pub fn attribute_file_to_task(repo: &Path, file: &str) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["log", "-1", "--format=%s%n%b", "--", file])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    if text.trim().is_empty() {
+        return None;
+    }
+    extract_task_id(&text)
+}
+
+/// Render the SessionStart triage banner for a supervisor session, or
+/// `None` when the worktree is clean / git is unavailable / cas_root
+/// cannot be resolved. The banner is best-effort and must never fail a
+/// session start.
+///
+/// Output shape (example):
+/// ```text
+/// ⚠ Prior-factory WIP detected in main worktree (3 files, 2 modified, 1 untracked):
+///   [modified]  src/foo.rs                (last touched by cas-a9ab)
+///   [modified]  src/bar.rs                (last touched by cas-4181)
+///   [untracked] src/baz.rs                (unattributed — no git history)
+///
+/// Triage BEFORE spawning workers: decide salvage / commit / discard.
+/// Full history: .cas/logs/factory-session-{date}.log
+/// ```
+pub fn build_session_start_wip_banner(cas_root: &Path) -> Option<String> {
+    let summary = wip_candidates(cas_root)?;
+    if summary.is_clean() {
+        return None;
+    }
+    let mut out = String::new();
+    out.push_str(&format!(
+        "⚠ Prior-factory WIP detected in main worktree ({} files, {} modified, {} untracked):\n",
+        summary.entries.len(),
+        summary.modified_count(),
+        summary.untracked_count(),
+    ));
+    for entry in &summary.entries {
+        let attribution = if entry.is_untracked() {
+            "(unattributed — no git history)".to_string()
+        } else {
+            match attribute_file_to_task(&summary.worktree, &entry.path) {
+                Some(task_id) => format!("(last touched by {task_id})"),
+                None => "(no task id in last commit)".to_string(),
+            }
+        };
+        out.push_str(&format!(
+            "  [{:10}] {}  {}\n",
+            entry.label(),
+            entry.path,
+            attribution,
+        ));
+    }
+    out.push_str(
+        "\nTriage BEFORE spawning workers: decide salvage / commit / discard.\n\
+         Full history: .cas/logs/factory-session-{date}.log (see cas-supervisor-checklist)\n",
+    );
+    Some(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -455,6 +577,129 @@ mod tests {
             resolved.canonicalize().unwrap(),
             main.canonicalize().unwrap(),
             "linked-worktree cas_root must resolve upward to the main repo, got {resolved:?}"
+        );
+    }
+
+    /// extract_task_id must pick the first canonical `cas-xxxx` (4 hex) token
+    /// and reject non-hex / too-long / non-terminated variants so a commit
+    /// subject like "refactor cas-module" does not falsely attribute.
+    #[test]
+    fn extract_task_id_accepts_canonical_and_rejects_garbage() {
+        // Happy path: first 4-hex token wins, case-insensitive, boundary aware.
+        assert_eq!(
+            extract_task_id("fix(foo): ship cas-a9ab and follow-up cas-4181"),
+            Some("cas-a9ab".to_string())
+        );
+        assert_eq!(
+            extract_task_id("CAS-4181 uppercase"),
+            Some("cas-4181".to_string())
+        );
+        assert_eq!(
+            extract_task_id("see cas-d0f9."),
+            Some("cas-d0f9".to_string())
+        );
+
+        // Non-hex characters in the 4-char window are rejected.
+        assert_eq!(extract_task_id("cas-zzzz is fake"), None);
+        // Too-long hex run (> 4 chars without a boundary) is rejected.
+        assert_eq!(extract_task_id("cas-a9abc is nope"), None);
+        // Non-boundary alphanumeric (e.g. cas-module) is rejected.
+        assert_eq!(extract_task_id("refactor cas-module"), None);
+        assert_eq!(extract_task_id("nothing here"), None);
+    }
+
+    /// attribute_file_to_task must resolve a modified file to the cas-id in
+    /// the last commit that touched it. Confirms the core attribution primitive
+    /// used by the SessionStart banner.
+    #[test]
+    fn attribute_file_to_task_finds_cas_id_in_last_commit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_repo(repo);
+        fs::write(repo.join("a.txt"), "v1").unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["add", "a.txt"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["commit", "-q", "-m", "feat(a): initial ship (cas-a9ab)"])
+            .status()
+            .unwrap();
+
+        assert_eq!(
+            attribute_file_to_task(repo, "a.txt"),
+            Some("cas-a9ab".to_string())
+        );
+
+        // An untracked file has no git history → None.
+        fs::write(repo.join("new.txt"), "").unwrap();
+        assert_eq!(attribute_file_to_task(repo, "new.txt"), None);
+
+        // Commit without a cas-id still returns None (no false positives).
+        fs::write(repo.join("b.txt"), "").unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["add", "b.txt"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["commit", "-q", "-m", "chore(b): no task id here"])
+            .status()
+            .unwrap();
+        assert_eq!(attribute_file_to_task(repo, "b.txt"), None);
+    }
+
+    /// The SessionStart banner must surface the attribution line and the
+    /// triage instruction; returning None on a clean tree prevents noise.
+    #[test]
+    fn build_session_start_wip_banner_renders_attribution_and_skips_clean() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_repo(repo);
+
+        // Seed + commit + modify: modified entry should carry attribution.
+        fs::write(repo.join("src.rs"), "v1").unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["add", "src.rs"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["commit", "-q", "-m", "feat: ship (cas-4181)"])
+            .status()
+            .unwrap();
+        fs::write(repo.join("src.rs"), "v2").unwrap();
+        // Also drop an untracked file to exercise the unattributed branch.
+        fs::write(repo.join("scratch.tmp"), "").unwrap();
+
+        let cas_root = repo.join(".cas");
+        fs::create_dir_all(&cas_root).unwrap();
+
+        let banner = build_session_start_wip_banner(&cas_root)
+            .expect("banner rendered for dirty worktree");
+        assert!(banner.contains("Prior-factory WIP detected"));
+        assert!(banner.contains("src.rs"));
+        assert!(banner.contains("(last touched by cas-4181)"));
+        assert!(banner.contains("scratch.tmp"));
+        assert!(banner.contains("unattributed"));
+        assert!(banner.contains("Triage BEFORE spawning workers"));
+
+        // Clean the tree → banner suppressed, no noise on normal sessions.
+        fs::remove_file(repo.join("scratch.tmp")).unwrap();
+        fs::write(repo.join("src.rs"), "v1").unwrap();
+        assert!(
+            build_session_start_wip_banner(&cas_root).is_none(),
+            "clean tree must not emit a banner"
         );
     }
 }

--- a/cas-cli/src/hooks/handlers/session_hygiene.rs
+++ b/cas-cli/src/hooks/handlers/session_hygiene.rs
@@ -56,7 +56,36 @@ impl PorcelainEntry {
 /// worktree is its parent directory. Returns `None` if the layout is
 /// unexpected.
 pub fn main_worktree_path(cas_root: &Path) -> Option<PathBuf> {
-    cas_root.parent().map(PathBuf::from)
+    let repo_adjacent = cas_root.parent()?;
+
+    // Ask git for the *common* git dir; in a linked worktree this points at
+    // the main repo's `.git`, whereas `--git-dir` would point at
+    // `.git/worktrees/<name>`. The main worktree then lives one dir above
+    // the common dir (assuming the normal `<repo>/.git` layout). Falls
+    // back to `cas_root.parent()` when git is unavailable or the layout is
+    // unexpected, preserving the prior best-effort behaviour.
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo_adjacent)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return Some(repo_adjacent.to_path_buf());
+    }
+    let common = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if common.is_empty() {
+        return Some(repo_adjacent.to_path_buf());
+    }
+    let common_path = PathBuf::from(common);
+    // `.git` common dir → main worktree is its parent.
+    if common_path.file_name().and_then(|s| s.to_str()) == Some(".git") {
+        if let Some(parent) = common_path.parent() {
+            return Some(parent.to_path_buf());
+        }
+    }
+    // Bare repo or unusual layout — give up safely.
+    Some(repo_adjacent.to_path_buf())
 }
 
 /// Run `git status --porcelain=v1` in `repo` and parse the output.
@@ -287,5 +316,145 @@ mod tests {
         assert!(!summary.is_clean());
         assert_eq!(summary.untracked_count(), 1);
         assert_eq!(summary.modified_count(), 0);
+    }
+
+    /// Table-drive `label()` across every documented porcelain code so a silent
+    /// rename of an arm (e.g. 'modified-staged' → 'staged') fails loudly.
+    #[test]
+    fn porcelain_entry_label_covers_documented_codes() {
+        let cases: &[(&str, &str)] = &[
+            ("??", "untracked"),
+            (" M", "modified"),
+            ("M ", "modified-staged"),
+            ("MM", "modified-staged"),
+            ("AM", "modified-staged"),
+            ("A ", "added"),
+            ("D ", "deleted"),
+            (" D", "deleted"),
+            ("R ", "changed"), // Rename falls through today; guard arm.
+            ("UU", "changed"), // Unmerged falls through today.
+        ];
+        for (code, expected) in cases {
+            let entry = PorcelainEntry {
+                status: (*code).to_string(),
+                path: "x".into(),
+            };
+            assert_eq!(
+                entry.label(),
+                *expected,
+                "label mismatch for porcelain code {code:?}"
+            );
+        }
+    }
+
+    /// Multiple `write_session_end_manifest` calls in the same day must append
+    /// rather than overwrite — the daily log is the cross-session breadcrumb
+    /// trail; losing history silently defeats the feature.
+    #[test]
+    fn manifest_is_append_only_across_multiple_sessions_same_day() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_repo(repo);
+        let cas_root = repo.join(".cas");
+        fs::create_dir_all(&cas_root).unwrap();
+
+        let p1 = write_session_end_manifest(&cas_root, "sess-one", None, None)
+            .expect("first manifest");
+        let p2 = write_session_end_manifest(&cas_root, "sess-two", Some("worker-b"), Some("worker"))
+            .expect("second manifest");
+        assert_eq!(p1, p2, "same daily log path expected");
+
+        let body = fs::read_to_string(&p1).unwrap();
+        assert!(body.contains("session_id: sess-one"));
+        assert!(body.contains("session_id: sess-two"));
+        assert!(body.contains("agent: unknown (unknown)")); // first call, None/None
+        assert!(body.contains("agent: worker-b (worker)")); // second call
+        assert_eq!(
+            body.matches("---").count(),
+            2,
+            "each session-end must produce its own '---' block"
+        );
+    }
+
+    /// A clean worktree records `git_status: (clean)` so audits can tell the
+    /// difference between "nothing was wrong" and "manifest never wrote".
+    #[test]
+    fn manifest_records_clean_tree_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_repo(repo);
+        // Commit so the tree is fully clean (empty repo also counts, but
+        // committing exercises the "tree exists + clean" code path).
+        fs::write(repo.join(".gitkeep"), "").unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["add", ".gitkeep"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["commit", "-q", "-m", "init"])
+            .status()
+            .unwrap();
+
+        let cas_root = repo.join(".cas");
+        fs::create_dir_all(&cas_root).unwrap();
+        let log = write_session_end_manifest(&cas_root, "sess-clean", None, None)
+            .expect("manifest written");
+        let body = fs::read_to_string(&log).unwrap();
+        assert!(
+            body.contains("git_status: (clean)"),
+            "clean worktree should be recorded, got: {body}"
+        );
+    }
+
+    /// When `cas_root` lives under a linked worktree (the factory layout:
+    /// `<repo>/.cas/worktrees/<name>/.cas`), `main_worktree_path` must resolve
+    /// to the main repo — not the linked worktree — otherwise the hygiene
+    /// manifest attributes the worker's own WIP as "main worktree" and
+    /// inverts the supervisor triage promise (cas-a9ab adversarial finding).
+    #[test]
+    fn main_worktree_path_resolves_to_main_repo_from_linked_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let main = tmp.path().join("main");
+        fs::create_dir_all(&main).unwrap();
+        init_repo(&main);
+        // A commit is required so the repo has HEAD before linking a worktree.
+        fs::write(main.join("seed.txt"), "").unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(&main)
+            .args(["add", "seed.txt"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(&main)
+            .args(["commit", "-q", "-m", "seed"])
+            .status()
+            .unwrap();
+
+        let linked = tmp.path().join("linked");
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&main)
+            .args(["worktree", "add", "-b", "feature"])
+            .arg(&linked)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git worktree add must succeed for this test");
+
+        // Worker-style layout: cas_root is <linked>/.cas.
+        let linked_cas = linked.join(".cas");
+        fs::create_dir_all(&linked_cas).unwrap();
+
+        let resolved = main_worktree_path(&linked_cas).expect("main path resolved");
+        assert_eq!(
+            resolved.canonicalize().unwrap(),
+            main.canonicalize().unwrap(),
+            "linked-worktree cas_root must resolve upward to the main repo, got {resolved:?}"
+        );
     }
 }

--- a/cas-cli/src/hooks/handlers/session_hygiene.rs
+++ b/cas-cli/src/hooks/handlers/session_hygiene.rs
@@ -284,10 +284,30 @@ pub fn attribute_file_to_task(repo: &Path, file: &str) -> Option<String> {
     extract_task_id(&text)
 }
 
+/// Maximum WIP entries the SessionStart banner itself renders inline.
+///
+/// Above this cap we print a "... and N more" suffix and direct the
+/// supervisor to `gc_report` for the full list. The cap exists for two
+/// reasons surfaced in review:
+///
+/// 1. Each tracked entry spawns `git log -1` for attribution. On a
+///    pathological dirty tree (hundreds of files after a prior-session
+///    crash) an uncapped banner turns the SessionStart hook into a
+///    multi-second stall, which the user experiences as Claude Code
+///    hanging on startup. 20 entries ≤ ~1s at 20–50ms per subprocess.
+/// 2. The full SessionStart preview window is limited. Flooding it with
+///    attribution lines buries the codemap/overview signals.
+const WIP_BANNER_MAX_ENTRIES: usize = 20;
+
 /// Render the SessionStart triage banner for a supervisor session, or
 /// `None` when the worktree is clean / git is unavailable / cas_root
 /// cannot be resolved. The banner is best-effort and must never fail a
 /// session start.
+///
+/// The banner caps itself at [`WIP_BANNER_MAX_ENTRIES`] inline rows and
+/// forwards the overflow count to `gc_report` so the supervisor can
+/// paginate on demand — this bounds both `git log` subprocess fan-out
+/// and the token budget the banner eats from the context window.
 ///
 /// Output shape (example):
 /// ```text
@@ -311,7 +331,9 @@ pub fn build_session_start_wip_banner(cas_root: &Path) -> Option<String> {
         summary.modified_count(),
         summary.untracked_count(),
     ));
-    for entry in &summary.entries {
+    let total = summary.entries.len();
+    let shown = total.min(WIP_BANNER_MAX_ENTRIES);
+    for entry in summary.entries.iter().take(shown) {
         let attribution = if entry.is_untracked() {
             "(unattributed — no git history)".to_string()
         } else {
@@ -321,10 +343,16 @@ pub fn build_session_start_wip_banner(cas_root: &Path) -> Option<String> {
             }
         };
         out.push_str(&format!(
-            "  [{:10}] {}  {}\n",
+            "  [{:15}] {}  {}\n",
             entry.label(),
             entry.path,
             attribution,
+        ));
+    }
+    if total > shown {
+        let extra = total - shown;
+        out.push_str(&format!(
+            "  ... and {extra} more — run `mcp__cas__coordination action=gc_report` for the full list.\n",
         ));
     }
     out.push_str(
@@ -654,6 +682,44 @@ mod tests {
             .status()
             .unwrap();
         assert_eq!(attribute_file_to_task(repo, "b.txt"), None);
+    }
+
+    /// On a pathological dirty tree (hundreds of files) the banner must
+    /// cap its inline rows and direct the supervisor to `gc_report` for
+    /// the overflow. Guards against SessionStart latency regressions —
+    /// every rendered row spawns `git log -1`, so an uncapped banner
+    /// stalls session boot (cas-aeec adversarial P1).
+    #[test]
+    fn build_session_start_wip_banner_caps_rows_on_large_wip_trees() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_repo(repo);
+        // Untracked files don't need committing — faster than seeding
+        // real history and exercises the 'unattributed' path which
+        // still must be capped.
+        let total = WIP_BANNER_MAX_ENTRIES + 7;
+        for i in 0..total {
+            fs::write(repo.join(format!("wip_{i:03}.tmp")), "").unwrap();
+        }
+        let cas_root = repo.join(".cas");
+        fs::create_dir_all(&cas_root).unwrap();
+
+        let banner =
+            build_session_start_wip_banner(&cas_root).expect("banner for dirty tree");
+        // The "[" opens each inline row. Count occurrences.
+        let rows = banner.matches('[').count();
+        assert_eq!(
+            rows, WIP_BANNER_MAX_ENTRIES,
+            "banner must cap inline rows at WIP_BANNER_MAX_ENTRIES, got {rows}"
+        );
+        assert!(
+            banner.contains(&format!("and {} more", total - WIP_BANNER_MAX_ENTRIES)),
+            "banner must announce the overflow count"
+        );
+        assert!(
+            banner.contains("gc_report"),
+            "overflow line must direct supervisor to gc_report"
+        );
     }
 
     /// The SessionStart banner must surface the attribution line and the

--- a/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
@@ -517,6 +517,27 @@ impl CasCore {
     }
 
     /// List tasks claimed by this agent
+    ///
+    /// ### Spawn-time race resilience (EPIC cas-9508 / cas-5572)
+    ///
+    /// Workers are assigned by supervisors via `task update assignee=<worker-name>`.
+    /// At the moment a fresh worker makes its first `action=mine` call, the agent
+    /// store row for that worker may not yet reflect the final worker name
+    /// (agent_name could still be a stale/default value, or the row lookup
+    /// could race eager-registration) — and the task's `assignee` column will
+    /// hold the worker-name string set by the supervisor.
+    ///
+    /// To make the first poll reliably return freshly-assigned tasks without
+    /// requiring a coordination-message kick, this handler matches assignees
+    /// against a **set** of known identifiers for the current agent:
+    ///
+    /// - the canonical `agent_id` (session UUID),
+    /// - the `agent_name` from the agent_store row, if any,
+    /// - the `CAS_AGENT_NAME` env var (set by the factory PTY spawner), and
+    /// - the `CAS_SESSION_ID` env var (belt-and-suspenders for the UUID).
+    ///
+    /// Matching is case-insensitive on trimmed values to tolerate minor
+    /// spelling drift between supervisor and worker views.
     pub async fn cas_tasks_mine(
         &self,
         Parameters(req): Parameters<LimitRequest>,
@@ -531,17 +552,45 @@ impl CasCore {
             .map(|a| a.name)
             .unwrap_or_else(|_| agent_id.clone());
 
+        // Collect all identifiers that may have been used as the `assignee`
+        // value for this agent. Factory workers are frequently assigned by
+        // their friendly worker-name before the agent_store row is fully
+        // populated, so we include the env-provided name/session as well.
+        // See doc-comment above for the spawn-time race this guards against.
+        let mut identities: Vec<String> = Vec::with_capacity(4);
+        let mut push_identity = |s: &str| {
+            let t = s.trim();
+            if !t.is_empty() && !identities.iter().any(|i| i.eq_ignore_ascii_case(t)) {
+                identities.push(t.to_string());
+            }
+        };
+        push_identity(&agent_id);
+        push_identity(&agent_name);
+        if let Ok(env_name) = std::env::var("CAS_AGENT_NAME") {
+            push_identity(&env_name);
+        }
+        if let Ok(env_session) = std::env::var("CAS_SESSION_ID") {
+            push_identity(&env_session);
+        }
+
         let leases = agent_store.list_agent_leases(&agent_id).unwrap_or_default();
         let mut assigned: Vec<Task> = task_store
             .list(None)
             .unwrap_or_default()
             .into_iter()
             .filter(|t| {
-                t.status != TaskStatus::Closed
-                    && matches!(
-                        t.assignee.as_deref(),
-                        Some(a) if a == agent_id || a == agent_name
-                    )
+                if t.status == TaskStatus::Closed {
+                    return false;
+                }
+                match t.assignee.as_deref() {
+                    Some(a) => {
+                        let a_trim = a.trim();
+                        identities
+                            .iter()
+                            .any(|id| id.eq_ignore_ascii_case(a_trim))
+                    }
+                    None => false,
+                }
             })
             .collect();
 
@@ -582,6 +631,15 @@ impl CasCore {
                 lease_info,
                 if task.assignee.as_deref() == Some(agent_id.as_str()) {
                     " (assignee=agent_id)"
+                } else if task
+                    .assignee
+                    .as_deref()
+                    .map(|a| !a.eq_ignore_ascii_case(agent_name.as_str()))
+                    .unwrap_or(false)
+                {
+                    // Matched via a fallback identity (e.g. CAS_AGENT_NAME
+                    // env) — useful signal during the spawn-time race window.
+                    " (assignee=alias)"
                 } else {
                     ""
                 }

--- a/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
@@ -313,24 +313,155 @@ impl CasCore {
     }
 
     /// Release a claimed task
+    /// Release a task lease, with auto-recovery for dead-session orphans.
+    ///
+    /// ### Dead-session auto-recovery (EPIC cas-9508 / cas-1a7c)
+    ///
+    /// Previously, `release` returned `"No active lease found"` when the task
+    /// row was `InProgress` but the lease had been garbage-collected (e.g. the
+    /// worker session died without cleanly releasing). The status stayed
+    /// `InProgress` forever, and callers had to manually `update status=open`
+    /// to recover. This divergence between lease state and task status was a
+    /// persistent source of factory-session friction.
+    ///
+    /// Release now detects the "no active lease + status != Closed/Open"
+    /// case, transitions the task to `Open`, clears the assignee, appends an
+    /// audit note to `task.notes`, and returns success. The message reflects
+    /// whether a real lease was released or the task was auto-recovered so
+    /// callers can act accordingly.
     pub async fn cas_task_release(
         &self,
         Parameters(req): Parameters<TaskReleaseRequest>,
     ) -> Result<CallToolResult, McpError> {
         let agent_store = self.open_agent_store()?;
+        let task_store = self.open_task_store()?;
 
         // Get the registered agent ID (matches how claim works)
         let agent_id = self.get_agent_id()?;
 
-        agent_store
-            .release_lease(&req.task_id, &agent_id)
-            .map_err(|e| McpError {
-                code: ErrorCode::INVALID_PARAMS,
-                message: Cow::from(format!("Failed to release task: {e}")),
-                data: None,
-            })?;
+        match agent_store.release_lease(&req.task_id, &agent_id) {
+            Ok(()) => Ok(Self::success(format!("Released task: {}", req.task_id))),
+            Err(e) => {
+                // Auto-recovery path: no active lease but the task row may
+                // still be in a non-open state from a dead session. Flip it
+                // back to Open with an audit note rather than surfacing the
+                // raw "no lease" error to the caller.
+                let err_str = e.to_string();
+                let is_not_found = err_str.contains("No active lease found");
 
-        Ok(Self::success(format!("Released task: {}", req.task_id)))
+                if is_not_found {
+                    if let Ok(mut task) = task_store.get(&req.task_id) {
+                        if task.status != TaskStatus::Closed
+                            && task.status != TaskStatus::Open
+                        {
+                            let prior_status = task.status;
+                            let prior_assignee = task.assignee.clone();
+                            task.status = TaskStatus::Open;
+                            task.assignee = None;
+                            let ts = chrono::Utc::now().format("%Y-%m-%d %H:%M");
+                            let audit = format!(
+                                "[{ts}] release: lease absent; auto-recovered from {prior_status:?} (prior assignee: {}) to Open — assumed orphaned by dead session",
+                                prior_assignee.as_deref().unwrap_or("<none>")
+                            );
+                            task.notes = if task.notes.is_empty() {
+                                audit
+                            } else {
+                                format!("{}\n\n{}", task.notes, audit)
+                            };
+                            task.updated_at = chrono::Utc::now();
+                            task_store.update(&task).map_err(|upd_err| McpError {
+                                code: ErrorCode::INTERNAL_ERROR,
+                                message: Cow::from(format!(
+                                    "Release auto-recovery: failed to update task: {upd_err}"
+                                )),
+                                data: None,
+                            })?;
+                            return Ok(Self::success(format!(
+                                "Released task: {} (auto-recovered from {:?} — lease was absent; status reset to Open)",
+                                req.task_id, prior_status
+                            )));
+                        }
+                    }
+                }
+
+                Err(McpError {
+                    code: ErrorCode::INVALID_PARAMS,
+                    message: Cow::from(format!("Failed to release task: {e}")),
+                    data: None,
+                })
+            }
+        }
+    }
+
+    /// Reset a task to a clean Open state, clearing any lease + assignee.
+    ///
+    /// ### Dead-session recovery verb (EPIC cas-9508 / cas-1a7c)
+    ///
+    /// `reset` is the atomic "revive this task from a dead session" verb.
+    /// Unlike `release`, it does not require the caller to own the lease —
+    /// it force-releases any active lease on the task, clears the assignee,
+    /// transitions the status to `Open`, and records an audit note. Intended
+    /// for supervisor / operator use when a worker died mid-task and left
+    /// orphaned lease + InProgress rows behind.
+    ///
+    /// Safety: refuses to reset a `Closed` task (use `reopen` instead).
+    pub async fn cas_task_reset(
+        &self,
+        Parameters(req): Parameters<TaskReleaseRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let agent_store = self.open_agent_store()?;
+        let task_store = self.open_task_store()?;
+
+        let mut task = task_store.get(&req.task_id).map_err(|e| McpError {
+            code: ErrorCode::INVALID_PARAMS,
+            message: Cow::from(format!("Task not found: {e}")),
+            data: None,
+        })?;
+
+        if task.status == TaskStatus::Closed {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from(format!(
+                    "Cannot reset closed task {} — use `action=reopen` instead",
+                    req.task_id
+                )),
+                data: None,
+            });
+        }
+
+        // Force-release any active lease on the task (no ownership check).
+        // `release_lease_for_task` returns Ok(true) if a lease was released,
+        // Ok(false) if none existed — either is fine here.
+        let lease_released = agent_store
+            .release_lease_for_task(&req.task_id)
+            .unwrap_or(false);
+
+        let prior_status = task.status;
+        let prior_assignee = task.assignee.clone();
+        task.status = TaskStatus::Open;
+        task.assignee = None;
+        let ts = chrono::Utc::now().format("%Y-%m-%d %H:%M");
+        let audit = format!(
+            "[{ts}] reset: force-transitioned {prior_status:?}→Open (prior assignee: {}, lease released: {lease_released}) — dead-session recovery",
+            prior_assignee.as_deref().unwrap_or("<none>")
+        );
+        task.notes = if task.notes.is_empty() {
+            audit
+        } else {
+            format!("{}\n\n{}", task.notes, audit)
+        };
+        task.updated_at = chrono::Utc::now();
+
+        task_store.update(&task).map_err(|e| McpError {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: Cow::from(format!("reset: failed to update task: {e}")),
+            data: None,
+        })?;
+
+        Ok(Self::success(format!(
+            "Reset task: {} (was {:?}, assignee cleared, lease released: {})",
+            req.task_id, prior_status, lease_released
+        )))
     }
 
     /// List tasks available for claiming

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -2268,4 +2268,74 @@ mod code_review_gate_tests {
         let out = run_code_review_gate(&t, &req, dir.path());
         assert!(matches!(out, CodeReviewGateOutcome::Proceed));
     }
+
+    // --- cas-3086: persisted-envelope fallback ------------------------------
+
+    #[test]
+    fn persisted_envelope_satisfies_gate_when_req_missing() {
+        // Simulates supervisor-close: the worker persisted a clean
+        // envelope on a prior (jailed) close attempt; supervisor
+        // calls close without re-running review and without
+        // bypass_code_review=true.
+        let _g = env_lock();
+        let dir = repo_with_staged(&[("src/foo.rs", "fn new() {}\n")]);
+        let mut t = base_task();
+        t.deliverables.review_envelope = Some(autofix_envelope(Vec::new()));
+        let req = base_req(&t.id); // no findings in request
+        let out = run_code_review_gate(&t, &req, dir.path());
+        assert!(
+            matches!(out, CodeReviewGateOutcome::Proceed),
+            "persisted clean envelope must let supervisor-close proceed without bypass"
+        );
+    }
+
+    #[test]
+    fn persisted_envelope_with_p0_still_blocks() {
+        // Forwarding a receipt does not weaken the P0 gate.
+        let _g = env_lock();
+        let dir = repo_with_staged(&[("src/foo.rs", "fn new() {}\n")]);
+        let mut t = base_task();
+        t.deliverables.review_envelope = Some(autofix_envelope(vec![p0_finding()]));
+        let req = base_req(&t.id);
+        let out = run_code_review_gate(&t, &req, dir.path());
+        match out {
+            CodeReviewGateOutcome::Reject(msg) => {
+                assert!(msg.contains("P0 BLOCK"), "P0 must still block: {msg}");
+            }
+            other => panic!("expected P0 block on persisted envelope, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn request_envelope_takes_precedence_over_persisted() {
+        // If the caller sends a fresh envelope, that's what the gate
+        // sees — the persisted one is a fallback, not a merge.
+        let _g = env_lock();
+        let dir = repo_with_staged(&[("src/foo.rs", "fn new() {}\n")]);
+        let mut t = base_task();
+        // Persisted envelope has a P0 — would block if chosen.
+        t.deliverables.review_envelope = Some(autofix_envelope(vec![p0_finding()]));
+        let mut req = base_req(&t.id);
+        // Request envelope is clean — should let the close proceed.
+        req.code_review_findings = Some(autofix_envelope(Vec::new()));
+        let out = run_code_review_gate(&t, &req, dir.path());
+        assert!(
+            matches!(out, CodeReviewGateOutcome::Proceed),
+            "explicit request envelope must win over persisted fallback"
+        );
+    }
+
+    #[test]
+    fn persisted_malformed_envelope_is_rejected() {
+        let _g = env_lock();
+        let dir = repo_with_staged(&[("src/foo.rs", "fn new() {}\n")]);
+        let mut t = base_task();
+        t.deliverables.review_envelope = Some("not-json".to_string());
+        let req = base_req(&t.id);
+        let out = run_code_review_gate(&t, &req, dir.path());
+        assert!(
+            matches!(out, CodeReviewGateOutcome::Reject(_)),
+            "malformed persisted envelope must be rejected, not silently bypassed"
+        );
+    }
 }

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -773,7 +773,43 @@ impl CasCore {
         //     overrides because that would mask a misconfigured
         //     harness.
         let close_project_root = self.cas_root.parent().unwrap_or(&self.cas_root);
-        match run_code_review_gate(&task, &req, close_project_root) {
+
+        // cas-3086: Epic-close should not re-gate on the union diff
+        // when every subtask already carries a valid ReviewOutcome
+        // receipt (persisted on deliverables.review_envelope). The
+        // subtasks were each individually reviewed before their own
+        // close; running the multi-persona reviewer on the unioned
+        // diff is redundant cost and wrong-shape signal.
+        let epic_subtask_receipts_cover = if task.task_type == TaskType::Epic {
+            use cas_store::code_review::close_gate::{GateDecision, evaluate_gate};
+            match task_store.get_subtasks(&req.id) {
+                Ok(subtasks) if !subtasks.is_empty() => subtasks.iter().all(|t| {
+                    t.deliverables
+                        .review_envelope
+                        .as_deref()
+                        .and_then(|e| serde_json::from_str::<cas_types::ReviewOutcome>(e).ok())
+                        .filter(|o| o.validate().is_ok())
+                        // Defense-in-depth (per verifier): a receipt
+                        // with a residual P0 must not let the epic-close
+                        // bypass the gate, even though such a subtask
+                        // shouldn't have been closed in the first place.
+                        // Guards against direct DB writes or bugs that
+                        // leak P0s past the subtask gate.
+                        .map(|o| matches!(evaluate_gate(&o.residual), GateDecision::Allow))
+                        .unwrap_or(false)
+                }),
+                _ => false,
+            }
+        } else {
+            false
+        };
+
+        let gate_outcome = if epic_subtask_receipts_cover {
+            CodeReviewGateOutcome::Proceed
+        } else {
+            run_code_review_gate(&task, &req, close_project_root)
+        };
+        match gate_outcome {
             CodeReviewGateOutcome::Proceed => {}
             CodeReviewGateOutcome::AppendDecisionNote(note) => {
                 let mut t = task.clone();

--- a/cas-cli/src/mcp/tools/service/core.rs
+++ b/cas-cli/src/mcp/tools/service/core.rs
@@ -449,6 +449,16 @@ impl CasService {
         self.inner.cas_task_release(Parameters(inner_req)).await
     }
 
+    pub(super) async fn task_reset(&self, req: TaskRequest) -> Result<CallToolResult, McpError> {
+        use crate::mcp::tools::TaskReleaseRequest;
+        let inner_req = TaskReleaseRequest {
+            task_id: req
+                .id
+                .ok_or_else(|| Self::error(ErrorCode::INVALID_PARAMS, "id required — pass as `id` (not `task_id`, `taskId`, or `_id`). Example: mcp__cas__task action=reset id=cas-abc1"))?,
+        };
+        self.inner.cas_task_reset(Parameters(inner_req)).await
+    }
+
     pub(super) async fn task_transfer(&self, req: TaskRequest) -> Result<CallToolResult, McpError> {
         use crate::mcp::tools::TaskTransferRequest;
         let inner_req = TaskTransferRequest {

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -748,6 +748,38 @@ impl CasService {
             }
         }
 
+        // Task cas-a9ab: surface uncommitted files in the main worktree as
+        // "likely prior-factory WIP". Informational only — we never auto-delete.
+        if let Some(summary) =
+            crate::hooks::handlers::session_hygiene::wip_candidates(&self.inner.cas_root)
+        {
+            out.push_str(&format!(
+                "\nMain worktree: {}\n",
+                summary.worktree.display()
+            ));
+            if summary.is_clean() {
+                out.push_str("Prior-factory WIP candidates: none (worktree clean)\n");
+            } else {
+                out.push_str(&format!(
+                    "Prior-factory WIP candidates: {} ({} untracked, {} modified)\n",
+                    summary.entries.len(),
+                    summary.untracked_count(),
+                    summary.modified_count(),
+                ));
+                for entry in &summary.entries {
+                    out.push_str(&format!(
+                        "  [{}] {} {}\n",
+                        entry.label(),
+                        entry.status,
+                        entry.path,
+                    ));
+                }
+                out.push_str(
+                    "\nNote: these are not auto-deleted. Inspect, then commit/salvage/discard.\n",
+                );
+            }
+        }
+
         Ok(Self::success(out))
     }
 

--- a/cas-cli/src/mcp/tools/service/mod.rs
+++ b/cas-cli/src/mcp/tools/service/mod.rs
@@ -247,7 +247,7 @@ impl CasService {
     // ========================================================================
 
     #[tool(
-        description = "Task operations. Actions: create, show, update, start, close, reopen, delete, list, ready (actionable), blocked, notes (add progress), dep_add, dep_remove, dep_list, claim, release, transfer, available, mine. Prefer `start` for normal worker execution; use `claim` for manual lease control/recovery. IMPORTANT for 'close': verification must pass first. Workers should attempt close; if close returns verification-required guidance, follow the indicated verifier ownership workflow."
+        description = "Task operations. Actions: create, show, update, start, close, reopen, delete, list, ready (actionable), blocked, notes (add progress), dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine. Prefer `start` for normal worker execution; use `claim` for manual lease control/recovery; use `reset` to revive a task orphaned by a dead session (atomic: force-releases lease, clears assignee, forces status=open). IMPORTANT for 'close': verification must pass first. Workers should attempt close; if close returns verification-required guidance, follow the indicated verifier ownership workflow."
     )]
     pub async fn task(
         &self,
@@ -269,6 +269,7 @@ impl CasService {
                     | "dep_remove"
                     | "claim"
                     | "release"
+                    | "reset"
                     | "transfer"
             );
 
@@ -293,13 +294,14 @@ impl CasService {
                 "dep_list" => this.task_dep_list(req).await,
                 "claim" => this.task_claim(req).await,
                 "release" => this.task_release(req).await,
+                "reset" => this.task_reset(req).await,
                 "transfer" => this.task_transfer(req).await,
                 "available" => this.task_available(req).await,
                 "mine" => this.task_mine(req).await,
                 _ => Err(Self::error(
                     ErrorCode::INVALID_PARAMS,
                     format!(
-                        "Unknown task action: {}. Valid: create, show, update, start, close, reopen, delete, list, ready, blocked, notes, dep_add, dep_remove, dep_list, claim, release, transfer, available, mine",
+                        "Unknown task action: {}. Valid: create, show, update, start, close, reopen, delete, list, ready, blocked, notes, dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine",
                         req.action
                     ),
                 )),

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -1470,6 +1470,84 @@ mod tests {
         );
     }
 
+    /// If the currently-tracked epic is no longer present in `epic_tasks`
+    /// (closed, deleted, or cross-project filter drift) the strict-improvement
+    /// gate must treat the slot as vacant so a legitimate new Open-with-branch
+    /// epic can take over. Regression guard for the cas-4181 adversarial
+    /// "ghost current_epic_id freezes TUI" concern.
+    #[test]
+    fn runtime_detector_recovers_when_tracked_epic_disappears() {
+        use cas_factory::TaskSummary;
+        use cas_types::{Priority, TaskStatus, TaskType};
+
+        use super::{DirectorData, DirectorEvent, DirectorEventDetector};
+
+        let new_id = "epic-new";
+
+        let data = DirectorData {
+            ready_tasks: vec![TaskSummary {
+                id: "task-ready".to_string(),
+                title: "Ready subtask of new epic".to_string(),
+                status: TaskStatus::Open,
+                priority: Priority::MEDIUM,
+                assignee: None,
+                task_type: TaskType::Task,
+                epic: Some(new_id.to_string()),
+                branch: None,
+            }],
+            in_progress_tasks: Vec::new(),
+            epic_tasks: vec![TaskSummary {
+                id: new_id.to_string(),
+                title: "New epic".to_string(),
+                status: TaskStatus::Open,
+                priority: Priority::MEDIUM,
+                assignee: None,
+                task_type: TaskType::Epic,
+                epic: None,
+                branch: Some("epic/new".to_string()),
+            }],
+            agents: Vec::new(),
+            activity: Vec::new(),
+            agent_id_to_name: HashMap::new(),
+            changes: Vec::new(),
+            git_loaded: false,
+            reminders: Vec::new(),
+            epic_closed_counts: HashMap::new(),
+        };
+
+        let mut detector = DirectorEventDetector::new(
+            vec!["worker-1".to_string()],
+            "supervisor".to_string(),
+        );
+        detector.initialize(&DirectorData {
+            ready_tasks: Vec::new(),
+            in_progress_tasks: Vec::new(),
+            epic_tasks: Vec::new(),
+            agents: Vec::new(),
+            activity: Vec::new(),
+            agent_id_to_name: HashMap::new(),
+            changes: Vec::new(),
+            git_loaded: false,
+            reminders: Vec::new(),
+            epic_closed_counts: HashMap::new(),
+        });
+
+        // current_epic_id points at a ghost epic not in data.epic_tasks.
+        let events = detector.detect_changes(&data, Some("epic-ghost"));
+
+        let started_for_new = events.iter().any(|e| {
+            matches!(
+                e,
+                DirectorEvent::EpicStarted { epic_id, .. } if epic_id == new_id
+            )
+        });
+        assert!(
+            started_for_new,
+            "EpicStarted must fire for the legitimate new epic when the \
+             tracked current_epic_id refers to a ghost not in epic_tasks"
+        );
+    }
+
     /// Sibling sanity test: when no epic is currently tracked (init-time
     /// detect_changes), the runtime detector must pick the *same* best
     /// Open-with-branch epic as `detect_epic_state` — not the lex-greatest.

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -470,7 +470,12 @@ impl FactoryApp {
         // Detect state changes BEFORE filtering so new epics are visible to the
         // event detector. This allows EpicStarted to fire and update epic_state,
         // which the filter depends on for subsequent refresh cycles.
-        let events = self.event_detector.detect_changes(&self.director_data);
+        // Pass the currently-tracked epic id so `EpicStarted` is gated on
+        // strict improvement: a stray zero-subtask Open-with-branch epic
+        // cannot hijack `epic_state` mid-session (see task cas-4181).
+        let events = self
+            .event_detector
+            .detect_changes(&self.director_data, self.epic_state.epic_id());
 
         // Update epic_state immediately from detected events so the filter below
         // uses the correct epic_id (otherwise a new epic's tasks get filtered out)
@@ -923,37 +928,18 @@ pub(crate) fn detect_epic_state(
     // Fall back to open epics that have a branch set (auto-created branch).
     // Prefer epics with active subtasks (in-progress > ready) over stale ones.
     // This prevents stale cross-project epics from shadowing the active epic.
-    {
-        let open_epics: Vec<_> = data
-            .epic_tasks
-            .iter()
-            .filter(|e| e.status == TaskStatus::Open && e.branch.is_some())
-            .collect();
-
-        if !open_epics.is_empty() {
-            // Count in-progress and ready subtasks per epic
-            let count_subtasks = |tasks: &[cas_factory::TaskSummary], epic_id: &str| -> usize {
-                tasks.iter().filter(|t| t.epic.as_deref() == Some(epic_id)).count()
-            };
-
-            if let Some(best) = open_epics.iter().max_by(|a, b| {
-                let a_ip = count_subtasks(&data.in_progress_tasks, &a.id);
-                let b_ip = count_subtasks(&data.in_progress_tasks, &b.id);
-                a_ip.cmp(&b_ip)
-                    .then_with(|| {
-                        let a_ready = count_subtasks(&data.ready_tasks, &a.id);
-                        let b_ready = count_subtasks(&data.ready_tasks, &b.id);
-                        a_ready.cmp(&b_ready)
-                    })
-                    // Deterministic tie-break: greatest ID last resort
-                    .then_with(|| a.id.cmp(&b.id))
-            }) {
-                return EpicState::Active {
-                    epic_id: best.id.clone(),
-                    epic_title: best.title.clone(),
-                };
-            }
-        }
+    // The picker is shared with the runtime EpicStarted event detector so the
+    // two paths cannot disagree on which Open-with-branch epic is "best" —
+    // divergence there caused a mid-session hijack bug (see task cas-4181).
+    if let Some(best) = crate::ui::factory::director::pick_best_open_branch_epic(
+        &data.epic_tasks,
+        &data.in_progress_tasks,
+        &data.ready_tasks,
+    ) {
+        return EpicState::Active {
+            epic_id: best.id.clone(),
+            epic_title: best.title.clone(),
+        };
     }
 
     // Completing state is transitioned to via handle_epic_events() when EpicCompleted fires
@@ -1061,7 +1047,7 @@ mod tests {
             epic_closed_counts: HashMap::new(),
         });
 
-        let events = detector.detect_changes(&data);
+        let events = detector.detect_changes(&data, None);
 
         // Verify EpicStarted was fired
         let epic_started = events.iter().any(|e| {
@@ -1346,5 +1332,231 @@ mod tests {
             }
             other => panic!("Expected Active, got {other:?}"),
         }
+    }
+
+    /// Regression test for cas-4181: factory TUI epic hijack.
+    ///
+    /// Two Open-with-branch epics exist:
+    ///   - `epic-aaa` — lex-earlier, has both in-progress and ready subtasks.
+    ///   - `epic-zzz` — lex-later, zero subtasks (the would-be hijacker).
+    ///
+    /// Before this fix, the runtime `EpicStarted` detector used a
+    /// "greatest-lex-ID wins" tiebreak that disagreed with the init path's
+    /// subtask-count heuristic. That caused `epic-zzz` to hijack the factory
+    /// panel mid-session. After the fix both paths share
+    /// `pick_best_open_branch_epic` and the active `epic-aaa` wins init;
+    /// the strict-improvement gate then blocks `epic-zzz` from firing
+    /// `EpicStarted` at all while `epic-aaa` is already the tracked epic.
+    #[test]
+    fn runtime_detector_does_not_hijack_active_epic_with_stray_open_branch_epic() {
+        use cas_factory::{EpicState, TaskSummary};
+        use cas_types::{Priority, TaskStatus, TaskType};
+
+        use super::{DirectorData, DirectorEvent, DirectorEventDetector};
+
+        let active_id = "epic-aaa";
+        let hijacker_id = "epic-zzz";
+
+        let data = DirectorData {
+            ready_tasks: vec![TaskSummary {
+                id: "task-ready".to_string(),
+                title: "Ready subtask of active epic".to_string(),
+                status: TaskStatus::Open,
+                priority: Priority::MEDIUM,
+                assignee: None,
+                task_type: TaskType::Task,
+                epic: Some(active_id.to_string()),
+                branch: None,
+            }],
+            in_progress_tasks: vec![TaskSummary {
+                id: "task-ip".to_string(),
+                title: "In-progress subtask of active epic".to_string(),
+                status: TaskStatus::InProgress,
+                priority: Priority::MEDIUM,
+                assignee: Some("worker-1".to_string()),
+                task_type: TaskType::Task,
+                epic: Some(active_id.to_string()),
+                branch: None,
+            }],
+            epic_tasks: vec![
+                TaskSummary {
+                    id: active_id.to_string(),
+                    title: "Active epic".to_string(),
+                    status: TaskStatus::Open,
+                    priority: Priority::MEDIUM,
+                    assignee: None,
+                    task_type: TaskType::Epic,
+                    epic: None,
+                    branch: Some("epic/active".to_string()),
+                },
+                TaskSummary {
+                    id: hijacker_id.to_string(),
+                    title: "Stray zero-subtask epic".to_string(),
+                    status: TaskStatus::Open,
+                    priority: Priority::MEDIUM,
+                    assignee: None,
+                    task_type: TaskType::Epic,
+                    epic: None,
+                    branch: Some("epic/hijacker".to_string()),
+                },
+            ],
+            agents: Vec::new(),
+            activity: Vec::new(),
+            agent_id_to_name: HashMap::new(),
+            changes: Vec::new(),
+            git_loaded: false,
+            reminders: Vec::new(),
+            epic_closed_counts: HashMap::new(),
+        };
+
+        // Init path: detect_epic_state must prefer the active (lex-earlier,
+        // has subtasks) epic over the stray lex-later one.
+        let state = super::detect_epic_state(&data, None);
+        match &state {
+            EpicState::Active { epic_id, .. } => {
+                assert_eq!(
+                    epic_id, active_id,
+                    "detect_epic_state must prefer the epic with active subtasks \
+                     regardless of lex-ID order (cas-4181 init path)"
+                );
+            }
+            other => panic!("Expected Active, got {other:?}"),
+        }
+
+        // Runtime path: event detector sees both epics as new Open-with-branch.
+        // With current_epic_id pointing at the active epic, the strict-improvement
+        // gate must suppress any EpicStarted for the stray hijacker.
+        let mut detector = DirectorEventDetector::new(
+            vec!["worker-1".to_string()],
+            "supervisor".to_string(),
+        );
+        detector.initialize(&DirectorData {
+            ready_tasks: Vec::new(),
+            in_progress_tasks: Vec::new(),
+            epic_tasks: Vec::new(),
+            agents: Vec::new(),
+            activity: Vec::new(),
+            agent_id_to_name: HashMap::new(),
+            changes: Vec::new(),
+            git_loaded: false,
+            reminders: Vec::new(),
+            epic_closed_counts: HashMap::new(),
+        });
+
+        let events = detector.detect_changes(&data, state.epic_id());
+
+        let hijack_started = events.iter().any(|e| {
+            matches!(
+                e,
+                DirectorEvent::EpicStarted { epic_id, .. } if epic_id == hijacker_id
+            )
+        });
+        assert!(
+            !hijack_started,
+            "EpicStarted must NOT fire for the zero-subtask hijacker epic \
+             while an active epic is already tracked (cas-4181 runtime path)"
+        );
+
+        // And the active epic itself should also not re-fire — it's already tracked.
+        let active_refired = events.iter().any(|e| {
+            matches!(
+                e,
+                DirectorEvent::EpicStarted { epic_id, .. } if epic_id == active_id
+            )
+        });
+        assert!(
+            !active_refired,
+            "EpicStarted must not refire for the already-tracked active epic"
+        );
+    }
+
+    /// Sibling sanity test: when no epic is currently tracked (init-time
+    /// detect_changes), the runtime detector must pick the *same* best
+    /// Open-with-branch epic as `detect_epic_state` — not the lex-greatest.
+    #[test]
+    fn runtime_detector_picks_same_epic_as_init_when_no_current_epic() {
+        use cas_factory::TaskSummary;
+        use cas_types::{Priority, TaskStatus, TaskType};
+
+        use super::{DirectorData, DirectorEvent, DirectorEventDetector};
+
+        let active_id = "epic-aaa";
+        let hijacker_id = "epic-zzz";
+
+        let data = DirectorData {
+            ready_tasks: vec![TaskSummary {
+                id: "task-ready".to_string(),
+                title: "Ready subtask".to_string(),
+                status: TaskStatus::Open,
+                priority: Priority::MEDIUM,
+                assignee: None,
+                task_type: TaskType::Task,
+                epic: Some(active_id.to_string()),
+                branch: None,
+            }],
+            in_progress_tasks: Vec::new(),
+            epic_tasks: vec![
+                TaskSummary {
+                    id: active_id.to_string(),
+                    title: "Active epic".to_string(),
+                    status: TaskStatus::Open,
+                    priority: Priority::MEDIUM,
+                    assignee: None,
+                    task_type: TaskType::Epic,
+                    epic: None,
+                    branch: Some("epic/active".to_string()),
+                },
+                TaskSummary {
+                    id: hijacker_id.to_string(),
+                    title: "Stray epic".to_string(),
+                    status: TaskStatus::Open,
+                    priority: Priority::MEDIUM,
+                    assignee: None,
+                    task_type: TaskType::Epic,
+                    epic: None,
+                    branch: Some("epic/hijacker".to_string()),
+                },
+            ],
+            agents: Vec::new(),
+            activity: Vec::new(),
+            agent_id_to_name: HashMap::new(),
+            changes: Vec::new(),
+            git_loaded: false,
+            reminders: Vec::new(),
+            epic_closed_counts: HashMap::new(),
+        };
+
+        let mut detector = DirectorEventDetector::new(
+            vec!["worker-1".to_string()],
+            "supervisor".to_string(),
+        );
+        detector.initialize(&DirectorData {
+            ready_tasks: Vec::new(),
+            in_progress_tasks: Vec::new(),
+            epic_tasks: Vec::new(),
+            agents: Vec::new(),
+            activity: Vec::new(),
+            agent_id_to_name: HashMap::new(),
+            changes: Vec::new(),
+            git_loaded: false,
+            reminders: Vec::new(),
+            epic_closed_counts: HashMap::new(),
+        });
+
+        let events = detector.detect_changes(&data, None);
+
+        let started_for: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                DirectorEvent::EpicStarted { epic_id, .. } => Some(epic_id.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            started_for,
+            vec![active_id],
+            "with no current epic, EpicStarted must fire for the subtask-winning \
+             epic, not the lex-greatest one (cas-4181)"
+        );
     }
 }

--- a/cas-cli/src/ui/factory/daemon/runtime/teams.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/teams.rs
@@ -567,13 +567,28 @@ impl TeamsManager {
         // Prune messages older than INBOX_RETENTION so the file cannot grow
         // unbounded across sessions — see cas-7f57 and the comment on
         // INBOX_RETENTION above.
+        //
+        // Unread messages (`read: false`) are preserved regardless of age
+        // so a supervisor's recovery/unblock prompt to a wedged worker
+        // cannot silently evaporate after the 2h window. See
+        // memory `feedback_supervisor_stop_message_latency` — stale
+        // STOP messages are already a known delivery hazard, and age-only
+        // retention would strictly worsen that failure mode.
         let retention_cutoff = now_utc - INBOX_RETENTION;
-        messages.retain(|m| match chrono::DateTime::parse_from_rfc3339(&m.timestamp) {
-            Ok(ts) => ts.with_timezone(&chrono::Utc) >= retention_cutoff,
-            // Unparseable timestamp: keep the message rather than silently
-            // drop real data; a future migration can clean these up.
-            Err(_) => true,
+        let messages_before_retain = messages.len();
+        messages.retain(|m| {
+            if !m.read {
+                return true;
+            }
+            match chrono::DateTime::parse_from_rfc3339(&m.timestamp) {
+                Ok(ts) => ts.with_timezone(&chrono::Utc) >= retention_cutoff,
+                // Unparseable timestamp: keep the message rather than
+                // silently drop real data; a future migration can clean
+                // these up.
+                Err(_) => true,
+            }
         });
+        let retention_pruned = messages.len() != messages_before_retain;
 
         // Dedup guard: if an identical (from, text) message exists within
         // the dedup window, skip the append. This is the coordination
@@ -601,10 +616,13 @@ impl TeamsManager {
                 target_agent = target,
                 "inbox write skipped — identical message within dedup window"
             );
-            // We still need to persist the pruned message list (retention
-            // sweep ran) so the inbox doesn't hoard stale entries.
-            let json = serde_json::to_string_pretty(&messages)?;
-            std::fs::write(&inbox_path, json)?;
+            // Only re-serialize+write if the retention sweep actually
+            // removed anything; otherwise this is a pure no-op and we
+            // avoid a write storm on hot duplicate senders.
+            if retention_pruned {
+                let json = serde_json::to_string_pretty(&messages)?;
+                std::fs::write(&inbox_path, json)?;
+            }
             unsafe { libc::flock(fd, libc::LOCK_UN) };
             return Ok(());
         }
@@ -1087,6 +1105,105 @@ mod tests {
         );
     }
 
+    /// A duplicate write beyond `INBOX_DEDUP_WINDOW` must pass through
+    /// and append — dedup is time-bounded, not permanent. Guards against
+    /// off-by-one sign flips on the cutoff comparison.
+    #[test]
+    fn write_to_inbox_does_not_dedup_past_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = manager_in(tmp.path(), "t_expire");
+        std::fs::create_dir_all(&mgr.inboxes_dir).unwrap();
+
+        // Seed inbox with a 15-minute-old duplicate (beyond 10-min window).
+        let old_ts = (chrono::Utc::now() - chrono::Duration::minutes(15))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let seeded = vec![InboxMessage {
+            from: DIRECTOR_AGENT_NAME.to_string(),
+            text: "ping".to_string(),
+            summary: Some("ping".to_string()),
+            timestamp: old_ts,
+            color: "green".to_string(),
+            // Must be marked read or retention will keep it for
+            // unrelated reasons; we want dedup to be the only variable.
+            read: true,
+        }];
+        let inbox_path = mgr.inboxes_dir.join("swift-fox.json");
+        std::fs::write(&inbox_path, serde_json::to_string_pretty(&seeded).unwrap())
+            .unwrap();
+
+        // Fresh write with identical (from, text). Must pass through.
+        mgr.write_to_inbox("swift-fox", DIRECTOR_AGENT_NAME, "ping", None, None)
+            .unwrap();
+
+        let inbox: Vec<InboxMessage> = serde_json::from_str(
+            &std::fs::read_to_string(&inbox_path).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            inbox.len(),
+            2,
+            "15-minute-old duplicate is beyond dedup window and must not suppress a fresh write"
+        );
+    }
+
+    /// Unread messages (`read: false`) survive the retention sweep even
+    /// when older than `INBOX_RETENTION`. Guards the cas-7f57 adversarial
+    /// P1 finding: a supervisor recovery prompt to a wedged worker must
+    /// not silently evaporate after 2h.
+    #[test]
+    fn write_to_inbox_retention_preserves_unread_messages() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = manager_in(tmp.path(), "t_unread");
+        std::fs::create_dir_all(&mgr.inboxes_dir).unwrap();
+
+        // Seed a 3h-old UNREAD message (beyond 2h retention). Also seed
+        // a 3h-old READ message to prove the distinction.
+        let stale_ts = (chrono::Utc::now() - chrono::Duration::hours(3))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let seeded = vec![
+            InboxMessage {
+                from: "supervisor".to_string(),
+                text: "unblock yourself".to_string(),
+                summary: Some("unblock yourself".to_string()),
+                timestamp: stale_ts.clone(),
+                color: "green".to_string(),
+                read: false,
+            },
+            InboxMessage {
+                from: DIRECTOR_AGENT_NAME.to_string(),
+                text: "already-acked nag".to_string(),
+                summary: Some("already-acked nag".to_string()),
+                timestamp: stale_ts,
+                color: "green".to_string(),
+                read: true,
+            },
+        ];
+        let inbox_path = mgr.inboxes_dir.join("swift-fox.json");
+        std::fs::write(&inbox_path, serde_json::to_string_pretty(&seeded).unwrap())
+            .unwrap();
+
+        mgr.write_to_inbox("swift-fox", DIRECTOR_AGENT_NAME, "fresh", None, None)
+            .unwrap();
+
+        let inbox: Vec<InboxMessage> = serde_json::from_str(
+            &std::fs::read_to_string(&inbox_path).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(inbox.len(), 2, "inbox should retain unread + fresh, got {inbox:?}");
+        assert!(
+            inbox.iter().any(|m| m.text == "unblock yourself" && !m.read),
+            "unread supervisor recovery message must survive retention"
+        );
+        assert!(
+            !inbox.iter().any(|m| m.text == "already-acked nag"),
+            "stale read message must still be pruned"
+        );
+        assert!(
+            inbox.iter().any(|m| m.text == "fresh"),
+            "fresh write should have landed"
+        );
+    }
+
     /// Retention sweep: messages older than `INBOX_RETENTION` are dropped
     /// on every write so the inbox file cannot grow unbounded across
     /// sessions. Simulated by seeding a message with an old timestamp and
@@ -1107,7 +1224,9 @@ mod tests {
             summary: Some("ancient history".to_string()),
             timestamp: stale_ts,
             color: "green".to_string(),
-            read: false,
+            // Must be marked read — unread messages are preserved
+            // regardless of age by design.
+            read: true,
         }];
         let inbox_path = mgr.inboxes_dir.join("swift-fox.json");
         std::fs::write(&inbox_path, serde_json::to_string_pretty(&seeded).unwrap()).unwrap();

--- a/cas-cli/src/ui/factory/daemon/runtime/teams.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/teams.rs
@@ -19,6 +19,30 @@ const AGENT_COLORS: &[&str] = &["green", "blue", "yellow", "cyan", "magenta", "r
 /// team member.
 pub const DIRECTOR_AGENT_NAME: &str = "director";
 
+/// Dedup window for identical (from, text) inbox writes (task cas-7f57).
+///
+/// The daemon can re-fire the same auto-prompt (e.g. "You have been assigned
+/// cas-X") in a number of documented-but-unintended paths — event-detector
+/// last_state resets across refresh ticks, prompt_queue retry loops on pane
+/// busy, teams-inbox outbox replays on client reconnect. Workers live-reported
+/// receiving dozens of identical assignment messages minutes apart for tasks
+/// that were already Closed, each costing ~100–500 tokens of context per
+/// repeat. This is the coordination-layer guard: if the target's inbox
+/// already contains a message with identical `from` + `text` within the last
+/// `INBOX_DEDUP_WINDOW`, we skip the append and no-op the write. The deeper
+/// causes are left as follow-ups; this stops the bleeding at the delivery
+/// boundary.
+const INBOX_DEDUP_WINDOW: chrono::Duration = chrono::Duration::minutes(10);
+
+/// Retention window for messages in the inbox file (task cas-7f57).
+///
+/// Inbox files are append-only today and `read: false` is never flipped to
+/// true (see history comment on the field). Without pruning, every session
+/// boot replays the entire accumulated history to Claude Code. On every
+/// write we drop messages older than this window so the file stays bounded
+/// and stale messages cannot haunt future sessions.
+const INBOX_RETENTION: chrono::Duration = chrono::Duration::hours(2);
+
 /// A single message in a Teams inbox file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InboxMessage {
@@ -532,13 +556,58 @@ impl TeamsManager {
             serde_json::from_str(&content).unwrap_or_default()
         };
 
-        // Append new message
-        let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let now_utc = chrono::Utc::now();
+        let now = now_utc.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
         let resolved_color = color.unwrap_or("green").to_string();
 
         // Always set summary — native Claude Code expects it.
         // Fall back to the message text when no explicit summary is provided.
         let resolved_summary = summary.unwrap_or(message).to_string();
+
+        // Prune messages older than INBOX_RETENTION so the file cannot grow
+        // unbounded across sessions — see cas-7f57 and the comment on
+        // INBOX_RETENTION above.
+        let retention_cutoff = now_utc - INBOX_RETENTION;
+        messages.retain(|m| match chrono::DateTime::parse_from_rfc3339(&m.timestamp) {
+            Ok(ts) => ts.with_timezone(&chrono::Utc) >= retention_cutoff,
+            // Unparseable timestamp: keep the message rather than silently
+            // drop real data; a future migration can clean these up.
+            Err(_) => true,
+        });
+
+        // Dedup guard: if an identical (from, text) message exists within
+        // the dedup window, skip the append. This is the coordination
+        // message-dedupe layer called out in the cas-7f57 acceptance
+        // criteria — prevents the director/prompt_queue/outbox replay
+        // paths from writing the same "You have been assigned cas-X"
+        // message to the same worker repeatedly.
+        let dedup_cutoff = now_utc - INBOX_DEDUP_WINDOW;
+        let is_recent_duplicate = messages.iter().rev().any(|m| {
+            if m.from != from || m.text != message {
+                return false;
+            }
+            match chrono::DateTime::parse_from_rfc3339(&m.timestamp) {
+                Ok(ts) => ts.with_timezone(&chrono::Utc) >= dedup_cutoff,
+                Err(_) => false,
+            }
+        });
+
+        if is_recent_duplicate {
+            tracing::debug!(
+                target: "cas::coordination",
+                stage = "dedup_skip",
+                channel = "teams_inbox",
+                from = from,
+                target_agent = target,
+                "inbox write skipped — identical message within dedup window"
+            );
+            // We still need to persist the pruned message list (retention
+            // sweep ran) so the inbox doesn't hoard stale entries.
+            let json = serde_json::to_string_pretty(&messages)?;
+            std::fs::write(&inbox_path, json)?;
+            unsafe { libc::flock(fd, libc::LOCK_UN) };
+            return Ok(());
+        }
 
         messages.push(InboxMessage {
             from: from.to_string(),
@@ -944,5 +1013,115 @@ mod tests {
         if let Some(dir) = expected_path.parent() {
             let _ = std::fs::remove_dir_all(dir);
         }
+    }
+
+    /// Cross-refresh replay: identical (from, text) writes within
+    /// `INBOX_DEDUP_WINDOW` must no-op, dropping the duplicate before it
+    /// reaches the worker. This is the core regression guard for cas-7f57
+    /// — workers observed "You have been assigned cas-X" messages replayed
+    /// minutes apart for tasks that were already Closed.
+    #[test]
+    fn write_to_inbox_dedups_identical_messages_within_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = manager_in(tmp.path(), "t1");
+        std::fs::create_dir_all(&mgr.inboxes_dir).unwrap();
+        mgr.ensure_inbox("swift-fox").unwrap();
+
+        let msg = "You have been assigned cas-7f57\nTask: dup guard";
+        mgr.write_to_inbox("swift-fox", DIRECTOR_AGENT_NAME, msg, None, None)
+            .unwrap();
+        mgr.write_to_inbox("swift-fox", DIRECTOR_AGENT_NAME, msg, None, None)
+            .unwrap();
+        mgr.write_to_inbox("swift-fox", DIRECTOR_AGENT_NAME, msg, None, None)
+            .unwrap();
+
+        let inbox: Vec<InboxMessage> = serde_json::from_str(
+            &std::fs::read_to_string(mgr.inboxes_dir.join("swift-fox.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            inbox.len(),
+            1,
+            "identical within-window writes must dedupe down to one entry; inbox={inbox:?}"
+        );
+
+        // A genuinely different payload still gets through.
+        mgr.write_to_inbox(
+            "swift-fox",
+            DIRECTOR_AGENT_NAME,
+            "Worker is idle — pick up a task",
+            None,
+            None,
+        )
+        .unwrap();
+        let inbox: Vec<InboxMessage> = serde_json::from_str(
+            &std::fs::read_to_string(mgr.inboxes_dir.join("swift-fox.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(inbox.len(), 2, "distinct payload must not be deduped");
+    }
+
+    /// Writes from different senders with the same text are independent —
+    /// dedup keys on (from, text). Guards against overly aggressive
+    /// collapse that would swallow legitimate cross-sender broadcasts.
+    #[test]
+    fn write_to_inbox_dedup_is_per_sender() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = manager_in(tmp.path(), "t2");
+        std::fs::create_dir_all(&mgr.inboxes_dir).unwrap();
+        mgr.ensure_inbox("swift-fox").unwrap();
+
+        mgr.write_to_inbox("swift-fox", DIRECTOR_AGENT_NAME, "ping", None, None)
+            .unwrap();
+        mgr.write_to_inbox("swift-fox", "supervisor", "ping", None, None)
+            .unwrap();
+
+        let inbox: Vec<InboxMessage> = serde_json::from_str(
+            &std::fs::read_to_string(mgr.inboxes_dir.join("swift-fox.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            inbox.len(),
+            2,
+            "same text from different senders must both be retained; inbox={inbox:?}"
+        );
+    }
+
+    /// Retention sweep: messages older than `INBOX_RETENTION` are dropped
+    /// on every write so the inbox file cannot grow unbounded across
+    /// sessions. Simulated by seeding a message with an old timestamp and
+    /// then writing a fresh one.
+    #[test]
+    fn write_to_inbox_prunes_messages_older_than_retention() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = manager_in(tmp.path(), "t3");
+        std::fs::create_dir_all(&mgr.inboxes_dir).unwrap();
+
+        // Seed an inbox file with a stale message (3h ago, beyond the 2h
+        // retention window).
+        let stale_ts = (chrono::Utc::now() - chrono::Duration::hours(3))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let seeded = vec![InboxMessage {
+            from: DIRECTOR_AGENT_NAME.to_string(),
+            text: "ancient history".to_string(),
+            summary: Some("ancient history".to_string()),
+            timestamp: stale_ts,
+            color: "green".to_string(),
+            read: false,
+        }];
+        let inbox_path = mgr.inboxes_dir.join("swift-fox.json");
+        std::fs::write(&inbox_path, serde_json::to_string_pretty(&seeded).unwrap()).unwrap();
+
+        // One fresh write — the stale message should be swept on the same
+        // lock pass.
+        mgr.write_to_inbox("swift-fox", DIRECTOR_AGENT_NAME, "fresh", None, None)
+            .unwrap();
+
+        let inbox: Vec<InboxMessage> = serde_json::from_str(
+            &std::fs::read_to_string(&inbox_path).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(inbox.len(), 1);
+        assert_eq!(inbox[0].text, "fresh");
     }
 }

--- a/cas-cli/src/ui/factory/director/events.rs
+++ b/cas-cli/src/ui/factory/director/events.rs
@@ -610,7 +610,19 @@ impl DirectorEventDetector {
                     &data.in_progress_tasks,
                     &data.ready_tasks,
                 ) {
-                    let should_fire = match current_epic_id {
+                    // A tracked epic that has since been closed/deleted is
+                        // treated as vacant so a legitimate new Open-with-branch
+                        // epic can take over instead of the UI freezing on a
+                        // ghost id (cas-4181 adversarial finding).
+                        let cur_still_exists = current_epic_id
+                            .map(|cur| data.epic_tasks.iter().any(|e| e.id == cur))
+                            .unwrap_or(false);
+                    let effective_current = if cur_still_exists {
+                        current_epic_id
+                    } else {
+                        None
+                    };
+                    let should_fire = match effective_current {
                         // No active epic yet — any valid candidate wins.
                         None => true,
                         // Same epic already active — no change to announce.
@@ -791,9 +803,9 @@ pub(crate) fn open_branch_epic_score(
 /// final tiebreak.
 ///
 /// Used by both `ui::factory::app::detect_epic_state` (init-time epic
-/// resolution) and `DirectorEventDetector::detect_changes_for_epic`
-/// (runtime `EpicStarted` detection) so the two paths cannot disagree on
-/// which Open-with-branch epic should own the factory panel.
+/// resolution) and `DirectorEventDetector::detect_changes` (runtime
+/// `EpicStarted` detection) so the two paths cannot disagree on which
+/// Open-with-branch epic should own the factory panel.
 ///
 /// Returns `None` if no epic in `epic_tasks` is `Open` with a branch set.
 pub(crate) fn pick_best_open_branch_epic<'a>(

--- a/cas-cli/src/ui/factory/director/events.rs
+++ b/cas-cli/src/ui/factory/director/events.rs
@@ -366,10 +366,23 @@ impl DirectorEventDetector {
         self.removed_workers.insert(name.to_string());
     }
 
-    /// Detect changes between the last state and new data
+    /// Detect changes between the last state and new data.
     ///
-    /// Returns a list of detected events. Call this after each refresh.
-    pub fn detect_changes(&mut self, data: &DirectorData) -> Vec<DirectorEvent> {
+    /// Returns a list of detected events. Call after each refresh.
+    ///
+    /// `current_epic_id` is the factory app's currently-tracked epic (pass
+    /// `None` at init time before any epic has been resolved). When `Some`,
+    /// `EpicStarted` for an Open-with-branch epic is only emitted if the
+    /// candidate is **strictly better** than the active epic under the shared
+    /// subtask-count heuristic (see [`pick_best_open_branch_epic`]). This
+    /// prevents a fresh zero-subtask Open-with-branch epic from overwriting
+    /// the active `epic_state` mid-session (see task cas-4181).
+    /// `InProgress` epic transitions still emit unconditionally.
+    pub fn detect_changes(
+        &mut self,
+        data: &DirectorData,
+        current_epic_id: Option<&str>,
+    ) -> Vec<DirectorEvent> {
         let now = Instant::now();
         let new_state = DirectorState::from_data(data);
         let mut events = Vec::new();
@@ -548,13 +561,13 @@ impl DirectorEventDetector {
         // Detect epic state changes
         // EpicStarted fires when:
         // 1. An epic transitions to InProgress (highest priority)
-        // 2. A new Open-with-branch epic appears (mirrors detect_epic_state init logic)
-        //
-        // When multiple qualify, prefer InProgress over Open-with-branch, and among
-        // Open-with-branch pick the lexicographically greatest ID for determinism.
+        // 2. A newly-appearing Open-with-branch epic is strictly better than
+        //    the currently-active epic under the shared subtask-count
+        //    heuristic. The picker and the init-time `detect_epic_state`
+        //    share `pick_best_open_branch_epic` so they cannot diverge.
         {
             let mut in_progress_started: Option<(&str, &str)> = None;
-            let mut open_branch_started: Option<(&str, &str)> = None;
+            let mut saw_new_open_branch = false;
 
             for epic in &data.epic_tasks {
                 if epic.status == TaskStatus::InProgress {
@@ -569,7 +582,6 @@ impl DirectorEventDetector {
                         in_progress_started = Some((&epic.id, &epic.title));
                     }
                 } else if epic.status == TaskStatus::Open && epic.branch.is_some() {
-                    // New Open-with-branch epic that wasn't previously tracked with a branch
                     let was_open_with_branch = self
                         .last_state
                         .epic_statuses
@@ -578,24 +590,57 @@ impl DirectorEventDetector {
                         .unwrap_or(false);
 
                     if !was_open_with_branch {
-                        // Among new Open-with-branch epics, pick greatest ID for stability
-                        if open_branch_started
-                            .map(|(id, _)| epic.id.as_str() > id)
-                            .unwrap_or(true)
-                        {
-                            open_branch_started = Some((&epic.id, &epic.title));
-                        }
+                        saw_new_open_branch = true;
                     }
                 }
             }
 
-            // InProgress takes priority over Open-with-branch
-            let epic_started = in_progress_started.or(open_branch_started);
-            if let Some((id, title)) = epic_started {
+            // InProgress transitions always fire.
+            if let Some((id, title)) = in_progress_started {
                 events.push(DirectorEvent::EpicStarted {
                     epic_id: id.to_string(),
                     epic_title: title.to_string(),
                 });
+            } else if saw_new_open_branch {
+                // Pick the best Open-with-branch epic using the shared
+                // heuristic (subtasks, then lex ID). Applies the
+                // strict-improvement gate when a current epic is known.
+                if let Some(candidate) = pick_best_open_branch_epic(
+                    &data.epic_tasks,
+                    &data.in_progress_tasks,
+                    &data.ready_tasks,
+                ) {
+                    let should_fire = match current_epic_id {
+                        // No active epic yet — any valid candidate wins.
+                        None => true,
+                        // Same epic already active — no change to announce.
+                        Some(cur) if cur == candidate.id => false,
+                        // Different epic — only announce if it is strictly
+                        // better than the currently-active epic under the
+                        // shared heuristic. A zero-subtask fresh epic cannot
+                        // hijack an active one that has subtasks.
+                        Some(cur) => {
+                            let cand_score = open_branch_epic_score(
+                                &candidate.id,
+                                &data.in_progress_tasks,
+                                &data.ready_tasks,
+                            );
+                            let cur_score = open_branch_epic_score(
+                                cur,
+                                &data.in_progress_tasks,
+                                &data.ready_tasks,
+                            );
+                            cand_score > cur_score
+                        }
+                    };
+
+                    if should_fire {
+                        events.push(DirectorEvent::EpicStarted {
+                            epic_id: candidate.id.clone(),
+                            epic_title: candidate.title.clone(),
+                        });
+                    }
+                }
             }
         }
 
@@ -715,6 +760,58 @@ impl DirectorEventDetector {
             .cloned()
             .unwrap_or_else(|| agent_id.to_string())
     }
+}
+
+/// Score an Open-with-branch epic by active-subtask counts.
+///
+/// Returns `(in_progress_count, ready_count)` for subtasks whose `epic`
+/// field matches `epic_id`. The tuple compares lexicographically: an
+/// epic with more in-progress subtasks always outranks one with fewer,
+/// regardless of ready-count. Used by both the init-time picker and the
+/// runtime EpicStarted strict-improvement gate.
+pub(crate) fn open_branch_epic_score(
+    epic_id: &str,
+    in_progress_tasks: &[TaskSummary],
+    ready_tasks: &[TaskSummary],
+) -> (usize, usize) {
+    let ip = in_progress_tasks
+        .iter()
+        .filter(|t| t.epic.as_deref() == Some(epic_id))
+        .count();
+    let ready = ready_tasks
+        .iter()
+        .filter(|t| t.epic.as_deref() == Some(epic_id))
+        .count();
+    (ip, ready)
+}
+
+/// Pick the best Open-with-branch epic from `epic_tasks` using the shared
+/// heuristic: highest in-progress subtask count wins; then highest ready
+/// subtask count; then lexicographically greatest ID as a deterministic
+/// final tiebreak.
+///
+/// Used by both `ui::factory::app::detect_epic_state` (init-time epic
+/// resolution) and `DirectorEventDetector::detect_changes_for_epic`
+/// (runtime `EpicStarted` detection) so the two paths cannot disagree on
+/// which Open-with-branch epic should own the factory panel.
+///
+/// Returns `None` if no epic in `epic_tasks` is `Open` with a branch set.
+pub(crate) fn pick_best_open_branch_epic<'a>(
+    epic_tasks: &'a [TaskSummary],
+    in_progress_tasks: &[TaskSummary],
+    ready_tasks: &[TaskSummary],
+) -> Option<&'a TaskSummary> {
+    epic_tasks
+        .iter()
+        .filter(|e| e.status == TaskStatus::Open && e.branch.is_some())
+        .max_by(|a, b| {
+            let a_score = open_branch_epic_score(&a.id, in_progress_tasks, ready_tasks);
+            let b_score = open_branch_epic_score(&b.id, in_progress_tasks, ready_tasks);
+            a_score
+                .cmp(&b_score)
+                // Deterministic final tiebreak: greatest lex ID wins.
+                .then_with(|| a.id.cmp(&b.id))
+        })
 }
 
 #[cfg(test)]

--- a/cas-cli/src/ui/factory/director/events_tests/tests.rs
+++ b/cas-cli/src/ui/factory/director/events_tests/tests.rs
@@ -95,7 +95,7 @@ fn test_detect_task_assigned() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     assert!(events.iter().any(|e| matches!(
         e,
@@ -147,7 +147,7 @@ fn test_detect_task_completed() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     assert!(events.iter().any(|e| matches!(
         e,
@@ -212,7 +212,7 @@ fn test_detect_worker_idle() {
 
     // Tick 1 of sustained idle — must NOT emit (debounce threshold is 2 ticks).
     let idle = idle_data_for("agent-1", "swift-fox");
-    let events_tick1 = detector.detect_changes(&idle);
+    let events_tick1 = detector.detect_changes(&idle, None);
     assert!(
         !events_tick1
             .iter()
@@ -222,7 +222,7 @@ fn test_detect_worker_idle() {
     );
 
     // Tick 2 of sustained idle — now emit.
-    let events_tick2 = detector.detect_changes(&idle);
+    let events_tick2 = detector.detect_changes(&idle, None);
     assert!(
         events_tick2.iter().any(|e| matches!(
             e,
@@ -232,7 +232,7 @@ fn test_detect_worker_idle() {
     );
 
     // Tick 3 of sustained idle — already emitted, do not re-emit every tick.
-    let events_tick3 = detector.detect_changes(&idle);
+    let events_tick3 = detector.detect_changes(&idle, None);
     assert!(
         !events_tick3
             .iter()
@@ -264,7 +264,8 @@ fn test_no_worker_idle_on_transient_close_then_start() {
     ));
 
     // Transient idle: one refresh tick catches the close-X → start-Y gap.
-    let events_transient = detector.detect_changes(&idle_data_for("agent-1", "swift-fox"));
+    let events_transient =
+        detector.detect_changes(&idle_data_for("agent-1", "swift-fox"), None);
     assert!(
         !events_transient
             .iter()
@@ -274,12 +275,10 @@ fn test_no_worker_idle_on_transient_close_then_start() {
     );
 
     // Next refresh: worker has claimed task-2. Idle streak should be reset.
-    let events_claimed = detector.detect_changes(&working_data_for(
-        "agent-1",
-        "swift-fox",
-        "task-2",
-        "Second task",
-    ));
+    let events_claimed = detector.detect_changes(
+        &working_data_for("agent-1", "swift-fox", "task-2", "Second task"),
+        None,
+    );
     assert!(
         !events_claimed
             .iter()
@@ -290,8 +289,8 @@ fn test_no_worker_idle_on_transient_close_then_start() {
     // Sanity: a subsequent sustained idle still emits after the threshold,
     // so the reset didn't break normal idle detection.
     let idle = idle_data_for("agent-1", "swift-fox");
-    let _ = detector.detect_changes(&idle); // tick 1
-    let events_tick2 = detector.detect_changes(&idle); // tick 2
+    let _ = detector.detect_changes(&idle, None); // tick 1
+    let events_tick2 = detector.detect_changes(&idle, None); // tick 2
     assert!(
         events_tick2.iter().any(|e| matches!(
             e,
@@ -340,7 +339,7 @@ fn test_ignore_non_factory_agents() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     // Should not detect assignment since "other-agent" is not in factory
     assert!(
@@ -393,7 +392,7 @@ fn test_debouncing() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events1 = detector.detect_changes(&data2);
+    let events1 = detector.detect_changes(&data2, None);
     assert_eq!(events1.len(), 1);
     assert!(matches!(
         &events1[0],
@@ -402,7 +401,7 @@ fn test_debouncing() {
 
     // Re-initialize and try again immediately - should be debounced
     detector.last_state = DirectorState::from_data(&data1);
-    let events2 = detector.detect_changes(&data2);
+    let events2 = detector.detect_changes(&data2, None);
     assert!(
         events2.is_empty(),
         "Expected debounced event, but got {events2:?}"
@@ -478,7 +477,7 @@ fn test_detect_epic_started() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     assert!(events.iter().any(|e| matches!(
         e,
@@ -521,7 +520,7 @@ fn test_detect_epic_completed() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     assert!(events.iter().any(|e| matches!(
         e,
@@ -563,7 +562,7 @@ fn test_no_epic_event_when_unchanged() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     // No epic events should be emitted
     assert!(!events.iter().any(|e| matches!(
@@ -631,8 +630,8 @@ fn test_idle_events_suppressed_for_removed_workers() {
     };
 
     // Two idle ticks are required to cross the consecutive-tick debounce.
-    let _ = detector.detect_changes(&data2);
-    let events = detector.detect_changes(&data2);
+    let _ = detector.detect_changes(&data2, None);
+    let events = detector.detect_changes(&data2, None);
 
     // calm-owl idle event should be emitted
     assert!(
@@ -699,8 +698,8 @@ fn test_idle_rate_limit_longer_than_general_debounce() {
     };
 
     // Two idle ticks are required to cross the consecutive-tick debounce.
-    let _ = detector.detect_changes(&data2);
-    let events = detector.detect_changes(&data2);
+    let _ = detector.detect_changes(&data2, None);
+    let events = detector.detect_changes(&data2, None);
     assert!(
         events.iter().any(|e| matches!(
             e,
@@ -713,7 +712,7 @@ fn test_idle_rate_limit_longer_than_general_debounce() {
     // (past the 30s general debounce but within the 5-minute idle rate limit).
     // We drive this through detect_changes rather than poking last_state directly
     // so the consecutive-idle counters reset the way they would in production.
-    let _ = detector.detect_changes(&data1);
+    let _ = detector.detect_changes(&data1, None);
 
     // Manually advance the idle debounce time to 60s ago (past 30s general debounce)
     let key = "idle:swift-fox".to_string();
@@ -721,7 +720,7 @@ fn test_idle_rate_limit_longer_than_general_debounce() {
         *time = std::time::Instant::now() - Duration::from_secs(60);
     }
 
-    let events2 = detector.detect_changes(&data2);
+    let events2 = detector.detect_changes(&data2, None);
     assert!(
         !events2.iter().any(|e| matches!(
             e,
@@ -770,7 +769,7 @@ fn test_detect_epic_started_open_with_branch() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     assert!(
         events.iter().any(|e| matches!(
@@ -826,7 +825,7 @@ fn test_no_duplicate_epic_started_for_existing_open_with_branch() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     assert!(
         !events.iter().any(|e| matches!(
@@ -874,7 +873,7 @@ fn test_in_progress_epic_takes_priority_over_open_with_branch() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     // InProgress should win
     assert!(
@@ -937,7 +936,7 @@ fn test_closed_task_not_redispatched_to_idle_worker() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     // TaskCompleted is fine and expected; TaskAssigned for task-1 must NOT fire
     assert!(
@@ -1006,7 +1005,7 @@ fn test_closed_task_leaked_into_ready_tasks_not_dispatched() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     assert!(
         !events.iter().any(|e| matches!(
@@ -1065,7 +1064,7 @@ fn test_blocked_task_not_dispatched() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     // TaskBlocked is expected (separate dispatch concern, routed to
     // supervisor not worker); TaskAssigned must NOT fire.
@@ -1132,7 +1131,7 @@ fn test_closed_task_with_stale_assignee_not_redispatched() {
         epic_closed_counts: HashMap::new(),
     };
 
-    let events = detector.detect_changes(&data2);
+    let events = detector.detect_changes(&data2, None);
 
     assert!(
         !events.iter().any(|e| matches!(

--- a/cas-cli/src/ui/factory/director/mod.rs
+++ b/cas-cli/src/ui/factory/director/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod tasks;
 
 pub use data::{AgentSummary, DirectorData, DirectorStores, TaskSummary};
 pub use events::{DirectorEvent, DirectorEventDetector};
+pub(crate) use events::pick_best_open_branch_epic;
 pub use panel::PanelRegistry;
 pub use prompts::{Prompt, generate_prompt, with_response_instructions};
 // PanelAreas, SidecarFocus, SidecarState, ViewMode, DiffLine, DiffLineType, render, render_with_state are already public in this module

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -1146,3 +1146,200 @@ async fn test_subtask_start_auto_starts_epic() {
         "Epic should be in progress after subtask start: {text}"
     );
 }
+
+// ============================================================================
+// cas-5572 (EPIC cas-9508): Spawn-time `action=mine` race regression
+//
+// Reproduces the factory-session friction described in
+// docs/requests/BUG-factory-session-observations-2026-04-22.md §1: after
+// `coordination spawn_workers` + `task update assignee=<worker-name>`, a
+// freshly-spawned worker's first `action=mine` call was returning "no open
+// tasks" even when `task show` on the supervisor side immediately confirmed
+// the assignment.
+//
+// Root cause: `cas_tasks_mine` previously matched only `assignee == agent_id
+// || agent_name` where `agent_name` was read from the agent-store row. When
+// the worker's agent row has not yet been populated with the final friendly
+// name — or the lookup transiently falls back to `agent_id` — the filter
+// missed name-based assignments. The fix widens the match to also consider
+// `CAS_AGENT_NAME` / `CAS_SESSION_ID` env vars and compares case-insensitively
+// on trimmed values.
+// ============================================================================
+
+#[tokio::test]
+async fn test_task_mine_matches_env_worker_name_during_spawn_race() {
+    let (_temp, service) = setup_cas();
+
+    // Simulate the spawn-race condition: the agent-store row still shows
+    // the default "test-agent" name, but the supervisor has already assigned
+    // the task to the worker's *friendly* name (e.g. "warm-gopher-85"). In
+    // the real factory flow the friendly name arrives via CAS_AGENT_NAME in
+    // the worker process's env.
+    let worker_name = "warm-gopher-85";
+
+    // Acquire the env lock since we're mutating CAS_AGENT_NAME.
+    let _env_guard = env_test_lock();
+    let prev_name = std::env::var("CAS_AGENT_NAME").ok();
+    // SAFETY: env lock is held for the duration of this test body.
+    unsafe {
+        std::env::set_var("CAS_AGENT_NAME", worker_name);
+    }
+
+    // Create a task, then update its assignee to the worker's friendly name —
+    // exactly what a supervisor does via `task update assignee=<worker-name>`.
+    let create_req = TaskCreateRequest {
+        title: "Spawn-race assignment".to_string(),
+        description: None,
+        priority: 1,
+        task_type: "task".to_string(),
+        labels: None,
+        notes: None,
+        blocked_by: None,
+        design: None,
+        acceptance_criteria: None,
+        external_ref: None,
+        assignee: None,
+        demo_statement: None,
+        execution_note: None,
+        epic: None,
+    };
+    let created = service
+        .cas_task_create(Parameters(create_req))
+        .await
+        .expect("task_create should succeed");
+    let id = extract_task_id(&extract_text(created))
+        .expect("task id")
+        .to_string();
+
+    let update_req = TaskUpdateRequest {
+        id: id.clone(),
+        title: None,
+        notes: None,
+        priority: None,
+        labels: None,
+        description: None,
+        design: None,
+        acceptance_criteria: None,
+        demo_statement: None,
+        execution_note: None,
+        external_ref: None,
+        assignee: Some(worker_name.to_string()),
+        status: None,
+        epic: None,
+        epic_verification_owner: None,
+    };
+    service
+        .cas_task_update(Parameters(update_req))
+        .await
+        .expect("task_update should succeed");
+
+    // The worker's first `action=mine` poll — the assignee on the task row
+    // is the friendly `worker_name`, but the agent_store row still carries
+    // the default "test-agent" name from setup_cas(). Before the fix this
+    // returned "No open tasks"; after the fix, CAS_AGENT_NAME bridges the
+    // gap and the task surfaces.
+    let mine_req = LimitRequest {
+        limit: Some(20),
+        scope: "all".to_string(),
+        sort: None,
+        sort_order: None,
+        team_id: None,
+    };
+    let result = service
+        .cas_tasks_mine(Parameters(mine_req))
+        .await
+        .expect("tasks_mine should succeed");
+    let text = extract_text(result);
+
+    // Restore env before any assertion to avoid poisoning sibling tests on
+    // panic. SAFETY: still holding env lock.
+    unsafe {
+        match prev_name {
+            Some(v) => std::env::set_var("CAS_AGENT_NAME", v),
+            None => std::env::remove_var("CAS_AGENT_NAME"),
+        }
+    }
+
+    assert!(
+        text.contains(&id),
+        "cas_tasks_mine must surface tasks assigned by friendly worker-name \
+         (via CAS_AGENT_NAME env) even when the agent-store row still holds \
+         the default name. Got: {text}"
+    );
+    assert!(
+        !text.starts_with("No open tasks"),
+        "cas_tasks_mine should not report empty during spawn-race window. Got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_task_mine_matches_case_insensitive_and_trimmed() {
+    let (_temp, service) = setup_cas();
+
+    // Exercise the defensive matching path: assignee spelled with differing
+    // case and surrounding whitespace still matches the current agent.
+    let create_req = TaskCreateRequest {
+        title: "Case-trim mine match".to_string(),
+        description: None,
+        priority: 2,
+        task_type: "task".to_string(),
+        labels: None,
+        notes: None,
+        blocked_by: None,
+        design: None,
+        acceptance_criteria: None,
+        external_ref: None,
+        assignee: None,
+        demo_statement: None,
+        execution_note: None,
+        epic: None,
+    };
+    let created = service
+        .cas_task_create(Parameters(create_req))
+        .await
+        .expect("create");
+    let id = extract_task_id(&extract_text(created))
+        .expect("id")
+        .to_string();
+
+    let update_req = TaskUpdateRequest {
+        id: id.clone(),
+        title: None,
+        notes: None,
+        priority: None,
+        labels: None,
+        description: None,
+        design: None,
+        acceptance_criteria: None,
+        demo_statement: None,
+        execution_note: None,
+        external_ref: None,
+        // The default test-agent name is "test-agent"; assert we still
+        // match when the supervisor sprays mixed case + whitespace.
+        assignee: Some("  TEST-Agent  ".to_string()),
+        status: None,
+        epic: None,
+        epic_verification_owner: None,
+    };
+    service
+        .cas_task_update(Parameters(update_req))
+        .await
+        .expect("update");
+
+    let mine_req = LimitRequest {
+        limit: Some(20),
+        scope: "all".to_string(),
+        sort: None,
+        sort_order: None,
+        team_id: None,
+    };
+    let result = service
+        .cas_tasks_mine(Parameters(mine_req))
+        .await
+        .expect("mine");
+    let text = extract_text(result);
+    assert!(
+        text.contains(&id),
+        "mine should tolerate case + whitespace drift in assignee: {text}"
+    );
+}

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -1272,6 +1272,386 @@ async fn test_task_mine_matches_env_worker_name_during_spawn_race() {
     );
 }
 
+// ============================================================================
+// cas-1a7c (EPIC cas-9508): task lease + status divergence recovery.
+//
+// Acceptance criteria:
+//   - `action=release` on a lease-less InProgress task clears status to open
+//     with an audit trail.
+//   - `action=reset` verb exists and is tested for dead-session recovery.
+//   - `action=show` called immediately after `action=update` reflects the
+//     updated status.
+// ============================================================================
+
+#[tokio::test]
+async fn test_release_autorecovers_lease_less_in_progress_task() {
+    let (_temp, service) = setup_cas();
+
+    // Seed: create task and move it to InProgress without a live lease
+    // (simulating a dead-session orphan where status diverged from lease).
+    let created = service
+        .cas_task_create(Parameters(TaskCreateRequest {
+            title: "Orphaned in-progress".to_string(),
+            description: None,
+            priority: 2,
+            task_type: "task".to_string(),
+            labels: None,
+            notes: None,
+            blocked_by: None,
+            design: None,
+            acceptance_criteria: None,
+            external_ref: None,
+            assignee: Some("dead-worker".to_string()),
+            demo_statement: None,
+            execution_note: None,
+            epic: None,
+        }))
+        .await
+        .expect("create");
+    let id = extract_task_id(&extract_text(created))
+        .expect("id")
+        .to_string();
+
+    service
+        .cas_task_update(Parameters(TaskUpdateRequest {
+            id: id.clone(),
+            title: None,
+            notes: None,
+            priority: None,
+            labels: None,
+            description: None,
+            design: None,
+            acceptance_criteria: None,
+            demo_statement: None,
+            execution_note: None,
+            external_ref: None,
+            assignee: None,
+            status: Some("in_progress".to_string()),
+            epic: None,
+            epic_verification_owner: None,
+        }))
+        .await
+        .expect("status update");
+
+    // Call release — no active lease exists for this agent, and the task is
+    // InProgress. The handler must auto-recover instead of surfacing the raw
+    // "No active lease found" error.
+    let released = service
+        .cas_task_release(Parameters(cas::mcp::tools::TaskReleaseRequest {
+            task_id: id.clone(),
+        }))
+        .await
+        .expect("release auto-recovery must succeed for lease-less InProgress");
+    let text = extract_text(released);
+    assert!(
+        text.contains("auto-recovered") || text.contains("Released"),
+        "release output should acknowledge auto-recovery: {text}"
+    );
+
+    // Show must reflect Open status immediately after release.
+    let shown = service
+        .cas_task_show(Parameters(TaskShowRequest {
+            id: id.clone(),
+            with_deps: false,
+        }))
+        .await
+        .expect("show");
+    let text = extract_text(shown);
+    assert!(
+        text.contains("Open") || text.contains("open"),
+        "task must be Open after release auto-recovery: {text}"
+    );
+    assert!(
+        text.contains("auto-recovered") || text.contains("assumed orphaned"),
+        "task notes must contain audit trail: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_release_still_errors_when_no_lease_and_task_already_open() {
+    let (_temp, service) = setup_cas();
+
+    // Baseline: no lease, status=Open. Release should NOT silently succeed —
+    // there's nothing to recover, surface the underlying error.
+    let created = service
+        .cas_task_create(Parameters(TaskCreateRequest {
+            title: "Plain open task".to_string(),
+            description: None,
+            priority: 2,
+            task_type: "task".to_string(),
+            labels: None,
+            notes: None,
+            blocked_by: None,
+            design: None,
+            acceptance_criteria: None,
+            external_ref: None,
+            assignee: None,
+            demo_statement: None,
+            execution_note: None,
+            epic: None,
+        }))
+        .await
+        .expect("create");
+    let id = extract_task_id(&extract_text(created))
+        .expect("id")
+        .to_string();
+
+    let res = service
+        .cas_task_release(Parameters(cas::mcp::tools::TaskReleaseRequest {
+            task_id: id.clone(),
+        }))
+        .await;
+    assert!(
+        res.is_err(),
+        "release on a plain Open task without a lease should error"
+    );
+}
+
+#[tokio::test]
+async fn test_reset_clears_lease_assignee_and_forces_open() {
+    let (_temp, service) = setup_cas();
+
+    let created = service
+        .cas_task_create(Parameters(TaskCreateRequest {
+            title: "Needs reset".to_string(),
+            description: None,
+            priority: 1,
+            task_type: "task".to_string(),
+            labels: None,
+            notes: None,
+            blocked_by: None,
+            design: None,
+            acceptance_criteria: None,
+            external_ref: None,
+            assignee: Some("dead-worker".to_string()),
+            demo_statement: None,
+            execution_note: None,
+            epic: None,
+        }))
+        .await
+        .expect("create");
+    let id = extract_task_id(&extract_text(created))
+        .expect("id")
+        .to_string();
+
+    service
+        .cas_task_update(Parameters(TaskUpdateRequest {
+            id: id.clone(),
+            title: None,
+            notes: None,
+            priority: None,
+            labels: None,
+            description: None,
+            design: None,
+            acceptance_criteria: None,
+            demo_statement: None,
+            execution_note: None,
+            external_ref: None,
+            assignee: None,
+            status: Some("in_progress".to_string()),
+            epic: None,
+            epic_verification_owner: None,
+        }))
+        .await
+        .expect("status update");
+
+    let res = service
+        .cas_task_reset(Parameters(cas::mcp::tools::TaskReleaseRequest {
+            task_id: id.clone(),
+        }))
+        .await
+        .expect("reset must succeed");
+    let text = extract_text(res);
+    assert!(
+        text.contains("Reset task"),
+        "reset output must confirm: {text}"
+    );
+
+    // Show must reflect the reset: Open, no assignee, audit note present.
+    let shown = service
+        .cas_task_show(Parameters(TaskShowRequest {
+            id: id.clone(),
+            with_deps: false,
+        }))
+        .await
+        .expect("show");
+    let text = extract_text(shown);
+    assert!(
+        text.contains("Open") || text.contains("open"),
+        "status must be Open after reset: {text}"
+    );
+    assert!(
+        text.contains("reset:") || text.contains("dead-session"),
+        "reset audit note must be present: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_reset_refuses_closed_task() {
+    let (_temp, service) = setup_cas();
+
+    let created = service
+        .cas_task_create(Parameters(TaskCreateRequest {
+            title: "Already closed".to_string(),
+            description: None,
+            priority: 2,
+            task_type: "task".to_string(),
+            labels: None,
+            notes: None,
+            blocked_by: None,
+            design: None,
+            acceptance_criteria: None,
+            external_ref: None,
+            assignee: None,
+            demo_statement: None,
+            execution_note: None,
+            epic: None,
+        }))
+        .await
+        .expect("create");
+    let id = extract_task_id(&extract_text(created))
+        .expect("id")
+        .to_string();
+
+    service
+        .cas_task_update(Parameters(TaskUpdateRequest {
+            id: id.clone(),
+            title: None,
+            notes: None,
+            priority: None,
+            labels: None,
+            description: None,
+            design: None,
+            acceptance_criteria: None,
+            demo_statement: None,
+            execution_note: None,
+            external_ref: None,
+            assignee: None,
+            status: Some("closed".to_string()),
+            epic: None,
+            epic_verification_owner: None,
+        }))
+        .await
+        .expect("close via update");
+
+    let err = service
+        .cas_task_reset(Parameters(cas::mcp::tools::TaskReleaseRequest {
+            task_id: id.clone(),
+        }))
+        .await;
+    assert!(
+        err.is_err(),
+        "reset must refuse to operate on closed tasks — use reopen instead"
+    );
+}
+
+/// cas-1a7c AC3: `action=show` immediately after `action=update` must reflect
+/// the updated status. Asserts there's no read-after-write snapshot lag in
+/// the MCP task store path.
+#[tokio::test]
+async fn test_show_after_update_reflects_new_status_without_lag() {
+    let (_temp, service) = setup_cas();
+
+    let created = service
+        .cas_task_create(Parameters(TaskCreateRequest {
+            title: "Status readback".to_string(),
+            description: None,
+            priority: 2,
+            task_type: "task".to_string(),
+            labels: None,
+            notes: None,
+            blocked_by: None,
+            design: None,
+            acceptance_criteria: None,
+            external_ref: None,
+            assignee: None,
+            demo_statement: None,
+            execution_note: None,
+            epic: None,
+        }))
+        .await
+        .expect("create");
+    let id = extract_task_id(&extract_text(created))
+        .expect("id")
+        .to_string();
+
+    // Move to InProgress.
+    service
+        .cas_task_update(Parameters(TaskUpdateRequest {
+            id: id.clone(),
+            title: None,
+            notes: None,
+            priority: None,
+            labels: None,
+            description: None,
+            design: None,
+            acceptance_criteria: None,
+            demo_statement: None,
+            execution_note: None,
+            external_ref: None,
+            assignee: None,
+            status: Some("in_progress".to_string()),
+            epic: None,
+            epic_verification_owner: None,
+        }))
+        .await
+        .expect("update to in_progress");
+
+    let shown = service
+        .cas_task_show(Parameters(TaskShowRequest {
+            id: id.clone(),
+            with_deps: false,
+        }))
+        .await
+        .expect("show");
+    let text = extract_text(shown);
+    assert!(
+        text.contains("InProgress")
+            || text.contains("In Progress")
+            || text.contains("in_progress"),
+        "show immediately after update must return InProgress: {text}"
+    );
+
+    // Now flip back to Open. Show must reflect Open, not a cached InProgress.
+    service
+        .cas_task_update(Parameters(TaskUpdateRequest {
+            id: id.clone(),
+            title: None,
+            notes: None,
+            priority: None,
+            labels: None,
+            description: None,
+            design: None,
+            acceptance_criteria: None,
+            demo_statement: None,
+            execution_note: None,
+            external_ref: None,
+            assignee: Some("new-worker".to_string()),
+            status: Some("open".to_string()),
+            epic: None,
+            epic_verification_owner: None,
+        }))
+        .await
+        .expect("update back to open");
+
+    let shown = service
+        .cas_task_show(Parameters(TaskShowRequest {
+            id: id.clone(),
+            with_deps: false,
+        }))
+        .await
+        .expect("show");
+    let text = extract_text(shown);
+    assert!(
+        text.contains("Open") || text.contains("open"),
+        "show immediately after update back to open must not return stale InProgress: {text}"
+    );
+    assert!(
+        !text.contains("InProgress") && !text.contains("In Progress"),
+        "show output must not contain stale InProgress status after update to Open: {text}"
+    );
+}
+
 #[tokio::test]
 async fn test_task_mine_matches_case_insensitive_and_trimmed() {
     let (_temp, service) = setup_cas();

--- a/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
@@ -2166,3 +2166,162 @@ code_review_findings: None,
         timed_out.summary
     );
 }
+
+/// cas-3086: end-to-end. A worker runs cas-code-review, passes the clean
+/// ReviewOutcome envelope into `task.close`, and the close is rejected on
+/// the verification jail. The envelope must be persisted on the task's
+/// deliverables. A follow-up supervisor close — verification already
+/// approved, **no** `bypass_code_review=true`, **no** `code_review_findings`
+/// replayed — must succeed because the persisted receipt is forwarded
+/// into the gate.
+///
+/// This is the expensive-bypass cycle Report §7 is killing: before this
+/// fix, supervisor-close had to either set `bypass_code_review=true`
+/// (wrong-shape audit) or re-invoke the multi-persona reviewer ($0.30–0.50
+/// per retry) even though the worker had already run the review.
+#[tokio::test]
+async fn test_close_forwards_persisted_review_envelope_after_jail() {
+    use std::process::Command;
+
+    let (temp, service) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    let task_store = open_task_store(&cas_dir).unwrap();
+    let verification_store = open_verification_store(&cas_dir).unwrap();
+
+    // Make the project root (cas_root.parent()) a real git repo with
+    // staged code changes so the cas-code-review gate actually fires —
+    // otherwise `has_reviewable_changes` returns false and the gate
+    // silently skips, which would mask the forwarded-envelope logic.
+    let project_root = temp.path();
+    let git = |args: &[&str]| {
+        let ok = Command::new("git")
+            .args(args)
+            .current_dir(project_root)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .status()
+            .expect("git")
+            .success();
+        assert!(ok, "git {args:?} failed");
+    };
+    git(&["init", "-q", "-b", "main"]);
+    std::fs::write(project_root.join("seed.txt"), "seed\n").unwrap();
+    git(&["add", "seed.txt"]);
+    git(&["commit", "-q", "-m", "seed"]);
+    // Stage a real code change so is_reviewable_path returns true.
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    std::fs::write(project_root.join("src/lib.rs"), "fn f() {}\n").unwrap();
+    git(&["add", "src/lib.rs"]);
+
+    let req = TaskCreateRequest {
+        title: "cas-3086: persisted-envelope forwarding".to_string(),
+        description: None,
+        priority: 2,
+        task_type: "task".to_string(),
+        labels: None,
+        notes: None,
+        blocked_by: None,
+        design: None,
+        acceptance_criteria: None,
+        external_ref: None,
+        assignee: None,
+        demo_statement: None,
+        execution_note: None,
+        epic: None,
+    };
+    let id = extract_task_id(&extract_text(
+        service
+            .cas_task_create(Parameters(req))
+            .await
+            .expect("task_create"),
+    ))
+    .expect("task id")
+    .to_string();
+
+    {
+        let mut t = task_store.get(&id).expect("task exists");
+        t.status = cas::types::TaskStatus::InProgress;
+        task_store.update(&t).expect("update");
+    }
+
+    // Worker builds a clean envelope (zero residual findings) and hands
+    // it in on the first close attempt.
+    let clean_envelope = serde_json::json!({
+        "residual": [],
+        "pre_existing": [],
+        "mode": "autofix",
+    })
+    .to_string();
+
+    let first_close_text = extract_text(
+        service
+            .cas_task_close(Parameters(TaskCloseRequest {
+                id: id.clone(),
+                reason: Some("worker ran review, retrying close".to_string()),
+                bypass_code_review: None,
+                code_review_findings: Some(clean_envelope.clone()),
+            }))
+            .await
+            .expect("close returns"),
+    );
+    assert!(
+        first_close_text.contains("VERIFICATION REQUIRED"),
+        "first close must hit verification jail: {first_close_text}"
+    );
+
+    // The envelope must have been persisted on the task BEFORE the jail
+    // rejection ran. This is the cas-3086 invariant: worker's review
+    // receipt survives unrelated close-gate rejections.
+    let after_jail = task_store.get(&id).expect("task exists");
+    assert_eq!(
+        after_jail.deliverables.review_envelope.as_deref(),
+        Some(clean_envelope.as_str()),
+        "envelope must be persisted even when close is rejected on the verification jail"
+    );
+
+    // Simulate the task-verifier subagent writing an approved verdict.
+    let ver = Verification::approved(
+        "ver-cas-3086".to_string(),
+        id.clone(),
+        "verified".to_string(),
+    );
+    verification_store.add(&ver).expect("add verification");
+
+    // Supervisor closes — no bypass_code_review, no code_review_findings.
+    // Pre-fix: gate would return CODE_REVIEW_REQUIRED because the
+    // request has no envelope and nothing was persisted. Post-fix: the
+    // persisted envelope is forwarded, the gate proceeds.
+    let _guard = ScopedSupervisorEnv::new();
+    let supervisor_close_text = extract_text(
+        service
+            .cas_task_close(Parameters(TaskCloseRequest {
+                id: id.clone(),
+                reason: Some("closing on worker's behalf; review already passed".to_string()),
+                bypass_code_review: None,
+                code_review_findings: None,
+            }))
+            .await
+            .expect("supervisor close returns"),
+    );
+
+    assert!(
+        supervisor_close_text.contains("Closed"),
+        "supervisor close must succeed via forwarded envelope: {supervisor_close_text}"
+    );
+    assert!(
+        !supervisor_close_text.contains("CODE_REVIEW_REQUIRED"),
+        "supervisor close must NOT demand a fresh envelope: {supervisor_close_text}"
+    );
+    assert!(
+        !supervisor_close_text.contains("bypass_code_review"),
+        "supervisor close should not have needed the bypass path: {supervisor_close_text}"
+    );
+
+    let closed = task_store.get(&id).expect("task exists");
+    assert_eq!(closed.status, cas::types::TaskStatus::Closed);
+}

--- a/docs/requests/BUG-cloud-client-404-on-session-start.md
+++ b/docs/requests/BUG-cloud-client-404-on-session-start.md
@@ -1,0 +1,57 @@
+---
+from: Petra Stella Cloud team
+date: 2026-04-23
+priority: P2
+cas_task: cas-4244
+---
+
+# Cloud client 404 on every factory session start — phone-home effectively dead
+
+## Problem
+
+The cloud client hits HTTP `404` immediately on factory session start, retries 10x over ~4 min, then gives up permanently. Observed in **every single factory session** across `domdms` and `gabber-studio` (12+ "giving up" messages in logs).
+
+Net effect: cloud phone-home / sync is effectively dead for all factory sessions.
+
+## Likely cause
+
+A route change on petra-stella-cloud that the client doesn't match (or a route the client still expects that we never shipped). We need you to identify which endpoint the client is hitting on session start so we can confirm whether the fix is on the server (restore the route) or the client (update to the current path).
+
+## Asks
+
+1. Surface the exact URL the client is requesting (path + method) from the first failing log line. Post it as a comment on cas-4244 or in a reply file in our inbox.
+2. Once the route is identified, either:
+   - Update the client to match the current server routes (listed below), OR
+   - Tell us which route is missing and we'll add or redirect it on the server side.
+
+## Current server routes (for reference)
+
+Personal sync:
+
+- `POST /api/sync/push`
+- `POST /api/sync/pull`
+- `GET  /api/sync/status`
+- CRUD under `/api/sync/entities/...`
+
+Team sync (scoped by teamId):
+
+- `POST /api/teams/[teamId]/sync/push`
+- `POST /api/teams/[teamId]/sync/pull`
+- `GET  /api/teams/[teamId]/sync/status`
+
+Patterns / device auth:
+
+- `GET  /api/patterns` (read-only rules-as-patterns)
+- `POST /device/code`, `POST /device/token`, `POST /device/authorize`
+
+Account:
+
+- `GET  /api/account/usage` (added in commit `c489d9a`)
+
+If the client is hitting something outside this set (e.g., a `/phone-home`, `/sync/session`, `/heartbeat`, or old `/v1/...` prefix) — that's the smoking gun.
+
+## Acceptance criteria
+
+- Fresh factory session starts with zero `404`s from the cloud client
+- No `"giving up"` messages in factory logs tied to cloud phone-home
+- Verified across at least two different project factory sessions (domdms + gabber-studio are the easiest reproductions)

--- a/docs/requests/BUG-cloud-push-client-detect-skipped-rows.md
+++ b/docs/requests/BUG-cloud-push-client-detect-skipped-rows.md
@@ -1,0 +1,53 @@
+---
+from: Petra Stella Cloud team
+date: 2026-04-23
+priority: P1
+cas_task: cas-f645
+---
+
+# Cloud push client must detect server-side skipped rows
+
+## Problem
+
+Surfaced during cas-0bdc code review (adversarial + security personas).
+
+After cas-0bdc, the server's push route silently skips conflict updates when the incoming `project_canonical_id` doesn't match an existing row's project_id. Postgres `ON CONFLICT DO UPDATE ... WHERE false ... RETURNING` excludes skipped rows entirely, so the client sees a `200` response with **fewer rows in the result than it sent**.
+
+The client in `cas-cli/src/cloud/syncer/push.rs` calls `self.queue.mark_synced(item.id)` for every item in the sub-batch as soon as `push_sub_batch` returns `Ok(())` — it never inspects the response body to verify which rows actually landed.
+
+Consequences:
+
+1. A client pushing under the wrong `project_canonical_id` marks its local queue entries as synced even though the server rejected them.
+2. The user gets no signal anything went wrong.
+3. On a fresh machine clone or local DB wipe, the un-synced data is gone (server-of-record holds the other project's version).
+
+This is the client-side complement to server-side cas-0bdc and to sibling request `BUG-reject-null-project-id-on-push.md` (cas-d656, server-side, already filed in cloud inbox).
+
+## Design
+
+**Server change (petra-stella-cloud — we will own this).** Extend `PushResult` to include a `skipped` count per entity type. Compare `upsertResults.length` vs `allValues.length` per batch and categorize the difference. At minimum, log `reqLog.warn` when any rows are skipped so ops has a signal. Ideally return a per-entity `{inserted, updated, skipped}` object.
+
+**Client change (cas-src — you).** In `push_batch` / `push_sub_batch`, inspect the `PushResult` response and only call `mark_synced(item.id)` for items whose corresponding entity-type count in the response implies the row was accepted. If the server reports any skipped rows, surface a warning via `tracing::warn!` and leave the items in the queue for manual inspection. Consider a new `CloudError::PartialPushConflict` variant.
+
+## Touchpoints
+
+Client (cas-src):
+
+- `cas-cli/src/cloud/syncer/push.rs:286-304` — `push_batch` `mark_synced` loop
+- `cas-cli/src/cloud/syncer/push.rs:435-448` — `push_sub_batch` response handling
+- `cas-cli/src/cloud/types.rs` (or wherever `PushResult` lives) — add `skipped: Option<HashMap<String, usize>>`
+
+Server (already scoped on our side):
+
+- `petra-stella-cloud/app/api/sync/push/route.ts` — emit `skipped` count
+- `petra-stella-cloud/app/api/teams/[teamId]/sync/push/route.ts` — same
+
+## Acceptance criteria
+
+- A cross-project push surfaces a warning in both server logs and client output, and the affected local queue items remain un-marked-synced (retryable)
+- Existing happy-path pushes are unchanged
+- Test asserts that when the server returns a response with `skipped > 0`, the client does not call `mark_synced` for the skipped items
+
+## Coordination
+
+Server-side `skipped` field shape — please align on the JSON schema before the client PR lands. Propose a shape in a comment on this file or on cas-f645 notes, and we'll match on the cloud side.

--- a/docs/requests/BUG-factory-session-observations-2026-04-22.md
+++ b/docs/requests/BUG-factory-session-observations-2026-04-22.md
@@ -1,0 +1,244 @@
+---
+from: abundant-mines factory session (supervisor quick-sparrow-64, session 48456bb1-d1c7-45be-b1af-f95ca3b03301)
+date: 2026-04-22
+priority: P1
+cas_task: (none)
+---
+
+# Factory session friction — observations from a real EPIC run
+
+Report from a supervisor that ran two back-to-back multi-worker EPICs (cas-9b16 invite flow batch 3 with 3 workers, then a cas-code-review follow-up EPIC with 3 more workers) on the abundant-mines project today. Every individual issue below is minor in isolation; in aggregate they add real overhead to a factory session. Ordered by impact.
+
+The goal of this report is to give the CAS team concrete evidence — log excerpts, timestamps, exact supervisor-side workarounds — for issues that are otherwise easy to dismiss as "the user did it wrong."
+
+## 1. Spawn-time `action=mine` race (P1, reproducible every session)
+
+### Symptoms
+
+After `mcp__cas__coordination action=spawn_workers count=N isolate=true`:
+
+1. Supervisor runs `mcp__cas__task action=update id=<task> assignee=<worker-name>` for each worker.
+2. Supervisor queues a context-briefing message via `mcp__cas__coordination action=message` for each worker.
+3. Within ~1–30 seconds of spawn, each worker runs `mcp__cas__task action=mine` and reports **"No open tasks found"** — then flips to idle, then sits.
+
+Happened in **both** EPIC runs today. Six workers in total, six races.
+
+### Concrete evidence
+
+**Run 1 (17:22 UTC, cas-9b16 EPIC):**
+
+```
+17:22:41 — noble-octopus-76  → "action=mine returns no open assignments"
+17:22:45 — fair-panther-98   → "no open tasks"
+17:22:58 — happy-cheetah-24  → "No assigned tasks, ready for work"
+```
+
+Supervisor's `action=update assignee=...` calls at 17:21:xx succeeded (`Updated task cas-a224: assignee, status` etc.). `mcp__cas__task action=show` immediately after showed the correct assignee. The workers still reported empty `action=mine` for 30+ seconds.
+
+**Run 2 (18:14 UTC, cas-4b2a / cas-f1ac / cas-ff31 follow-up EPIC):**
+
+```
+18:14:46 — smooth-swan-26    → "action=mine returns no open tasks"
+18:14:50 — gentle-puma-76    → "No assigned tasks"
+18:14:51 — vivid-marten-83   → "No open tasks. Ready for assignment"
+```
+
+Same pattern. All three `action=update` calls had returned `Updated task cas-<id>: assignee` before the workers polled.
+
+### Workaround supervisor had to apply
+
+After the idle notifications arrived, supervisor sent a direct `coordination action=message` to each worker with their exact task ID and an instruction to run `action=start id=<id>`. Workers responded correctly once the message landed, confirming the assignment **was** in the DB — they just hadn't seen it via `action=mine` at spawn time.
+
+### Likely root cause (hypothesis)
+
+- Worker's first `action=mine` runs on a worker-side read path that caches (or reads before) the supervisor's write propagates.
+- Or: `action=mine` has a `started_at` / `lease-active` filter that excludes freshly-assigned tasks until the worker calls `action=start` explicitly.
+- Or: the worker's first-poll heuristic doesn't wait for coordination queue drain.
+
+Running `mcp__cas__task action=show id=<id>` from the supervisor side always showed the assignment correctly during the window when the worker reported empty `action=mine`, so the write DID land — the read path that `action=mine` uses is the divergent piece.
+
+### Proposed fix
+
+Either:
+- **(a)** Worker-side: on first boot, wait for coordination queue drain before running `action=mine`. The coordination-message kick was sufficient in both runs — imply that if you build the initial poll into the boot sequence.
+- **(b)** Server-side: make `action=mine` return tasks assigned to the caller regardless of lease/`started_at` state; let the filter shift to a flag (`--only-started`, `--include-pending`).
+- **(c)** Document-side: tell supervisors the canonical first-message pattern is "assign via `action=update`, then kick via `coordination message` with the task ID." Today's skill doesn't make the kick explicit, so supervisors have to discover it empirically.
+
+**Supervisor-level cost:** ~45–60 seconds per EPIC burned on wait + kick. In aggregate across today's sessions, ~5 min of dead time.
+
+---
+
+## 2. Factory worker verification jail deadlock under outdated binary (P1 operational)
+
+### Symptoms
+
+In the cas-9b16 EPIC, **every** worker close hit `VERIFICATION_JAIL_BLOCKED`:
+
+```
+cas-2599 (fair-panther-98)   → VERIFICATION_JAIL_BLOCKED on close
+cas-8e9b (noble-octopus-76)  → VERIFICATION_JAIL_BLOCKED on close
+```
+
+The skill docs (`.claude/skills/cas-supervisor/SKILL.md`) explicitly say this is fixed by commit `bba6fbf` (factory worker exemption). The running `cas serve` binary at session start predates that commit.
+
+### Supervisor-side impact
+
+Per the documented "binary outdated" recovery path, supervisor used `mcp__cas__task action=close id=<id> bypass_code_review=true reason="...verification jail deadlock..."`. This works, but:
+
+- Required spawning `task-verifier` subagents manually twice to produce verification receipts before close would accept the bypass. Receipts: `ver-095e38c4d78f` (cas-2599), `ver-7fe0c55780f7` (cas-8e9b). Each cost ~$0.10–0.15 and 2–3 min wall-clock.
+- Workers sat idle polling the DB the entire time, generating ~6 idle-notification messages each. Their "VERIFICATION_JAIL_BLOCKED" state is observable and they responsibly did nothing — but they didn't know *why* they were stuck or that supervisor was working on it.
+
+### Observations
+
+- Factory workers polling the DB for task state (as documented by the skill) is the right pattern — they correctly observed the close landed after supervisor bypass and stood down.
+- **But**: during the 3–5 minute window while supervisor was verifying + bypassing, workers are both (a) blocking compute and (b) generating message noise that the supervisor has to scroll past.
+- Consider: a "close pending — verifier path in progress" status that the worker can observe on `action=show` so they know to quiet down, not keep polling.
+
+### Ask
+
+This isn't a CAS bug per se — the fix exists, the binary is just out of date. But the operational guidance in the skill should emphasize:
+
+> **Before starting a factory session:** verify `cas serve` is running a binary rebuilt after `bba6fbf`. Run `cargo build --release && restart cas serve` if unsure. An outdated binary will cost ~5 min per closed task to the jail/bypass path.
+
+Currently this note is in the "Worker Failure Recovery" section, easy to miss on a fresh session.
+
+---
+
+## 3. Orphan untracked files from prior factory sessions block cherry-pick (P1 hygiene)
+
+### Symptoms
+
+Twice today, when cherry-picking a worker's branch back to `develop`:
+
+```
+error: The following untracked working tree files would be overwritten by merge:
+  apps/backend/src/team/team.service.spec.ts
+Please move or remove them before you merge.
+Aborting
+```
+
+Then later:
+
+```
+error: The following untracked working tree files would be overwritten by merge:
+  apps/backend/src/users/users.service.spec.ts
+```
+
+Both files were **leftover uncommitted output** from prior factory session(s) on `develop`, not committed by anyone. Diffing them showed partially-written test files from workers whose sessions ended without a `git clean` or commit.
+
+### Supervisor-side workaround
+
+Read the untracked file + the worker's version, confirmed the worker's version was a superset (or divergent-but-task-current), `rm`'d the untracked file, re-ran cherry-pick. Clean.
+
+### Root cause
+
+Factory worker sessions that end mid-task (user interruption, crash, compaction trigger) leave their work-in-progress on the shared `develop` working tree when operating in non-isolated mode, OR the worktree-based workers were cherry-picking into develop and something broke mid-operation.
+
+### Ask
+
+- When a factory session ends (session_end / shutdown / crash), CAS could at least *log* what's untracked in the supervisor's worktree so the next supervisor knows there's salvageable state.
+- Or: add a `mcp__cas__coordination action=gc_report` variant that surfaces "untracked files in main worktree that appear to be from prior factory work" so supervisor can decide whether to salvage, stash, or delete.
+
+---
+
+## 4. Prior-session WIP on develop working tree (P1 — related to #3)
+
+### Symptoms
+
+Starting this session, `git status` in abundant-mines showed ~30 modified files in the working tree, none committed. Subset was legitimately mine (the swc-jest swap the user requested), but ~5 files were clearly prior factory WIP on lane C / E subtasks that the previous session had not committed:
+
+- `apps/backend/src/invites/invites.service.ts` (+45 lines, lane E email-match hardening)
+- `apps/backend/src/users/users.service.ts` (+155 lines, lane E JIT rework)
+- `apps/backend/src/workspaces/workspace-access-control.service.ts` (+4 lines, lane C cache work)
+- `apps/backend/src/workspaces/workspace.service.ts` (+5 lines, lane C/E shared)
+- `apps/backend/src/integrations/qbo-payment-sync.service.ts` (+67 lines, unrelated earlier work)
+
+### Supervisor-side workaround
+
+- Made a selective commit of just my changes (the swc swap) so fresh workers would inherit a clean base.
+- Committed the prior WIP as a separate `wip: carry-over from prior factory session` commit so fresh workers could either build on it or discard per-lane.
+- **This workaround assumes I can reason about what was prior WIP vs my session's work. A supervisor joining a session cold has no such visibility.**
+
+### Ask
+
+Same surface as #3. A boot-time report of "uncommitted state in the main worktree at session start" would let supervisors triage before spawning workers. Today the only signal is reading `git status` + a lot of cross-referencing against recent task close history to guess which WIP belongs to which lane.
+
+---
+
+## 5. Stale task state (`InProgress` + dead assignee) after session death (P2)
+
+### Symptoms
+
+At session start, three tasks (cas-a224, cas-8e9b, cas-2599) were showing `Status: InProgress` with assignees pointing to workers that no longer existed. `worker_status` confirmed "Workers: None active" + "Filtered stale agent record(s): 3".
+
+Tried `mcp__cas__task action=release id=cas-a224` (and peers): all returned `No active lease found for task cas-a224`. The workers had died without releasing leases, but the **status** was still InProgress. Lease and status had diverged.
+
+Had to use `action=update status=open assignee=<new-worker>` to force both fields at once. Even after that, `action=show` still displayed `Status: InProgress` on the task record (as of the cas-a224 show I ran immediately after the update).
+
+### Ask
+
+- If `action=release` fails because there's no active lease, but the task is `InProgress`, consider auto-cleaning the status to `open` (with an audit note).
+- Or: surface a `mcp__cas__task action=reset id=<id>` verb that the docs explicitly recommend for "revive a task from a dead session".
+- The `action=show` display-after-write divergence is probably just a read snapshot lag, but it's confusing when you're mid-recovery and trying to confirm the fix landed.
+
+---
+
+## 6. Duplicate / replay coordination messages from "director" (P2 noise)
+
+### Symptoms
+
+Workers reported (unprompted):
+
+> **happy-cheetah-24:** "I'm receiving repeated 'You have been assigned cas-a224' notifications from the director, but the task is already Closed (verified). Ignoring as noise."
+> **noble-octopus-76:** "Outbox is replaying stale assignment broadcasts but I'm not re-acting on them."
+
+Workers were smart enough to ignore, but each dup message cost them ~100–500 tokens of context to read and decide "this is old".
+
+### Observation
+
+The team config for this session had two non-supervisor members: `supervisor` (me) and `director`. I (the supervisor) never sent dup messages — worker tooling confirmed the dups came from `director`. It looked like `director` was either replaying the outbox or independently polling+notifying on task state transitions even after close.
+
+### Ask
+
+If `director` is a real agent role, its message-throttle / replay-detection needs tightening. If it's a ghost from a prior session, agent GC should clean it.
+
+---
+
+## 7. `bypass_code_review=true` required for supervisor-close on worker-verified work (P2 UX gap)
+
+### Symptoms
+
+When supervisor-closing a task whose **worker already ran `cas-code-review` autofix in their own session** (with ReviewOutcome envelope produced, no P0s, 3 safe_auto fixes applied), the close still required `bypass_code_review=true` with an explicit justification. Twice today: cas-2599 and cas-9b16 (epic).
+
+### Why this is friction
+
+- The worker *already did* the code review. Their envelope is attached to their close attempt's notes. There's no reviewer gap — there's a missing API shape.
+- Re-running `cas-code-review` on the same diff from the supervisor side wastes ~$0.30–$0.50 in Sonnet calls for no additional signal.
+- Forcing `bypass_code_review=true` with a justification string is the right escape hatch for "this review literally doesn't apply," but it's the wrong shape for "the review already happened, just in a different session."
+
+### Ask
+
+- A supervisor-close variant that accepts `code_review_findings: <ReviewOutcome JSON>` from a cited earlier review run (e.g., `code_review_findings_from_task_note: 1`), so the gate can validate that a review *did* happen without re-running it.
+- Or: when a worker fails to close because of verification jail but their cas-code-review ran successfully in-session, persist the envelope on the task so the subsequent supervisor-close can forward it.
+
+### Relatedly, for epics specifically
+
+Epic-close (cas-9b16) also hit this gate. Epics don't have unique diffs — they're the union of already-reviewed subtask diffs. The gate probably shouldn't fire for epic close at all, or should fire on "any unclosed subtask with residual code-review findings" instead of "the epic itself has reviewable changes."
+
+---
+
+## Summary for triage
+
+| # | Issue | Severity | Session cost today |
+|---|---|---|---|
+| 1 | Spawn race on `action=mine` | P1 | ~1 min × 2 sessions = 2 min |
+| 2 | Verification jail under outdated binary | P1 operational | ~8 min × 2 closes = 16 min |
+| 3 | Orphan untracked files blocking cherry-pick | P1 hygiene | ~3 min × 2 occurrences = 6 min |
+| 4 | Prior-session WIP on develop working tree | P1 hygiene | ~5 min triage at session start |
+| 5 | Stale `InProgress` + dead assignee | P2 | ~2 min × 3 tasks = 6 min |
+| 6 | Director replay / dup messages | P2 | minor context drain per worker |
+| 7 | `bypass_code_review` for worker-verified close | P2 UX | ~2 min × 2 closes + wasted tokens |
+
+**Total supervisor time on friction: ~40 min of an otherwise-productive session.** Most of that is recoverable with (1), (3), and (7) alone.
+
+Happy to clarify or produce additional evidence on any of the above — I still have the session transcript at `/home/pippenz/.claude/projects/-home-pippenz-Petrastella-abundant-mines/48456bb1-d1c7-45be-b1af-f95ca3b03301/`.

--- a/docs/requests/FEATURE-cloud-sync-pull-team-memories.md
+++ b/docs/requests/FEATURE-cloud-sync-pull-team-memories.md
@@ -1,0 +1,81 @@
+---
+from: Petra Stella Cloud team
+date: 2026-04-23
+priority: P2
+cas_task: cas-e38e
+---
+
+# `cas cloud sync` should also pull team-memories for active project
+
+## Problem
+
+When a user runs `cas cloud sync` from a CAS-initialized project directory with a configured team, the command pulls only personal-scope data. Team-scoped memories for the project's canonical id are silently excluded — the user has to know about the separate `cas cloud team-memories` command.
+
+The "Full sync (push then pull)" naming is misleading when team scope is silently dropped.
+
+## Motivation
+
+Discovered during Ben onboarding (2026-04-23). After 206 personal entries were promoted to team scope across 7 projects, Ben ran `cas cloud sync` from `~/projects/ozer` and it reported **0 entries synced**. He only got his 39 team memories after learning about `cas cloud team-memories` and running it manually.
+
+## Files (cas-src)
+
+- Modify: `src/cli/cloud.rs` (or wherever the `sync` subcommand handler lives)
+- Reference: existing `cas cloud team-memories` implementation as the pull-team-scope pattern to invoke
+
+## Approach
+
+After the existing personal pull completes, if a team is configured for the current project AND the project has a canonical id, additionally invoke the team-memories pull for that project.
+
+- No team or no canonical id → behave exactly as today (silent skip, no warning)
+- Do NOT change push behavior
+- Print personal and team counts as separate lines in the summary
+
+## Test scenarios
+
+- Happy path: project with team configured + canonical id → personal pull + team-memories pull both run, summary lists both counts separately
+- No team configured → behaves identically to today
+- Team configured but project has no canonical id → personal pull runs, team pull skipped silently
+- Network error on team pull after successful personal pull → personal counts shown, team failure reported as a warning (not a hard error that loses personal pull info)
+
+## Verification fixtures
+
+**Database state (petra-stella-cloud Neon project `gentle-butterfly-19534503`):**
+
+- Team "Petra Stella" UUID: `2a57bec9-5dfa-4a8f-b711-31f9aeb8d6cb`
+- 206 entries promoted to team scope across 7 projects: cas-src (77), taxes (44), ozer (39), domdms (28), petra-stella-cloud (10), abundant-mines (7), closure-club (1)
+- Daniel user_id: `3535edb0-a949-4200-883d-3c2c0d46de77`
+- Ben user_id: `f7f4ca76-c7f0-427d-9e1f-e1e1b0430d7a`
+
+**Live verification box — `root@starscream` (Hetzner), Ben's account:**
+
+- 19 CAS-initialized projects under `~/projects/` (ozer, domdms, cas-src, petra-stella-cloud, abundant-mines, closure-club, gabber-studio, …)
+- Ben's CAS env at `~/.config/cas/env` provides `CAS_CLOUD_TOKEN` and `CAS_CLOUD_ENDPOINT=https://petra-stella-cloud.vercel.app`
+- `~/.zshrc` auto-logs in on shell start and defines `cas-login` alias
+
+**Reproduction smoke test (from ben's account):**
+
+1. `ssh root@starscream`, `su - ben`
+2. `cd ~/projects/ozer`
+3. `cas cloud sync` — today reports "0 entries synced" for team stuff; after your fix should report both personal AND team counts in one command.
+
+## Cloud API already in place
+
+- Team pull endpoint: `app/api/teams/[teamId]/sync/pull/route.ts` — the same endpoint `cas cloud team-memories` already hits. Your sync handler just needs to invoke the same pull after the personal pull.
+
+## Acceptance criteria
+
+From a project dir with team configured, a single `cas cloud sync` invocation pulls both personal and team-scoped entries. Output explicitly lists team-memory counts. Behavior unchanged when no team is set or project has no canonical id. All four test scenarios pass.
+
+## Demo
+
+User `cd`'s into `~/projects/ozer`, runs `cas cloud sync`, sees a single output containing both personal sync counts and `Team memories: 39 merged` without running any second command.
+
+## Non-goals
+
+- Does not change `cas cloud team-memories` behavior
+- Does not auto-pull for projects other than the current one
+- Does not change global team config behavior (see sibling request `FEATURE-global-team-config.md` / cas-eb38)
+
+## Coordination
+
+Sibling: `FEATURE-global-team-config.md` (cas-eb38). Both touch team-config read paths — probably one worker takes both.

--- a/docs/requests/FEATURE-global-team-config.md
+++ b/docs/requests/FEATURE-global-team-config.md
@@ -1,0 +1,83 @@
+---
+from: Petra Stella Cloud team
+date: 2026-04-23
+priority: P2
+cas_task: cas-eb38
+---
+
+# Make team config global with per-project override
+
+## Problem
+
+Active team configuration is currently per-project only. `cas cloud team set <uuid>` writes into the repo's `.cas/cloud.json`, so a user with N CAS-initialized projects must run it N times before `cas cloud team-memories` will return anything. Pure friction for the common single-team case.
+
+## Motivation
+
+Discovered during Ben onboarding (2026-04-23). Ben has 19 CAS-initialized projects on `starscream`. After bulk-promoting 206 entries to the Petra Stella team, he has to run `cas cloud team set 2a57bec9-…` 19 times to consume them, and repeat the dance for every new project he initializes.
+
+## Files (cas-src)
+
+- Modify: team config read path (grep for where `cas cloud team show` and team-memories pull look up the configured team UUID)
+- Modify: `cas cloud team set` command to default to global write, with a `--project` flag to opt into per-project scope
+- Add: `~/.cas/` config schema entry for global team (extend existing `cloud.json` is probably the cleanest — audit on starscream)
+- Migrate: existing per-project `team` settings must continue to resolve correctly on read
+
+## Approach
+
+Two-level resolution. Read order:
+
+1. Per-project `.cas/cloud.json` team field if set
+2. Else global `~/.cas/cloud.json` (or equivalent) team field if set
+3. Else "no team configured" error as today
+
+`cas cloud team set` writes **global by default**; `--project` (or `--here`) writes to the local project. `cas cloud team show` reports both the resolved team and which level it came from.
+
+**Migration:** do NOT auto-migrate per-project → global. Too easy to surprise users with legitimate multi-team setups.
+
+## Test scenarios
+
+- Fresh user: `cas cloud team set <uuid>` (no flag) → global file written, every CAS-initialized project sees the team
+- User opts into per-project: `cas cloud team set <uuid> --project` → only the current dir gets it; other projects fall back to global
+- Existing per-project user (from before this change): per-project value still resolves correctly even after global is set to a different team
+- `cas cloud team show` output identifies whether the active team came from project-level or global config
+- `cas cloud team clear` with no flag clears the global; with `--project` clears the local override
+
+## Verification fixtures
+
+**Live box — `root@starscream`, Ben's account:**
+
+- 19 existing `~/projects/*` to test bulk-apply behavior
+- Current per-project config lives in `.cas/cloud.json` inside each repo (confirm exact path/schema from code — not audited in detail here)
+- Ben's CAS env at `~/.config/cas/env` provides token + endpoint
+
+**Schema decision you need to make:**
+
+- Global file path/name (`~/.cas/team.json` vs extending `~/.cas/cloud.json`) — look at existing `~/.cas/` artifacts (`cas.db`, `cloud.json`, `backup/`, factory sockets) and pick the cleanest fit. `cloud.json` already exists there — probably the right home.
+- Resolution precedence: **per-project > global**. Do not reverse.
+
+**Team UUID for verification:** `2a57bec9-5dfa-4a8f-b711-31f9aeb8d6cb` (Petra Stella, the only real team in the cloud right now).
+
+**Reproduction smoke test:**
+
+1. On starscream as ben: pick a project with no team set (one of Ben's 19 that he hasn't touched)
+2. Today: `cd ~/projects/<unset-project> && cas cloud team-memories` → "No team configured"
+3. After your fix: `cas cloud team set <uuid>` from `~` once, then the above `cas cloud team-memories` works in every unset project without further setup
+4. Also test: a project where team was previously set to a DIFFERENT uuid via old per-project config — must still resolve to that uuid, not the new global default
+
+## Acceptance criteria
+
+Single `cas cloud team set <uuid>` (no flag) applied globally — verified by 5 different projects all reporting the team without any further config. `--project` flag still creates per-project override that takes precedence. Pre-existing per-project configs continue to resolve correctly. `cas cloud team show` indicates resolution source. All five test scenarios pass.
+
+## Demo
+
+From any directory: `cas cloud team set <uuid>`, then `cd ~/projects/ozer && cas cloud team show` and `cd ~/projects/cas-src && cas cloud team show` — both report the same team without any further setup. Then `cas cloud team set <other-uuid> --project` in cas-src reports a different team only there.
+
+## Non-goals
+
+- Does not change team-membership semantics in cloud DB
+- Does not change `cas cloud team-memories` pull behavior (separate request — see `FEATURE-cloud-sync-pull-team-memories.md` / cas-e38e)
+- Does not introduce per-org or per-host scoping — just project-overrides-global, two levels
+
+## Coordination
+
+Sibling: `FEATURE-cloud-sync-pull-team-memories.md` (cas-e38e). Shared code paths around team-config read — probably one worker takes both.


### PR DESCRIPTION
## Summary

Seven tasks from EPIC **cas-9508** (Factory session friction) plus build tooling & docs. Based on a P1 friction report from yesterday's abundant-mines session; addresses the supervisor/worker pain points that added ~40 min of overhead per multi-worker EPIC.

**Closed in this batch (7/11)**:
- **cas-5572** — `action=mine` race: worker identity matching widened to {agent_id, agent_name, CAS_AGENT_NAME, CAS_SESSION_ID} with case/trim tolerance. Eliminates the spawn-race kick pattern.
- **cas-4181** — Factory TUI epic hijack: unified init + runtime picker via shared helper; strict-improvement gate on `EpicStarted`; ghost-epic liveness escape. Compile-time enforced.
- **cas-1a7c** — Lease/status divergence: `action=release` auto-recovers lease-less InProgress tasks with audit note; new `action=reset` verb for dead-session recovery.
- **cas-3086** — Close flow: persist worker `ReviewOutcome` envelope on task record at close attempt; supervisor-close forwards persisted envelope without `bypass_code_review`; epic-close short-circuits when all subtasks carry valid receipts (with P0 defense-in-depth so subtask residuals still block).
- **cas-a9ab** — SessionEnd hygiene: manifest written to `.cas/logs/factory-session-{date}.log`; `gc_report` MCP verb; `git rev-parse --git-common-dir` for correct main-worktree resolution inside factory layout.
- **cas-aeec** — SessionStart WIP triage: supervisor-only banner surfaces uncommitted state with per-file `(last touched by cas-xxxx)` attribution; 20-row cap with `gc_report` overflow.
- **cas-7f57** — Director dup messages: `TeamsManager::write_to_inbox` dedupes identical (from, text) within 10-min window + prunes read messages >2h. Unread messages preserved regardless of age (supervisor recovery prompts cannot evaporate). All ops under `flock(LOCK_EX)`.

**Side deliverables**:
- `.cargo/config.toml` — linker swapped from `lld` to `mold` (typically 2-5× faster link, dominates incremental Rust test loop). Paired with `cargo-nextest` installed host-wide.
- `docs/requests/` — session observation report + 4 cross-team request docs from Petra Stella Cloud.

**Still open under EPIC cas-9508** (for follow-up session): cas-4513 (Claude Code JS-crash detection, 514-line WIP salvaged), cas-d0f9 (supervisor-skill preflight, doc-only), cas-2749 (worker crash recovery), cas-6cb0 (typed `LeaseNotFound`, P3).

Every closed task has verifier approval receipts in its close reason + `ReviewOutcome` envelopes persisted on the task record.

## Test plan

- [ ] `cargo nextest run -p cas-cli` green (covers `mcp_tools_test`, `hooks::`, `session_hygiene`, factory suite — all confirmed green at close time on individual worker branches; merge-combined run needs verification)
- [ ] `cargo build --release` clean
- [ ] Factory TUI smoke test: start session, confirm epic panel tracks active epic (not lex-greatest)
- [ ] Fresh worker spawn + `action=mine` returns assignment within 1s without coordination kick
- [ ] Supervisor-close on a worker-jailed task forwards persisted `ReviewOutcome` without `bypass_code_review=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)