### PR TITLE
docs(cas-6b8b): reposition `cas cloud team set` as override-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,25 +302,34 @@ Share learnings across a team without manual flags. After an admin has
 created a team in the CAS Cloud dashboard:
 
 ```bash
-# One-time setup per machine — UUID from your team dashboard
+# Standard setup — log in, then set your user-wide team default by slug
 cas login
-cas cloud team set 550e8400-e29b-41d4-a716-446655440000
+cas cloud team default petra-stella   # slug from your team dashboard
 
 # From now on, every memory captured via mcp__cas__memory
 # action=remember (Claude Code) in a Project-scoped, non-Preference
-# context automatically dual-enqueues into the team push queue.
+# context automatically dual-enqueues into the team push queue
+# across all your CAS-initialized projects.
 
 # Next sync drains both personal and team queues
 cas cloud sync
 ```
 
-Teammates on a fresh machine see what you've shared with the same
-zero-flag setup:
+Teammates on a fresh machine get the same setup:
 
 ```bash
 cas login
-cas cloud team set 550e8400-e29b-41d4-a716-446655440000
+cas cloud team default petra-stella
 cas cloud team-memories
+```
+
+**Multiple teams.** If you belong to more than one team, set the
+user-wide default once, then override per-project as needed:
+
+```bash
+cas cloud team default petra-stella          # user-wide default (all projects)
+cas cloud team set <uuid>                    # per-project override (this dir only)
+cas cloud team default --personal            # revert to personal scope (no team)
 ```
 
 **Backfilling pre-existing memories.** If you had personal entries

--- a/cas-cli/src/cli/memory.rs
+++ b/cas-cli/src/cli/memory.rs
@@ -95,7 +95,8 @@ pub fn execute_share(args: &ShareArgs, cas_root: &Path) -> anyhow::Result<()> {
         eprintln!(
             "warning: no active team configured (or team_auto_promote disabled). \
              Entries will be marked share=Team on disk but no team-queue rows will \
-             be enqueued until you run `cas cloud team set <uuid>` and write again."
+             be enqueued until you run `cas cloud team default <slug>` (user-wide) \
+             or `cas cloud team set <uuid>` (per-project) and write again."
         );
     }
 

--- a/cas-cli/src/mcp/tools/service/worktree_verification_team_ops.rs
+++ b/cas-cli/src/mcp/tools/service/worktree_verification_team_ops.rs
@@ -170,7 +170,8 @@ impl CasService {
                 output.push_str("\nUse `team show` for detailed team statistics.");
             } else {
                 output.push_str("No team configured.\n\n");
-                output.push_str("To join a team, use `cas cloud team set <team-id>`.\n");
+                output.push_str("To set a user-wide team default, run `cas cloud team default <slug>`.\n");
+                output.push_str("For a per-project override, use `cas cloud team set <uuid>`.\n");
                 output.push_str("To view all your teams, visit the CAS Cloud web dashboard.");
             }
 
@@ -199,7 +200,7 @@ impl CasService {
                 .ok_or_else(|| {
                     Self::error(
                         ErrorCode::INVALID_PARAMS,
-                        "team_id required (or set default with cas cloud team set)",
+                        "team_id required (or set user-wide default with `cas cloud team default <slug>`)",
                     )
                 })?;
 


### PR DESCRIPTION
## Summary

- README "Team Memories" section updated: new primary flow is `cas login` + `cas cloud team default <slug>`; `cas cloud team set <uuid>` repositioned as per-project override (advanced)
- `cas memory share --all` documented as retroactive promotion path (was already there, now more prominent)
- `--personal` flag documented for reverting to personal scope
- Runtime guidance strings in `worktree_verification_team_ops.rs` and `memory.rs` updated to suggest `cas cloud team default <slug>` first, then `team set` as the per-project form

CLI `--help` for `cas cloud team set` was already repositioned in cas-6804.

## Test plan

- [ ] `cargo build -p cas` → clean (no errors)
- [ ] `grep -n "cas cloud team default" README.md` → ≥4 occurrences showing new flow
- [ ] `grep -n "override\|escape hatch" cas-cli/src/cli/cloud.rs` → Set carries override-only positioning
- [ ] `cas memory share --all` still documented in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)