### PR TITLE
feat(factory): wire per-role reasoning_effort from LlmConfig through spawn pipeline

### DIFF
--- a/cas-cli/src/cli/factory/daemon.rs
+++ b/cas-cli/src/cli/factory/daemon.rs
@@ -88,6 +88,8 @@ pub(super) fn execute_daemon(
         worker_cli,
         supervisor_model: llm.model_for_role("supervisor").map(String::from),
         worker_model: llm.model_for_role("worker").map(String::from),
+        supervisor_effort: llm.reasoning_effort_for_role("supervisor").map(String::from),
+        worker_effort: llm.reasoning_effort_for_role("worker").map(String::from),
         enable_worktrees: !no_worktrees,
         worktree_root,
         notify: NotifyConfig {

--- a/cas-cli/src/cli/factory/mod.rs
+++ b/cas-cli/src/cli/factory/mod.rs
@@ -894,6 +894,8 @@ pub fn execute(args: &FactoryArgs, cli: &Cli, cas_root: Option<&std::path::Path>
         worker_cli: preflight.worker_cli,
         supervisor_model: llm.model_for_role("supervisor").map(String::from),
         worker_model: llm.model_for_role("worker").map(String::from),
+        supervisor_effort: llm.reasoning_effort_for_role("supervisor").map(String::from),
+        worker_effort: llm.reasoning_effort_for_role("worker").map(String::from),
         enable_worktrees: preflight.enable_worktrees,
         worktree_root: args.worktree_root.clone(),
         notify: notify_config,

--- a/cas-cli/src/ui/factory/app/init.rs
+++ b/cas-cli/src/ui/factory/app/init.rs
@@ -124,6 +124,8 @@ impl FactoryApp {
             worker_cli: config.worker_cli,
             supervisor_model: config.supervisor_model.clone(),
             worker_model: config.worker_model.clone(),
+            supervisor_effort: config.supervisor_effort.clone(),
+            worker_effort: config.worker_effort.clone(),
             include_director: false,
             rows,
             cols,

--- a/cas-cli/src/ui/factory/daemon/fork_first.rs
+++ b/cas-cli/src/ui/factory/daemon/fork_first.rs
@@ -330,6 +330,8 @@ impl DaemonInitPhase {
             worker_cli: self.factory_config.worker_cli,
             supervisor_model: self.factory_config.supervisor_model.clone(),
             worker_model: self.factory_config.worker_model.clone(),
+            supervisor_effort: self.factory_config.supervisor_effort.clone(),
+            worker_effort: self.factory_config.worker_effort.clone(),
             include_director: false,
             rows,
             cols,

--- a/crates/cas-factory/src/config.rs
+++ b/crates/cas-factory/src/config.rs
@@ -169,6 +169,10 @@ pub struct FactoryConfig {
     pub supervisor_model: Option<String>,
     /// Model for workers (passed as --model flag to CLI)
     pub worker_model: Option<String>,
+    /// Reasoning effort for supervisor (passed as --effort flag; defaults to "high")
+    pub supervisor_effort: Option<String>,
+    /// Reasoning effort for workers (passed as --effort flag; defaults to "medium")
+    pub worker_effort: Option<String>,
     /// Enable worktree-based worker isolation (default: true)
     pub enable_worktrees: bool,
     /// Directory where worker worktrees are created (default: ../cas-worktrees)
@@ -204,6 +208,8 @@ impl Default for FactoryConfig {
             worker_cli: cas_mux::SupervisorCli::Claude,
             supervisor_model: None,
             worker_model: None,
+            supervisor_effort: None,
+            worker_effort: None,
             enable_worktrees: true,
             worktree_root: None,
             notify: NotifyConfig::default(),

--- a/crates/cas-factory/src/core.rs
+++ b/crates/cas-factory/src/core.rs
@@ -134,6 +134,7 @@ impl FactoryCore {
         // Create mux with no panes initially
         let mut mux = Mux::new(rows, cols);
         mux.set_worker_cli(config.worker_cli);
+        mux.set_worker_model(config.worker_model.clone());
         mux.set_worker_effort(config.worker_effort.clone());
 
         // Initialize recording if enabled

--- a/crates/cas-factory/src/core.rs
+++ b/crates/cas-factory/src/core.rs
@@ -134,6 +134,7 @@ impl FactoryCore {
         // Create mux with no panes initially
         let mut mux = Mux::new(rows, cols);
         mux.set_worker_cli(config.worker_cli);
+        mux.set_worker_effort(config.worker_effort.clone());
 
         // Initialize recording if enabled
         let recording = if config.record {
@@ -203,6 +204,7 @@ impl FactoryCore {
             self.config.worker_cli,
             &self.worker_names,
             self.config.supervisor_model.as_deref(),
+            self.config.supervisor_effort.as_deref(),
             None, // teams: cas-factory doesn't use native Agent Teams yet
         )
         .map_err(|e| FactoryError::Mux(e.to_string()))?;
@@ -461,6 +463,8 @@ mod tests {
             worker_cli: cas_mux::SupervisorCli::Claude,
             supervisor_model: None,
             worker_model: None,
+            supervisor_effort: None,
+            worker_effort: None,
             enable_worktrees: false,
             worktree_root: None,
             notify: Default::default(),

--- a/crates/cas-factory/tests/factory_integration.rs
+++ b/crates/cas-factory/tests/factory_integration.rs
@@ -186,6 +186,8 @@ fn test_config() -> FactoryConfig {
         worker_cli: SupervisorCli::Claude,
         supervisor_model: None,
         worker_model: None,
+        supervisor_effort: None,
+        worker_effort: None,
         enable_worktrees: false,
         worktree_root: None,
         notify: NotifyConfig::default(),

--- a/crates/cas-mux/examples/factory.rs
+++ b/crates/cas-mux/examples/factory.rs
@@ -33,6 +33,8 @@ async fn main() -> anyhow::Result<()> {
         worker_cli: SupervisorCli::Claude,
         supervisor_model: None,
         worker_model: None,
+        supervisor_effort: None,
+        worker_effort: None,
         include_director: false, // No director for this demo
         rows: 24,
         cols: 120,

--- a/crates/cas-mux/src/mux.rs
+++ b/crates/cas-mux/src/mux.rs
@@ -37,6 +37,10 @@ pub struct MuxConfig {
     pub supervisor_model: Option<String>,
     /// Model for workers (passed as --model flag)
     pub worker_model: Option<String>,
+    /// Reasoning effort for supervisor (passed as --effort flag; defaults to "high")
+    pub supervisor_effort: Option<String>,
+    /// Reasoning effort for workers (passed as --effort flag; defaults to "medium")
+    pub worker_effort: Option<String>,
     /// Include director pane
     pub include_director: bool,
     /// Terminal size
@@ -60,6 +64,8 @@ impl Default for MuxConfig {
             worker_cli: SupervisorCli::Claude,
             supervisor_model: None,
             worker_model: None,
+            supervisor_effort: None,
+            worker_effort: None,
             include_director: true,
             rows: 24,
             cols: 80,
@@ -107,6 +113,8 @@ pub struct Mux {
     worker_cli: SupervisorCli,
     /// Worker model used for dynamic worker spawns
     worker_model: Option<String>,
+    /// Worker reasoning effort used for dynamic worker spawns
+    worker_effort: Option<String>,
 }
 
 impl Mux {
@@ -122,6 +130,7 @@ impl Mux {
             cols,
             worker_cli: SupervisorCli::Claude,
             worker_model: None,
+            worker_effort: None,
         }
     }
 
@@ -135,11 +144,17 @@ impl Mux {
         self.worker_model = model;
     }
 
+    /// Set reasoning effort used for worker pane spawns.
+    pub fn set_worker_effort(&mut self, effort: Option<String>) {
+        self.worker_effort = effort;
+    }
+
     /// Create a multiplexer with factory configuration
     pub fn factory(config: MuxConfig) -> Result<Self> {
         let mut mux = Self::new(config.rows, config.cols);
         mux.set_worker_cli(config.worker_cli);
         mux.set_worker_model(config.worker_model.clone());
+        mux.set_worker_effort(config.worker_effort.clone());
 
         // Calculate pane sizes based on layout
         // Layout: [Workers] [Supervisor] [Director]
@@ -171,6 +186,7 @@ impl Mux {
                 &config.supervisor_name,
                 config.worker_cli,
                 config.worker_model.as_deref(),
+                config.worker_effort.as_deref(),
                 pane_rows,
                 pane_cols,
                 teams,
@@ -190,6 +206,7 @@ impl Mux {
             config.worker_cli,
             &worker_names,
             config.supervisor_model.as_deref(),
+            config.supervisor_effort.as_deref(),
             sup_teams,
         )?;
         mux.add_pane(supervisor);
@@ -419,6 +436,7 @@ impl Mux {
             supervisor_name,
             self.worker_cli,
             self.worker_model.as_deref(),
+            self.worker_effort.as_deref(),
             self.rows,
             self.cols,
             teams,

--- a/crates/cas-mux/src/pane/mod.rs
+++ b/crates/cas-mux/src/pane/mod.rs
@@ -197,7 +197,6 @@ impl Pane {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     pub fn worker(
         name: &str,
         cwd: PathBuf,
@@ -205,6 +204,7 @@ impl Pane {
         supervisor_name: &str,
         cli: SupervisorCli,
         model: Option<&str>,
+        effort: Option<&str>,
         rows: u16,
         cols: u16,
         teams: Option<&TeamsSpawnConfig>,
@@ -219,6 +219,7 @@ impl Pane {
                     Some(supervisor_name),
                     None,
                     model,
+                    effort,
                     teams,
                 );
                 let pty = Pty::spawn(name, config)?;
@@ -233,6 +234,7 @@ impl Pane {
                     Some(supervisor_name),
                     None,
                     model,
+                    effort,
                     teams,
                 );
                 let pty = Pty::spawn(name, config)?;
@@ -252,6 +254,7 @@ impl Pane {
         worker_cli: SupervisorCli,
         worker_names: &[String],
         model: Option<&str>,
+        effort: Option<&str>,
         teams: Option<&TeamsSpawnConfig>,
     ) -> Result<Self> {
         let worker_cli_str = worker_cli.as_str();
@@ -271,6 +274,7 @@ impl Pane {
                     None,
                     Some(worker_cli_str),
                     model,
+                    effort,
                     teams,
                 );
                 Self::push_supervisor_env(&mut config.env, cli, &worker_names_csv);
@@ -286,6 +290,7 @@ impl Pane {
                     None,
                     Some(worker_cli_str),
                     model,
+                    effort,
                     teams,
                 );
                 Self::push_supervisor_env(&mut config.env, cli, &worker_names_csv);

--- a/crates/cas-pty/src/pty.rs
+++ b/crates/cas-pty/src/pty.rs
@@ -1019,6 +1019,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_pty_config_claude_custom_effort() {
+        let config = PtyConfig::claude(
+            "test-agent",
+            "worker",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None,  // model
+            Some("low"),  // effort override
+            None,  // teams
+        );
+        let effort_idx = config
+            .args
+            .iter()
+            .position(|a| a == "--effort")
+            .expect("--effort must be present");
+        assert_eq!(
+            config.args[effort_idx + 1], "low",
+            "custom effort should override hardcoded default"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pty_config_claude_supervisor_default_effort() {
+        // When effort is None and role is supervisor, must default to "high"
+        let config = PtyConfig::claude(
+            "sup",
+            "supervisor",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None,  // model
+            None,  // no effort — should fall back to "high"
+            None,  // teams
+        );
+        let effort_idx = config
+            .args
+            .iter()
+            .position(|a| a == "--effort")
+            .expect("--effort must be present");
+        assert_eq!(config.args[effort_idx + 1], "high");
+    }
+
+    #[tokio::test]
+    async fn test_pty_config_claude_worker_default_effort() {
+        // When effort is None and role is worker, must default to "medium"
+        let config = PtyConfig::claude(
+            "wrk",
+            "worker",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None,  // model
+            None,  // no effort — should fall back to "medium"
+            None,  // teams
+        );
+        let effort_idx = config
+            .args
+            .iter()
+            .position(|a| a == "--effort")
+            .expect("--effort must be present");
+        assert_eq!(config.args[effort_idx + 1], "medium");
+    }
+
+    #[tokio::test]
     async fn test_pty_config_claude_with_teams_lead() {
         let teams = TeamsSpawnConfig {
             team_name: "test-team".to_string(),

--- a/crates/cas-pty/src/pty.rs
+++ b/crates/cas-pty/src/pty.rs
@@ -102,6 +102,7 @@ impl PtyConfig {
         supervisor_name: Option<&str>,
         factory_worker_cli: Option<&str>,
         model: Option<&str>,
+        effort: Option<&str>,
         teams: Option<&TeamsSpawnConfig>,
     ) -> Self {
         // Use the lead_session_id for the team lead so leadSessionId in the
@@ -181,15 +182,12 @@ impl PtyConfig {
         }
         // Supervisors need deeper reasoning for planning/coordination;
         // workers execute well-defined tasks where high effort suffices.
+        // Config-provided effort takes precedence; role-based defaults preserve
+        // backward compatibility when no config value is set.
+        let resolved_effort =
+            effort.unwrap_or(if role == "supervisor" { "xhigh" } else { "high" });
         args.push("--effort".to_string());
-        args.push(
-            if role == "supervisor" {
-                "xhigh"
-            } else {
-                "high"
-            }
-            .to_string(),
-        );
+        args.push(resolved_effort.to_string());
 
         // Add native Agent Teams CLI flags.
         // All agents (including the supervisor) get --teammate-mode tmux
@@ -257,6 +255,7 @@ impl PtyConfig {
         supervisor_name: Option<&str>,
         factory_worker_cli: Option<&str>,
         model: Option<&str>,
+        _effort: Option<&str>,
         _teams: Option<&TeamsSpawnConfig>,
     ) -> Self {
         // Native Agent Teams is Claude Code-only; Codex CLI does not support it.
@@ -805,8 +804,9 @@ mod tests {
             None,
             None,
             None,
-            None,
-            None,
+            None,  // model
+            None,  // effort
+            None,  // teams
         );
         assert_eq!(config.command, "claude");
         assert!(
@@ -840,8 +840,9 @@ mod tests {
             Some(&cas_root),
             None,
             None,
-            None,
-            None,
+            None,  // model
+            None,  // effort
+            None,  // teams
         );
         assert!(
             config
@@ -860,8 +861,9 @@ mod tests {
             None,
             Some("test-supervisor"),
             None,
-            None,
-            None,
+            None,  // model
+            None,  // effort
+            None,  // teams
         );
         assert!(
             config
@@ -880,8 +882,9 @@ mod tests {
             None,
             None,
             None,
-            None,
-            None,
+            None,  // model
+            None,  // effort
+            None,  // teams
         );
         assert!(
             config
@@ -901,7 +904,8 @@ mod tests {
             None,
             None,
             Some("claude-opus-4-6"),
-            None,
+            None,  // effort
+            None,  // teams
         );
         assert!(config.args.contains(&"--model".to_string()));
         assert!(config.args.contains(&"claude-opus-4-6".to_string()));
@@ -916,8 +920,9 @@ mod tests {
             None,
             None,
             None,
-            None,
-            None,
+            None,  // model
+            None,  // effort
+            None,  // teams
         );
         assert!(!config.args.contains(&"--model".to_string()));
     }
@@ -932,7 +937,8 @@ mod tests {
             None,
             None,
             Some("gpt-5.3-codex"),
-            None,
+            None,  // effort
+            None,  // teams
         );
         assert!(config.args.contains(&"--model".to_string()));
         assert!(config.args.contains(&"gpt-5.3-codex".to_string()));
@@ -947,8 +953,9 @@ mod tests {
             None,
             None,
             None,
-            None,
-            None,
+            None,  // model
+            None,  // effort
+            None,  // teams
         );
         let all_args = config.args.join(" ");
         assert!(
@@ -966,8 +973,9 @@ mod tests {
             None,
             None,
             None,
-            None,
-            None,
+            None,  // model
+            None,  // effort
+            None,  // teams
         );
         let all_args = config.args.join(" ");
         assert!(
@@ -995,7 +1003,8 @@ mod tests {
             None,
             None,
             None,
-            None,
+            None,  // model
+            None,  // effort
             Some(&teams),
         );
         assert!(config.args.contains(&"--team-name".to_string()));
@@ -1044,10 +1053,32 @@ mod tests {
 
     #[tokio::test]
     async fn test_pty_config_claude_supervisor_default_effort() {
-        // When effort is None and role is supervisor, must default to "high"
+        // When effort is None and role is supervisor, must default to "xhigh"
         let config = PtyConfig::claude(
             "sup",
             "supervisor",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None,  // model
+            None,  // no effort — should fall back to "xhigh"
+            None,  // teams
+        );
+        let effort_idx = config
+            .args
+            .iter()
+            .position(|a| a == "--effort")
+            .expect("--effort must be present");
+        assert_eq!(config.args[effort_idx + 1], "xhigh");
+    }
+
+    #[tokio::test]
+    async fn test_pty_config_claude_worker_default_effort() {
+        // When effort is None and role is worker, must default to "high"
+        let config = PtyConfig::claude(
+            "wrk",
+            "worker",
             PathBuf::from("/tmp"),
             None,
             None,
@@ -1062,28 +1093,6 @@ mod tests {
             .position(|a| a == "--effort")
             .expect("--effort must be present");
         assert_eq!(config.args[effort_idx + 1], "high");
-    }
-
-    #[tokio::test]
-    async fn test_pty_config_claude_worker_default_effort() {
-        // When effort is None and role is worker, must default to "medium"
-        let config = PtyConfig::claude(
-            "wrk",
-            "worker",
-            PathBuf::from("/tmp"),
-            None,
-            None,
-            None,
-            None,  // model
-            None,  // no effort — should fall back to "medium"
-            None,  // teams
-        );
-        let effort_idx = config
-            .args
-            .iter()
-            .position(|a| a == "--effort")
-            .expect("--effort must be present");
-        assert_eq!(config.args[effort_idx + 1], "medium");
     }
 
     #[tokio::test]
@@ -1105,7 +1114,8 @@ mod tests {
             None,
             None,
             None,
-            None,
+            None,  // model
+            None,  // effort
             Some(&teams),
         );
         // Lead also gets --teammate-mode so it polls its inbox


### PR DESCRIPTION
## Summary

- Threads `reasoning_effort` config per-role (`supervisor`/`worker`) through the full factory spawn pipeline, mirroring the existing `model` pattern
- Both spawn paths covered: `Mux::factory()` (static init) and `FactoryCore::spawn_supervisor/spawn_worker()` (dynamic)
- Role-based defaults updated to match origin/main: `xhigh` for supervisor, `high` for worker when no config set
- Autofix applied: `FactoryCore::new` now also calls `mux.set_worker_model()` for symmetry with `set_worker_effort()`
- Rebased onto `af5358a` (v2.11.0); all new test call sites from origin/main updated for new 9-arg `PtyConfig::claude/codex` signatures

## Files changed

- `crates/cas-pty/src/pty.rs` — added `effort: Option<&str>` param; `unwrap_or` defaults to `xhigh`/`high`; 10 new test call sites updated
- `crates/cas-mux/src/pane/mod.rs` — forwarded effort through `Pane::supervisor()` and `Pane::worker()`
- `crates/cas-mux/src/mux.rs` — added `supervisor_effort`/`worker_effort` to `MuxConfig`; stored `worker_effort` in `Mux` for dynamic spawn
- `crates/cas-factory/src/config.rs` — added `supervisor_effort`/`worker_effort` to `FactoryConfig`
- `crates/cas-factory/src/core.rs` — wired `worker_effort` and `worker_model` through `FactoryCore::new()`
- `cas-cli/src/cli/factory/mod.rs`, `daemon.rs` — reads from `LlmConfig::reasoning_effort_for_role()`
- `cas-cli/src/ui/factory/app/init.rs`, `daemon/fork_first.rs` — forwarded through `MuxConfig`

## Test plan

- [x] 3 new unit tests in `pty.rs`: custom effort, supervisor default (`xhigh`), worker default (`high`)
- [x] All 37 `cas-pty` tests pass
- [x] `cas-mux` and `cas-factory` packages compile and test clean
- [x] Full `cas` crate compiles (warnings only, pre-existing)
- [x] Verifier approved (confidence 0.95)
- [x] Code review: no P0 findings; 1 P2 safe_auto autofix applied; follow-up tasks created

Closes: cas-63d9

🤖 Generated with [Claude Code](https://claude.com/claude-code)