### PR TITLE
feat(cas-6804): add `cas cloud team default` subcommand

### DIFF
--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -4,7 +4,7 @@
 
 use clap::{Parser, Subcommand};
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::cli::Cli;
@@ -47,20 +47,41 @@ pub enum CloudCommands {
 /// Subcommands for `cas cloud team`
 #[derive(Subcommand)]
 pub enum CloudTeamCommands {
-    /// Set the active team by UUID
+    /// Set the user-level default team (resolves slug or UUID against cached memberships)
     ///
-    /// The team is persisted in `~/.cas/cloud.json` and used by team-scoped
-    /// sync operations (push to `/api/teams/{uuid}/sync/push`, pull via
-    /// `cas cloud team-memories`).
+    /// Writes `default_team_id` to `~/.cas/cloud.json`. All projects without an
+    /// explicit per-project team override (`cas cloud team set`) will use this
+    /// default for team-scoped sync.
     ///
-    /// Only UUID input is supported today — slug resolution requires a
-    /// cloud-side endpoint that is not yet available. Find your team UUID
-    /// in the CAS Cloud dashboard under team settings.
+    /// Use `--personal` to revert to personal scope (clears the default).
+    ///
+    /// Requires cached team memberships — run `cas cloud login` first if you see
+    /// "team not found" errors.
+    Default(CloudTeamDefaultArgs),
+    /// Set the per-project team override by UUID (advanced / escape hatch)
+    ///
+    /// Writes `team_id` to `<project>/.cas/cloud.json`. Prefer
+    /// `cas cloud team default <slug>` for the normal first-time setup path.
     Set(CloudTeamSetArgs),
     /// Show the currently configured team
     Show,
     /// Clear the configured team (no more team-scoped sync)
     Clear,
+}
+
+/// Arguments for `cas cloud team default`.
+#[derive(Parser)]
+pub struct CloudTeamDefaultArgs {
+    /// Team slug or UUID to set as the user-level default.
+    ///
+    /// Resolved against the cached team memberships in `~/.cas/cloud.json`.
+    /// Omit when using `--personal`.
+    #[arg(required_unless_present = "personal")]
+    pub slug_or_uuid: Option<String>,
+
+    /// Clear the default team and revert to personal scope.
+    #[arg(long, conflicts_with = "slug_or_uuid")]
+    pub personal: bool,
 }
 
 #[derive(Parser)]
@@ -278,6 +299,15 @@ pub fn execute_team(
     cas_root: &Path,
 ) -> anyhow::Result<()> {
     match cmd {
+        CloudTeamCommands::Default(args) => {
+            // `default` writes to the user-level ~/.cas/cloud.json, not the
+            // project's .cas/. Resolve the user cas dir here so the inner
+            // function stays injected (and testable).
+            let user_cas_dir = dirs::home_dir()
+                .map(|h| h.join(".cas"))
+                .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
+            execute_team_default_inner(args, cli, &user_cas_dir)
+        }
         CloudTeamCommands::Set(args) => execute_team_set(args, cli, cas_root),
         CloudTeamCommands::Show => execute_team_show(cli, cas_root).map(|_| ()),
         CloudTeamCommands::Clear => execute_team_clear(cli),
@@ -330,6 +360,132 @@ fn execute_project_set(
         fmt.newline()?;
     }
     Ok(())
+}
+
+// ─── TEAM DEFAULT ────────────────────────────────────────────────────────────
+
+/// Testable entrypoint for `cas cloud team default` — call this directly from
+/// integration tests to avoid touching the real `~/.cas/cloud.json`.
+///
+/// `user_cas_dir` is normally `~/.cas/` (resolved by the dispatcher) but can
+/// be any tempdir in tests — same injected-path pattern as `execute_team_set`.
+#[doc(hidden)]
+pub fn execute_team_default_for_test(
+    args: &CloudTeamDefaultArgs,
+    cli: &Cli,
+    user_cas_dir: &PathBuf,
+) -> anyhow::Result<serde_json::Value> {
+    execute_team_default_inner(args, cli, user_cas_dir)?;
+    // Return the updated config as JSON for assertion convenience.
+    let cfg = CloudConfig::load_from_cas_dir(user_cas_dir)?;
+    Ok(serde_json::json!({
+        "default_team_id": cfg.default_team_id,
+    }))
+}
+
+/// Inner implementation for `cas cloud team default`.
+///
+/// Accepts an injected `user_cas_dir` so integration tests can point it at a
+/// tempdir.  The dispatcher resolves `~/.cas/` before calling this.
+fn execute_team_default_inner(
+    args: &CloudTeamDefaultArgs,
+    cli: &Cli,
+    user_cas_dir: &Path,
+) -> anyhow::Result<()> {
+    let mut config = CloudConfig::load_from_cas_dir(user_cas_dir)?;
+
+    if args.personal {
+        let was_set = config.default_team_id.is_some();
+        config.default_team_id = None;
+        config.save_to_cas_dir(user_cas_dir)?;
+
+        if cli.json {
+            println!(
+                "{}",
+                serde_json::json!({ "status": "ok", "default_team_id": serde_json::Value::Null, "was_set": was_set })
+            );
+        } else {
+            let theme = ActiveTheme::default();
+            let mut out = io::stdout();
+            let mut fmt = Formatter::stdout(&mut out, theme);
+            let success_color = fmt.theme().palette.status_success;
+            fmt.newline()?;
+            fmt.write_colored("  \u{2713} ", success_color)?;
+            fmt.write_raw(if was_set {
+                "Default team cleared — syncing to personal scope"
+            } else {
+                "No default team was configured"
+            })?;
+            fmt.newline()?;
+        }
+        return Ok(());
+    }
+
+    // Slug-or-UUID lookup against cached teams[].
+    let query = args
+        .slug_or_uuid
+        .as_deref()
+        .expect("slug_or_uuid is required unless --personal is set");
+
+    let matched = config
+        .teams
+        .iter()
+        .find(|t| t.slug == query || t.id == query)
+        .cloned();
+
+    match matched {
+        Some(team) => {
+            config.default_team_id = Some(team.id.clone());
+            config.save_to_cas_dir(user_cas_dir)?;
+
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "status": "ok",
+                        "default_team_id": team.id,
+                        "team_slug": team.slug,
+                        "team_name": team.name,
+                    })
+                );
+            } else {
+                let theme = ActiveTheme::default();
+                let mut out = io::stdout();
+                let mut fmt = Formatter::stdout(&mut out, theme);
+                let success_color = fmt.theme().palette.status_success;
+                fmt.newline()?;
+                fmt.write_colored("  \u{2713} ", success_color)?;
+                fmt.write_raw("Default team set")?;
+                fmt.newline()?;
+                fmt.write_muted("  Team:  ")?;
+                fmt.write_raw(&team.name)?;
+                fmt.newline()?;
+                fmt.write_muted("  Slug:  ")?;
+                fmt.write_raw(&team.slug)?;
+                fmt.newline()?;
+                fmt.write_muted("  UUID:  ")?;
+                fmt.write_raw(&team.id)?;
+                fmt.newline()?;
+            }
+            Ok(())
+        }
+        None => {
+            let hint = if config.teams.is_empty() {
+                "Run `cas cloud login` to refresh team membership.".to_string()
+            } else {
+                let available: Vec<&str> = config.teams.iter().map(|t| t.slug.as_str()).collect();
+                format!(
+                    "Available teams: {}.\nRun `cas cloud login` to refresh team membership.",
+                    available.join(", ")
+                )
+            };
+            anyhow::bail!(
+                "Team {:?} not found in cached memberships.\n{}",
+                query,
+                hint
+            )
+        }
+    }
 }
 
 fn execute_team_set(

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -17,6 +17,8 @@ use std::sync::Mutex;
 use crate::error::CasError;
 use crate::store::find_cas_root;
 
+// `dirs` used by `user_config_path()` / `load_user()` / `save_user()`
+
 /// Cached project canonical ID. Only `Some` results are cached; if resolution
 /// returns `None` (e.g. `find_cas_root()` fails because the process started
 /// outside a CAS project), the next call retries instead of locking in `None`
@@ -450,6 +452,39 @@ impl Default for CloudConfig {
 }
 
 impl CloudConfig {
+    /// Return the path to the user-level `~/.cas/cloud.json`.
+    ///
+    /// Returns `None` only when `dirs::home_dir()` fails — practically
+    /// unreachable on any supported platform (Linux/macOS).
+    pub fn user_config_path() -> Option<PathBuf> {
+        dirs::home_dir().map(|h| h.join(".cas").join("cloud.json"))
+    }
+
+    /// Load the user-level cloud config from `~/.cas/cloud.json`.
+    ///
+    /// Falls back to `Default::default()` when the file is absent — identical
+    /// semantics to `load_from` for a missing file.  This is the user-scope
+    /// counterpart to `load()` (project scope).
+    pub fn load_user() -> Result<Self, CasError> {
+        match Self::user_config_path() {
+            Some(path) => Self::load_from(&path),
+            None => Ok(Self::default()),
+        }
+    }
+
+    /// Save the user-level cloud config to `~/.cas/cloud.json`.
+    ///
+    /// Creates `~/.cas/` if it does not already exist.  This is the
+    /// user-scope counterpart to `save()` (project scope).
+    pub fn save_user(&self) -> Result<(), CasError> {
+        let path = Self::user_config_path()
+            .ok_or_else(|| CasError::Other("Cannot determine home directory".to_string()))?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        self.save_to(&path)
+    }
+
     /// Load cloud config from .cas/cloud.json
     pub fn load() -> Result<Self, CasError> {
         let path = Self::config_path()?;

--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -23,7 +23,7 @@ mod sync_queue;
 mod syncer;
 
 pub use config::{
-    CloudConfig, canonical_id_from_config_toml, derive_canonical_id_from_git_remote,
+    CloudConfig, TeamInfo, canonical_id_from_config_toml, derive_canonical_id_from_git_remote,
     get_project_canonical_id, set_canonical_id_in_config_toml,
 };
 pub(crate) use config::{default_endpoint, is_acceptable_endpoint};

--- a/cas-cli/tests/team_default_test.rs
+++ b/cas-cli/tests/team_default_test.rs
@@ -1,0 +1,228 @@
+//! Integration tests for `cas cloud team default` subcommand (cas-6804).
+//!
+//! Verifies:
+//! - Setting default by slug resolves against cached teams[] and writes
+//!   `default_team_id` to the injected user_cas_dir.
+//! - Setting default by UUID works the same way.
+//! - `--personal` clears `default_team_id`.
+//! - Clear error when slug/uuid doesn't match any cached team.
+//! - Helpful error when teams[] is empty (not yet refreshed via login).
+//!
+//! Tests use the injected `user_cas_dir` path (via
+//! `execute_team_default_for_test`) to avoid touching the real
+//! `~/.cas/cloud.json` — same pattern as `team_set_slug_resolution_test.rs`.
+
+use cas::cli::cloud::{CloudTeamDefaultArgs, execute_team_default_for_test};
+use cas::cloud::{CloudConfig, TeamInfo};
+use tempfile::TempDir;
+
+mod common;
+use common::make_cli_json;
+
+/// Build a user-level cas dir (tempdir) seeded with the given teams and
+/// optional default_team_id. Returns the TempDir (caller must keep it alive).
+fn seed_user_cas_dir(teams: Vec<TeamInfo>, default_team_id: Option<String>) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    let mut cfg = CloudConfig::default();
+    cfg.token = Some("test-token".to_string());
+    cfg.teams = teams;
+    cfg.default_team_id = default_team_id;
+    cfg.save_to_cas_dir(dir).unwrap();
+    tmp
+}
+
+fn make_team(id: &str, slug: &str, name: &str) -> TeamInfo {
+    TeamInfo {
+        id: id.to_string(),
+        slug: slug.to_string(),
+        name: name.to_string(),
+        role: "member".to_string(),
+    }
+}
+
+// ── Happy-path: set by slug ──────────────────────────────────────────────────
+
+/// AC: `cas cloud team default <slug>` resolves slug against cached teams[]
+/// and writes `default_team_id` (the UUID) to user-level cloud.json.
+#[test]
+fn team_default_by_slug_writes_team_id() {
+    let teams = vec![
+        make_team("tid-alpha", "alpha-team", "Alpha Team"),
+        make_team("tid-beta", "beta-team", "Beta Team"),
+    ];
+    let tmp = seed_user_cas_dir(teams, None);
+    let dir = tmp.path().to_path_buf();
+
+    let args = CloudTeamDefaultArgs {
+        slug_or_uuid: Some("alpha-team".to_string()),
+        personal: false,
+    };
+    let cli = make_cli_json();
+
+    let result = execute_team_default_for_test(&args, &cli, &dir).unwrap();
+    assert_eq!(
+        result["default_team_id"].as_str(),
+        Some("tid-alpha"),
+        "default_team_id must be the UUID of the matched team, not the slug"
+    );
+
+    // Verify it persisted to disk.
+    let loaded = CloudConfig::load_from_cas_dir(&dir).unwrap();
+    assert_eq!(loaded.default_team_id, Some("tid-alpha".to_string()));
+}
+
+// ── Happy-path: set by UUID ──────────────────────────────────────────────────
+
+/// AC: `cas cloud team default <uuid>` resolves against teams[].id and writes
+/// `default_team_id` to user-level cloud.json.
+#[test]
+fn team_default_by_uuid_writes_team_id() {
+    let teams = vec![make_team("tid-gamma", "gamma-team", "Gamma Team")];
+    let tmp = seed_user_cas_dir(teams, None);
+    let dir = tmp.path().to_path_buf();
+
+    let args = CloudTeamDefaultArgs {
+        slug_or_uuid: Some("tid-gamma".to_string()),
+        personal: false,
+    };
+    let cli = make_cli_json();
+
+    let result = execute_team_default_for_test(&args, &cli, &dir).unwrap();
+    assert_eq!(result["default_team_id"].as_str(), Some("tid-gamma"));
+
+    let loaded = CloudConfig::load_from_cas_dir(&dir).unwrap();
+    assert_eq!(loaded.default_team_id, Some("tid-gamma".to_string()));
+}
+
+// ── Happy-path: --personal clears default ───────────────────────────────────
+
+/// AC: `cas cloud team default --personal` clears `default_team_id` to None.
+#[test]
+fn team_default_personal_clears_default_team_id() {
+    let teams = vec![make_team("tid-delta", "delta-team", "Delta Team")];
+    let tmp = seed_user_cas_dir(teams, Some("tid-delta".to_string()));
+    let dir = tmp.path().to_path_buf();
+
+    // Precondition: default_team_id is set.
+    let pre = CloudConfig::load_from_cas_dir(&dir).unwrap();
+    assert_eq!(pre.default_team_id, Some("tid-delta".to_string()));
+
+    let args = CloudTeamDefaultArgs {
+        slug_or_uuid: None,
+        personal: true,
+    };
+    let cli = make_cli_json();
+    let result = execute_team_default_for_test(&args, &cli, &dir).unwrap();
+    assert!(
+        result["default_team_id"].is_null(),
+        "default_team_id must be null after --personal, got: {}",
+        result
+    );
+
+    let loaded = CloudConfig::load_from_cas_dir(&dir).unwrap();
+    assert!(
+        loaded.default_team_id.is_none(),
+        "default_team_id must be None on disk after --personal"
+    );
+}
+
+/// AC: `cas cloud team default --personal` is a no-op (not an error) when no
+/// default was set.
+#[test]
+fn team_default_personal_is_noop_when_not_set() {
+    let tmp = seed_user_cas_dir(vec![], None);
+    let dir = tmp.path().to_path_buf();
+
+    let args = CloudTeamDefaultArgs {
+        slug_or_uuid: None,
+        personal: true,
+    };
+    let cli = make_cli_json();
+    let result = execute_team_default_for_test(&args, &cli, &dir);
+    assert!(result.is_ok(), "--personal on unset config must not error");
+    let loaded = CloudConfig::load_from_cas_dir(&dir).unwrap();
+    assert!(loaded.default_team_id.is_none());
+}
+
+// ── Error path: slug/uuid not found in teams[] ───────────────────────────────
+
+/// AC: clear error when the slug/UUID is not in the cached teams[].
+#[test]
+fn team_default_errors_when_slug_not_found() {
+    let teams = vec![make_team("tid-eta", "eta-team", "Eta Team")];
+    let tmp = seed_user_cas_dir(teams, None);
+    let dir = tmp.path().to_path_buf();
+
+    let args = CloudTeamDefaultArgs {
+        slug_or_uuid: Some("nonexistent-team".to_string()),
+        personal: false,
+    };
+    let cli = make_cli_json();
+    let err = execute_team_default_for_test(&args, &cli, &dir)
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        err.contains("nonexistent-team"),
+        "error must echo the unknown query, got: {err}"
+    );
+}
+
+/// AC: when teams[] is empty, error message tells the user to run
+/// `cas cloud login` to refresh team membership.
+#[test]
+fn team_default_errors_with_login_hint_when_teams_empty() {
+    let tmp = seed_user_cas_dir(vec![], None);
+    let dir = tmp.path().to_path_buf();
+
+    let args = CloudTeamDefaultArgs {
+        slug_or_uuid: Some("my-team".to_string()),
+        personal: false,
+    };
+    let cli = make_cli_json();
+    let err = execute_team_default_for_test(&args, &cli, &dir)
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        err.contains("cas cloud login"),
+        "error must suggest running `cas cloud login` when teams[] is empty, got: {err}"
+    );
+}
+
+// ── Persistence invariants ───────────────────────────────────────────────────
+
+/// Existing `team_id` (per-project field) in the same cloud.json must not
+/// be disturbed when `default_team_id` is written — the two fields are
+/// independent.
+#[test]
+fn team_default_does_not_overwrite_existing_team_id() {
+    let teams = vec![make_team("tid-zeta", "zeta-team", "Zeta Team")];
+    let tmp = seed_user_cas_dir(teams, None);
+    let dir = tmp.path().to_path_buf();
+
+    // Pre-seed a team_id (per-project override field).
+    let mut pre = CloudConfig::load_from_cas_dir(&dir).unwrap();
+    pre.team_id = Some("original-project-team-id".to_string());
+    pre.save_to_cas_dir(&dir).unwrap();
+
+    let args = CloudTeamDefaultArgs {
+        slug_or_uuid: Some("zeta-team".to_string()),
+        personal: false,
+    };
+    let cli = make_cli_json();
+    execute_team_default_for_test(&args, &cli, &dir).unwrap();
+
+    let loaded = CloudConfig::load_from_cas_dir(&dir).unwrap();
+    assert_eq!(
+        loaded.team_id,
+        Some("original-project-team-id".to_string()),
+        "existing team_id (per-project) must be preserved"
+    );
+    assert_eq!(
+        loaded.default_team_id,
+        Some("tid-zeta".to_string()),
+        "default_team_id must be written"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `cas cloud team default <slug|uuid>` — resolves against cached `teams[]`, writes `default_team_id` to `~/.cas/cloud.json`
- Adds `cas cloud team default --personal` — clears `default_team_id` (personal scope)
- Updates `cas cloud team set` help text to reposition it as per-project override / escape hatch
- Adds `user_config_path()`, `load_user()`, `save_user()` to `CloudConfig` for explicit user-level config access
- Re-exports `TeamInfo` from the `cas` crate (needed by integration tests)
- `cas cloud team set` (per-project override) untouched

## Test plan

- [ ] `cargo test --test team_default_test` → 7/7 pass
  - slug lookup writes UUID as default_team_id
  - UUID lookup works the same way
  - `--personal` clears default_team_id
  - `--personal` is noop when unset (no error)
  - error when slug/UUID not in cached teams[]
  - error with `cas cloud login` hint when teams[] is empty
  - existing team_id (per-project) preserved after default write
- [ ] `cargo test --test team_set_slug_resolution_test` → 6/6 pass (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)