### PR TITLE
fix(director): suppress WorkerIdle while prompt queue has pending messages (cas-afb7)

### DIFF
--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -1185,6 +1185,7 @@ mod tests {
             current_task: None,
             latest_activity: None,
             last_heartbeat: None,
+            pending_messages: 0,
         };
 
         assert!(

--- a/cas-cli/src/ui/factory/director/events.rs
+++ b/cas-cli/src/ui/factory/director/events.rs
@@ -518,6 +518,18 @@ impl DirectorEventDetector {
                 continue;
             }
 
+            if agent.pending_messages > 0 {
+                // Worker has unread messages in the prompt queue — don't count
+                // this tick as idle. A freshly spawned worker appears task-less
+                // before it has polled its first assignment; firing `WorkerIdle`
+                // here would cause the supervisor to re-assign on top of the
+                // queued message (spawn race, cas-afb7). Reset the streak so the
+                // counter only starts accumulating after the queue is drained.
+                self.consecutive_idle_ticks.remove(&agent.id);
+                self.idle_already_emitted.remove(&agent.id);
+                continue;
+            }
+
             let count = self
                 .consecutive_idle_ticks
                 .entry(agent.id.clone())

--- a/cas-cli/src/ui/factory/director/events_tests/tests.rs
+++ b/cas-cli/src/ui/factory/director/events_tests/tests.rs
@@ -49,6 +49,7 @@ fn make_agent(id: &str, name: &str, current_task: Option<&str>) -> AgentSummary 
         current_task: current_task.map(String::from),
         latest_activity: None,
         last_heartbeat: Some(chrono::Utc::now()),
+        pending_messages: 0,
     }
 }
 
@@ -1074,6 +1075,75 @@ fn test_blocked_task_not_dispatched() {
             DirectorEvent::TaskAssigned { task_id, .. } if task_id == "task-1"
         )),
         "Blocked task must not produce TaskAssigned: {events:?}"
+    );
+}
+
+/// Regression test for cas-afb7: spawn race where `WorkerIdle` fires before
+/// the prompt queue is drained on first poll.
+///
+/// A freshly spawned worker appears task-less before it has polled its first
+/// assignment from the prompt queue. The idle detector must not emit
+/// `WorkerIdle` as long as `pending_messages > 0`. Once the queue is drained
+/// (pending_messages == 0), normal debounce-threshold idle detection resumes.
+#[test]
+fn test_no_worker_idle_while_pending_messages_in_queue() {
+    let mut detector =
+        DirectorEventDetector::new(vec!["swift-fox".to_string()], "supervisor".to_string());
+
+    // Fresh worker: no task, one pending message (task assignment queued).
+    let data_with_pending = DirectorData {
+        ready_tasks: vec![],
+        in_progress_tasks: vec![],
+        epic_tasks: vec![],
+        agents: vec![AgentSummary {
+            id: "agent-1".to_string(),
+            name: "swift-fox".to_string(),
+            status: AgentStatus::Active,
+            current_task: None,
+            latest_activity: None,
+            last_heartbeat: Some(chrono::Utc::now()),
+            pending_messages: 1,
+        }],
+        activity: vec![],
+        agent_id_to_name: [("agent-1".to_string(), "swift-fox".to_string())]
+            .into_iter()
+            .collect(),
+        changes: vec![],
+        git_loaded: true,
+        reminders: vec![],
+        epic_closed_counts: HashMap::new(),
+    };
+    detector.initialize(&data_with_pending);
+
+    // Two consecutive ticks with pending_messages == 1: must NOT emit WorkerIdle.
+    let events_tick1 = detector.detect_changes(&data_with_pending, None);
+    let events_tick2 = detector.detect_changes(&data_with_pending, None);
+    assert!(
+        !events_tick1
+            .iter()
+            .chain(events_tick2.iter())
+            .any(|e| matches!(e, DirectorEvent::WorkerIdle { .. })),
+        "WorkerIdle must not fire while the worker has unread prompt-queue messages (spawn race)"
+    );
+
+    // Once the queue drains (pending_messages == 0), idle detection resumes.
+    // IDLE_CONSECUTIVE_TICKS == 2, so tick-1 must still be suppressed.
+    let idle = idle_data_for("agent-1", "swift-fox");
+    let events_after_drain_tick1 = detector.detect_changes(&idle, None);
+    assert!(
+        !events_after_drain_tick1
+            .iter()
+            .any(|e| matches!(e, DirectorEvent::WorkerIdle { .. })),
+        "First idle tick after queue drained must not fire (debounce threshold not yet reached)"
+    );
+    // Tick-2 crosses the threshold: WorkerIdle must now fire.
+    let events_after_drain_tick2 = detector.detect_changes(&idle, None);
+    assert!(
+        events_after_drain_tick2.iter().any(|e| matches!(
+            e,
+            DirectorEvent::WorkerIdle { worker } if worker == "swift-fox"
+        )),
+        "WorkerIdle must fire once pending messages are gone and idle threshold is met"
     );
 }
 

--- a/crates/cas-factory/src/director.rs
+++ b/crates/cas-factory/src/director.rs
@@ -8,8 +8,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use cas_store::{
-    AgentStore, EventStore, Reminder, ReminderStore, SqliteAgentStore, SqliteEventStore,
-    SqliteReminderStore, SqliteTaskStore, SqliteWorktreeStore, WorktreeStore,
+    AgentStore, EventStore, PromptQueueStore, QueuedPrompt, Reminder, ReminderStore,
+    SqliteAgentStore, SqliteEventStore, SqlitePromptQueueStore, SqliteReminderStore,
+    SqliteTaskStore, SqliteWorktreeStore, WorktreeStore,
 };
 use cas_types::{
     AgentRole, AgentStatus, Event, EventType, Priority, Task, TaskStatus, TaskType,
@@ -28,11 +29,16 @@ pub struct DirectorStores {
     pub agent_store: SqliteAgentStore,
     pub worktree_store: Option<SqliteWorktreeStore>,
     pub reminder_store: Option<SqliteReminderStore>,
+    /// Best-effort handle for per-agent pending-message counts. Used by the
+    /// idle detector to suppress `WorkerIdle` while a worker has unread
+    /// messages in the prompt queue (spawn-race fix, cas-afb7).
+    pub prompt_queue_store: Option<SqlitePromptQueueStore>,
 }
 
 impl DirectorStores {
-    /// Open all stores for a CAS directory. Worktree and reminder stores
-    /// are best-effort (None on failure) since they are not critical.
+    /// Open all stores for a CAS directory. Worktree, reminder, and
+    /// prompt-queue stores are best-effort (None on failure) since they are
+    /// not critical.
     pub fn open(cas_dir: &Path) -> anyhow::Result<Self> {
         Ok(Self {
             task_store: SqliteTaskStore::open(cas_dir)?,
@@ -40,6 +46,7 @@ impl DirectorStores {
             agent_store: SqliteAgentStore::open(cas_dir)?,
             worktree_store: SqliteWorktreeStore::open(cas_dir).ok(),
             reminder_store: SqliteReminderStore::open(cas_dir).ok(),
+            prompt_queue_store: SqlitePromptQueueStore::open(cas_dir).ok(),
         })
     }
 }
@@ -70,6 +77,10 @@ pub struct AgentSummary {
     pub latest_activity: Option<(String, chrono::DateTime<chrono::Utc>)>,
     /// Last heartbeat timestamp
     pub last_heartbeat: Option<chrono::DateTime<chrono::Utc>>,
+    /// Number of pending (unprocessed) prompt-queue messages addressed to
+    /// this agent. Used by the idle detector to suppress `WorkerIdle` when
+    /// the worker has unread messages (spawn race mitigation, cas-afb7).
+    pub pending_messages: u32,
 }
 
 /// A group of tasks under an epic
@@ -289,6 +300,26 @@ impl DirectorData {
         };
         let agents_list = AgentStore::list(agent_store, None)?;
 
+        // Compute per-agent pending message counts (best-effort, non-fatal).
+        // These are used by the idle detector to suppress `WorkerIdle` when a
+        // freshly spawned worker has unread messages waiting in the queue before
+        // it has had a chance to poll them (spawn race fix, cas-afb7).
+        let agent_names_for_pq: Vec<&str> = agents_list.iter().map(|a| a.name.as_str()).collect();
+        let pending_msgs: Vec<QueuedPrompt> =
+            if let Some(pq) = stores.and_then(|s| s.prompt_queue_store.as_ref()) {
+                pq.peek_for_targets(&agent_names_for_pq, None, 500)
+                    .unwrap_or_default()
+            } else {
+                SqlitePromptQueueStore::open(cas_dir)
+                    .ok()
+                    .and_then(|pq| pq.peek_for_targets(&agent_names_for_pq, None, 500).ok())
+                    .unwrap_or_default()
+            };
+        let mut pending_counts: HashMap<String, u32> = HashMap::new();
+        for msg in pending_msgs {
+            *pending_counts.entry(msg.target).or_insert(0) += 1;
+        }
+
         let mut agent_id_to_name = HashMap::new();
         let agents: Vec<AgentSummary> = agents_list
             .into_iter()
@@ -304,6 +335,7 @@ impl DirectorData {
                 // Task assignees store agent names (not IDs), so look up by name
                 let current_task = assignee_tasks.get(&a.name).cloned();
                 let latest_activity = agent_latest_activity.get(&a.id).cloned();
+                let pending_messages = pending_counts.get(&a.name).copied().unwrap_or(0);
                 AgentSummary {
                     id: a.id,
                     name: a.name,
@@ -311,6 +343,7 @@ impl DirectorData {
                     current_task,
                     latest_activity,
                     last_heartbeat: Some(a.last_heartbeat),
+                    pending_messages,
                 }
             })
             .collect();

--- a/crates/cas-factory/tests/director_data_integration.rs
+++ b/crates/cas-factory/tests/director_data_integration.rs
@@ -530,6 +530,7 @@ fn test_agent_summary_fields() {
         current_task: Some("cas-1234".to_string()),
         latest_activity: Some(("Edited file".to_string(), now)),
         last_heartbeat: Some(now),
+        pending_messages: 0,
     };
 
     assert_eq!(summary.id, "agent-123");


### PR DESCRIPTION
## Summary

- Fixes spawn race (cas-afb7): `WorkerIdle` was firing before newly spawned workers drained their first queued message from the supervisor
- Adds `pending_messages: u32` to `AgentSummary`; populated each refresh cycle from `SqlitePromptQueueStore.peek_for_targets` (best-effort, 0 on failure)
- Adds `prompt_queue_store: Option<SqlitePromptQueueStore>` to `DirectorStores` for cached access
- Gates `consecutive_idle_ticks` increment: if `agent.pending_messages > 0`, reset streak and skip — same as the existing `current_task.is_some()` guard
- Regression test: 2 ticks with `pending_messages=1` must not emit `WorkerIdle`; fires normally after queue drains and threshold (2 ticks) is met

## Test plan

- [x] `cargo test --workspace` — all tests pass
- [x] Regression test `test_no_worker_idle_while_pending_messages_in_queue` passes
- [x] All existing idle-detection tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)