### PR TITLE
Recovery: cas-9393 + cas-d571 unmerged work + cas-c0e0 FactoryConfig regression fix

### DIFF
--- a/cas-cli/src/cli/factory/daemon.rs
+++ b/cas-cli/src/cli/factory/daemon.rs
@@ -90,6 +90,8 @@ pub(super) fn execute_daemon(
         worker_model: llm.model_for_role("worker").map(String::from),
         supervisor_effort: llm.reasoning_effort_for_role("supervisor").map(String::from),
         worker_effort: llm.reasoning_effort_for_role("worker").map(String::from),
+        resolved_worker_specs: vec![],
+        resolved_supervisor_spec: None,
         enable_worktrees: !no_worktrees,
         worktree_root,
         notify: NotifyConfig {

--- a/cas-cli/src/cli/factory/mod.rs
+++ b/cas-cli/src/cli/factory/mod.rs
@@ -896,6 +896,8 @@ pub fn execute(args: &FactoryArgs, cli: &Cli, cas_root: Option<&std::path::Path>
         worker_model: llm.model_for_role("worker").map(String::from),
         supervisor_effort: llm.reasoning_effort_for_role("supervisor").map(String::from),
         worker_effort: llm.reasoning_effort_for_role("worker").map(String::from),
+        resolved_worker_specs: vec![],
+        resolved_supervisor_spec: None,
         enable_worktrees: preflight.enable_worktrees,
         worktree_root: args.worktree_root.clone(),
         notify: notify_config,

--- a/cas-cli/src/config/settings.rs
+++ b/cas-cli/src/config/settings.rs
@@ -533,7 +533,7 @@ pub struct LlmConfig {
 }
 
 /// Per-role LLM overrides (supervisor or worker)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LlmRoleConfig {
     /// Override harness for this role
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -671,5 +671,135 @@ mod tests {
         let fc = parsed.get("factory").expect("section present");
         assert_eq!(fc.cargo_build_jobs, FactoryConfig::default().cargo_build_jobs);
         assert_eq!(fc.nice_cargo, FactoryConfig::default().nice_cargo);
+    }
+
+    // ── LlmConfig::reasoning_effort_for_role ─────────────────────────────────
+    // cas-9393: critical-path method feeds supervisor_effort and worker_effort
+    // through the factory spawn pipeline — must have full coverage.
+
+    /// No config at all → None for every role.
+    #[test]
+    fn reasoning_effort_for_role_no_config_returns_none() {
+        let llm = LlmConfig::default();
+        assert_eq!(llm.reasoning_effort_for_role("supervisor"), None);
+        assert_eq!(llm.reasoning_effort_for_role("worker"), None);
+    }
+
+    /// Top-level `reasoning_effort` is the fallback when no per-role override
+    /// is present. Both supervisor and worker should see it.
+    #[test]
+    fn reasoning_effort_for_role_top_level_fallback() {
+        let llm = LlmConfig {
+            reasoning_effort: Some("medium".to_string()),
+            ..LlmConfig::default()
+        };
+        assert_eq!(
+            llm.reasoning_effort_for_role("supervisor"),
+            Some("medium"),
+            "supervisor should fall back to top-level reasoning_effort"
+        );
+        assert_eq!(
+            llm.reasoning_effort_for_role("worker"),
+            Some("medium"),
+            "worker should fall back to top-level reasoning_effort"
+        );
+    }
+
+    /// A supervisor-specific override shadows the top-level value for the
+    /// supervisor role, while the worker still sees the top-level value.
+    #[test]
+    fn reasoning_effort_for_role_supervisor_override() {
+        let llm = LlmConfig {
+            reasoning_effort: Some("high".to_string()),
+            supervisor: Some(LlmRoleConfig {
+                reasoning_effort: Some("low".to_string()),
+                ..LlmRoleConfig::default()
+            }),
+            ..LlmConfig::default()
+        };
+        assert_eq!(
+            llm.reasoning_effort_for_role("supervisor"),
+            Some("low"),
+            "supervisor override must shadow top-level value"
+        );
+        assert_eq!(
+            llm.reasoning_effort_for_role("worker"),
+            Some("high"),
+            "worker must still see top-level when no worker override is set"
+        );
+    }
+
+    /// A worker-specific override shadows the top-level value for the worker
+    /// role, while the supervisor still sees the top-level value.
+    #[test]
+    fn reasoning_effort_for_role_worker_override() {
+        let llm = LlmConfig {
+            reasoning_effort: Some("medium".to_string()),
+            worker: Some(LlmRoleConfig {
+                reasoning_effort: Some("high".to_string()),
+                ..LlmRoleConfig::default()
+            }),
+            ..LlmConfig::default()
+        };
+        assert_eq!(
+            llm.reasoning_effort_for_role("worker"),
+            Some("high"),
+            "worker override must shadow top-level value"
+        );
+        assert_eq!(
+            llm.reasoning_effort_for_role("supervisor"),
+            Some("medium"),
+            "supervisor must still see top-level when no supervisor override is set"
+        );
+    }
+
+    /// Per-role overrides are independent: supervisor and worker can each have
+    /// their own distinct effort level without interfering with each other.
+    #[test]
+    fn reasoning_effort_for_role_independent_overrides() {
+        let llm = LlmConfig {
+            reasoning_effort: None,
+            supervisor: Some(LlmRoleConfig {
+                reasoning_effort: Some("low".to_string()),
+                ..LlmRoleConfig::default()
+            }),
+            worker: Some(LlmRoleConfig {
+                reasoning_effort: Some("high".to_string()),
+                ..LlmRoleConfig::default()
+            }),
+            ..LlmConfig::default()
+        };
+        assert_eq!(
+            llm.reasoning_effort_for_role("supervisor"),
+            Some("low"),
+            "supervisor-only override must not bleed into worker"
+        );
+        assert_eq!(
+            llm.reasoning_effort_for_role("worker"),
+            Some("high"),
+            "worker-only override must not bleed into supervisor"
+        );
+    }
+
+    /// An unknown / unrecognised role is treated as having no per-role override.
+    /// It falls back to the top-level value, or None if the top-level is unset.
+    #[test]
+    fn reasoning_effort_for_role_unknown_role_falls_back_to_top_level() {
+        let llm_with_top = LlmConfig {
+            reasoning_effort: Some("medium".to_string()),
+            ..LlmConfig::default()
+        };
+        assert_eq!(
+            llm_with_top.reasoning_effort_for_role("orchestrator"),
+            Some("medium"),
+            "unknown role must fall back to top-level reasoning_effort"
+        );
+
+        let llm_no_top = LlmConfig::default();
+        assert_eq!(
+            llm_no_top.reasoning_effort_for_role("orchestrator"),
+            None,
+            "unknown role with no top-level must return None"
+        );
     }
 }

--- a/cas-cli/src/config/settings.rs
+++ b/cas-cli/src/config/settings.rs
@@ -802,4 +802,64 @@ mod tests {
             "unknown role with no top-level must return None"
         );
     }
+
+    /// A per-role block may exist (e.g. to override harness or model) without
+    /// setting `reasoning_effort`. In that case the top-level value must still
+    /// be returned — the `and_then` short-circuit must not swallow the fallback.
+    #[test]
+    fn reasoning_effort_for_role_partial_override_falls_back_to_top_level() {
+        let llm = LlmConfig {
+            reasoning_effort: Some("high".to_string()),
+            supervisor: Some(LlmRoleConfig {
+                harness: Some("codex".to_string()),
+                reasoning_effort: None, // effort NOT set in the role block
+                ..LlmRoleConfig::default()
+            }),
+            ..LlmConfig::default()
+        };
+        assert_eq!(
+            llm.reasoning_effort_for_role("supervisor"),
+            Some("high"),
+            "partial role override (harness set, effort absent) must fall back to top-level"
+        );
+    }
+
+    /// Round-trip via TOML deserialization: verifies that the serde attributes
+    /// on `LlmRoleConfig::reasoning_effort` are correct and that the field is
+    /// not silently dropped during deserialization.
+    #[test]
+    fn reasoning_effort_for_role_toml_roundtrip() {
+        let toml_str = r#"
+[llm]
+reasoning_effort = "medium"
+
+[llm.supervisor]
+reasoning_effort = "low"
+
+[llm.worker]
+reasoning_effort = "high"
+"#;
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            llm: LlmConfig,
+        }
+        let parsed: Wrapper = toml::from_str(toml_str).expect("valid toml");
+        let llm = parsed.llm;
+        assert_eq!(
+            llm.reasoning_effort_for_role("supervisor"),
+            Some("low"),
+            "supervisor reasoning_effort must survive TOML deserialization"
+        );
+        assert_eq!(
+            llm.reasoning_effort_for_role("worker"),
+            Some("high"),
+            "worker reasoning_effort must survive TOML deserialization"
+        );
+        // Top-level fallback still works after round-trip
+        assert_eq!(
+            llm.reasoning_effort_for_role("orchestrator"),
+            Some("medium"),
+            "top-level reasoning_effort must survive TOML deserialization"
+        );
+    }
 }

--- a/crates/cas-factory/src/config.rs
+++ b/crates/cas-factory/src/config.rs
@@ -169,9 +169,9 @@ pub struct FactoryConfig {
     pub supervisor_model: Option<String>,
     /// Model for workers (passed as --model flag to CLI)
     pub worker_model: Option<String>,
-    /// Reasoning effort for supervisor (passed as --effort flag; defaults to "high")
+    /// Reasoning effort for supervisor (passed as --effort flag; defaults to "xhigh")
     pub supervisor_effort: Option<String>,
-    /// Reasoning effort for workers (passed as --effort flag; defaults to "medium")
+    /// Reasoning effort for workers (passed as --effort flag; defaults to "high")
     pub worker_effort: Option<String>,
     /// Enable worktree-based worker isolation (default: true)
     pub enable_worktrees: bool,

--- a/crates/cas-mux/src/mux.rs
+++ b/crates/cas-mux/src/mux.rs
@@ -37,7 +37,7 @@ pub struct MuxConfig {
     pub supervisor_model: Option<String>,
     /// Model for workers (passed as --model flag)
     pub worker_model: Option<String>,
-    /// Reasoning effort for supervisor (passed as --effort flag; defaults to "high")
+    /// Reasoning effort for supervisor (passed as --effort flag; defaults to "xhigh")
     pub supervisor_effort: Option<String>,
     /// Reasoning effort for workers (passed as --effort flag; defaults to "high")
     pub worker_effort: Option<String>,

--- a/crates/cas-mux/src/mux.rs
+++ b/crates/cas-mux/src/mux.rs
@@ -5,7 +5,7 @@
 use crate::error::{Error, Result};
 use crate::harness::SupervisorCli;
 use crate::pane::{Pane, PaneId, PaneKind};
-use crate::pty::{PtyEvent, TeamsSpawnConfig};
+use crate::pty::{PtyConfig, PtyEvent, TeamsSpawnConfig};
 use cas_factory_protocol::ServerMessage;
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -147,6 +147,70 @@ impl Mux {
     /// Set reasoning effort used for worker pane spawns.
     pub fn set_worker_effort(&mut self, effort: Option<String>) {
         self.worker_effort = effort;
+    }
+
+    /// Build the `PtyConfig`s that `factory()` would spawn for each worker and
+    /// supervisor pane, without actually spawning any processes.
+    ///
+    /// Returns `(agent_name, PtyConfig)` pairs — workers first, then the
+    /// supervisor. The director pane (no PTY) is excluded.
+    ///
+    /// Primary use: integration tests that need to verify effort / model args
+    /// flow from `MuxConfig` all the way to the CLI subprocess arguments,
+    /// without requiring a real `claude` or `codex` binary.
+    pub fn factory_pane_configs(config: &MuxConfig) -> Vec<(String, PtyConfig)> {
+        let num_panes = config.workers + 1 + if config.include_director { 1 } else { 0 };
+        let pane_cols = config.cols / num_panes as u16;
+        let pane_rows = config.rows;
+
+        let worker_names: Vec<String> = if config.worker_names.is_empty() {
+            (0..config.workers)
+                .map(|i| format!("worker-{}", i + 1))
+                .collect()
+        } else {
+            config.worker_names.clone()
+        };
+
+        let mut result = Vec::with_capacity(worker_names.len() + 1);
+
+        for name in &worker_names {
+            let worker_cwd = config
+                .worker_cwds
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| config.cwd.clone());
+            let teams = config.teams_configs.get(name);
+            let pty_config = Pane::build_worker_config(
+                name,
+                worker_cwd,
+                config.cas_root.as_ref(),
+                &config.supervisor_name,
+                config.worker_cli,
+                config.worker_model.as_deref(),
+                config.worker_effort.as_deref(),
+                teams,
+            );
+            result.push((name.clone(), pty_config));
+        }
+
+        let sup_teams = config.teams_configs.get(&config.supervisor_name);
+        let sup_config = Pane::build_supervisor_config(
+            &config.supervisor_name,
+            config.cwd.clone(),
+            config.cas_root.as_ref(),
+            config.supervisor_cli,
+            config.worker_cli,
+            &worker_names,
+            config.supervisor_model.as_deref(),
+            config.supervisor_effort.as_deref(),
+            sup_teams,
+        );
+        // Unused in the config-only path but keep signature consistent with
+        // factory() so callers can reference the same parameter set.
+        let _ = (pane_rows, pane_cols);
+        result.push((config.supervisor_name.clone(), sup_config));
+
+        result
     }
 
     /// Create a multiplexer with factory configuration

--- a/crates/cas-mux/src/mux.rs
+++ b/crates/cas-mux/src/mux.rs
@@ -39,7 +39,7 @@ pub struct MuxConfig {
     pub worker_model: Option<String>,
     /// Reasoning effort for supervisor (passed as --effort flag; defaults to "high")
     pub supervisor_effort: Option<String>,
-    /// Reasoning effort for workers (passed as --effort flag; defaults to "medium")
+    /// Reasoning effort for workers (passed as --effort flag; defaults to "high")
     pub worker_effort: Option<String>,
     /// Include director pane
     pub include_director: bool,
@@ -159,10 +159,6 @@ impl Mux {
     /// flow from `MuxConfig` all the way to the CLI subprocess arguments,
     /// without requiring a real `claude` or `codex` binary.
     pub fn factory_pane_configs(config: &MuxConfig) -> Vec<(String, PtyConfig)> {
-        let num_panes = config.workers + 1 + if config.include_director { 1 } else { 0 };
-        let pane_cols = config.cols / num_panes as u16;
-        let pane_rows = config.rows;
-
         let worker_names: Vec<String> = if config.worker_names.is_empty() {
             (0..config.workers)
                 .map(|i| format!("worker-{}", i + 1))
@@ -205,9 +201,6 @@ impl Mux {
             config.supervisor_effort.as_deref(),
             sup_teams,
         );
-        // Unused in the config-only path but keep signature consistent with
-        // factory() so callers can reference the same parameter set.
-        let _ = (pane_rows, pane_cols);
         result.push((config.supervisor_name.clone(), sup_config));
 
         result

--- a/crates/cas-mux/src/mux_tests/tests.rs
+++ b/crates/cas-mux/src/mux_tests/tests.rs
@@ -1,5 +1,118 @@
 use crate::mux::*;
 
+// ── cas-d571: effort config flows through Mux::factory() to PTY args ─────────
+// Tests the full MuxConfig → Mux::factory_pane_configs() → PtyConfig.args chain.
+// Uses `factory_pane_configs` (config-only, no spawn) so tests run without a
+// real `claude` or `codex` binary present.
+
+#[test]
+fn factory_pane_configs_supervisor_effort_reaches_pty_args() {
+    use std::path::PathBuf;
+    let config = MuxConfig {
+        cwd: PathBuf::from("/tmp/test"),
+        workers: 1,
+        supervisor_effort: Some("low".to_string()),
+        worker_effort: Some("high".to_string()),
+        include_director: false,
+        supervisor_cli: crate::harness::SupervisorCli::Claude,
+        worker_cli: crate::harness::SupervisorCli::Claude,
+        ..MuxConfig::default()
+    };
+    let configs = Mux::factory_pane_configs(&config);
+
+    let (_, sup_config) = configs
+        .iter()
+        .find(|(name, _)| name == &config.supervisor_name)
+        .expect("supervisor config must be present");
+    let effort_idx = sup_config
+        .args
+        .iter()
+        .position(|a| a == "--effort")
+        .expect("supervisor PTY args must contain --effort");
+    assert_eq!(
+        sup_config.args[effort_idx + 1], "low",
+        "MuxConfig::supervisor_effort must reach supervisor PTY --effort arg"
+    );
+}
+
+#[test]
+fn factory_pane_configs_worker_effort_reaches_pty_args() {
+    use std::path::PathBuf;
+    let config = MuxConfig {
+        cwd: PathBuf::from("/tmp/test"),
+        workers: 1,
+        supervisor_effort: Some("low".to_string()),
+        worker_effort: Some("high".to_string()),
+        include_director: false,
+        supervisor_cli: crate::harness::SupervisorCli::Claude,
+        worker_cli: crate::harness::SupervisorCli::Claude,
+        ..MuxConfig::default()
+    };
+    let configs = Mux::factory_pane_configs(&config);
+
+    let (_, worker_config) = configs
+        .iter()
+        .find(|(name, _)| name != &config.supervisor_name)
+        .expect("at least one worker config must be present");
+    let effort_idx = worker_config
+        .args
+        .iter()
+        .position(|a| a == "--effort")
+        .expect("worker PTY args must contain --effort");
+    assert_eq!(
+        worker_config.args[effort_idx + 1], "high",
+        "MuxConfig::worker_effort must reach worker PTY --effort arg"
+    );
+}
+
+#[test]
+fn factory_pane_configs_none_effort_uses_role_defaults() {
+    use std::path::PathBuf;
+    // When MuxConfig effort fields are None, PtyConfig::claude defaults fire:
+    // supervisor → "xhigh", worker → "high"
+    let config = MuxConfig {
+        cwd: PathBuf::from("/tmp/test"),
+        workers: 1,
+        supervisor_effort: None,
+        worker_effort: None,
+        include_director: false,
+        supervisor_cli: crate::harness::SupervisorCli::Claude,
+        worker_cli: crate::harness::SupervisorCli::Claude,
+        ..MuxConfig::default()
+    };
+    let configs = Mux::factory_pane_configs(&config);
+
+    let (_, sup_config) = configs
+        .iter()
+        .find(|(name, _)| name == &config.supervisor_name)
+        .expect("supervisor config must be present");
+    let sup_effort_idx = sup_config
+        .args
+        .iter()
+        .position(|a| a == "--effort")
+        .expect("supervisor PTY args must contain --effort");
+    assert_eq!(
+        sup_config.args[sup_effort_idx + 1], "xhigh",
+        "supervisor with no effort override must default to xhigh"
+    );
+
+    let (_, worker_config) = configs
+        .iter()
+        .find(|(name, _)| name != &config.supervisor_name)
+        .expect("worker config must be present");
+    let worker_effort_idx = worker_config
+        .args
+        .iter()
+        .position(|a| a == "--effort")
+        .expect("worker PTY args must contain --effort");
+    assert_eq!(
+        worker_config.args[worker_effort_idx + 1], "high",
+        "worker with no effort override must default to high"
+    );
+}
+
+// ── end cas-d571 ──────────────────────────────────────────────────────────────
+
 #[test]
 fn test_mux_new() {
     let mux = Mux::new(24, 80);

--- a/crates/cas-mux/src/mux_tests/tests.rs
+++ b/crates/cas-mux/src/mux_tests/tests.rs
@@ -1,4 +1,5 @@
 use crate::mux::*;
+use std::path::PathBuf;
 
 // ── cas-d571: effort config flows through Mux::factory() to PTY args ─────────
 // Tests the full MuxConfig → Mux::factory_pane_configs() → PtyConfig.args chain.
@@ -7,7 +8,6 @@ use crate::mux::*;
 
 #[test]
 fn factory_pane_configs_supervisor_effort_reaches_pty_args() {
-    use std::path::PathBuf;
     let config = MuxConfig {
         cwd: PathBuf::from("/tmp/test"),
         workers: 1,
@@ -29,15 +29,18 @@ fn factory_pane_configs_supervisor_effort_reaches_pty_args() {
         .iter()
         .position(|a| a == "--effort")
         .expect("supervisor PTY args must contain --effort");
+    let effort_val = sup_config
+        .args
+        .get(effort_idx + 1)
+        .expect("--effort must be followed by a value in supervisor PTY args");
     assert_eq!(
-        sup_config.args[effort_idx + 1], "low",
+        effort_val, "low",
         "MuxConfig::supervisor_effort must reach supervisor PTY --effort arg"
     );
 }
 
 #[test]
 fn factory_pane_configs_worker_effort_reaches_pty_args() {
-    use std::path::PathBuf;
     let config = MuxConfig {
         cwd: PathBuf::from("/tmp/test"),
         workers: 1,
@@ -59,8 +62,12 @@ fn factory_pane_configs_worker_effort_reaches_pty_args() {
         .iter()
         .position(|a| a == "--effort")
         .expect("worker PTY args must contain --effort");
+    let effort_val = worker_config
+        .args
+        .get(effort_idx + 1)
+        .expect("--effort must be followed by a value in worker PTY args");
     assert_eq!(
-        worker_config.args[effort_idx + 1], "high",
+        effort_val, "high",
         "MuxConfig::worker_effort must reach worker PTY --effort arg"
     );
     // supervisor must be last in the returned vec (workers-first ordering)
@@ -73,7 +80,6 @@ fn factory_pane_configs_worker_effort_reaches_pty_args() {
 
 #[test]
 fn factory_pane_configs_none_effort_uses_role_defaults() {
-    use std::path::PathBuf;
     // When MuxConfig effort fields are None, PtyConfig::claude defaults fire:
     // supervisor → "xhigh", worker → "high"
     let config = MuxConfig {
@@ -97,8 +103,12 @@ fn factory_pane_configs_none_effort_uses_role_defaults() {
         .iter()
         .position(|a| a == "--effort")
         .expect("supervisor PTY args must contain --effort");
+    let sup_effort_val = sup_config
+        .args
+        .get(sup_effort_idx + 1)
+        .expect("--effort must be followed by a value in supervisor PTY args");
     assert_eq!(
-        sup_config.args[sup_effort_idx + 1], "xhigh",
+        sup_effort_val, "xhigh",
         "supervisor with no effort override must default to xhigh"
     );
 
@@ -111,8 +121,12 @@ fn factory_pane_configs_none_effort_uses_role_defaults() {
         .iter()
         .position(|a| a == "--effort")
         .expect("worker PTY args must contain --effort");
+    let worker_effort_val = worker_config
+        .args
+        .get(worker_effort_idx + 1)
+        .expect("--effort must be followed by a value in worker PTY args");
     assert_eq!(
-        worker_config.args[worker_effort_idx + 1], "high",
+        worker_effort_val, "high",
         "worker with no effort override must default to high"
     );
 }

--- a/crates/cas-mux/src/mux_tests/tests.rs
+++ b/crates/cas-mux/src/mux_tests/tests.rs
@@ -52,8 +52,8 @@ fn factory_pane_configs_worker_effort_reaches_pty_args() {
 
     let (_, worker_config) = configs
         .iter()
-        .find(|(name, _)| name != &config.supervisor_name)
-        .expect("at least one worker config must be present");
+        .find(|(name, _)| name == "worker-1")
+        .expect("worker-1 config must be present");
     let effort_idx = worker_config
         .args
         .iter()
@@ -62,6 +62,12 @@ fn factory_pane_configs_worker_effort_reaches_pty_args() {
     assert_eq!(
         worker_config.args[effort_idx + 1], "high",
         "MuxConfig::worker_effort must reach worker PTY --effort arg"
+    );
+    // supervisor must be last in the returned vec (workers-first ordering)
+    assert_eq!(
+        configs.last().unwrap().0,
+        config.supervisor_name,
+        "supervisor must be the last entry in factory_pane_configs output"
     );
 }
 
@@ -98,8 +104,8 @@ fn factory_pane_configs_none_effort_uses_role_defaults() {
 
     let (_, worker_config) = configs
         .iter()
-        .find(|(name, _)| name != &config.supervisor_name)
-        .expect("worker config must be present");
+        .find(|(name, _)| name == "worker-1")
+        .expect("worker-1 config must be present");
     let worker_effort_idx = worker_config
         .args
         .iter()

--- a/crates/cas-mux/src/pane/mod.rs
+++ b/crates/cas-mux/src/pane/mod.rs
@@ -196,6 +196,45 @@ impl Pane {
         Self::with_pty(name, PaneKind::Shell, pty, rows, cols)
     }
 
+    /// Build the `PtyConfig` that `worker()` would spawn, without actually
+    /// spawning a process. Used by `Mux::factory_pane_configs` and tests.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_worker_config(
+        name: &str,
+        cwd: PathBuf,
+        cas_root: Option<&PathBuf>,
+        supervisor_name: &str,
+        cli: SupervisorCli,
+        model: Option<&str>,
+        effort: Option<&str>,
+        teams: Option<&TeamsSpawnConfig>,
+    ) -> PtyConfig {
+        match cli {
+            SupervisorCli::Claude => PtyConfig::claude(
+                name,
+                "worker",
+                cwd,
+                cas_root,
+                Some(supervisor_name),
+                None,
+                model,
+                effort,
+                teams,
+            ),
+            SupervisorCli::Codex => PtyConfig::codex(
+                name,
+                "worker",
+                cwd,
+                cas_root,
+                Some(supervisor_name),
+                None,
+                model,
+                effort,
+                teams,
+            ),
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn worker(
         name: &str,
@@ -209,38 +248,59 @@ impl Pane {
         cols: u16,
         teams: Option<&TeamsSpawnConfig>,
     ) -> Result<Self> {
-        match cli {
-            SupervisorCli::Claude => {
-                let config = PtyConfig::claude(
-                    name,
-                    "worker",
-                    cwd,
-                    cas_root,
-                    Some(supervisor_name),
-                    None,
-                    model,
-                    effort,
-                    teams,
-                );
-                let pty = Pty::spawn(name, config)?;
-                Self::with_pty(name, PaneKind::Worker, pty, rows, cols)
-            }
-            SupervisorCli::Codex => {
-                let config = PtyConfig::codex(
-                    name,
-                    "worker",
-                    cwd,
-                    cas_root,
-                    Some(supervisor_name),
-                    None,
-                    model,
-                    effort,
-                    teams,
-                );
-                let pty = Pty::spawn(name, config)?;
-                Self::with_pty(name, PaneKind::Worker, pty, rows, cols)
-            }
-        }
+        let config = Self::build_worker_config(
+            name, cwd, cas_root, supervisor_name, cli, model, effort, teams,
+        );
+        let pty = Pty::spawn(name, config)?;
+        Self::with_pty(name, PaneKind::Worker, pty, rows, cols)
+    }
+
+    /// Build the `PtyConfig` that `supervisor()` would spawn, without actually
+    /// spawning a process. Used by `Mux::factory_pane_configs` and tests.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_supervisor_config(
+        name: &str,
+        cwd: PathBuf,
+        cas_root: Option<&PathBuf>,
+        cli: SupervisorCli,
+        worker_cli: SupervisorCli,
+        worker_names: &[String],
+        model: Option<&str>,
+        effort: Option<&str>,
+        teams: Option<&TeamsSpawnConfig>,
+    ) -> PtyConfig {
+        let worker_cli_str = worker_cli.as_str();
+        let worker_names_csv = if worker_names.is_empty() {
+            None
+        } else {
+            Some(worker_names.join(","))
+        };
+        let mut config = match cli {
+            SupervisorCli::Claude => PtyConfig::claude(
+                name,
+                "supervisor",
+                cwd,
+                cas_root,
+                None,
+                Some(worker_cli_str),
+                model,
+                effort,
+                teams,
+            ),
+            SupervisorCli::Codex => PtyConfig::codex(
+                name,
+                "supervisor",
+                cwd,
+                cas_root,
+                None,
+                Some(worker_cli_str),
+                model,
+                effort,
+                teams,
+            ),
+        };
+        Self::push_supervisor_env(&mut config.env, cli, &worker_names_csv);
+        config
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -257,47 +317,11 @@ impl Pane {
         effort: Option<&str>,
         teams: Option<&TeamsSpawnConfig>,
     ) -> Result<Self> {
-        let worker_cli_str = worker_cli.as_str();
-        let worker_names_csv = if worker_names.is_empty() {
-            None
-        } else {
-            Some(worker_names.join(","))
-        };
-
-        match cli {
-            SupervisorCli::Claude => {
-                let mut config = PtyConfig::claude(
-                    name,
-                    "supervisor",
-                    cwd,
-                    cas_root,
-                    None,
-                    Some(worker_cli_str),
-                    model,
-                    effort,
-                    teams,
-                );
-                Self::push_supervisor_env(&mut config.env, cli, &worker_names_csv);
-                let pty = Pty::spawn(name, config)?;
-                Self::with_pty(name, PaneKind::Supervisor, pty, rows, cols)
-            }
-            SupervisorCli::Codex => {
-                let mut config = PtyConfig::codex(
-                    name,
-                    "supervisor",
-                    cwd,
-                    cas_root,
-                    None,
-                    Some(worker_cli_str),
-                    model,
-                    effort,
-                    teams,
-                );
-                Self::push_supervisor_env(&mut config.env, cli, &worker_names_csv);
-                let pty = Pty::spawn(name, config)?;
-                Self::with_pty(name, PaneKind::Supervisor, pty, rows, cols)
-            }
-        }
+        let config = Self::build_supervisor_config(
+            name, cwd, cas_root, cli, worker_cli, worker_names, model, effort, teams,
+        );
+        let pty = Pty::spawn(name, config)?;
+        Self::with_pty(name, PaneKind::Supervisor, pty, rows, cols)
     }
 
     fn push_supervisor_env(


### PR DESCRIPTION
## Summary

Recovery PR consolidating three pieces:

1. **cas-9393** (b427984, 68a5767) — Unit tests for `LlmConfig::reasoning_effort_for_role`. Originally on `factory/happy-puma-54`. Closed in CAS but never merged to main.
2. **cas-d571** (1b52d90, cc46094, d7eb478, 6bbcee1) — Integration tests for effort config flow through `Mux::factory()`, including extracted `Pane::build_worker_config` + `Pane::build_supervisor_config` + `Mux::factory_pane_configs` builders. Originally on `factory/happy-puma-54`. Closed in CAS but never merged to main.
3. **cas-c0e0 regression fix** (5f99ac2) — Add missing `resolved_worker_specs` + `resolved_supervisor_spec` defaults to `FactoryConfig` constructors in `cas-cli/src/cli/factory/{daemon.rs:82, mod.rs:888}`. cas-c0e0 (3dc7488) added these fields but didn't update the cas-cli constructors. Without this fix, `cargo build -p cas` and `cargo test --workspace` fail E0063 on main.

## Test plan

- [x] `cargo test -p cas --lib config::settings::tests` — 10/10 pass (cas-9393's 8 tests + 2 pre-existing).
- [x] `cargo test -p cas-mux --lib` — 28/28 pass (was 25 on main, +3 from cas-d571 effort flow tests).
- [x] `cargo test -p cas-factory --lib` — 93/93 pass (cas-c0e0 regression no longer blocks).
- [x] `cargo build --workspace` — succeeds (cas-cli compile fixed).
- [ ] `cargo test --workspace` — full suite still has pre-existing breakage in `cas-cli/tests/{mcp_tools_test,factory_mcp_ops_test}` from a separate API drift (`CasService::new` signature change + `FactoryRequest.id` field added without updating test callsites). Not introduced by this PR. Will file as a separate task.

## Why a single recovery PR

happy-puma-54's branch had 8 commits ahead of main; 2 of those (`a1d63f1` codex config, `ba0ab4c` ghostty deletion) duplicate content that already lives on main via the squash merges of PR #5 and PR #6, with a merge conflict in `.codex/config.toml`. Cherry-picking only the 6 useful commits onto a fresh branch from main avoided the conflict. The factory-config regression fix piggybacks because it was discovered while running the full test suite on the recovery branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)