### PR TITLE
fix(cas-8f23): split Applied → AppliedSetDefault + AppliedAlreadyDefault

### DIFF
--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -1646,7 +1646,7 @@ fn execute_pull(args: &CloudPullArgs, cli: &Cli, cas_root: &Path) -> anyhow::Res
 /// `pub(crate)` so `cli/auth.rs` can call it without going through the public
 /// API surface.
 pub(crate) fn print_backfill_notice(cli: &Cli, outcome: &BackfillOutcome) {
-    if let BackfillOutcome::Applied { team_id, team_slug, team_name } = outcome {
+    if let BackfillOutcome::AppliedSetDefault { team_id, team_slug, team_name } = outcome {
         if !cli.json {
             eprintln!();
             eprintln!("  ✓ Team membership detected — syncing to team scope");

--- a/cas-cli/src/cloud/backfill.rs
+++ b/cas-cli/src/cloud/backfill.rs
@@ -20,17 +20,21 @@ use crate::cloud::CloudConfig;
 /// Outcome of [`maybe_apply_team_backfill_inner`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum BackfillOutcome {
-    /// Backfill ran: `default_team_id` was auto-set (or was already set by
-    /// the server) and the one-time notice has been armed.  The caller is
-    /// responsible for printing the user-facing notice.
-    Applied {
-        /// The team UUID that is now the default.
+    /// Backfill auto-picked the default team (single-team user whose
+    /// `default_team_id` was `None`).  The caller should print the
+    /// first-run notice — this is the "we just changed something" path.
+    AppliedSetDefault {
+        /// The team UUID that was just set as the default.
         team_id: String,
         /// URL-safe slug (for display in the notice).
         team_slug: String,
         /// Display name (for display in the notice).
         team_name: String,
     },
+    /// `default_team_id` was already set by the server (via T2 `/api/me`).
+    /// We just marked `team_backfill_notified = true`; nothing changed for
+    /// the user — no notice needed.
+    AppliedAlreadyDefault,
     /// `team_backfill_notified` was already `true` — no-op.
     AlreadyNotified,
     /// `teams[]` is empty — user has no team membership; no notice.
@@ -62,38 +66,36 @@ pub fn maybe_apply_team_backfill_inner(user_cas_dir: &Path) -> BackfillOutcome {
         return BackfillOutcome::NoMembership;
     }
 
-    // Determine the team to promote to.
-    let promoted_team = if let Some(ref dtid) = cfg.default_team_id.clone() {
-        // Server already set a default (via T2 me.rs). Find the team record
-        // for the notice display text, falling back to the UUID if not found
-        // in the cached list.
-        let info = cfg.teams.iter().find(|t| &t.id == dtid).cloned();
-        let (slug, name) = info
-            .as_ref()
-            .map(|t| (t.slug.clone(), t.name.clone()))
-            .unwrap_or_else(|| (dtid.clone(), dtid.clone()));
-        Some((dtid.clone(), slug, name))
+    // Determine the outcome variant and whether we need to mutate anything.
+    if let Some(ref dtid) = cfg.default_team_id.clone() {
+        // Server already set a default (via T2 me.rs) — just mark notified
+        // and return the silent variant.  Nothing changed from the user's
+        // perspective; no first-run notice needed.
+        cfg.team_backfill_notified = true;
+        if let Err(e) = std::fs::create_dir_all(user_cas_dir) {
+            tracing::warn!(error = %e, "backfill: could not create user_cas_dir");
+        }
+        let _ = cfg.save_to_cas_dir(user_cas_dir);
+        let _ = dtid; // explicit: we read it above only to detect presence
+        BackfillOutcome::AppliedAlreadyDefault
     } else if cfg.teams.len() == 1 {
-        // Implicit single-team auto-pick.
-        let t = &cfg.teams[0];
+        // Implicit single-team auto-pick — we are setting the default for the
+        // first time.  Print the first-run notice.
+        let t = cfg.teams[0].clone();
         cfg.default_team_id = Some(t.id.clone());
-        Some((t.id.clone(), t.slug.clone(), t.name.clone()))
+        cfg.team_backfill_notified = true;
+        if let Err(e) = std::fs::create_dir_all(user_cas_dir) {
+            tracing::warn!(error = %e, "backfill: could not create user_cas_dir");
+        }
+        let _ = cfg.save_to_cas_dir(user_cas_dir);
+        BackfillOutcome::AppliedSetDefault {
+            team_id: t.id,
+            team_slug: t.slug,
+            team_name: t.name,
+        }
     } else {
         // Multiple teams, no server default → ambiguous; no auto-set.
-        None
-    };
-
-    match promoted_team {
-        Some((team_id, team_slug, team_name)) => {
-            cfg.team_backfill_notified = true;
-            // Persist; ignore write errors (best-effort — the notice still fires).
-            if let Err(e) = std::fs::create_dir_all(user_cas_dir) {
-                tracing::warn!(error = %e, "backfill: could not create user_cas_dir");
-            }
-            let _ = cfg.save_to_cas_dir(user_cas_dir);
-            BackfillOutcome::Applied { team_id, team_slug, team_name }
-        }
-        None => BackfillOutcome::MultiTeamAmbiguous,
+        BackfillOutcome::MultiTeamAmbiguous
     }
 }
 

--- a/cas-cli/tests/team_backfill_test.rs
+++ b/cas-cli/tests/team_backfill_test.rs
@@ -57,11 +57,11 @@ fn backfill_auto_sets_sole_team_and_marks_notified() {
     let outcome = maybe_apply_team_backfill_inner(temp.path());
 
     match outcome {
-        BackfillOutcome::Applied { ref team_id, ref team_slug, .. } => {
+        BackfillOutcome::AppliedSetDefault { ref team_id, ref team_slug, .. } => {
             assert_eq!(team_id, "tid-solo");
             assert_eq!(team_slug, "solo-team");
         }
-        other => panic!("expected Applied, got {other:?}"),
+        other => panic!("expected AppliedSetDefault, got {other:?}"),
     }
 
     let saved = read_user_config(temp.path());
@@ -122,10 +122,11 @@ fn backfill_no_auto_set_on_multi_team_no_default() {
     assert!(!saved.team_backfill_notified);
 }
 
-/// Server already populated default_team_id (via T2 me.rs) — T6 shows the
-/// notice and marks notified, without overwriting the already-correct value.
+/// Server already populated `default_team_id` (via T2 me.rs) — T6 returns
+/// `AppliedAlreadyDefault` (silent, no notice) and marks notified, without
+/// overwriting the already-correct value.
 #[test]
-fn backfill_notifies_when_default_already_set_by_server() {
+fn backfill_silent_when_default_already_set_by_server() {
     let temp = TempDir::new().unwrap();
     let mut cfg = CloudConfig::default();
     cfg.teams = vec![
@@ -136,17 +137,14 @@ fn backfill_notifies_when_default_already_set_by_server() {
     write_user_config(temp.path(), &cfg);
 
     let outcome = maybe_apply_team_backfill_inner(temp.path());
-    match outcome {
-        BackfillOutcome::Applied { ref team_id, .. } => {
-            assert_eq!(team_id, "tid-a");
-        }
-        other => panic!("expected Applied, got {other:?}"),
-    }
+    assert_eq!(outcome, BackfillOutcome::AppliedAlreadyDefault,
+        "server-set default must return AppliedAlreadyDefault, not the noisy AppliedSetDefault");
 
     let saved = read_user_config(temp.path());
     assert_eq!(saved.default_team_id.as_deref(), Some("tid-a"),
         "existing default_team_id must be preserved");
-    assert!(saved.team_backfill_notified);
+    assert!(saved.team_backfill_notified,
+        "team_backfill_notified must be set even on the silent path");
 }
 
 /// After login, `fetch_and_cache_teams` writes `teams[]` into user config.
@@ -171,12 +169,12 @@ fn backfill_fires_after_login_team_fetch() {
     let outcome = maybe_apply_team_backfill_inner(temp.path());
 
     match outcome {
-        BackfillOutcome::Applied { ref team_id, ref team_slug, ref team_name } => {
+        BackfillOutcome::AppliedSetDefault { ref team_id, ref team_slug, ref team_name } => {
             assert_eq!(team_id, "tid-login");
             assert_eq!(team_slug, "login-team");
             assert_eq!(team_name, "Login Team");
         }
-        other => panic!("expected Applied after login-path backfill, got {other:?}"),
+        other => panic!("expected AppliedSetDefault after login-path backfill, got {other:?}"),
     }
 
     let saved = read_user_config(temp.path());
@@ -189,6 +187,35 @@ fn backfill_fires_after_login_team_fetch() {
     let outcome2 = maybe_apply_team_backfill_inner(temp.path());
     assert_eq!(outcome2, BackfillOutcome::AlreadyNotified,
         "second backfill call must be AlreadyNotified — must not re-fire on re-login");
+}
+
+/// Login path: when the server already set `default_team_id` (multi-team user
+/// whose org has a server-side default), the login-path backfill must return
+/// `AppliedAlreadyDefault` — silent, no first-run notice — so users who were
+/// already in team scope don't see a misleading "just enrolled" message.
+#[test]
+fn login_path_silent_when_default_already_server_set() {
+    let temp = TempDir::new().unwrap();
+
+    // Simulate state after fetch_and_cache_teams for a multi-team user whose
+    // server returned a default_team_id.
+    let mut cfg = CloudConfig::default();
+    cfg.teams = vec![
+        make_team("tid-x", "team-x", "Team X"),
+        make_team("tid-y", "team-y", "Team Y"),
+    ];
+    cfg.default_team_id = Some("tid-x".to_string()); // server-supplied default
+    write_user_config(temp.path(), &cfg);
+
+    let outcome = maybe_apply_team_backfill_inner(temp.path());
+    assert_eq!(outcome, BackfillOutcome::AppliedAlreadyDefault,
+        "login path must be silent when server already supplied default_team_id");
+
+    let saved = read_user_config(temp.path());
+    assert_eq!(saved.default_team_id.as_deref(), Some("tid-x"),
+        "server-set default_team_id must be preserved");
+    assert!(saved.team_backfill_notified,
+        "team_backfill_notified must be set to block future re-fires");
 }
 
 /// `cas cloud team default --personal` must set `team_backfill_notified=true`


### PR DESCRIPTION
## Summary

- Splits `BackfillOutcome::Applied` into two variants:
  - `AppliedSetDefault { team_id, team_slug, team_name }` — we auto-picked the sole team for the first time; print the first-run notice
  - `AppliedAlreadyDefault` — `default_team_id` was already set server-side (T2 `/api/me`); just mark `team_backfill_notified`, stay silent
- Updates `print_backfill_notice` in `cli/cloud.rs` to only print on `AppliedSetDefault`
- Login paths (wired in PR #15) automatically benefit — same `print_backfill_notice` helper

## Test changes

- `backfill_notifies_when_default_already_set_by_server` → renamed to `backfill_silent_when_default_already_set_by_server`; now asserts `AppliedAlreadyDefault`
- New test `login_path_silent_when_default_already_server_set` — verifies login path for multi-team user with server-set default stays silent

## Test plan

- [x] `cargo test --test team_backfill_test` → 8/8 pass
- [x] `cargo build -p cas` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)