### PR TITLE
feat(cas-55ac): per-turn UserPromptSubmit reminder for factory supervisors (≤512B)

### DIFF
--- a/cas-cli/src/hooks/handlers/handlers_middle/prompt_capture.rs
+++ b/cas-cli/src/hooks/handlers/handlers_middle/prompt_capture.rs
@@ -1,5 +1,27 @@
 use crate::hooks::handlers::*;
 
+/// Build the per-turn supervisor reminder (≤512 bytes).
+///
+/// Emitted by `handle_user_prompt_submit` when `is_factory_agent && role==supervisor`.
+/// Refreshes Hard Rules every turn to prevent mid-session drift where supervisors
+/// forget their role and start using incorrect tools (e.g. `AskUserQuestion` for workers,
+/// or `SendMessage` instead of `mcp__cas__coordination`).
+///
+/// Identity is resolved at call time from process env vars set by the factory daemon:
+/// - `CAS_AGENT_NAME` → supervisor name (e.g. "loyal-bear-96")
+/// - `CAS_FACTORY_SESSION` → team/session name (e.g. "cas-src-wild-dragon-82")
+pub(crate) fn build_supervisor_reminder() -> String {
+    let name = std::env::var("CAS_AGENT_NAME").unwrap_or_else(|_| "supervisor".to_string());
+    let team = std::env::var("CAS_FACTORY_SESSION").unwrap_or_else(|_| "team".to_string());
+    format!(
+        "[supervisor reminder]\n\
+         You are {name}, supervisor of team {team}. Hard rules:\n\
+         \u{2022} AskUserQuestion \u{2192} human user ONLY. Workers/teammates \u{2192} mcp__cas__coordination action=message.\n\
+         \u{2022} Never SendMessage. Never close worker tasks. Never implement non-trivial work yourself.\n\
+         \u{2022} Never poll/monitor/sleep. End your turn after assigning. Wait for messages."
+    )
+}
+
 pub fn handle_user_prompt_submit(
     input: &HookInput,
     cas_root: Option<&Path>,
@@ -9,6 +31,17 @@ pub fn handle_user_prompt_submit(
         Some(p) if !p.trim().is_empty() => p.trim(),
         _ => return Ok(HookOutput::empty()),
     };
+
+    // === SUPERVISOR REMINDER (cas-55ac) ===
+    // Emit a per-turn Hard Rules reminder for factory supervisors.
+    // Runs BEFORE the cas_root check (no store needed) and returns early,
+    // skipping attribution capture (supervisors don't write code).
+    if crate::harness_policy::is_factory_agent(input)
+        && crate::harness_policy::is_supervisor(input)
+    {
+        let reminder = build_supervisor_reminder();
+        return Ok(HookOutput::with_user_prompt_context(reminder));
+    }
 
     // Check if CAS is initialized (needed for all operations)
     let cas_root = match cas_root {

--- a/cas-cli/src/hooks/handlers/handlers_tests/mod.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/mod.rs
@@ -6,3 +6,4 @@ mod preferences_context;
 mod reviews;
 mod ripple_path_scope;
 mod send_message_autoroute;
+mod supervisor_reminder;

--- a/cas-cli/src/hooks/handlers/handlers_tests/supervisor_reminder.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/supervisor_reminder.rs
@@ -1,0 +1,143 @@
+//! Tests for cas-55ac: Per-turn UserPromptSubmit reminder for factory supervisors.
+//!
+//! The `UserPromptSubmit` hook now emits a ≤512B role reminder when
+//! `is_factory_agent && role==supervisor`. The reminder refreshes Hard Rules
+//! every turn to counter mid-session drift. Non-supervisor and non-factory
+//! sessions remain unchanged (returns empty).
+
+use cas_core::hooks::types::{HookInput, HookSpecificOutput};
+
+use crate::hooks::handlers::handle_user_prompt_submit;
+
+fn supervisor_input() -> HookInput {
+    HookInput {
+        session_id: "test-supervisor-session".to_string(),
+        cwd: "/test".to_string(),
+        hook_event_name: "UserPromptSubmit".to_string(),
+        user_prompt: Some("What tasks are ready?".to_string()),
+        agent_role: Some("supervisor".to_string()),
+        ..HookInput::default()
+    }
+}
+
+fn worker_input() -> HookInput {
+    HookInput {
+        session_id: "test-worker-session".to_string(),
+        cwd: "/test".to_string(),
+        hook_event_name: "UserPromptSubmit".to_string(),
+        user_prompt: Some("What tasks are ready?".to_string()),
+        agent_role: Some("worker".to_string()),
+        ..HookInput::default()
+    }
+}
+
+fn non_factory_input() -> HookInput {
+    HookInput {
+        session_id: "test-solo-session".to_string(),
+        cwd: "/test".to_string(),
+        hook_event_name: "UserPromptSubmit".to_string(),
+        user_prompt: Some("What tasks are ready?".to_string()),
+        agent_role: None,
+        ..HookInput::default()
+    }
+}
+
+/// AC1: Supervisor receives a non-empty UserPromptSubmit additionalContext.
+/// AC4: Output byte length ≤ 512.
+/// Both checked together since they require the same setup.
+#[test]
+fn supervisor_gets_reminder_within_512_bytes() {
+    let input = supervisor_input();
+    let output = handle_user_prompt_submit(&input, None).unwrap();
+
+    let context = match &output.hook_specific_output {
+        Some(HookSpecificOutput::UserPromptSubmit { additional_context }) => additional_context,
+        other => panic!(
+            "Expected UserPromptSubmit hookSpecificOutput, got: {other:?}"
+        ),
+    };
+
+    let byte_len = context.as_bytes().len();
+    assert!(
+        byte_len <= 512,
+        "Supervisor reminder exceeds 512 bytes: {byte_len} bytes\n---\n{context}\n---"
+    );
+}
+
+/// AC1: The reminder contains all 6 Hard Rule keywords.
+#[test]
+fn supervisor_reminder_contains_all_6_hard_rule_keywords() {
+    let input = supervisor_input();
+    let output = handle_user_prompt_submit(&input, None).unwrap();
+
+    let context = match &output.hook_specific_output {
+        Some(HookSpecificOutput::UserPromptSubmit { additional_context }) => additional_context,
+        other => panic!(
+            "Expected UserPromptSubmit hookSpecificOutput, got: {other:?}"
+        ),
+    };
+
+    // All 6 Hard Rule keywords must appear in the reminder.
+    let keywords = [
+        "AskUserQuestion",
+        "mcp__cas__coordination",
+        "SendMessage",
+        "close",
+        "implement",
+        "poll",
+    ];
+    for kw in keywords {
+        assert!(
+            context.contains(kw),
+            "Supervisor reminder missing keyword '{kw}':\n---\n{context}\n---"
+        );
+    }
+}
+
+/// AC2: Worker sessions return empty (no reminder injected).
+#[test]
+fn worker_does_not_get_supervisor_reminder() {
+    let input = worker_input();
+    let output = handle_user_prompt_submit(&input, None).unwrap();
+
+    let json = serde_json::to_string(&output).unwrap();
+    assert_eq!(
+        json, "{}",
+        "Worker session must return empty HookOutput, got: {json}"
+    );
+}
+
+/// AC2: Non-factory (generic Claude) sessions return empty.
+#[test]
+fn non_factory_does_not_get_supervisor_reminder() {
+    let input = non_factory_input();
+    let output = handle_user_prompt_submit(&input, None).unwrap();
+
+    let json = serde_json::to_string(&output).unwrap();
+    assert_eq!(
+        json, "{}",
+        "Non-factory session must return empty HookOutput, got: {json}"
+    );
+}
+
+/// AC1: Supervisor reminder includes identity placeholders (name, team).
+/// The reminder text must contain the identity section so the supervisor
+/// knows which role it's been assigned.
+#[test]
+fn supervisor_reminder_contains_identity_context() {
+    let input = supervisor_input();
+    let output = handle_user_prompt_submit(&input, None).unwrap();
+
+    let context = match &output.hook_specific_output {
+        Some(HookSpecificOutput::UserPromptSubmit { additional_context }) => additional_context,
+        other => panic!(
+            "Expected UserPromptSubmit hookSpecificOutput, got: {other:?}"
+        ),
+    };
+
+    // The reminder must include an identity line (supervisor of team ...)
+    assert!(
+        context.contains("supervisor"),
+        "Reminder must identify the role as 'supervisor':\n---\n{context}\n---"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `build_supervisor_reminder()` in `prompt_capture.rs` — emits a ≤512B Hard Rules reminder via `HookOutput::with_user_prompt_context`
- Branches early in `handle_user_prompt_submit` when `is_factory_agent && is_supervisor`, returns before the `cas_root` check (no store needed)
- Worker and non-factory sessions unchanged (empty output)

## Test plan

- [x] test-first: 5 failing tests committed first (`supervisor_reminder.rs`)
- [x] All 5 tests pass (`cargo test -p cas --lib supervisor_reminder`, exit 0)
- [x] Pre-existing unrelated failure (`test_supervisor_guidance_under_12kb`) confirmed as cas-61af scope
- [ ] AC3 (live JSONL validation) — runtime check by supervisor

🤖 Generated with [Claude Code](https://claude.com/claude-code)