### PR TITLE
feat(cas-7331): fetch /api/me after login + lazy refresh in sync

### DIFF
--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -208,6 +208,9 @@ insta = { version = "1.42", features = ["yaml", "json", "redactions"] }
 # HTTP mocking for cloud sync tests
 wiremock = "0.6"
 
+# Date/time in integration tests (teams_fetch_test.rs)
+chrono = { version = "0.4", features = ["serde"] }
+
 # Parametrized tests and fixtures
 rstest = "0.24"
 

--- a/cas-cli/src/cli/auth.rs
+++ b/cas-cli/src/cli/auth.rs
@@ -7,7 +7,7 @@ use std::io;
 use clap::{Parser, Subcommand};
 
 use crate::cli::Cli;
-use crate::cloud::{default_endpoint, is_acceptable_endpoint};
+use crate::cloud::{FetchTeamsOutcome, default_endpoint, fetch_and_cache_teams, is_acceptable_endpoint};
 use crate::ui::components::{
     Component, Formatter, Spinner, SpinnerMsg, clear_inline, render_inline_view, rerender_inline,
 };
@@ -345,6 +345,33 @@ fn execute_device_flow_login(args: &LoginArgs, cli: &Cli) -> anyhow::Result<()> 
                             config.save()?;
                         }
 
+                        // Best-effort: fetch team membership from /api/me and
+                        // cache into ~/.cas/cloud.json so T3's resolution chain
+                        // works offline immediately after login.
+                        match fetch_and_cache_teams(&args.endpoint, access_token) {
+                            FetchTeamsOutcome::Updated { team_count } => {
+                                tracing::debug!(
+                                    team_count,
+                                    "fetched and cached team membership from /api/me"
+                                );
+                            }
+                            FetchTeamsOutcome::Empty => {
+                                tracing::debug!("logged in but /api/me returned zero team memberships");
+                            }
+                            FetchTeamsOutcome::AuthFailed => {
+                                eprintln!(
+                                    "warning: could not fetch team membership (/api/me returned 401). \
+                                     Run `cas cloud login` again to refresh."
+                                );
+                            }
+                            FetchTeamsOutcome::NetworkError(msg) => {
+                                eprintln!(
+                                    "warning: could not fetch team membership: {msg}. \
+                                     Team auto-scope will work after the next `cas cloud sync`."
+                                );
+                            }
+                        }
+
                         if cli.json {
                             println!(r#"{{"status":"ok","email":"{}"}}"#, email.unwrap_or(""));
                         } else {
@@ -514,6 +541,26 @@ fn execute_login_with_token(token: &str, endpoint: &str, cli: &Cli) -> anyhow::R
         config.endpoint = endpoint.to_string();
         config.token = Some(token.to_string());
         config.save()?;
+    }
+
+    // Best-effort: fetch team membership from /api/me and cache into
+    // ~/.cas/cloud.json so T3's resolution chain works immediately.
+    match fetch_and_cache_teams(endpoint, token) {
+        FetchTeamsOutcome::Updated { team_count } => {
+            tracing::debug!(
+                team_count,
+                "fetched and cached team membership from /api/me"
+            );
+        }
+        FetchTeamsOutcome::Empty => {
+            tracing::debug!("logged in but /api/me returned zero team memberships");
+        }
+        FetchTeamsOutcome::AuthFailed | FetchTeamsOutcome::NetworkError(_) => {
+            // Token was just verified, so a 401 or network error here is
+            // a transient anomaly.  Swallow it silently; the next sync
+            // will retry via the lazy-refresh path.
+            tracing::warn!("could not fetch team membership from /api/me during token login (non-fatal)");
+        }
     }
 
     if cli.json {

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::cli::Cli;
-use crate::cloud::{CloudConfig, get_project_canonical_id};
+use crate::cloud::{CloudConfig, FetchTeamsOutcome, fetch_and_cache_teams, get_project_canonical_id,
+    teams_cache_stale, user_level_cloud_json_path};
 use crate::ui::components::Formatter;
 use crate::ui::theme::ActiveTheme;
 
@@ -1643,6 +1644,52 @@ fn execute_pull(args: &CloudPullArgs, cli: &Cli, cas_root: &Path) -> anyhow::Res
 /// `execute_team_push` / `execute_team_pull`.
 #[doc(hidden)]
 pub fn execute_sync(args: &CloudSyncArgs, cli: &Cli, cas_root: &Path) -> anyhow::Result<()> {
+    // T2 lazy refresh: re-fetch /api/me when teams[] is empty or the last
+    // fetch is more than 24 h old.  Best-effort — failure is logged but does
+    // not abort sync.
+    if !args.dry_run {
+        let user_cfg = user_level_cloud_json_path()
+            .and_then(|p| {
+                p.parent().map(|d| CloudConfig::load_from_cas_dir(d).ok()).flatten()
+            });
+        let stale = user_cfg
+            .as_ref()
+            .map(|cfg| teams_cache_stale(cfg, 86_400))
+            .unwrap_or(true);
+
+        if stale {
+            // Only refresh when we have a token; load from project config
+            // (that's where the token lives after login).
+            if let Ok(proj_cfg) = CloudConfig::load() {
+                if let Some(token) = proj_cfg.token.as_deref() {
+                    match fetch_and_cache_teams(&proj_cfg.endpoint, token) {
+                        FetchTeamsOutcome::Updated { team_count } => {
+                            tracing::debug!(
+                                team_count,
+                                "lazy-refreshed team membership from /api/me during sync"
+                            );
+                        }
+                        FetchTeamsOutcome::Empty => {
+                            tracing::debug!("lazy /api/me refresh: zero team memberships");
+                        }
+                        FetchTeamsOutcome::AuthFailed => {
+                            eprintln!(
+                                "warning: could not refresh team membership (/api/me 401). \
+                                 Token may be expired — run `cas cloud login` to re-authenticate."
+                            );
+                        }
+                        FetchTeamsOutcome::NetworkError(msg) => {
+                            tracing::warn!(
+                                error = %msg,
+                                "lazy /api/me refresh failed (non-fatal, continuing sync)"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     execute_push(
         &CloudPushArgs {
             entries_only: false,

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -385,6 +385,18 @@ pub struct CloudConfig {
     /// `skip_serializing_if` so pre-T4 files stay clean.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_team_id: Option<String>,
+
+    /// UTC timestamp of the last successful `/api/me` fetch that populated
+    /// `teams[]`.  Used by T2's staleness check: when `teams` is non-empty
+    /// and this timestamp is within 24 h, the lazy refresh in
+    /// `execute_sync` is skipped to avoid an extra HTTP round-trip per
+    /// sync cycle.
+    ///
+    /// `None` means teams have never been fetched (triggers refresh on next
+    /// sync).  Absent in existing `cloud.json` → `None` via
+    /// `#[serde(default)]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub teams_fetched_at: Option<DateTime<Utc>>,
 }
 
 /// Return true when `url` is a safe endpoint value.
@@ -464,6 +476,7 @@ impl Default for CloudConfig {
             team_auto_promote: None,
             teams: Vec::new(),
             default_team_id: None,
+            teams_fetched_at: None,
         }
     }
 }

--- a/cas-cli/src/cloud/me.rs
+++ b/cas-cli/src/cloud/me.rs
@@ -1,0 +1,193 @@
+//! `/api/me` fetch + cache — T2 of EPIC cas-ab88.
+//!
+//! Calls `GET {endpoint}/api/me`, parses the `teams[]` and
+//! `default_team_id` fields, and writes them into the user-level
+//! `~/.cas/cloud.json` (or the path pointed to by `CAS_USER_CLOUD_JSON`
+//! when set — the same test seam used by T3 and T4).
+//!
+//! # Failure model
+//!
+//! All callers treat the fetch as best-effort:
+//! - Network errors → `FetchTeamsOutcome::NetworkError(msg)` — caller logs a warning.
+//! - `401 Unauthorized` → `FetchTeamsOutcome::AuthFailed` — token is stale; caller warns.
+//! - `200 OK` with `"teams": []` → `FetchTeamsOutcome::Empty` — valid, zero-membership user.
+//! - `200 OK` with teams → `FetchTeamsOutcome::Updated { team_count }`.
+//!
+//! The function **never** propagates an error that would interrupt `cas login`
+//! or `cas cloud sync`; all failure branches return a typed outcome instead.
+
+use std::path::Path;
+
+use chrono::Utc;
+use tracing::warn;
+
+use super::config::user_level_cloud_json_path;
+use crate::cloud::{CloudConfig, TeamInfo};
+
+/// Outcome of a `/api/me` fetch-and-cache attempt.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FetchTeamsOutcome {
+    /// Fetch succeeded and `team_count` team records were stored.
+    Updated { team_count: usize },
+    /// Fetch succeeded but the user belongs to zero teams.
+    Empty,
+    /// Server returned 401 — token is invalid or expired.
+    AuthFailed,
+    /// Network or parse failure; `msg` carries a human-readable reason.
+    NetworkError(String),
+}
+
+/// Call `/api/me`, cache the resulting `teams[]` + `default_team_id` into the
+/// user-level config, and return a typed outcome.
+///
+/// `endpoint` must not have a trailing slash. `token` is the Bearer token.
+///
+/// The user config path is resolved via `user_level_cloud_json_path()` (honours
+/// the `CAS_USER_CLOUD_JSON` test-seam env var).  Returns
+/// `FetchTeamsOutcome::NetworkError` when the path cannot be determined.
+///
+/// This is the public entry point for production callers (login paths, lazy
+/// refresh in sync).  Tests that need path injection use
+/// `fetch_and_cache_teams_inner` directly.
+pub fn fetch_and_cache_teams(endpoint: &str, token: &str) -> FetchTeamsOutcome {
+    match user_level_cloud_json_path() {
+        Some(path) => {
+            let cas_dir = match path.parent() {
+                Some(d) => d.to_path_buf(),
+                None => {
+                    return FetchTeamsOutcome::NetworkError(
+                        "cannot determine user .cas directory from cloud.json path".to_string(),
+                    );
+                }
+            };
+            fetch_and_cache_teams_inner(endpoint, token, &cas_dir)
+        }
+        None => FetchTeamsOutcome::NetworkError(
+            "cannot determine home directory to locate user cloud config".to_string(),
+        ),
+    }
+}
+
+/// Testable inner implementation — accepts an injected `user_cas_dir` so
+/// integration tests can point it at a tempdir instead of `~/.cas/`.
+///
+/// Reads the existing user config from `<user_cas_dir>/cloud.json` (if any),
+/// merges in the fresh `teams[]` and `default_team_id` from the server, stamps
+/// `teams_fetched_at`, and writes the result back.  All other config fields
+/// (token, endpoint, team_id, …) are preserved.
+pub fn fetch_and_cache_teams_inner(
+    endpoint: &str,
+    token: &str,
+    user_cas_dir: &Path,
+) -> FetchTeamsOutcome {
+    let url = format!("{endpoint}/api/me");
+
+    let response = ureq::get(&url)
+        .set("Authorization", &format!("Bearer {token}"))
+        .timeout(std::time::Duration::from_secs(10))
+        .call();
+
+    match response {
+        Ok(resp) => {
+            let body: serde_json::Value = match resp.into_json() {
+                Ok(v) => v,
+                Err(e) => {
+                    return FetchTeamsOutcome::NetworkError(format!(
+                        "/api/me response could not be parsed as JSON: {e}"
+                    ));
+                }
+            };
+
+            // Parse teams[].
+            let teams: Vec<TeamInfo> = body
+                .get("teams")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or_default();
+
+            // Parse optional default_team_id (may be null or absent).
+            let default_team_id: Option<String> = body
+                .get("default_team_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            let team_count = teams.len();
+
+            // Read-modify-write user config.
+            if let Err(e) = update_user_config(user_cas_dir, teams, default_team_id) {
+                warn!(
+                    error = %e,
+                    user_cas_dir = %user_cas_dir.display(),
+                    "failed to write teams to user cloud config after /api/me fetch"
+                );
+                return FetchTeamsOutcome::NetworkError(format!(
+                    "could not persist teams to user config: {e}"
+                ));
+            }
+
+            if team_count == 0 {
+                FetchTeamsOutcome::Empty
+            } else {
+                FetchTeamsOutcome::Updated { team_count }
+            }
+        }
+
+        Err(ureq::Error::Status(401, _)) => FetchTeamsOutcome::AuthFailed,
+
+        Err(ureq::Error::Status(code, resp)) => {
+            let body = resp.into_string().unwrap_or_default();
+            FetchTeamsOutcome::NetworkError(format!(
+                "/api/me returned HTTP {code}: {body}"
+            ))
+        }
+
+        Err(ureq::Error::Transport(e)) => {
+            FetchTeamsOutcome::NetworkError(format!("/api/me network error: {e}"))
+        }
+    }
+}
+
+/// Read `<user_cas_dir>/cloud.json` (falling back to default if absent),
+/// replace `teams`, `default_team_id`, and stamp `teams_fetched_at`, then
+/// write back.  All other fields are preserved.
+fn update_user_config(
+    user_cas_dir: &Path,
+    teams: Vec<TeamInfo>,
+    default_team_id: Option<String>,
+) -> Result<(), crate::error::CasError> {
+    let mut cfg = CloudConfig::load_from_cas_dir(user_cas_dir)?;
+    cfg.teams = teams;
+    // Only overwrite default_team_id when the server provides one; if the
+    // server returns null and the user already has a local preference from
+    // `cas cloud team default`, preserve the local preference.
+    if default_team_id.is_some() {
+        cfg.default_team_id = default_team_id;
+    }
+    cfg.teams_fetched_at = Some(Utc::now());
+
+    // Ensure the directory exists before writing.
+    if let Some(parent) = user_cas_dir.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::create_dir_all(user_cas_dir).ok();
+
+    cfg.save_to_cas_dir(user_cas_dir)
+}
+
+/// Returns `true` when a fresh `/api/me` call is warranted:
+///   - `teams` is empty (never fetched), OR
+///   - `teams_fetched_at` is `None`, OR
+///   - the last fetch was more than `max_age_secs` seconds ago.
+///
+/// Callers pass `86_400` (24 h) for the lazy-refresh path in `execute_sync`.
+pub fn teams_cache_stale(cfg: &CloudConfig, max_age_secs: i64) -> bool {
+    if cfg.teams.is_empty() {
+        return true;
+    }
+    match cfg.teams_fetched_at {
+        None => true,
+        Some(fetched_at) => {
+            let age = Utc::now().signed_duration_since(fetched_at);
+            age.num_seconds() >= max_age_secs
+        }
+    }
+}

--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -19,6 +19,7 @@
 mod config;
 mod coordinator;
 pub mod device;
+pub(crate) mod me;
 mod sync_queue;
 mod syncer;
 
@@ -26,7 +27,10 @@ pub use config::{
     CloudConfig, TeamInfo, canonical_id_from_config_toml, derive_canonical_id_from_git_remote,
     get_project_canonical_id, set_canonical_id_in_config_toml,
 };
-pub(crate) use config::{default_endpoint, is_acceptable_endpoint};
+pub(crate) use config::{default_endpoint, is_acceptable_endpoint, user_level_cloud_json_path};
+// T2: /api/me fetch helpers — `pub` so integration tests can call them directly.
+pub use me::{FetchTeamsOutcome, fetch_and_cache_teams, fetch_and_cache_teams_inner,
+    teams_cache_stale};
 #[cfg(test)]
 pub(crate) use config::CLOUD_ENV_LOCK;
 pub use coordinator::CloudCoordinator;

--- a/cas-cli/tests/teams_fetch_test.rs
+++ b/cas-cli/tests/teams_fetch_test.rs
@@ -1,0 +1,247 @@
+//! Integration tests for T2 of EPIC cas-ab88:
+//! `fetch_and_cache_teams_inner` + `/api/me` wiring.
+//!
+//! Tests use:
+//! - `wiremock` to stand up a local HTTP server that mimics `/api/me`.
+//! - An injected `TempDir` as the user cas dir (via
+//!   `fetch_and_cache_teams_inner`) so `~/.cas/cloud.json` is never touched.
+//!
+//! Coverage:
+//! 1. Happy path — `/api/me` returns `teams[]` and `default_team_id`;
+//!    verify both are persisted to the user cas dir and
+//!    `FetchTeamsOutcome::Updated { team_count }` is returned.
+//! 2. Empty teams — `/api/me` returns `"teams": []` (zero memberships);
+//!    verify `FetchTeamsOutcome::Empty` and `teams` is written as empty.
+//! 3. 401 Unauthorized — verify `FetchTeamsOutcome::AuthFailed`; no panic,
+//!    user config on disk is unchanged.
+//! 4. `teams_cache_stale` helper — fresh timestamp is not stale, absent
+//!    timestamp is stale, old timestamp is stale.
+
+use cas::cloud::{CloudConfig, FetchTeamsOutcome, fetch_and_cache_teams_inner, teams_cache_stale};
+use cas::cloud::TeamInfo;
+use tempfile::TempDir;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ── Happy path ───────────────────────────────────────────────────────────────
+
+/// AC: when `/api/me` returns a team list, the teams are persisted to the
+/// user-level cloud.json and `FetchTeamsOutcome::Updated { team_count }` is
+/// returned.
+#[tokio::test]
+async fn fetch_teams_happy_path_persists_teams_to_user_config() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/me"))
+        .and(header("Authorization", "Bearer test-tok"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "user_id": "uid-001",
+            "email": "alice@example.com",
+            "teams": [
+                {
+                    "id":   "team-aaa",
+                    "slug": "alpha-squad",
+                    "name": "Alpha Squad",
+                    "role": "owner"
+                },
+                {
+                    "id":   "team-bbb",
+                    "slug": "beta-squad",
+                    "name": "Beta Squad",
+                    "role": "member"
+                }
+            ],
+            "default_team_id": "team-aaa"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let outcome = fetch_and_cache_teams_inner(&server.uri(), "test-tok", tmp.path());
+
+    assert_eq!(
+        outcome,
+        FetchTeamsOutcome::Updated { team_count: 2 },
+        "expected Updated with team_count 2"
+    );
+
+    // Verify teams were written to the user cas dir.
+    let cfg = CloudConfig::load_from_cas_dir(tmp.path()).unwrap();
+    assert_eq!(
+        cfg.teams.len(),
+        2,
+        "two teams must be persisted"
+    );
+    assert_eq!(
+        cfg.teams[0],
+        TeamInfo {
+            id:   "team-aaa".to_string(),
+            slug: "alpha-squad".to_string(),
+            name: "Alpha Squad".to_string(),
+            role: "owner".to_string(),
+        }
+    );
+    assert_eq!(
+        cfg.default_team_id,
+        Some("team-aaa".to_string()),
+        "default_team_id from server must be persisted"
+    );
+    assert!(
+        cfg.teams_fetched_at.is_some(),
+        "teams_fetched_at must be set after a successful fetch"
+    );
+
+    server.verify().await;
+}
+
+// ── Empty teams ──────────────────────────────────────────────────────────────
+
+/// AC: when `/api/me` returns `"teams": []`, `FetchTeamsOutcome::Empty` is
+/// returned and an empty teams list is persisted (no panic).
+#[tokio::test]
+async fn fetch_teams_empty_membership_returns_empty_outcome() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/me"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "user_id": "uid-002",
+            "email":   "bob@example.com",
+            "teams":   [],
+            "default_team_id": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let outcome = fetch_and_cache_teams_inner(&server.uri(), "tok-empty", tmp.path());
+
+    assert_eq!(outcome, FetchTeamsOutcome::Empty);
+
+    let cfg = CloudConfig::load_from_cas_dir(tmp.path()).unwrap();
+    assert!(
+        cfg.teams.is_empty(),
+        "teams must be empty after zero-membership response"
+    );
+    assert!(
+        cfg.teams_fetched_at.is_some(),
+        "teams_fetched_at must be stamped even for empty response"
+    );
+
+    server.verify().await;
+}
+
+// ── 401 Unauthorized ─────────────────────────────────────────────────────────
+
+/// AC: when `/api/me` returns 401, `FetchTeamsOutcome::AuthFailed` is returned
+/// without panicking and the user config is unchanged (still default).
+#[tokio::test]
+async fn fetch_teams_401_returns_auth_failed() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/me"))
+        .respond_with(
+            ResponseTemplate::new(401)
+                .set_body_json(serde_json::json!({ "error": "invalid token" })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    // Pre-seed with a pre-existing (non-empty) config to prove it's unchanged.
+    let mut pre = CloudConfig::default();
+    pre.teams = vec![TeamInfo {
+        id:   "pre-existing-team".to_string(),
+        slug: "pre".to_string(),
+        name: "Pre".to_string(),
+        role: "member".to_string(),
+    }];
+    pre.save_to_cas_dir(tmp.path()).unwrap();
+
+    let outcome = fetch_and_cache_teams_inner(&server.uri(), "bad-token", tmp.path());
+
+    assert_eq!(
+        outcome,
+        FetchTeamsOutcome::AuthFailed,
+        "401 must produce AuthFailed"
+    );
+
+    // Confirm the pre-existing config was NOT touched.
+    let cfg = CloudConfig::load_from_cas_dir(tmp.path()).unwrap();
+    assert_eq!(
+        cfg.teams.len(),
+        1,
+        "pre-existing teams must be unchanged after 401"
+    );
+
+    server.verify().await;
+}
+
+// ── teams_cache_stale unit tests ─────────────────────────────────────────────
+
+/// A config with no teams and no `teams_fetched_at` is stale.
+#[test]
+fn teams_cache_stale_when_no_teams_and_no_timestamp() {
+    let cfg = CloudConfig::default();
+    assert!(
+        teams_cache_stale(&cfg, 86_400),
+        "empty teams with no timestamp must be stale"
+    );
+}
+
+/// A config with teams but no `teams_fetched_at` is stale.
+#[test]
+fn teams_cache_stale_when_teams_but_no_timestamp() {
+    let mut cfg = CloudConfig::default();
+    cfg.teams = vec![TeamInfo {
+        id:   "t1".to_string(),
+        slug: "s1".to_string(),
+        name: "S1".to_string(),
+        role: "member".to_string(),
+    }];
+    // teams_fetched_at is None by default.
+    assert!(
+        teams_cache_stale(&cfg, 86_400),
+        "teams present but no timestamp must be stale"
+    );
+}
+
+/// A config with a recent `teams_fetched_at` is NOT stale.
+#[test]
+fn teams_cache_not_stale_when_freshly_fetched() {
+    let mut cfg = CloudConfig::default();
+    cfg.teams = vec![TeamInfo {
+        id:   "t2".to_string(),
+        slug: "s2".to_string(),
+        name: "S2".to_string(),
+        role: "owner".to_string(),
+    }];
+    cfg.teams_fetched_at = Some(chrono::Utc::now());
+    assert!(
+        !teams_cache_stale(&cfg, 86_400),
+        "recently-fetched teams must NOT be stale"
+    );
+}
+
+/// A config whose `teams_fetched_at` is older than the threshold is stale.
+#[test]
+fn teams_cache_stale_after_expiry() {
+    let mut cfg = CloudConfig::default();
+    cfg.teams = vec![TeamInfo {
+        id:   "t3".to_string(),
+        slug: "s3".to_string(),
+        name: "S3".to_string(),
+        role: "member".to_string(),
+    }];
+    // Stamp a time 25 h ago.
+    cfg.teams_fetched_at = Some(chrono::Utc::now() - chrono::Duration::hours(25));
+    assert!(
+        teams_cache_stale(&cfg, 86_400),
+        "teams fetched >24 h ago must be stale"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `cloud/me.rs` with `fetch_and_cache_teams_inner` (testable via injected path) and `fetch_and_cache_teams` (production wrapper using `CAS_USER_CLOUD_JSON` seam)
- Wires best-effort `/api/me` call into both `cas login` paths (device flow + token) immediately after `config.save()`
- Adds 24-hour lazy refresh at the start of `execute_sync` — fires when `teams[]` is empty or `teams_fetched_at` is stale
- Adds `teams_fetched_at: Option<DateTime<Utc>>` to `CloudConfig` for staleness tracking
- 7 new integration tests (3 wiremock HTTP + 4 unit) in `tests/teams_fetch_test.rs`

## Test plan

- [x] `cargo test --test teams_fetch_test` — 7/7 pass (happy path, empty teams, 401, staleness unit tests)
- [x] `cargo test --test team_pull_wiring_test --test team_default_test --test active_team_id_integration_test` — all green
- [x] `cargo build` — clean (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)