### PR TITLE
test(cas-3b18): pin ghostty_vt no-error contract for empty-pane scroll

### DIFF
--- a/crates/cas-mux/src/pane/tests.rs
+++ b/crates/cas-mux/src/pane/tests.rs
@@ -308,4 +308,25 @@ mod cases {
     fn trailing_dec_partial_no_esc() {
         assert!(Pane::trailing_dec_partial(b"hello world").is_empty());
     }
+
+    /// Test that scrolling an empty pane (no scrollback) returns Ok (no-op, not an error).
+    ///
+    /// AC #5 (cas-3b18): `RUST_LOG=info` must produce no "Failed to scroll focused pane:"
+    /// or "Failed to scroll terminal: code …" log lines during normal scroll operations.
+    /// That warning fires only if `Pane::scroll` returns `Err`.  This test pins the
+    /// ghostty_vt contract: scrolling a viewport with no scrollback above the visible
+    /// region must be a silent no-op (return code 0), not an error.
+    #[test]
+    fn test_scroll_empty_pane_is_ok_not_error() {
+        let mut pane = Pane::director("test-empty", 24, 80).expect("create pane");
+        // No content fed — scrollback is empty (just the 24-row visible viewport).
+        assert!(
+            pane.scroll(-3).is_ok(),
+            "scrolling empty pane up should be a silent no-op (Ok), not an error"
+        );
+        assert!(
+            pane.scroll(3).is_ok(),
+            "scrolling empty pane down should be a silent no-op (Ok), not an error"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `test_scroll_empty_pane_is_ok_not_error` to `crates/cas-mux/src/pane/tests.rs`
- Pins the ghostty_vt contract: `scroll_viewport` returns code 0 (Ok, silent no-op) when there is no scrollback above the visible region — so `scroll_focused_pane` never emits a "Failed to scroll focused pane:" warn at `RUST_LOG=info` (AC #5)
- The primary alt-screen wheel-forwarding fix (cas-d5fa) was already in main via `factory/solid-cobra-88` (087bb74, 2026-05-12); this task completes characterization coverage

## Test plan

- [ ] `cargo test -p cas-mux --lib` — 55 tests pass (includes `test_scroll_empty_pane_is_ok_not_error`)
- [ ] `cargo test -p cas --lib -- ui::factory::app::sidecar_and_selection` — 11 scroll dispatch tests pass
- [ ] Termux two-finger scroll: user verification post-merge (interactive SSH required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)