### PR TITLE
feat(cas-8f23): first-run backfill UX — auto-promote + one-time notice

### DIFF
--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -8,8 +8,9 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::cli::Cli;
-use crate::cloud::{CloudConfig, FetchTeamsOutcome, fetch_and_cache_teams, get_project_canonical_id,
-    teams_cache_stale, user_level_cloud_json_path};
+use crate::cloud::{BackfillOutcome, CloudConfig, FetchTeamsOutcome, fetch_and_cache_teams,
+    get_project_canonical_id, maybe_apply_team_backfill, teams_cache_stale,
+    user_level_cloud_json_path};
 use crate::ui::components::Formatter;
 use crate::ui::theme::ActiveTheme;
 
@@ -398,6 +399,9 @@ fn execute_team_default_inner(
     if args.personal {
         let was_set = config.default_team_id.is_some();
         config.default_team_id = None;
+        // Mark the one-time backfill gate so future syncs do not re-promote
+        // the user to team scope against their explicit personal-scope choice.
+        config.team_backfill_notified = true;
         config.save_to_cas_dir(user_cas_dir)?;
 
         if cli.json {
@@ -1686,6 +1690,48 @@ pub fn execute_sync(args: &CloudSyncArgs, cli: &Cli, cas_root: &Path) -> anyhow:
                         }
                     }
                 }
+            }
+        }
+    }
+
+    // T6: first-run backfill notice — runs even when the teams cache is
+    // already fresh (cheap JSON read; gated by team_backfill_notified so it
+    // is a no-op after the first time). Must run before execute_push so the
+    // updated default_team_id is visible to the syncing stores opened inside
+    // execute_push via open_store → active_team_id().
+    if !args.dry_run {
+        match maybe_apply_team_backfill() {
+            BackfillOutcome::Applied { ref team_id, ref team_slug, ref team_name } => {
+                if !cli.json {
+                    eprintln!();
+                    eprintln!("  ✓ Team membership detected — syncing to team scope");
+                    eprintln!("    Team: {} ({})", team_name, team_slug);
+                    eprintln!("    UUID: {}", team_id);
+                    eprintln!();
+                    eprintln!("  Existing personal entries are NOT automatically promoted.");
+                    eprintln!("  To promote them retroactively, run:");
+                    eprintln!("    cas memory share --all");
+                    eprintln!();
+                    eprintln!("  To revert to personal scope:");
+                    eprintln!("    cas cloud team default --personal");
+                    eprintln!();
+                } else {
+                    // JSON callers get a structured event they can grep for.
+                    eprintln!(
+                        "{}",
+                        serde_json::json!({
+                            "event": "team_backfill_applied",
+                            "team_id": team_id,
+                            "team_slug": team_slug,
+                            "team_name": team_name,
+                        })
+                    );
+                }
+            }
+            BackfillOutcome::AlreadyNotified
+            | BackfillOutcome::NoMembership
+            | BackfillOutcome::MultiTeamAmbiguous => {
+                // No-op — these are expected quiet paths.
             }
         }
     }

--- a/cas-cli/src/cloud/backfill.rs
+++ b/cas-cli/src/cloud/backfill.rs
@@ -1,0 +1,113 @@
+//! First-run backfill UX — T6 of EPIC cas-ab88.
+//!
+//! On the first `cas cloud sync` after upgrade, when the user has team
+//! membership (populated by T2's `/api/me` fetch) but no explicit
+//! `default_team_id` configured, this module auto-promotes to the sole team
+//! (or uses the server-supplied default) and prints a one-time notice.
+//!
+//! # One-time gate
+//!
+//! `CloudConfig::team_backfill_notified` (user-level `~/.cas/cloud.json`)
+//! is set to `true` after the notice fires, and also when the user runs
+//! `cas cloud team default --personal`.  Once set, the backfill is
+//! permanently a no-op for that user.
+
+use std::path::Path;
+
+use crate::cloud::config::user_level_cloud_json_path;
+use crate::cloud::CloudConfig;
+
+/// Outcome of [`maybe_apply_team_backfill_inner`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum BackfillOutcome {
+    /// Backfill ran: `default_team_id` was auto-set (or was already set by
+    /// the server) and the one-time notice has been armed.  The caller is
+    /// responsible for printing the user-facing notice.
+    Applied {
+        /// The team UUID that is now the default.
+        team_id: String,
+        /// URL-safe slug (for display in the notice).
+        team_slug: String,
+        /// Display name (for display in the notice).
+        team_name: String,
+    },
+    /// `team_backfill_notified` was already `true` — no-op.
+    AlreadyNotified,
+    /// `teams[]` is empty — user has no team membership; no notice.
+    NoMembership,
+    /// User belongs to multiple teams and the server supplied no
+    /// `default_team_id` — cannot auto-pick; no notice, no auto-set.
+    MultiTeamAmbiguous,
+}
+
+/// Testable inner implementation — accepts an injected `user_cas_dir` so
+/// integration tests can point it at a tempdir instead of `~/.cas/`.
+///
+/// Reads user-level config, applies backfill logic, writes back if changed,
+/// and returns a typed outcome.  The caller (production wrapper or
+/// `execute_sync`) is responsible for printing any user-visible text.
+pub fn maybe_apply_team_backfill_inner(user_cas_dir: &Path) -> BackfillOutcome {
+    let mut cfg = match CloudConfig::load_from_cas_dir(user_cas_dir) {
+        Ok(c) => c,
+        Err(_) => CloudConfig::default(),
+    };
+
+    // One-time gate — also fires when user ran `--personal`.
+    if cfg.team_backfill_notified {
+        return BackfillOutcome::AlreadyNotified;
+    }
+
+    // No membership → nothing to promote.
+    if cfg.teams.is_empty() {
+        return BackfillOutcome::NoMembership;
+    }
+
+    // Determine the team to promote to.
+    let promoted_team = if let Some(ref dtid) = cfg.default_team_id.clone() {
+        // Server already set a default (via T2 me.rs). Find the team record
+        // for the notice display text, falling back to the UUID if not found
+        // in the cached list.
+        let info = cfg.teams.iter().find(|t| &t.id == dtid).cloned();
+        let (slug, name) = info
+            .as_ref()
+            .map(|t| (t.slug.clone(), t.name.clone()))
+            .unwrap_or_else(|| (dtid.clone(), dtid.clone()));
+        Some((dtid.clone(), slug, name))
+    } else if cfg.teams.len() == 1 {
+        // Implicit single-team auto-pick.
+        let t = &cfg.teams[0];
+        cfg.default_team_id = Some(t.id.clone());
+        Some((t.id.clone(), t.slug.clone(), t.name.clone()))
+    } else {
+        // Multiple teams, no server default → ambiguous; no auto-set.
+        None
+    };
+
+    match promoted_team {
+        Some((team_id, team_slug, team_name)) => {
+            cfg.team_backfill_notified = true;
+            // Persist; ignore write errors (best-effort — the notice still fires).
+            if let Err(e) = std::fs::create_dir_all(user_cas_dir) {
+                tracing::warn!(error = %e, "backfill: could not create user_cas_dir");
+            }
+            let _ = cfg.save_to_cas_dir(user_cas_dir);
+            BackfillOutcome::Applied { team_id, team_slug, team_name }
+        }
+        None => BackfillOutcome::MultiTeamAmbiguous,
+    }
+}
+
+/// Production wrapper — resolves `~/.cas/` (or `CAS_USER_CLOUD_JSON` test
+/// seam) and delegates to [`maybe_apply_team_backfill_inner`].
+///
+/// Returns `BackfillOutcome::NoMembership` when the home directory cannot
+/// be determined (treated as "nothing to do").
+pub fn maybe_apply_team_backfill() -> BackfillOutcome {
+    match user_level_cloud_json_path() {
+        Some(path) => match path.parent() {
+            Some(dir) => maybe_apply_team_backfill_inner(dir),
+            None => BackfillOutcome::NoMembership,
+        },
+        None => BackfillOutcome::NoMembership,
+    }
+}

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -397,6 +397,27 @@ pub struct CloudConfig {
     /// `#[serde(default)]`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub teams_fetched_at: Option<DateTime<Utc>>,
+
+    /// Set to `true` after the first-run backfill notice has been shown
+    /// (T6), OR when the user explicitly runs `cas cloud team default
+    /// --personal`.
+    ///
+    /// Guards two things at once:
+    /// 1. Prevents the one-time notice from firing more than once.
+    /// 2. Prevents `maybe_apply_team_backfill` from overriding an explicit
+    ///    `--personal` choice (the `--personal` handler sets this flag before
+    ///    saving so a later sync never re-promotes the user to team scope).
+    ///
+    /// Absent in existing `cloud.json` files → `false` via `#[serde(default)]`.
+    /// Not written to disk when `false` so pre-T6 files stay clean.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub team_backfill_notified: bool,
+}
+
+/// `skip_serializing_if` predicate for bool fields that default to `false`.
+/// Keeps `cloud.json` clean: the field is omitted when it has its zero value.
+fn is_false(b: &bool) -> bool {
+    !b
 }
 
 /// Return true when `url` is a safe endpoint value.
@@ -477,6 +498,7 @@ impl Default for CloudConfig {
             teams: Vec::new(),
             default_team_id: None,
             teams_fetched_at: None,
+            team_backfill_notified: false,
         }
     }
 }

--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -16,6 +16,7 @@
 //! 2. Processing the queue during idle periods (daemon)
 //! 3. Pulling latest changes on MCP server startup
 
+mod backfill;
 mod config;
 mod coordinator;
 pub mod device;
@@ -23,6 +24,8 @@ pub(crate) mod me;
 mod sync_queue;
 mod syncer;
 
+// T6: first-run backfill — `pub` so integration tests can call the inner seam.
+pub use backfill::{BackfillOutcome, maybe_apply_team_backfill, maybe_apply_team_backfill_inner};
 pub use config::{
     CloudConfig, TeamInfo, canonical_id_from_config_toml, derive_canonical_id_from_git_remote,
     get_project_canonical_id, set_canonical_id_in_config_toml,

--- a/cas-cli/tests/team_backfill_test.rs
+++ b/cas-cli/tests/team_backfill_test.rs
@@ -1,0 +1,182 @@
+//! Integration tests for T6 — first-run backfill UX after upgrade (cas-8f23).
+//!
+//! Exercises `cas::cloud::maybe_apply_team_backfill_inner` — the testable
+//! inner seam that reads/writes user-level cloud.json in a tempdir.
+//!
+//! Also covers the `cas cloud team default --personal` → sets
+//! `team_backfill_notified = true` behaviour that guards the backfill gate.
+//!
+//! Lives in `cas-cli/tests/` per the cas-1f44 pattern (integration behavior
+//! for user-visible UX belongs in the integration tree, not colocated with
+//! the module under test).
+
+use std::sync::Mutex;
+
+use cas::cloud::{BackfillOutcome, CloudConfig, TeamInfo, maybe_apply_team_backfill_inner};
+use cas::cli::cloud::{CloudTeamDefaultArgs, execute_team_default_for_test};
+use cas::cli::Cli;
+use tempfile::TempDir;
+
+/// Serialises `CAS_USER_CLOUD_JSON` mutations within this test binary.
+static USER_CLOUD_LOCK: Mutex<()> = Mutex::new(());
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+fn make_cli_json() -> Cli {
+    Cli { json: true, full: false, verbose: false, command: None }
+}
+
+fn make_team(id: &str, slug: &str, name: &str) -> TeamInfo {
+    TeamInfo {
+        id: id.to_string(),
+        slug: slug.to_string(),
+        name: name.to_string(),
+        role: "member".to_string(),
+    }
+}
+
+fn write_user_config(cas_dir: &std::path::Path, cfg: &CloudConfig) {
+    cfg.save_to_cas_dir(cas_dir).unwrap();
+}
+
+fn read_user_config(cas_dir: &std::path::Path) -> CloudConfig {
+    CloudConfig::load_from_cas_dir(cas_dir).unwrap()
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+/// Single-team user with no default set → auto-picks the sole team, marks notified.
+#[test]
+fn backfill_auto_sets_sole_team_and_marks_notified() {
+    let temp = TempDir::new().unwrap();
+    let mut cfg = CloudConfig::default();
+    cfg.teams = vec![make_team("tid-solo", "solo-team", "Solo Team")];
+    // default_team_id and team_backfill_notified both at default (None / false).
+    write_user_config(temp.path(), &cfg);
+
+    let outcome = maybe_apply_team_backfill_inner(temp.path());
+
+    match outcome {
+        BackfillOutcome::Applied { ref team_id, ref team_slug, .. } => {
+            assert_eq!(team_id, "tid-solo");
+            assert_eq!(team_slug, "solo-team");
+        }
+        other => panic!("expected Applied, got {other:?}"),
+    }
+
+    let saved = read_user_config(temp.path());
+    assert_eq!(saved.default_team_id.as_deref(), Some("tid-solo"),
+        "default_team_id must be persisted");
+    assert!(saved.team_backfill_notified, "team_backfill_notified must be true after backfill");
+}
+
+/// Already-notified user → no-op regardless of team state.
+#[test]
+fn backfill_no_op_when_already_notified() {
+    let temp = TempDir::new().unwrap();
+    let mut cfg = CloudConfig::default();
+    cfg.teams = vec![make_team("tid-1", "team-a", "Team A")];
+    cfg.team_backfill_notified = true;
+    write_user_config(temp.path(), &cfg);
+
+    let outcome = maybe_apply_team_backfill_inner(temp.path());
+    assert_eq!(outcome, BackfillOutcome::AlreadyNotified);
+
+    // Config must be unchanged.
+    let saved = read_user_config(temp.path());
+    assert_eq!(saved.default_team_id, None);
+}
+
+/// User with zero team memberships → no notice.
+#[test]
+fn backfill_no_op_when_no_teams() {
+    let temp = TempDir::new().unwrap();
+    let cfg = CloudConfig::default(); // teams = []
+    write_user_config(temp.path(), &cfg);
+
+    let outcome = maybe_apply_team_backfill_inner(temp.path());
+    assert_eq!(outcome, BackfillOutcome::NoMembership);
+
+    let saved = read_user_config(temp.path());
+    assert!(!saved.team_backfill_notified);
+}
+
+/// Multi-team user with no default → ambiguous, no auto-set.
+#[test]
+fn backfill_no_auto_set_on_multi_team_no_default() {
+    let temp = TempDir::new().unwrap();
+    let mut cfg = CloudConfig::default();
+    cfg.teams = vec![
+        make_team("tid-a", "team-a", "Team A"),
+        make_team("tid-b", "team-b", "Team B"),
+    ];
+    write_user_config(temp.path(), &cfg);
+
+    let outcome = maybe_apply_team_backfill_inner(temp.path());
+    assert_eq!(outcome, BackfillOutcome::MultiTeamAmbiguous);
+
+    let saved = read_user_config(temp.path());
+    assert_eq!(saved.default_team_id, None, "must not auto-set when ambiguous");
+    // We do NOT mark notified on ambiguous — a future `cas cloud team default`
+    // + sync should still surface naturally without needing a forced re-run.
+    assert!(!saved.team_backfill_notified);
+}
+
+/// Server already populated default_team_id (via T2 me.rs) — T6 shows the
+/// notice and marks notified, without overwriting the already-correct value.
+#[test]
+fn backfill_notifies_when_default_already_set_by_server() {
+    let temp = TempDir::new().unwrap();
+    let mut cfg = CloudConfig::default();
+    cfg.teams = vec![
+        make_team("tid-a", "team-a", "Team A"),
+        make_team("tid-b", "team-b", "Team B"),
+    ];
+    cfg.default_team_id = Some("tid-a".to_string()); // set by T2 server response
+    write_user_config(temp.path(), &cfg);
+
+    let outcome = maybe_apply_team_backfill_inner(temp.path());
+    match outcome {
+        BackfillOutcome::Applied { ref team_id, .. } => {
+            assert_eq!(team_id, "tid-a");
+        }
+        other => panic!("expected Applied, got {other:?}"),
+    }
+
+    let saved = read_user_config(temp.path());
+    assert_eq!(saved.default_team_id.as_deref(), Some("tid-a"),
+        "existing default_team_id must be preserved");
+    assert!(saved.team_backfill_notified);
+}
+
+/// `cas cloud team default --personal` must set `team_backfill_notified=true`
+/// so the backfill never fires and overrides the explicit personal-scope choice.
+#[test]
+fn personal_flag_blocks_future_backfill() {
+    let _guard = USER_CLOUD_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    let temp = TempDir::new().unwrap();
+    let mut cfg = CloudConfig::default();
+    cfg.teams = vec![make_team("tid-solo", "solo-team", "Solo Team")];
+    cfg.default_team_id = Some("tid-solo".to_string());
+    write_user_config(temp.path(), &cfg);
+
+    // User explicitly reverts to personal scope.
+    execute_team_default_for_test(
+        &CloudTeamDefaultArgs { slug_or_uuid: None, personal: true },
+        &make_cli_json(),
+        &temp.path().to_path_buf(),
+    ).expect("--personal must succeed");
+
+    let saved = read_user_config(temp.path());
+    assert_eq!(saved.default_team_id, None, "--personal must clear default_team_id");
+    assert!(saved.team_backfill_notified,
+        "--personal must set team_backfill_notified=true to block future auto-backfill");
+
+    // Running the backfill now must be a no-op.
+    let outcome = maybe_apply_team_backfill_inner(temp.path());
+    assert_eq!(outcome, BackfillOutcome::AlreadyNotified);
+    // default_team_id must stay None.
+    let saved2 = read_user_config(temp.path());
+    assert_eq!(saved2.default_team_id, None);
+}


### PR DESCRIPTION
## Summary

- Implements T6 (first-run backfill UX) of EPIC cas-ab88
- Adds `team_backfill_notified: bool` to CloudConfig (one-time gate + --personal sentinel)
- New `cloud/backfill.rs`: `BackfillOutcome` + `maybe_apply_team_backfill_inner` (testable) + `maybe_apply_team_backfill` (production)
- `execute_team_default --personal` now sets `team_backfill_notified=true` (blocks future auto-promotion)
- `execute_sync` calls backfill after T2 lazy-refresh; prints formatted terminal/JSON notice on `Applied`

## Test plan

- [x] 6 new integration tests in `team_backfill_test.rs`: sole-team auto-set, already-notified no-op, no-teams no-op, multi-team ambiguous, server-set default notice, --personal blocks future backfill
- [x] 49/49 cloud::config unit tests pass
- [x] team_sync (5/5), team_pull_wiring (7/7), memory_share (5/5), team_default (7/7), active_team_id (2/2) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)