### PR TITLE
fix(cas-5e4b): trim supervisor_guidance() to ≤8KB, debundle checklist

### DIFF
--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -878,17 +878,15 @@ pub fn extract_body(content: &str) -> &str {
 
 /// Get the supervisor guidance injected at factory SessionStart.
 ///
-/// Returns the trimmed supervisor SKILL.md plus the supervisor checklist.
+/// Returns only the trimmed supervisor SKILL.md body. The checklist
+/// (`cas-supervisor-checklist`) is a separate skill invocable via
+/// `/cas-supervisor-checklist` — bundling it pushed the SessionStart payload
+/// over the ~10KB Claude Code harness cap (measured by cas-ecd5, 2026-06-01),
+/// causing the full briefing to be silently replaced with a 2KB preview.
 /// task-tracking, memory, and search are autonomous skills the agent invokes
-/// on demand via the Skill tool — bundling them inflated SessionStart context
-/// past the harness "Output too large" threshold (the additionalContext got
-/// truncated to a 2KB preview), which silently disabled the supervisor guide.
+/// on demand via the Skill tool — same rationale.
 pub fn supervisor_guidance() -> String {
-    [
-        extract_body(SUPERVISOR_GUIDE),
-        extract_body(CHECKLIST_GUIDE),
-    ]
-    .join("\n\n---\n\n")
+    extract_body(SUPERVISOR_GUIDE).to_string()
 }
 
 /// Get the worker guidance injected at factory SessionStart.
@@ -932,9 +930,10 @@ This is the body content."#;
         let guide = supervisor_guidance();
         assert!(guide.contains("Factory Supervisor"));
         assert!(!guide.contains("managed_by:"));
+        // Checklist must NOT be bundled — it loads separately via /cas-supervisor-checklist.
         assert!(
-            guide.contains("Supervisor Checklist"),
-            "should include checklist"
+            !guide.contains("Supervisor Checklist"),
+            "should NOT bundle checklist — invocable separately via /cas-supervisor-checklist"
         );
         // task-tracking/memory/search are autonomous skills, not bundled.
         assert!(
@@ -947,18 +946,58 @@ This is the body content."#;
         );
     }
 
-    /// SessionStart additionalContext gets truncated to a small preview by
-    /// the Claude Code harness once the payload exceeds its threshold (the
-    /// pre-trim bundle was ~61KB and got cut to 2KB). The exact threshold
-    /// isn't documented; 12KB is a conservative ceiling that leaves room for
-    /// the rest of the SessionStart context (codemap banner, agent identity,
-    /// coordination block) to fit alongside without tripping truncation.
+    /// All 6 Hard Rules must appear verbatim in the supervisor briefing.
+    /// These keywords are the ones confirmed present in the model-visible
+    /// hook_additional_context bytes after the harness cap trim (cas-5e4b).
     #[test]
-    fn test_supervisor_guidance_under_12kb() {
+    fn test_supervisor_guidance_hard_rules() {
+        let guide = supervisor_guidance();
+        for keyword in [
+            "AskUserQuestion",
+            "SendMessage",
+            "coordination",
+            "Never close",
+            "Never implement",
+            "Never monitor",
+            "End your turn",
+        ] {
+            assert!(
+                guide.contains(keyword),
+                "supervisor_guidance() missing Hard Rule keyword: {keyword:?}"
+            );
+        }
+    }
+
+    /// The checklist is a separate skill invocable via /cas-supervisor-checklist.
+    /// Bundling it into supervisor_guidance() would push the SessionStart
+    /// payload over the ~10KB harness cap (cas-ecd5, 2026-06-01).
+    #[test]
+    fn test_supervisor_guidance_no_checklist() {
         let guide = supervisor_guidance();
         assert!(
-            guide.len() < 12_288,
-            "supervisor_guidance is {} bytes — over the 12KB ceiling. \
+            !guide.contains("# Supervisor Checklist"),
+            "supervisor_guidance() must not inline the checklist — \
+             it is invocable separately via /cas-supervisor-checklist"
+        );
+        // Cross-check: the checklist skill itself must still exist.
+        let checklist = extract_body(CHECKLIST_GUIDE);
+        assert!(
+            checklist.contains("# Supervisor Checklist"),
+            "CHECKLIST_GUIDE must still contain its content (invocable on demand)"
+        );
+    }
+
+    /// SessionStart additionalContext gets truncated by the Claude Code harness
+    /// once the payload exceeds its ~10KB threshold (measured empirically by
+    /// cas-ecd5, 2026-06-01). 8KB leaves ~2KB headroom for SessionStart banners
+    /// (codemap freshness, agent identity, WIP banner) to fit alongside without
+    /// tripping truncation. See memory `project_session_start_truncation.md`.
+    #[test]
+    fn test_supervisor_guidance_under_8kb() {
+        let guide = supervisor_guidance();
+        assert!(
+            guide.len() < 8_192,
+            "supervisor_guidance is {} bytes — over the 8KB ceiling. \
              Move content into cas-supervisor/references/ instead of \
              inlining it in cas-supervisor.md.",
             guide.len()
@@ -1008,27 +1047,40 @@ This is the body content."#;
     /// mirrors are checked so neither surface silently drifts.
     #[test]
     fn test_skills_document_context_budgeting_cas_5787() {
-        for (label, content) in [
+        // Common markers required in all four skill files.
+        let common = [
+            "## Context budgeting",
+            "Immutable Core",
+            "Task Context",
+            "Ephemeral",
+            "project_session_start_truncation.md",
+            "references/",
+        ];
+        // Supervisor cap was lowered to 8KB (cas-5e4b); worker cap remains 12KB.
+        let supervisor_files = [
             ("claude cas-supervisor.md", SUPERVISOR_GUIDE),
-            ("claude cas-worker.md", WORKER_GUIDE),
             (
                 "codex cas-supervisor.md",
                 include_str!("builtins/codex/skills/cas-supervisor.md"),
             ),
+        ];
+        let worker_files = [
+            ("claude cas-worker.md", WORKER_GUIDE),
             (
                 "codex cas-worker.md",
                 include_str!("builtins/codex/skills/cas-worker.md"),
             ),
-        ] {
-            for required in [
-                "## Context budgeting",
-                "Immutable Core",
-                "Task Context",
-                "Ephemeral",
-                "project_session_start_truncation.md",
-                "12 KB",
-                "references/",
-            ] {
+        ];
+        for (label, content) in supervisor_files {
+            for required in common.iter().chain(["8 KB"].iter()) {
+                assert!(
+                    content.contains(required),
+                    "{label} missing required Context-budgeting marker: {required:?}"
+                );
+            }
+        }
+        for (label, content) in worker_files {
+            for required in common.iter().chain(["12 KB"].iter()) {
                 assert!(
                     content.contains(required),
                     "{label} missing required Context-budgeting marker: {required:?}"

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor.md
@@ -26,6 +26,7 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 ## Hard Rules
 
 - **Never use SendMessage.** Use `mcp__cs__coordination action=message target=<name> message="..." summary="<brief summary>"` for all communication. SendMessage is blocked in factory mode.
+- **Never use AskUserQuestion for agent communication.** `AskUserQuestion` is strictly for asking the **human** user — it pauses the entire system waiting for human input. Never use it to communicate with workers. Use `mcp__cs__coordination action=message` for worker communication.
 - **Never spawn raw `Agent(isolation: "worktree")` subagents.** Always use `mcp__cs__coordination action=spawn_workers count=N isolate=true` to spawn workers — CAS-managed worktrees are tracked, leased, and cleaned up automatically on shutdown. `Agent(isolation="worktree")` worktrees bypass the factory entirely: they **leak** (no cleanup on shutdown, no merge pipeline, no lease management), and the runtime will reject the attempt with `🚫 Supervisors must not spawn isolated-worktree subagents. Use mcp__cas__coordination action=spawn_workers`. Non-isolation `Agent` calls for read-only research/review remain fine.
 - **Never implement tasks yourself. Delegate ALL non-trivial work to workers.** "Work" includes reports, analyses, investigations, multi-file edits, runbook updates, design write-ups — not just code. Trivial inline exceptions: read-only Q&A, a single `mcp__cs__memory` save, a single-line config change, status updates to the user. **Self-check before every tool call:** Am I about to READ (acceptable) or WRITE/CREATE (should be a task)? If it produces a file edit or new file, stop and create a task.
 - **Never close tasks for workers — unless the escape hatch applies.** Workers own their closes. **Escape hatch:** you may close directly when (1) all work is committed and progress notes match acceptance criteria, (2) worker is unresponsive 5+ min after at least one prompt, and (3) the task is on the critical path. Cherry-pick the worker's commit(s) first, then close with a `reason=` that includes the SHA and why the worker didn't close.
@@ -35,7 +36,7 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Counter-propose when you see a better path.** Three anchors required: (a) a specific citable source — pattern, library, prior incident, commit, measured characteristic; (b) a concrete cost of the current approach; (c) a concrete benefit of the alternative. No anchors → no counter-proposal; execute or ask a clarifying question.
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 
-### What "end your turn" means
+### End your turn
 
 After you assign tasks and send context to workers, **produce no more output**. No `git log`, no `task list`, no `worker_status`. Your next action only happens in response to a worker message or a user prompt.
 
@@ -48,28 +49,6 @@ New session? Run these 5 steps in order. Open the linked reference for detail.
 3. **Intake gate** — Assess all 8 intake checks against the user's request. Detail in [references/intake.md](cas-supervisor/references/intake.md).
 4. **Create EPIC** — `mcp__cs__task action=create task_type=epic title="..." description="..."`. Spec shape and templates in [references/planning.md](cas-supervisor/references/planning.md).
 5. **Spawn, assign, end turn** — `mcp__cs__coordination action=spawn_workers count=N isolate=true`, then assign with `update` (not `transfer`), send context, stop. Phases and merge flow in [references/workflow.md](cas-supervisor/references/workflow.md).
-
-## Supervisor-Owned Code Review (default since v2.13.0)
-
-The default `[code_review] owner` is `"supervisor"`. Workers skip the full multi-persona review at close and transition their tasks to `pending_supervisor_review`; you run the review at cherry-pick to the EPIC branch and at EPIC→base merge. This eliminates the ~14-minute, ~100K-token per-close blocking cost on the worker side. Do not dispatch workers with "run `/cas-code-review` on the diff" — that's the legacy inline-worker path.
-
-**Your responsibilities:**
-
-1. **Monitor the review queue** — Tasks in `pending_supervisor_review` are waiting for you. List them:
-   ```
-   mcp__cs__task action=list status=pending_supervisor_review
-   ```
-2. **Run the full review** — For each queued task, invoke `/cas-code-review mode=interactive task_id=<id>` or batch-review all pending tasks.
-3. **Deliver the verdict** — After review, send the worker a coordination message with the findings summary and any P0/P1 issues to address. If clean, confirm they can consider the task complete.
-4. **Record the verification** (optional) — `mcp__cs__verification action=add task_id=<id> status=approved summary="..."` to create an audit trail.
-
-**Pinning to legacy inline-worker review** (only if your project explicitly wants the old behavior — adds ~14 min per close):
-```toml
-[code_review]
-owner = "worker"
-```
-
-With `owner = "worker"`, each worker runs the full review inline at close and gates close on P0 findings. Most projects should leave this unset and use the supervisor default.
 
 ## Heterogeneous Teams (Claude supervisor + Codex workers)
 
@@ -88,17 +67,6 @@ mcp__cs__coordination action=spawn_workers count=2 cli=codex worker_names="alice
 
 `cli`, `model`, and `effort` are per-spawn overrides. See [references/reference.md](cas-supervisor/references/reference.md) for the full `spawn_workers` parameter table.
 
-## Running Scripts Against Prod
-
-For Vercel-deployed projects, pull real credentials into a local env file before running scripts that need to hit prod services (Neon, QStash, etc.):
-
-```bash
-vercel env pull .env.<env> --environment=<env>
-# e.g.: vercel env pull .env.production --environment=production
-```
-
-Run from the linked project directory. Add the resulting file to `.gitignore` immediately — never commit credentials.
-
 ## References
 
 Each file below is a focused chunk of the operational guide. Open the one you need — they are not pre-loaded.
@@ -109,22 +77,12 @@ Each file below is a focused chunk of the operational guide. Open the one you ne
 - **[workflow.md](cas-supervisor/references/workflow.md)** — Worker modes, count strategy, Phase 1–4, merge/sync, blocker handling.
 - **[worker-recovery.md](cas-supervisor/references/worker-recovery.md)** — `is-wedged` triage, dead/silent worker, garbage output, verification jail, resource-contention crashes.
 - **[reference.md](cas-supervisor/references/reference.md)** — Exact valid actions and field names, dispatch two-step pattern, `update` vs `transfer`, message field requirements.
-
-## When to open which reference
-
-| Situation | Open |
-|---|---|
-| About to spawn workers | preflight |
-| User just sent a request | intake |
-| Building or shaping an EPIC | planning |
-| Workers running, coordinating their work | workflow |
-| A worker pane looks broken or stuck | worker-recovery |
-| Hit "No active lease" / "missing field" / dispatch confusion | reference |
+- **[code-review-queue.md](cas-supervisor/references/code-review-queue.md)** — Supervisor-owned code review mode: queue monitoring, running full review, delivering verdict (cas-b51a).
 
 ## Context budgeting
 
 Three layers (`project_session_start_truncation.md`):
-- **Immutable Core** — skill body; 12 KB SessionStart cap (`test_*_guidance_under_12kb`); over = silent 2 KB preview.
+- **Immutable Core** — skill body; 8 KB SessionStart cap (`test_supervisor_guidance_under_8kb`); over = silent 2 KB preview.
 - **Task Context** — EPIC/task/memories, on demand.
 - **Ephemeral** — outputs, transcript; expendable.
 

--- a/cas-cli/src/builtins/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor.md
@@ -26,6 +26,7 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 ## Hard Rules
 
 - **Never use SendMessage.** Use `mcp__cas__coordination action=message target=<name> message="..." summary="<brief summary>"` for all communication. SendMessage is blocked in factory mode.
+- **Never use AskUserQuestion for agent communication.** `AskUserQuestion` is strictly for asking the **human** user — it pauses the entire system waiting for human input. Never use it to communicate with workers. Use `mcp__cas__coordination action=message` for worker communication.
 - **Never spawn raw `Agent(isolation: "worktree")` subagents.** Always use `mcp__cas__coordination action=spawn_workers count=N isolate=true` to spawn workers — CAS-managed worktrees are tracked, leased, and cleaned up automatically on shutdown. `Agent(isolation="worktree")` worktrees bypass the factory entirely: they **leak** (no cleanup on shutdown, no merge pipeline, no lease management), and the runtime will reject the attempt with `🚫 Supervisors must not spawn isolated-worktree subagents. Use mcp__cas__coordination action=spawn_workers`. Non-isolation `Agent` calls for read-only research/review remain fine.
 - **Never implement tasks yourself. Delegate ALL non-trivial work to workers.** "Work" includes reports, analyses, investigations, multi-file edits, runbook updates, design write-ups — not just code. Trivial inline exceptions: read-only Q&A, a single `mcp__cas__memory` save, a single-line config change, status updates to the user. **Self-check before every tool call:** Am I about to READ (acceptable) or WRITE/CREATE (should be a task)? If it produces a file edit or new file, stop and create a task.
 - **Never close tasks for workers — unless the escape hatch applies.** Workers own their closes. **Escape hatch:** you may close directly when (1) all work is committed and progress notes match acceptance criteria, (2) worker is unresponsive 5+ min after at least one prompt, and (3) the task is on the critical path. Cherry-pick the worker's commit(s) first, then close with a `reason=` that includes the SHA and why the worker didn't close.
@@ -35,7 +36,7 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Counter-propose when you see a better path.** Three anchors required: (a) a specific citable source — pattern, library, prior incident, commit, measured characteristic; (b) a concrete cost of the current approach; (c) a concrete benefit of the alternative. No anchors → no counter-proposal; execute or ask a clarifying question.
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 
-### What "end your turn" means
+### End your turn
 
 After you assign tasks and send context to workers, **produce no more output**. No `git log`, no `task list`, no `worker_status`. Your next action only happens in response to a worker message or a user prompt.
 
@@ -66,17 +67,6 @@ mcp__cas__coordination action=spawn_workers count=2 cli=codex worker_names="alic
 
 `cli`, `model`, and `effort` are per-spawn overrides. See [references/reference.md](cas-supervisor/references/reference.md) for the full `spawn_workers` parameter table.
 
-## Running Scripts Against Prod
-
-For Vercel-deployed projects, pull real credentials into a local env file before running scripts that need to hit prod services (Neon, QStash, etc.):
-
-```bash
-vercel env pull .env.<env> --environment=<env>
-# e.g.: vercel env pull .env.production --environment=production
-```
-
-Run from the linked project directory. Add the resulting file to `.gitignore` immediately — never commit credentials.
-
 ## References
 
 Each file below is a focused chunk of the operational guide. Open the one you need — they are not pre-loaded.
@@ -89,22 +79,10 @@ Each file below is a focused chunk of the operational guide. Open the one you ne
 - **[reference.md](cas-supervisor/references/reference.md)** — Exact valid actions and field names, dispatch two-step pattern, `update` vs `transfer`, message field requirements.
 - **[code-review-queue.md](cas-supervisor/references/code-review-queue.md)** — Supervisor-owned code review mode: queue monitoring, running full review, delivering verdict (cas-b51a).
 
-## When to open which reference
-
-| Situation | Open |
-|---|---|
-| About to spawn workers | preflight |
-| User just sent a request | intake |
-| Building or shaping an EPIC | planning |
-| Workers running, coordinating their work | workflow |
-| A worker pane looks broken or stuck | worker-recovery |
-| Hit "No active lease" / "missing field" / dispatch confusion | reference |
-| Tasks in `pending_supervisor_review`; running code review queue | code-review-queue |
-
 ## Context budgeting
 
 Three layers (`project_session_start_truncation.md`):
-- **Immutable Core** — skill body; 12 KB SessionStart cap (`test_*_guidance_under_12kb`); over = silent 2 KB preview.
+- **Immutable Core** — skill body; 8 KB SessionStart cap (`test_supervisor_guidance_under_8kb`); over = silent 2 KB preview.
 - **Task Context** — EPIC/task/memories, on demand.
 - **Ephemeral** — outputs, transcript; expendable.
 


### PR DESCRIPTION
## Summary

- Debundles `CHECKLIST_GUIDE` from `supervisor_guidance()` — checklist now loads on demand via `/cas-supervisor-checklist` only, saving 4.4KB
- Trims `cas-supervisor.md` (Claude + Codex) by removing inline `Running Scripts Against Prod` and `When to open which reference` table; removes inlined `Supervisor-Owned Code Review` section from Codex variant
- Adds `AskUserQuestion` Hard Rule to both variants (never use for agent-to-agent communication)
- Renames `### What "end your turn" means` → `### End your turn` to match test keyword
- Result: 13.6KB → 7887/7879 bytes (Claude/Codex), well under the ~10KB harness cap

## Test plan

- [ ] `cargo test test_supervisor_guidance` — 5 tests pass (under_8kb, hard_rules, no_checklist, loads, context_budgeting)
- [ ] No regressions in 35-test builtins suite
- [ ] Two pre-existing parallel race failures (`test_configure_creates_settings`, `solo_user_write_is_not_auto_approved`) both pass in isolation; not in this diff

Closes cas-5e4b

🤖 Generated with [Claude Code](https://claude.com/claude-code)