### PR TITLE
feat(cas-ea2f5): resolution chain in active_team_id()

### DIFF
--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -725,6 +725,99 @@ mod tests {
         assert_eq!(config.active_team_id(), None);
     }
 
+    // ── cas-ea2f5: resolution-chain unit tests (test-first, added before impl) ──
+
+    #[test]
+    fn test_active_team_id_user_default_team_fallback() {
+        let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // No project-level team_id, user config has default_team_id set → return it.
+        let project_cfg = CloudConfig::default(); // no team_id
+        let mut user_cfg = CloudConfig::default();
+        user_cfg.default_team_id = Some("user-default-team".to_string());
+
+        assert_eq!(
+            project_cfg.active_team_id_with_user_config(Some(&user_cfg)).as_deref(),
+            Some("user-default-team"),
+        );
+    }
+
+    #[test]
+    fn test_active_team_id_single_team_auto_pick() {
+        let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // No project-level team_id, user config has exactly 1 team, no default_team_id
+        // → return the sole team's id.
+        let project_cfg = CloudConfig::default();
+        let mut user_cfg = CloudConfig::default();
+        user_cfg.teams = vec![TeamInfo {
+            id: "solo-team-id".to_string(),
+            slug: "solo".to_string(),
+            name: "Solo".to_string(),
+            role: "member".to_string(),
+        }];
+
+        assert_eq!(
+            project_cfg.active_team_id_with_user_config(Some(&user_cfg)).as_deref(),
+            Some("solo-team-id"),
+        );
+    }
+
+    #[test]
+    fn test_active_team_id_multi_team_ambiguous_returns_none() {
+        let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // No project-level team_id, user config has 2 teams but no default_team_id
+        // → None (ambiguous).
+        let project_cfg = CloudConfig::default();
+        let mut user_cfg = CloudConfig::default();
+        user_cfg.teams = vec![
+            TeamInfo { id: "t1".to_string(), slug: "a".to_string(), name: "A".to_string(), role: "member".to_string() },
+            TeamInfo { id: "t2".to_string(), slug: "b".to_string(), name: "B".to_string(), role: "member".to_string() },
+        ];
+
+        assert_eq!(
+            project_cfg.active_team_id_with_user_config(Some(&user_cfg)),
+            None,
+        );
+    }
+
+    #[test]
+    fn test_active_team_id_project_override_beats_user_default() {
+        let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // Project-level team_id wins over user-level default_team_id.
+        let mut project_cfg = CloudConfig::default();
+        project_cfg.set_team("project-team", "proj");
+        let mut user_cfg = CloudConfig::default();
+        user_cfg.default_team_id = Some("user-default-team".to_string());
+
+        assert_eq!(
+            project_cfg.active_team_id_with_user_config(Some(&user_cfg)).as_deref(),
+            Some("project-team"),
+        );
+    }
+
+    #[test]
+    fn test_active_team_id_kill_switch_beats_user_config() {
+        let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // team_auto_promote=Some(false) short-circuits to None even when user
+        // config would otherwise supply a team.
+        let mut project_cfg = CloudConfig::default();
+        project_cfg.team_auto_promote = Some(false);
+        let mut user_cfg = CloudConfig::default();
+        user_cfg.default_team_id = Some("user-default-team".to_string());
+
+        assert_eq!(
+            project_cfg.active_team_id_with_user_config(Some(&user_cfg)),
+            None,
+        );
+    }
+
+    #[test]
+    fn test_active_team_id_no_user_config_no_project_team() {
+        let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // Neither project nor user config has team info → None.
+        let project_cfg = CloudConfig::default();
+        assert_eq!(project_cfg.active_team_id_with_user_config(None), None);
+    }
+
     #[test]
     fn test_team_sync_timestamps() {
         let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -421,6 +421,23 @@ pub(crate) fn default_endpoint() -> String {
         .unwrap_or_else(|| "https://petra-stella-cloud.vercel.app".to_string())
 }
 
+/// Resolve the path to the user-level `~/.cas/cloud.json`.
+///
+/// In normal operation returns `~/.cas/cloud.json`.
+///
+/// Test seam: when the `CAS_USER_CLOUD_JSON` environment variable is set to
+/// a non-empty value, that path is used instead. This mirrors the
+/// `CAS_CLOUD_ENDPOINT` pattern and lets integration tests inject a
+/// controlled user-level config without touching the real `~/.cas/`.
+pub(crate) fn user_level_cloud_json_path() -> Option<std::path::PathBuf> {
+    if let Ok(override_path) = std::env::var("CAS_USER_CLOUD_JSON") {
+        if !override_path.trim().is_empty() {
+            return Some(std::path::PathBuf::from(override_path));
+        }
+    }
+    dirs::home_dir().map(|h| h.join(".cas").join("cloud.json"))
+}
+
 /// Serialises all `CAS_CLOUD_ENDPOINT` mutations in tests.
 /// Defined outside `mod tests` so `auth.rs` tests can share the same mutex.
 #[cfg(test)]
@@ -561,19 +578,58 @@ impl CloudConfig {
         self.team_id.is_some()
     }
 
-    /// Return the team UUID to auto-promote writes to, or `None` if team
-    /// auto-promotion is disabled for this folder.
+    /// Core resolution logic for `active_team_id`, split out so unit tests
+    /// can inject a controlled user-level config without touching disk.
     ///
-    /// Distinct from `team_id` directly: this accessor honours the
-    /// `team_auto_promote` coarse kill-switch. `Some(false)` on
-    /// `team_auto_promote` returns `None` here even if `team_id` is set —
-    /// the user has opted out of automatic dual-enqueue. Callers building
-    /// the T1 filter predicate should use this accessor, not `team_id`.
-    pub fn active_team_id(&self) -> Option<&str> {
+    /// Resolution chain (highest priority first):
+    /// 0. Kill-switch: `team_auto_promote = Some(false)` → always `None`.
+    /// 1. `self.team_id` if `Some` → project-level explicit override.
+    /// 2. `user_cfg.default_team_id` if `Some` → user's preferred team.
+    /// 3. `user_cfg.teams.len() == 1` → implicit single-team auto-pick.
+    /// 4. `None` — ambiguous (0 or 2+ teams) or no user config at all.
+    pub fn active_team_id_with_user_config(&self, user_cfg: Option<&CloudConfig>) -> Option<String> {
+        // Step 0 — coarse kill-switch.
         if matches!(self.team_auto_promote, Some(false)) {
             return None;
         }
-        self.team_id.as_deref()
+        // Step 1 — project-level explicit override wins.
+        if let Some(ref tid) = self.team_id {
+            return Some(tid.clone());
+        }
+        // Steps 2–4 — fall through to user-level config.
+        if let Some(user) = user_cfg {
+            // Step 2 — user has a default team preference.
+            if let Some(ref dtid) = user.default_team_id {
+                return Some(dtid.clone());
+            }
+            // Step 3 — implicit single-team auto-pick.
+            if user.teams.len() == 1 {
+                return Some(user.teams[0].id.clone());
+            }
+        }
+        // Step 4 — ambiguous or no membership.
+        None
+    }
+
+    /// Return the team UUID to auto-promote writes to, or `None` if team
+    /// auto-promotion is disabled for this folder.
+    ///
+    /// Walks the full resolution chain — project-level `team_id` first, then
+    /// user-level `~/.cas/cloud.json` (`default_team_id` → single-team
+    /// auto-pick → `None`). Distinct from reading `team_id` directly: this
+    /// accessor honours the `team_auto_promote` coarse kill-switch.
+    /// `Some(false)` on `team_auto_promote` returns `None` here even if
+    /// `team_id` is set — the user has opted out of automatic dual-enqueue.
+    /// Callers building the T1 filter predicate should use this accessor,
+    /// not `team_id`.
+    ///
+    /// For unit-testable access without disk I/O, use
+    /// [`active_team_id_with_user_config`][Self::active_team_id_with_user_config]
+    /// directly.
+    pub fn active_team_id(&self) -> Option<String> {
+        let user_cfg = user_level_cloud_json_path()
+            .and_then(|p| CloudConfig::load_from(&p).ok());
+        self.active_team_id_with_user_config(user_cfg.as_ref())
     }
 
     /// Set the current team context
@@ -691,27 +747,34 @@ mod tests {
     #[test]
     fn test_active_team_id_returns_none_when_no_team_set() {
         let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // Ensure no user-level config leaks in from ~/.cas/cloud.json.
+        unsafe { std::env::set_var("CAS_USER_CLOUD_JSON", "/nonexistent/path/cloud.json"); }
         let config = CloudConfig::default();
         assert_eq!(config.active_team_id(), None);
+        unsafe { std::env::remove_var("CAS_USER_CLOUD_JSON"); }
     }
 
     #[test]
     fn test_active_team_id_returns_team_when_auto_promote_is_default() {
         let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         // team_auto_promote=None is the default — auto-promote enabled.
+        unsafe { std::env::set_var("CAS_USER_CLOUD_JSON", "/nonexistent/path/cloud.json"); }
         let mut config = CloudConfig::default();
         config.set_team("team-abc", "my-team");
-        assert_eq!(config.active_team_id(), Some("team-abc"));
+        assert_eq!(config.active_team_id().as_deref(), Some("team-abc"));
         assert!(config.team_auto_promote.is_none());
+        unsafe { std::env::remove_var("CAS_USER_CLOUD_JSON"); }
     }
 
     #[test]
     fn test_active_team_id_returns_team_when_auto_promote_is_true() {
         let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        unsafe { std::env::set_var("CAS_USER_CLOUD_JSON", "/nonexistent/path/cloud.json"); }
         let mut config = CloudConfig::default();
         config.set_team("team-abc", "my-team");
         config.team_auto_promote = Some(true);
-        assert_eq!(config.active_team_id(), Some("team-abc"));
+        assert_eq!(config.active_team_id().as_deref(), Some("team-abc"));
+        unsafe { std::env::remove_var("CAS_USER_CLOUD_JSON"); }
     }
 
     #[test]
@@ -719,10 +782,12 @@ mod tests {
         let _guard = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         // The coarse kill-switch from Decision 3 of filter-policy.md —
         // team_id still set, but dual-enqueue is disabled.
+        unsafe { std::env::set_var("CAS_USER_CLOUD_JSON", "/nonexistent/path/cloud.json"); }
         let mut config = CloudConfig::default();
         config.set_team("team-abc", "my-team");
         config.team_auto_promote = Some(false);
         assert_eq!(config.active_team_id(), None);
+        unsafe { std::env::remove_var("CAS_USER_CLOUD_JSON"); }
     }
 
     // ── cas-ea2f5: resolution-chain unit tests (test-first, added before impl) ──

--- a/cas-cli/tests/active_team_id_integration_test.rs
+++ b/cas-cli/tests/active_team_id_integration_test.rs
@@ -1,0 +1,148 @@
+//! Integration tests for the active_team_id() user-level resolution chain
+//! (cas-ea2f5, T3 of EPIC cas-ab88).
+//!
+//! Verifies that when a project-level cloud.json has no `team_id` but a
+//! user-level cloud.json (simulated via the `CAS_USER_CLOUD_JSON` env-var
+//! override) has `default_team_id` set, `open_store` dual-enqueues writes to
+//! the team queue — i.e. `active_team_id()` surfaces the user default and the
+//! syncing store picks it up at open time.
+
+use std::sync::Mutex;
+
+use cas::cloud::{CloudConfig, SyncQueue};
+use cas::store::open_store;
+use cas::types::{Entry, EntryType, Scope};
+use tempfile::TempDir;
+
+/// Serialises all mutations of `CAS_USER_CLOUD_JSON` across threads within
+/// this test binary (each integration test file compiles to its own binary,
+/// so this mutex is sufficient for intra-file serialisation).
+static USER_CLOUD_LOCK: Mutex<()> = Mutex::new(());
+
+/// Team UUID written to user-level cloud.json as `default_team_id`.
+const USER_DEFAULT_TEAM: &str = "user-default-0000-0000-000000000001";
+
+/// Build a project-level CloudConfig with a token (so `is_logged_in()` is
+/// true) but without `team_id` — simulates a fresh checkout where the user
+/// hasn't run `cas cloud team set`.
+fn make_project_cloud_config_no_team() -> CloudConfig {
+    let mut cfg = CloudConfig::default();
+    cfg.endpoint = "http://localhost:0".to_string();
+    cfg.token = Some("test-token".to_string());
+    // team_id intentionally absent
+    cfg
+}
+
+/// Build a user-level CloudConfig with `default_team_id` set.
+fn make_user_cloud_config_with_default(default_team_id: &str) -> CloudConfig {
+    let mut cfg = CloudConfig::default();
+    cfg.default_team_id = Some(default_team_id.to_string());
+    cfg
+}
+
+fn queue_len_for_team(cas_dir: &std::path::Path, team_id: &str) -> usize {
+    let queue = SyncQueue::open(cas_dir).unwrap();
+    queue.init().unwrap();
+    queue
+        .pending_for_team(team_id, 1000, 10)
+        .map(|rows| rows.len())
+        .unwrap_or(0)
+}
+
+/// When the project-level cloud.json has no team_id but the user-level
+/// cloud.json sets default_team_id, `store.add()` (the `cas remember` path)
+/// dual-enqueues to the team queue.
+#[test]
+fn remember_dual_enqueues_via_user_level_default_team_id() {
+    let _guard = USER_CLOUD_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    // Create a temp dir for the user-level ~/.cas/cloud.json substitute.
+    let user_home_temp = TempDir::new().unwrap();
+    let user_cloud_json = user_home_temp.path().join("cloud.json");
+    make_user_cloud_config_with_default(USER_DEFAULT_TEAM)
+        .save_to(&user_cloud_json)
+        .unwrap();
+
+    // Point active_team_id() at our controlled user-level cloud.json.
+    // SAFETY: serialised by USER_CLOUD_LOCK; no concurrent env mutation.
+    unsafe { std::env::set_var("CAS_USER_CLOUD_JSON", &user_cloud_json); }
+
+    // Create a project cas_dir with a token but no team_id.
+    let project_temp = TempDir::new().unwrap();
+    make_project_cloud_config_no_team()
+        .save_to_cas_dir(project_temp.path())
+        .unwrap();
+
+    // open_store calls active_team_id() at construction time.
+    // Because the project config has no team_id, the resolution chain
+    // falls through to the user-level default_team_id set above.
+    let store = open_store(project_temp.path()).expect("open_store must succeed");
+
+    // Add a project-scoped entry — SyncingEntryStore should dual-enqueue it
+    // to the team queue because active_team_id() returned USER_DEFAULT_TEAM.
+    let entry = Entry {
+        id: "2026-05-15-t3-integration".to_string(),
+        scope: Scope::Project,
+        entry_type: EntryType::Learning,
+        content: "T3 integration: user-level default_team_id".to_string(),
+        ..Default::default()
+    };
+    store.add(&entry).expect("store.add must succeed");
+
+    // Verify the entry landed in the team queue for USER_DEFAULT_TEAM.
+    let queue_rows = queue_len_for_team(project_temp.path(), USER_DEFAULT_TEAM);
+    assert!(
+        queue_rows > 0,
+        "expected ≥1 row in team queue for {USER_DEFAULT_TEAM}, got {queue_rows}"
+    );
+
+    unsafe { std::env::remove_var("CAS_USER_CLOUD_JSON"); }
+}
+
+/// Project-level team_id wins over user-level default_team_id — the store
+/// should enqueue to the project team, not the user default.
+#[test]
+fn project_team_id_beats_user_default_in_open_store() {
+    let _guard = USER_CLOUD_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    const PROJECT_TEAM: &str = "project-team-0000-0000-000000000002";
+
+    let user_home_temp = TempDir::new().unwrap();
+    let user_cloud_json = user_home_temp.path().join("cloud.json");
+    make_user_cloud_config_with_default(USER_DEFAULT_TEAM)
+        .save_to(&user_cloud_json)
+        .unwrap();
+
+    unsafe { std::env::set_var("CAS_USER_CLOUD_JSON", &user_cloud_json); }
+
+    let project_temp = TempDir::new().unwrap();
+    // Build a project config WITH an explicit team_id.
+    let mut project_cfg = make_project_cloud_config_no_team();
+    project_cfg.set_team(PROJECT_TEAM, "project-team");
+    project_cfg.save_to_cas_dir(project_temp.path()).unwrap();
+
+    let store = open_store(project_temp.path()).expect("open_store must succeed");
+
+    let entry = Entry {
+        id: "2026-05-15-t3-project-override".to_string(),
+        scope: Scope::Project,
+        entry_type: EntryType::Learning,
+        content: "T3 integration: project override".to_string(),
+        ..Default::default()
+    };
+    store.add(&entry).expect("store.add must succeed");
+
+    // Entry lands in the PROJECT_TEAM queue, not the user default.
+    let project_rows = queue_len_for_team(project_temp.path(), PROJECT_TEAM);
+    let user_rows = queue_len_for_team(project_temp.path(), USER_DEFAULT_TEAM);
+    assert!(
+        project_rows > 0,
+        "expected ≥1 row in project team queue {PROJECT_TEAM}, got {project_rows}"
+    );
+    assert_eq!(
+        user_rows, 0,
+        "user-default team queue must stay empty when project team_id is set"
+    );
+
+    unsafe { std::env::remove_var("CAS_USER_CLOUD_JSON"); }
+}


### PR DESCRIPTION
## Summary

- Implements the 4-step resolution chain in `CloudConfig::active_team_id()` (cas-ea2f5, EPIC cas-ab88)
- Adds `active_team_id_with_user_config(&self, user_cfg: Option<&CloudConfig>) -> Option<String>` — pure, testable core
- Adds `user_level_cloud_json_path()` with `CAS_USER_CLOUD_JSON` test seam (mirrors `CAS_CLOUD_ENDPOINT` pattern)
- Return type changed `Option<&str>` → `Option<String>`; all callers compile cleanly

Chain order:
0. Kill-switch: `team_auto_promote=Some(false)` → None
1. `self.team_id` if Some → project-level override
2. user-level ~/.cas/cloud.json default_team_id if Some
3. user-level teams.len()==1 → single-team auto-pick
4. None (ambiguous or no membership)

## Test plan

- [x] 6 new unit tests in cloud::config::tests covering all resolution steps
- [x] 4 existing active_team_id unit tests updated for new Option<String> return type + env isolation
- [x] 2 integration tests in cas-cli/tests/active_team_id_integration_test.rs
- [x] All 49 cloud::config unit tests pass; 2 integration tests pass
- [x] memory_share_test (5/5), team_pull_wiring_test (7/7), team_sync_test (5/5) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)