### PR TITLE
fix(cas-8f23): wire backfill into login paths + extract shared notice helper

### DIFF
--- a/cas-cli/src/cli/auth.rs
+++ b/cas-cli/src/cli/auth.rs
@@ -7,7 +7,9 @@ use std::io;
 use clap::{Parser, Subcommand};
 
 use crate::cli::Cli;
-use crate::cloud::{FetchTeamsOutcome, default_endpoint, fetch_and_cache_teams, is_acceptable_endpoint};
+use crate::cli::cloud::print_backfill_notice;
+use crate::cloud::{FetchTeamsOutcome, default_endpoint, fetch_and_cache_teams,
+    is_acceptable_endpoint, maybe_apply_team_backfill};
 use crate::ui::components::{
     Component, Formatter, Spinner, SpinnerMsg, clear_inline, render_inline_view, rerender_inline,
 };
@@ -372,6 +374,12 @@ fn execute_device_flow_login(args: &LoginArgs, cli: &Cli) -> anyhow::Result<()> 
                             }
                         }
 
+                        // T6: first-run backfill — auto-promote to team scope on first
+                        // login when the user has exactly one team (or the server already
+                        // set a default).  Best-effort; errors in the write are ignored.
+                        let backfill_outcome = maybe_apply_team_backfill();
+                        print_backfill_notice(cli, &backfill_outcome);
+
                         if cli.json {
                             println!(r#"{{"status":"ok","email":"{}"}}"#, email.unwrap_or(""));
                         } else {
@@ -562,6 +570,11 @@ fn execute_login_with_token(token: &str, endpoint: &str, cli: &Cli) -> anyhow::R
             tracing::warn!("could not fetch team membership from /api/me during token login (non-fatal)");
         }
     }
+
+    // T6: first-run backfill — auto-promote to team scope on first login when
+    // the user has exactly one team (or the server already set a default).
+    let backfill_outcome = maybe_apply_team_backfill();
+    print_backfill_notice(cli, &backfill_outcome);
 
     if cli.json {
         println!(r#"{{"status":"ok","message":"Logged in successfully"}}"#);

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -1638,6 +1638,43 @@ fn execute_pull(args: &CloudPullArgs, cli: &Cli, cas_root: &Path) -> anyhow::Res
 // SYNC
 // ═══════════════════════════════════════════════════════════════════════════════
 
+/// Print the T6 first-run backfill notice to stderr.
+///
+/// Extracted as a shared helper so both `execute_sync` and the auth login paths
+/// can emit the same notice without forking the display logic.
+///
+/// `pub(crate)` so `cli/auth.rs` can call it without going through the public
+/// API surface.
+pub(crate) fn print_backfill_notice(cli: &Cli, outcome: &BackfillOutcome) {
+    if let BackfillOutcome::Applied { team_id, team_slug, team_name } = outcome {
+        if !cli.json {
+            eprintln!();
+            eprintln!("  ✓ Team membership detected — syncing to team scope");
+            eprintln!("    Team: {} ({})", team_name, team_slug);
+            eprintln!("    UUID: {}", team_id);
+            eprintln!();
+            eprintln!("  Existing personal entries are NOT automatically promoted.");
+            eprintln!("  To promote them retroactively, run:");
+            eprintln!("    cas memory share --all");
+            eprintln!();
+            eprintln!("  To revert to personal scope:");
+            eprintln!("    cas cloud team default --personal");
+            eprintln!();
+        } else {
+            // JSON callers get a structured event they can grep for.
+            eprintln!(
+                "{}",
+                serde_json::json!({
+                    "event": "team_backfill_applied",
+                    "team_id": team_id,
+                    "team_slug": team_slug,
+                    "team_name": team_name,
+                })
+            );
+        }
+    }
+}
+
 /// Orchestrates `cas cloud sync` — personal push, team push, then personal pull
 /// (which transitively does team pull when a team is configured).
 ///
@@ -1700,40 +1737,8 @@ pub fn execute_sync(args: &CloudSyncArgs, cli: &Cli, cas_root: &Path) -> anyhow:
     // updated default_team_id is visible to the syncing stores opened inside
     // execute_push via open_store → active_team_id().
     if !args.dry_run {
-        match maybe_apply_team_backfill() {
-            BackfillOutcome::Applied { ref team_id, ref team_slug, ref team_name } => {
-                if !cli.json {
-                    eprintln!();
-                    eprintln!("  ✓ Team membership detected — syncing to team scope");
-                    eprintln!("    Team: {} ({})", team_name, team_slug);
-                    eprintln!("    UUID: {}", team_id);
-                    eprintln!();
-                    eprintln!("  Existing personal entries are NOT automatically promoted.");
-                    eprintln!("  To promote them retroactively, run:");
-                    eprintln!("    cas memory share --all");
-                    eprintln!();
-                    eprintln!("  To revert to personal scope:");
-                    eprintln!("    cas cloud team default --personal");
-                    eprintln!();
-                } else {
-                    // JSON callers get a structured event they can grep for.
-                    eprintln!(
-                        "{}",
-                        serde_json::json!({
-                            "event": "team_backfill_applied",
-                            "team_id": team_id,
-                            "team_slug": team_slug,
-                            "team_name": team_name,
-                        })
-                    );
-                }
-            }
-            BackfillOutcome::AlreadyNotified
-            | BackfillOutcome::NoMembership
-            | BackfillOutcome::MultiTeamAmbiguous => {
-                // No-op — these are expected quiet paths.
-            }
-        }
+        let outcome = maybe_apply_team_backfill();
+        print_backfill_notice(cli, &outcome);
     }
 
     execute_push(

--- a/cas-cli/tests/team_backfill_test.rs
+++ b/cas-cli/tests/team_backfill_test.rs
@@ -149,6 +149,48 @@ fn backfill_notifies_when_default_already_set_by_server() {
     assert!(saved.team_backfill_notified);
 }
 
+/// After login, `fetch_and_cache_teams` writes `teams[]` into user config.
+/// A subsequent `maybe_apply_team_backfill_inner` call (the same code path
+/// that auth.rs calls via the production wrapper) must auto-promote the sole
+/// team and mark the user as notified — matching what the wired login path does.
+#[test]
+fn backfill_fires_after_login_team_fetch() {
+    let temp = TempDir::new().unwrap();
+
+    // Simulate what fetch_and_cache_teams writes after a successful device-flow
+    // login: teams[] populated, default_team_id still None (T2 fills teams but
+    // leaves default_team_id for T6 to set).
+    let mut cfg = CloudConfig::default();
+    cfg.teams = vec![make_team("tid-login", "login-team", "Login Team")];
+    // default_team_id and team_backfill_notified both at default (None / false).
+    write_user_config(temp.path(), &cfg);
+
+    // This is what the login path calls (via the production wrapper which
+    // resolves user_cas_dir from CAS_USER_CLOUD_JSON; here we test the inner
+    // seam directly to stay hermetic).
+    let outcome = maybe_apply_team_backfill_inner(temp.path());
+
+    match outcome {
+        BackfillOutcome::Applied { ref team_id, ref team_slug, ref team_name } => {
+            assert_eq!(team_id, "tid-login");
+            assert_eq!(team_slug, "login-team");
+            assert_eq!(team_name, "Login Team");
+        }
+        other => panic!("expected Applied after login-path backfill, got {other:?}"),
+    }
+
+    let saved = read_user_config(temp.path());
+    assert_eq!(saved.default_team_id.as_deref(), Some("tid-login"),
+        "login backfill must persist default_team_id");
+    assert!(saved.team_backfill_notified,
+        "login backfill must set team_backfill_notified=true");
+
+    // Idempotency: a second call (e.g., re-login) must be a no-op.
+    let outcome2 = maybe_apply_team_backfill_inner(temp.path());
+    assert_eq!(outcome2, BackfillOutcome::AlreadyNotified,
+        "second backfill call must be AlreadyNotified — must not re-fire on re-login");
+}
+
 /// `cas cloud team default --personal` must set `team_backfill_notified=true`
 /// so the backfill never fires and overrides the explicit personal-scope choice.
 #[test]


### PR DESCRIPTION
## Summary

- Extracts the T6 backfill notice block from `execute_sync` into a `pub(crate) print_backfill_notice(cli, &outcome)` helper in `cli/cloud.rs` — eliminates the fork risk between sync and login paths
- Wires `maybe_apply_team_backfill()` + `print_backfill_notice` into **both** auth.rs login paths:
  - `execute_device_flow_login` (device-flow / OAuth login)
  - `execute_login_with_token` (PAT / token login)
- Adds `backfill_fires_after_login_team_fetch` integration test in `tests/team_backfill_test.rs` — simulates the state `fetch_and_cache_teams` deposits on login, then verifies backfill auto-promotes the sole team and is idempotent on re-login

## Test plan

- [x] `cargo test --test team_backfill_test` → 7/7 pass (was 6/6 before this PR)
- [x] `cargo test -p cas --lib -- cloud::config::tests` → 49/49 pass
- [x] `cargo build -p cas` → clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)