### PR TITLE
Fix Rust warning-denied build

### DIFF
--- a/cas-cli/src/cli/auth.rs
+++ b/cas-cli/src/cli/auth.rs
@@ -80,13 +80,15 @@ mod tests {
 
     /// Serialises CAS_CLOUD_ENDPOINT mutations in auth.rs tests via the same
     /// module-level mutex used by cloud::config tests — prevents cross-module races.
-    struct EnvGuard(std::sync::MutexGuard<'static, ()>);
+    struct EnvGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
     impl EnvGuard {
         fn new() -> Self {
             let g = CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
             // SAFETY: serialized via CLOUD_ENV_LOCK.
             unsafe { std::env::remove_var("CAS_CLOUD_ENDPOINT"); }
-            EnvGuard(g)
+            EnvGuard { _guard: g }
         }
         fn set(&self, k: &str, v: &str) {
             // SAFETY: serialized via CLOUD_ENV_LOCK.

--- a/cas-cli/src/cli/integrate/fs.rs
+++ b/cas-cli/src/cli/integrate/fs.rs
@@ -59,7 +59,7 @@ pub fn read_capped(path: &Path) -> anyhow::Result<String> {
             MAX_FILE_BYTES
         );
     }
-    let mut f = fs::File::open(path)
+    let f = fs::File::open(path)
         .with_context(|| format!("opening {}", path.display()))?;
     let mut s = String::new();
     f.take(MAX_FILE_BYTES + 1)

--- a/cas-cli/src/cli/integrate/integrations.rs
+++ b/cas-cli/src/cli/integrate/integrations.rs
@@ -14,9 +14,9 @@ use anyhow::Context;
 
 use super::github::{self, GithubAction};
 use super::lock::IntegrateLock;
-use super::neon::{self, LiveNeonClient, NeonDetection};
+use super::neon::{self, LiveNeonClient};
 use super::types::{IntegrationOutcome, IntegrationStatus};
-use super::vercel::{self, VercelDetection};
+use super::vercel;
 
 /// Caller-supplied flags that gate the run. Mirrors the `cas init` CLI
 /// surface.

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -1330,7 +1330,9 @@ mod tests {
     // Tests that construct CloudConfig::default() (or ..Default::default())
     // also acquire the lock because default_endpoint() now reads the env var.
 
-    struct EnvGuard(std::sync::MutexGuard<'static, ()>);
+    struct EnvGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
     impl EnvGuard {
         fn new() -> Self {
             let g = super::CLOUD_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -1339,7 +1341,7 @@ mod tests {
             unsafe {
                 std::env::remove_var("CAS_CLOUD_ENDPOINT");
             }
-            EnvGuard(g)
+            EnvGuard { _guard: g }
         }
         fn set(&self, k: &str, v: &str) {
             // SAFETY: serialized via CLOUD_ENV_LOCK.

--- a/cas-cli/src/duplicate_check.rs
+++ b/cas-cli/src/duplicate_check.rs
@@ -281,7 +281,9 @@ mod tests {
 
     /// Guard that clears the two gate env vars on drop so a test failure can't
     /// leave residue for the next test in the same process.
-    struct EnvGuard(std::sync::MutexGuard<'static, ()>);
+    struct EnvGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
     impl EnvGuard {
         fn new() -> Self {
             let g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -291,7 +293,7 @@ mod tests {
                 std::env::remove_var("CAS_WARN_DUPLICATES");
                 std::env::remove_var("CAS_SUPPRESS_DUPLICATE_WARNING");
             }
-            EnvGuard(g)
+            EnvGuard { _guard: g }
         }
         fn set(&self, k: &str, v: &str) {
             unsafe {

--- a/cas-cli/src/hooks/handlers/handlers_events/project_overview.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/project_overview.rs
@@ -403,6 +403,7 @@ pub enum ProjectOverviewStaleness {
 impl ProjectOverviewStaleness {
     /// `true` when this level warrants `severity="high"` in the SessionStart
     /// injection (drives "prepend vs append" in the hook).
+    #[cfg(test)]
     pub fn is_high_severity(&self, is_supervisor: bool) -> bool {
         match self {
             ProjectOverviewStaleness::Missing => true,
@@ -504,9 +505,8 @@ fn change_prefix(c: &ProjectOverviewChange) -> &'static str {
 /// Check if PRODUCT_OVERVIEW.md is missing or stale.
 ///
 /// `agent_role` is accepted for API symmetry with downstream hook wiring; the
-/// returned staleness is role-agnostic. Callers drive role-based severity by
-/// passing `is_supervisor` to `ProjectOverviewStaleness::is_high_severity` and
-/// `format_injection` at render time.
+/// returned staleness is role-agnostic. Callers can tailor rendering through
+/// `format_injection`.
 pub fn check_freshness(
     repo_root: &Path,
     agent_role: Option<&str>,

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -197,17 +197,22 @@ impl FactoryApp {
         // Harness — the field that was previously cached and never refreshed.
         let live_cli = cas_mux::SupervisorCli::from_str(llm.harness_for_role("worker"))
             .unwrap_or(cas_mux::SupervisorCli::Claude);
-        self.mux.set_worker_cli(live_cli);
         // Keep FactoryApp's own field in sync so queue_codex_worker_intro_prompt
         // and generate_prompt pick up the updated harness as well.
         self.worker_cli = live_cli;
 
         // Re-read model and effort for consistency; these were already correct
         // at startup but can drift if config changes mid-session.
-        self.mux
-            .set_worker_model(llm.model_for_role("worker").map(ToOwned::to_owned));
-        self.mux
-            .set_worker_effort(llm.reasoning_effort_for_role("worker").map(ToOwned::to_owned));
+        let worker_model = llm.model_for_role("worker").map(ToOwned::to_owned);
+        let worker_effort = llm
+            .reasoning_effort_for_role("worker")
+            .and_then(|effort| effort.parse::<cas_mux::Effort>().ok());
+        self.mux.set_default_worker_spec(cas_mux::WorkerSpec {
+            name: None,
+            cli: live_cli,
+            model: worker_model,
+            effort: worker_effort,
+        });
     }
 
     /// Add a new worker at runtime (synchronous - blocks during worktree creation).
@@ -759,7 +764,6 @@ impl FactoryApp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cas_store::TaskStore;
     use cas_types::{Task, TaskStatus};
     use tempfile::TempDir;
 

--- a/cas-cli/src/ui/factory/daemon/fork_first.rs
+++ b/cas-cli/src/ui/factory/daemon/fork_first.rs
@@ -380,18 +380,6 @@ impl DaemonInitPhase {
             self.factory_config.cwd.clone(),
         )?;
 
-        // Send InitComplete to boot screen
-        self.send_init_complete()?;
-        tracing::info!("Initialization complete, transitioning to daemon mode");
-
-        // Give boot screen client time to receive InitComplete before we close the socket
-        std::thread::sleep(std::time::Duration::from_millis(100));
-
-        // Close the init client (boot screen connection)
-        if let Some(stream) = self.init_client.take() {
-            drop(stream);
-        }
-
         // Defer cloud phone-home client start to daemon.run() where a Tokio
         // runtime is available.  In the fork-first path, run_with_progress()
         // executes *before* the Tokio runtime is created, so calling
@@ -454,6 +442,20 @@ impl DaemonInitPhase {
         );
         metadata.team_name = teams.as_ref().map(|t| t.team_name().to_string());
         session_manager.save_metadata(&metadata)?;
+
+        // The boot client switches to attach as soon as it receives InitComplete.
+        // Publish metadata first so the parent cannot race into `attach` and
+        // report the generated session as missing.
+        self.send_init_complete()?;
+        tracing::info!("Initialization complete, transitioning to daemon mode");
+
+        // Give boot screen client time to receive InitComplete before we close the socket.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Close the init client (boot screen connection).
+        if let Some(stream) = self.init_client.take() {
+            drop(stream);
+        }
 
         // Bind notification socket for instant prompt queue wakeup
         let notify_rx = match cas_factory::DaemonNotifier::bind(app.cas_dir()) {

--- a/cas-cli/src/ui/factory/daemon/runtime/gui_client.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/gui_client.rs
@@ -262,6 +262,7 @@ impl FactoryDaemon {
     pub(super) fn gui_notify_pane_exited(&mut self, pane_id: &str, exit_code: Option<i32>) {
         self.notify_pane_exited(pane_id, exit_code);
     }
+    #[allow(dead_code)]
     pub(super) fn gui_send_state_update(&mut self) {
         self.send_state_update();
     }
@@ -483,6 +484,7 @@ impl FactoryDaemon {
     }
 
     /// Broadcast a DaemonMessage to all connected GUI clients only.
+    #[allow(dead_code)]
     fn gui_broadcast(&mut self, msg: &DaemonMessage) {
         if let Some(frame) = encode_frame(msg) {
             for client in self.gui_clients.values_mut() {

--- a/cas-cli/src/ui/factory/daemon/runtime/relay.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/relay.rs
@@ -64,6 +64,7 @@ impl PaneBuffer {
     ///
     /// Handles CSI sequences (ESC[...X), OSC sequences (ESC]...ST/BEL),
     /// and two-byte ESC+char sequences.
+    #[allow(dead_code)]
     pub fn as_plain_text(&self) -> String {
         let bytes = self.as_bytes();
         strip_ansi(&bytes)
@@ -136,12 +137,14 @@ fn strip_ansi(bytes: &[u8]) -> String {
 }
 
 /// Interval between pane-tail snapshot writes.
+#[allow(dead_code)]
 const SNAPSHOT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Write ANSI-stripped plain text snapshots to disk for each pane.
 ///
 /// Files are written atomically (write to .tmp, then rename) to
 /// `~/.cas/sessions/{session_name}/pane-tail/{pane_id}.txt`.
+#[allow(dead_code)]
 pub(in crate::ui::factory::daemon) fn write_pane_snapshots(
     session_name: &str,
     pane_buffers: &HashMap<String, PaneBuffer>,

--- a/cas-cli/src/ui/factory/daemon/runtime/ws_client.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/ws_client.rs
@@ -1,6 +1,6 @@
 use crate::ui::factory::daemon::imports::*;
 use crate::ui::factory::protocol::{ClientMessage, DaemonMessage};
-use futures_util::{FutureExt, SinkExt, StreamExt};
+use futures_util::{FutureExt, SinkExt};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
 /// Encode a DaemonMessage as a WebSocket Binary frame (raw JSON, no length prefix).

--- a/cas-cli/src/ui/factory/director/mod.rs
+++ b/cas-cli/src/ui/factory/director/mod.rs
@@ -148,6 +148,7 @@ pub struct SidecarState<'a> {
 
 /// Panel areas for click detection
 #[derive(Debug, Clone, Copy, Default)]
+#[allow(dead_code)]
 pub struct PanelAreas {
     pub factory: Rect,
     pub tasks: Rect,

--- a/cas-cli/tests/fixtures/mod.rs
+++ b/cas-cli/tests/fixtures/mod.rs
@@ -2,11 +2,13 @@
 //!
 //! Provides reusable test infrastructure.
 
+#[cfg(any(target_os = "macos", feature = "claude_rs_e2e"))]
 mod cas_instance;
 #[cfg(feature = "claude_rs_e2e")]
 mod hook_instance;
 mod mock_server;
 
+#[cfg(any(target_os = "macos", feature = "claude_rs_e2e"))]
 pub use cas_instance::new_cas_instance;
 #[cfg(feature = "claude_rs_e2e")]
 pub use hook_instance::{HOOK_TEST_SESSION_ID, HookTestEnv};

--- a/crates/cas-factory-protocol/benches/compression_bench.rs
+++ b/crates/cas-factory-protocol/benches/compression_bench.rs
@@ -217,7 +217,8 @@ fn bench_roundtrip(c: &mut Criterion) {
             |b, data| {
                 b.iter(|| {
                     let compressed = compress(black_box(data));
-                    decompress(black_box(&compressed)).unwrap()
+                    let decompressed = decompress(black_box(&compressed)).unwrap();
+                    black_box(decompressed.as_ref().len());
                 })
             },
         );

--- a/crates/cas-tui-test/src/pty_runner.rs
+++ b/crates/cas-tui-test/src/pty_runner.rs
@@ -203,6 +203,7 @@ impl HeadfulConfig {
         self.fifo_dir().join(format!("cas-tui-headful-{name}.fifo"))
     }
 
+    #[cfg(target_os = "macos")]
     fn window_id_path(&self) -> PathBuf {
         let name = self
             .name
@@ -731,11 +732,6 @@ static SHARED_HEADFUL: OnceLock<SharedHeadful> = OnceLock::new();
 #[cfg(target_os = "macos")]
 fn escape_applescript_string(value: &str) -> String {
     value.replace('\\', "\\\\").replace('\"', "\\\"")
-}
-
-#[cfg(not(target_os = "macos"))]
-fn escape_applescript_string(value: &str) -> String {
-    value.to_string()
 }
 
 fn set_nonblocking(file: &std::fs::File) {


### PR DESCRIPTION
## Summary
- remove unused imports and unnecessary mutability reported by `RUSTFLAGS=-D warnings`
- replace deprecated `cas_mux` worker setter calls with `WorkerSpec`
- gate or annotate intentionally dormant test/diagnostic helpers so all Rust targets compile warning-clean
- fix the compression roundtrip benchmark closure so it does not return a value borrowing local compressed data
- fix the fork-first boot handoff race by saving session metadata before sending `InitComplete`, so the parent cannot attach before `~/.cas/sessions/<name>.json` exists

## Validation
- On `unstable` WSL in `/root/cas`: `ZIG=/root/cas/.context/zig/zig RUSTFLAGS="-D warnings" cargo check --workspace --all-targets -j16`
- On `unstable` WSL: `ZIG=/root/cas/.context/zig/zig cargo build --release -p cas -j16`
- On `unstable` WSL: `target/release/cas doctor`
- On `unstable` WSL after the boot-race fix: generated-session startup with `target/release/cas` reached `SYSTEM READY` without `Session ... not found or not running`.