### PR TITLE
Release v2.22.0 — Codex first-class harness + cross-harness delivery + secret redaction (HELD: depth-flag pending)

### DIFF
--- a/.claude/skills/cas-supervisor/SKILL.md
+++ b/.claude/skills/cas-supervisor/SKILL.md
@@ -89,6 +89,7 @@ Each file below is a focused chunk of the operational guide. Open the one you ne
 - **[worker-recovery.md](cas-supervisor/references/worker-recovery.md)** — `is-wedged` triage, dead/silent worker, garbage output, verification jail, resource-contention crashes.
 - **[reference.md](cas-supervisor/references/reference.md)** — Exact valid actions and field names, dispatch two-step pattern, `update` vs `transfer`, message field requirements.
 - **[code-review-queue.md](cas-supervisor/references/code-review-queue.md)** — Supervisor-owned code review mode: queue monitoring, running full review, delivering verdict (cas-b51a).
+- **[filing-cas-bugs.md](cas-supervisor/references/filing-cas-bugs.md)** — File every CAS-system bug as a tracked task, never chat-only or upstream (cas-src → in-repo; else `docs/requests/`).
 
 ## When to open which reference
 

--- a/.claude/skills/cas-supervisor/references/filing-cas-bugs.md
+++ b/.claude/skills/cas-supervisor/references/filing-cas-bugs.md
@@ -1,0 +1,12 @@
+# Filing CAS-system bugs
+
+A standing directive: **file every CAS-system bug you observe as a tracked task, by reflex.** Do not just mention it in chat, defer it to "later", or "report it upstream". A CAS-system bug you noticed but didn't capture is a bug that resurfaces.
+
+"CAS-system" means a defect in CAS itself: the verifier, hooks, factory/director orchestration, MCP dispatch, the task-verifier agent, worker/supervisor prompts, or builtin skills — regardless of which downstream project (gabber-studio, OpenClaw, etc.) surfaced it.
+
+## Where the bug goes depends on the repo
+
+- **If this repo is cas-src (the CAS source):** create an in-repo task (`task action=create task_type=bug`) and let a worker fix it here. Other projects consume CAS; they do not modify it — the fix lands in cas-src. This mirrors cas-src's `CLAUDE.md` → "## CAS system bugs are in-repo fixes".
+- **In any other project:** drop a `BUG-<slug>.md` file in cas-src's `docs/requests/` inbox (the cross-team relay convention), then continue your own work — don't block your project's task on the CAS fix.
+
+Never silently ignore a CAS-system bug, leave it chat-only, or treat cas-src as an untouchable external dependency. Capture it, route it, move on.

--- a/.claude/skills/cas-worker/SKILL.md
+++ b/.claude/skills/cas-worker/SKILL.md
@@ -27,6 +27,15 @@ You execute tasks assigned by the Supervisor. You may be working in an isolated 
 - **Spike** (`task_type=spike`) — produces understanding, not code. Deliverable is a decision/comparison/recommendation captured via `note_type=decision`. Spike acceptance criteria are question-based.
 - **Demo statements** — if a task has a `demo_statement`, the work must produce that observable outcome.
 
+## Task Depth
+
+Tasks carry a `depth` field, shown as `Depth:` in `task show` and `task mine`. Read it when you **start** — it sets your working style. Depth comes from the **task record**, never an env var.
+
+- **`light`** — Speed mode for feel-driven iteration. Ship the **minimal diff** that satisfies the ask, then stop. NO gold-plating: no unasked tests, docs, edge-case handling, or refactors. **Skip the 6 pre-close self-checks** in [close-gate.md](cas-worker/references/close-gate.md). The Definition of Done is "it runs on localhost" — the human is the evaluator, so stop there instead of chasing a DoD that doesn't exist.
+- **`deep` or unset** — Default. Full discipline: the close-gate and everything below apply unchanged.
+
+`light` relaxes thoroughness, not integrity: stay in your layer, respect non-goals, and never claim a proof you didn't run.
+
 ## Execution Posture
 
 Tasks may carry an `execution_note` field declaring the posture. Three values, or null:

--- a/.claude/skills/cas-worker/references/close-gate.md
+++ b/.claude/skills/cas-worker/references/close-gate.md
@@ -8,6 +8,10 @@ managed_by: cas
 
 Run all 6 self-verification checks before `mcp__cas__task action=close`. The gate is the same regardless of task type. Skip and you eat a verifier rejection round-trip.
 
+## Depth: `light` tasks skip this gate
+
+If the task you're closing is `depth=light` (check the `Depth:` line in `task show`), **skip the 6 pre-close self-checks below** and close once it runs on localhost. Light is speed mode: minimal diff, no gold-plating, the human is the evaluator — there is no DoD to chase. You must still not claim a proof you didn't run. For `depth=deep` or unset, run the full gate below.
+
 **Code review is not your job at close** under the v2.13.0+ default `[code_review] owner = "supervisor"`. The supervisor runs `/cas-code-review` at cherry-pick + EPIC merge time. Do not invoke the multi-persona review yourself unless your supervisor explicitly tells you to, or your project has opted in to legacy `owner = "worker"` in `.cas/config.toml` — the worker-inline path adds ~14 min and ~100K tokens per close, which is exactly what the v2.13.0 flip was designed to eliminate.
 
 ## Pre-Close Self-Verification

--- a/.codex/skills/cas-supervisor/SKILL.md
+++ b/.codex/skills/cas-supervisor/SKILL.md
@@ -109,6 +109,7 @@ Each file below is a focused chunk of the operational guide. Open the one you ne
 - **[workflow.md](cas-supervisor/references/workflow.md)** — Worker modes, count strategy, Phase 1–4, merge/sync, blocker handling.
 - **[worker-recovery.md](cas-supervisor/references/worker-recovery.md)** — `is-wedged` triage, dead/silent worker, garbage output, verification jail, resource-contention crashes.
 - **[reference.md](cas-supervisor/references/reference.md)** — Exact valid actions and field names, dispatch two-step pattern, `update` vs `transfer`, message field requirements.
+- **[filing-cas-bugs.md](cas-supervisor/references/filing-cas-bugs.md)** — File every CAS-system bug as a tracked task, never chat-only or upstream (cas-src → in-repo; else `docs/requests/`).
 
 ## When to open which reference
 

--- a/.codex/skills/cas-supervisor/references/filing-cas-bugs.md
+++ b/.codex/skills/cas-supervisor/references/filing-cas-bugs.md
@@ -1,0 +1,12 @@
+# Filing CAS-system bugs
+
+A standing directive: **file every CAS-system bug you observe as a tracked task, by reflex.** Do not just mention it in chat, defer it to "later", or "report it upstream". A CAS-system bug you noticed but didn't capture is a bug that resurfaces.
+
+"CAS-system" means a defect in CAS itself: the verifier, hooks, factory/director orchestration, MCP dispatch, the task-verifier agent, worker/supervisor prompts, or builtin skills — regardless of which downstream project (gabber-studio, OpenClaw, etc.) surfaced it.
+
+## Where the bug goes depends on the repo
+
+- **If this repo is cas-src (the CAS source):** create an in-repo task (`task action=create task_type=bug`) and let a worker fix it here. Other projects consume CAS; they do not modify it — the fix lands in cas-src. This mirrors cas-src's `CLAUDE.md` → "## CAS system bugs are in-repo fixes".
+- **In any other project:** drop a `BUG-<slug>.md` file in cas-src's `docs/requests/` inbox (the cross-team relay convention), then continue your own work — don't block your project's task on the CAS fix.
+
+Never silently ignore a CAS-system bug, leave it chat-only, or treat cas-src as an untouchable external dependency. Capture it, route it, move on.

--- a/.codex/skills/cas-worker/SKILL.md
+++ b/.codex/skills/cas-worker/SKILL.md
@@ -27,6 +27,15 @@ You execute tasks assigned by the Supervisor. You may be working in an isolated 
 - **Spike** (`task_type=spike`) — produces understanding, not code. Deliverable is a decision/comparison/recommendation captured via `note_type=decision`. Spike acceptance criteria are question-based.
 - **Demo statements** — if a task has a `demo_statement`, the work must produce that observable outcome.
 
+## Task Depth
+
+Tasks carry a `depth` field, shown as `Depth:` in `task show` and `task mine`. Read it when you **start** — it sets your working style. Depth comes from the **task record**, never an env var.
+
+- **`light`** — Speed mode for feel-driven iteration. Ship the **minimal diff** that satisfies the ask, then stop. NO gold-plating: no unasked tests, docs, edge-case handling, or refactors. **Skip the 6 pre-close self-checks** in [close-gate.md](cas-worker/references/close-gate.md). The Definition of Done is "it runs on localhost" — the human is the evaluator, so stop there instead of chasing a DoD that doesn't exist.
+- **`deep` or unset** — Default. Full discipline: the close-gate and everything below apply unchanged.
+
+`light` relaxes thoroughness, not integrity: stay in your layer, respect non-goals, and never claim a proof you didn't run.
+
 ## Execution Posture
 
 Tasks may carry an `execution_note` field declaring the posture. Three values, or null:

--- a/.codex/skills/cas-worker/references/close-gate.md
+++ b/.codex/skills/cas-worker/references/close-gate.md
@@ -8,6 +8,10 @@ managed_by: cas
 
 Run all 6 self-verification checks before `mcp__cas__task action=close`. The gate is the same regardless of task type. Skip and you eat a verifier rejection round-trip.
 
+## Depth: `light` tasks skip this gate
+
+If the task you're closing is `depth=light` (check the `Depth:` line in `task show`), **skip the 6 pre-close self-checks below** and close once it runs on localhost. Light is speed mode: minimal diff, no gold-plating, the human is the evaluator — there is no DoD to chase. You must still not claim a proof you didn't run. For `depth=deep` or unset, run the full gate below.
+
 **Code review is not your job at close** under the v2.13.0+ default `[code_review] owner = "supervisor"`. The supervisor runs `/cas-code-review` at cherry-pick + EPIC merge time. Do not invoke the multi-persona review yourself unless your supervisor explicitly tells you to, or your project has opted in to legacy `owner = "worker"` in `.cas/config.toml` — the worker-inline path adds ~14 min and ~100K tokens per close, which is exactly what the v2.13.0 flip was designed to eliminate.
 
 ## Pre-Close Self-Verification

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.21.0"
+version = "2.22.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.21.0"
+version = "2.22.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor.md
@@ -78,6 +78,7 @@ Each file below is a focused chunk of the operational guide. Open the one you ne
 - **[worker-recovery.md](cas-supervisor/references/worker-recovery.md)** — `is-wedged` triage, dead/silent worker, garbage output, verification jail, resource-contention crashes.
 - **[reference.md](cas-supervisor/references/reference.md)** — Exact valid actions and field names, dispatch two-step pattern, `update` vs `transfer`, message field requirements.
 - **[code-review-queue.md](cas-supervisor/references/code-review-queue.md)** — Supervisor-owned code review mode: queue monitoring, running full review, delivering verdict (cas-b51a).
+- **[filing-cas-bugs.md](cas-supervisor/references/filing-cas-bugs.md)** — File every CAS-system bug as a tracked task, never chat-only or upstream (cas-src → in-repo; else `docs/requests/`).
 
 ## Context budgeting
 

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/filing-cas-bugs.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/filing-cas-bugs.md
@@ -1,0 +1,12 @@
+# Filing CAS-system bugs
+
+A standing directive: **file every CAS-system bug you observe as a tracked task, by reflex.** Do not just mention it in chat, defer it to "later", or "report it upstream". A CAS-system bug you noticed but didn't capture is a bug that resurfaces.
+
+"CAS-system" means a defect in CAS itself: the verifier, hooks, factory/director orchestration, MCP dispatch, the task-verifier agent, worker/supervisor prompts, or builtin skills — regardless of which downstream project (gabber-studio, OpenClaw, etc.) surfaced it.
+
+## Where the bug goes depends on the repo
+
+- **If this repo is cas-src (the CAS source):** create an in-repo task (`task action=create task_type=bug`) and let a worker fix it here. Other projects consume CAS; they do not modify it — the fix lands in cas-src. This mirrors cas-src's `CLAUDE.md` → "## CAS system bugs are in-repo fixes".
+- **In any other project:** drop a `BUG-<slug>.md` file in cas-src's `docs/requests/` inbox (the cross-team relay convention), then continue your own work — don't block your project's task on the CAS fix.
+
+Never silently ignore a CAS-system bug, leave it chat-only, or treat cas-src as an untouchable external dependency. Capture it, route it, move on.

--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -30,6 +30,15 @@ You execute tasks assigned by the Supervisor. You may be working in an isolated 
 - **Spike** (`task_type=spike`) — produces understanding, not code. Deliverable is a decision/comparison/recommendation captured via `note_type=decision`. Spike acceptance criteria are question-based.
 - **Demo statements** — if a task has a `demo_statement`, the work must produce that observable outcome.
 
+## Task Depth
+
+Tasks carry a `depth` field, shown as `Depth:` in `task show` and `task mine`. Read it when you **start** — it sets your working style. Depth comes from the **task record**, never an env var.
+
+- **`light`** — Speed mode for feel-driven iteration. Ship the **minimal diff** that satisfies the ask, then stop. NO gold-plating: no unasked tests, docs, edge-case handling, or refactors. **Skip the 6 pre-close self-checks** in [close-gate.md](cas-worker/references/close-gate.md). The Definition of Done is "it runs on localhost" — the human is the evaluator, so stop there instead of chasing a DoD that doesn't exist.
+- **`deep` or unset** — Default. Full discipline: the close-gate and everything below apply unchanged.
+
+`light` relaxes thoroughness, not integrity: stay in your layer, respect non-goals, and never claim a proof you didn't run.
+
 ## Execution Posture
 
 Tasks may carry an `execution_note` field declaring the posture. Three values, or null:

--- a/cas-cli/src/builtins/codex/skills/cas-worker/references/close-gate.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker/references/close-gate.md
@@ -8,6 +8,10 @@ managed_by: cas
 
 Run all 6 self-verification checks before `mcp__cas__task action=close`. The gate is the same regardless of task type. Skip and you eat a verifier rejection round-trip.
 
+## Depth: `light` tasks skip this gate
+
+If the task you're closing is `depth=light` (check the `Depth:` line in `task show`), **skip the 6 pre-close self-checks below** and close once it runs on localhost. Light is speed mode: minimal diff, no gold-plating, the human is the evaluator — there is no DoD to chase. You must still not claim a proof you didn't run. For `depth=deep` or unset, run the full gate below.
+
 **Code review is not your job at close** under the v2.13.0+ default `[code_review] owner = "supervisor"`. The supervisor runs `/cas-code-review` at cherry-pick + EPIC merge time. Do not invoke the multi-persona review yourself unless your supervisor explicitly tells you to, or your project has opted in to legacy `owner = "worker"` in `.cas/config.toml` — the worker-inline path adds ~14 min and ~100K tokens per close, which is exactly what the v2.13.0 flip was designed to eliminate.
 
 ## Pre-Close Self-Verification

--- a/cas-cli/src/builtins/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor.md
@@ -78,6 +78,7 @@ Each file below is a focused chunk of the operational guide. Open the one you ne
 - **[worker-recovery.md](cas-supervisor/references/worker-recovery.md)** — `is-wedged` triage, dead/silent worker, garbage output, verification jail, resource-contention crashes.
 - **[reference.md](cas-supervisor/references/reference.md)** — Exact valid actions and field names, dispatch two-step pattern, `update` vs `transfer`, message field requirements.
 - **[code-review-queue.md](cas-supervisor/references/code-review-queue.md)** — Supervisor-owned code review mode: queue monitoring, running full review, delivering verdict (cas-b51a).
+- **[filing-cas-bugs.md](cas-supervisor/references/filing-cas-bugs.md)** — File every CAS-system bug as a tracked task, never chat-only or upstream (cas-src → in-repo; else `docs/requests/`).
 
 ## Context budgeting
 

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/filing-cas-bugs.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/filing-cas-bugs.md
@@ -1,0 +1,12 @@
+# Filing CAS-system bugs
+
+A standing directive: **file every CAS-system bug you observe as a tracked task, by reflex.** Do not just mention it in chat, defer it to "later", or "report it upstream". A CAS-system bug you noticed but didn't capture is a bug that resurfaces.
+
+"CAS-system" means a defect in CAS itself: the verifier, hooks, factory/director orchestration, MCP dispatch, the task-verifier agent, worker/supervisor prompts, or builtin skills — regardless of which downstream project (gabber-studio, OpenClaw, etc.) surfaced it.
+
+## Where the bug goes depends on the repo
+
+- **If this repo is cas-src (the CAS source):** create an in-repo task (`task action=create task_type=bug`) and let a worker fix it here. Other projects consume CAS; they do not modify it — the fix lands in cas-src. This mirrors cas-src's `CLAUDE.md` → "## CAS system bugs are in-repo fixes".
+- **In any other project:** drop a `BUG-<slug>.md` file in cas-src's `docs/requests/` inbox (the cross-team relay convention), then continue your own work — don't block your project's task on the CAS fix.
+
+Never silently ignore a CAS-system bug, leave it chat-only, or treat cas-src as an untouchable external dependency. Capture it, route it, move on.

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -30,6 +30,15 @@ You execute tasks assigned by the Supervisor. You may be working in an isolated 
 - **Spike** (`task_type=spike`) — produces understanding, not code. Deliverable is a decision/comparison/recommendation captured via `note_type=decision`. Spike acceptance criteria are question-based.
 - **Demo statements** — if a task has a `demo_statement`, the work must produce that observable outcome.
 
+## Task Depth
+
+Tasks carry a `depth` field, shown as `Depth:` in `task show` and `task mine`. Read it when you **start** — it sets your working style. Depth comes from the **task record**, never an env var.
+
+- **`light`** — Speed mode for feel-driven iteration. Ship the **minimal diff** that satisfies the ask, then stop. NO gold-plating: no unasked tests, docs, edge-case handling, or refactors. **Skip the 6 pre-close self-checks** in [close-gate.md](cas-worker/references/close-gate.md). The Definition of Done is "it runs on localhost" — the human is the evaluator, so stop there instead of chasing a DoD that doesn't exist.
+- **`deep` or unset** — Default. Full discipline: the close-gate and everything below apply unchanged.
+
+`light` relaxes thoroughness, not integrity: stay in your layer, respect non-goals, and never claim a proof you didn't run.
+
 ## Execution Posture
 
 Tasks may carry an `execution_note` field declaring the posture. Three values, or null:

--- a/cas-cli/src/builtins/skills/cas-worker/references/close-gate.md
+++ b/cas-cli/src/builtins/skills/cas-worker/references/close-gate.md
@@ -8,6 +8,10 @@ managed_by: cas
 
 Run all 6 self-verification checks before `mcp__cas__task action=close`. The gate is the same regardless of task type. Skip and you eat a verifier rejection round-trip.
 
+## Depth: `light` tasks skip this gate
+
+If the task you're closing is `depth=light` (check the `Depth:` line in `task show`), **skip the 6 pre-close self-checks below** and close once it runs on localhost. Light is speed mode: minimal diff, no gold-plating, the human is the evaluator — there is no DoD to chase. You must still not claim a proof you didn't run. For `depth=deep` or unset, run the full gate below.
+
 **Code review is not your job at close** under the v2.13.0+ default `[code_review] owner = "supervisor"`. The supervisor runs `/cas-code-review` at cherry-pick + EPIC merge time. Do not invoke the multi-persona review yourself unless your supervisor explicitly tells you to, or your project has opted in to legacy `owner = "worker"` in `.cas/config.toml` — the worker-inline path adds ~14 min and ~100K tokens per close, which is exactly what the v2.13.0 flip was designed to eliminate.
 
 ## Pre-Close Self-Verification

--- a/cas-cli/src/cli/mcp_cmd.rs
+++ b/cas-cli/src/cli/mcp_cmd.rs
@@ -62,6 +62,12 @@ pub enum McpCommands {
         /// Only show server names (don't connect to fetch tools)
         #[arg(short, long)]
         short: bool,
+
+        /// Show secret values (stdio env, http/sse auth + headers) in plaintext.
+        /// Off by default — `cas mcp list --json` redacts secrets unless this is
+        /// set (cas-9f07: a tool-less Codex worker leaked live tokens via --json).
+        #[arg(long)]
+        show_secrets: bool,
     },
 
     /// Import MCP servers from Claude or Codex config.
@@ -92,7 +98,9 @@ pub fn execute(cmd: &McpCommands, cli: &super::Cli, cas_root: &Path) -> Result<(
     match cmd {
         McpCommands::Add { raw } => execute_add(raw, cli, cas_root),
         McpCommands::Remove { name, scope } => execute_remove(name, scope, cli, cas_root),
-        McpCommands::List { short } => execute_list(*short, cli, cas_root),
+        McpCommands::List { short, show_secrets } => {
+            execute_list(*short, *show_secrets, cli, cas_root)
+        }
         McpCommands::Import {
             from,
             dry_run,
@@ -374,8 +382,42 @@ fn execute_remove(name: &str, scope: &str, cli: &super::Cli, cas_root: &Path) ->
 
 // ── List ─────────────────────────────────────────────────────────────
 
+/// Marker substituted for secret values in `cas mcp list` output unless
+/// `--show-secrets` is passed (cas-9f07).
 #[cfg(feature = "mcp-proxy")]
-fn execute_list(short: bool, cli: &super::Cli, cas_root: &Path) -> Result<()> {
+const SECRET_REDACTION: &str = "***REDACTED***";
+
+/// Redact the secret-bearing fields of a serialized `ServerConfig` JSON value
+/// in place (cas-9f07). `ServerConfig` carries stdio `env`, http/sse `auth`,
+/// and `headers` — all of which `serde_json::to_value` emits verbatim. A
+/// tool-less Codex worker that improvised `cas mcp list --json` leaked a live
+/// GitHub PAT, Neon API key, and Vercel token into its rollout log because of
+/// this. We replace each secret *value* with [`SECRET_REDACTION`] while leaving
+/// keys, server names, commands, args, URLs, and `oauth` visible so the listing
+/// still tells you which server holds which credential.
+#[cfg(feature = "mcp-proxy")]
+fn redact_server_secrets(value: &mut serde_json::Value) {
+    let serde_json::Value::Object(map) = value else {
+        return;
+    };
+    // http/sse `auth: Option<String>` — redact when present and non-null.
+    if let Some(auth) = map.get_mut("auth") {
+        if auth.is_string() {
+            *auth = serde_json::Value::String(SECRET_REDACTION.to_string());
+        }
+    }
+    // stdio `env` and http/sse `headers` — redact every value, keep the keys.
+    for field in ["env", "headers"] {
+        if let Some(serde_json::Value::Object(inner)) = map.get_mut(field) {
+            for v in inner.values_mut() {
+                *v = serde_json::Value::String(SECRET_REDACTION.to_string());
+            }
+        }
+    }
+}
+
+#[cfg(feature = "mcp-proxy")]
+fn execute_list(short: bool, show_secrets: bool, cli: &super::Cli, cas_root: &Path) -> Result<()> {
     use crate::ui::components::Table;
 
     // Merge project config (.cas/proxy.toml) with user config (~/.config/code-mode-mcp/config.toml)
@@ -405,6 +447,9 @@ fn execute_list(short: bool, cli: &super::Cli, cas_root: &Path) -> Result<()> {
             .iter()
             .map(|(name, cfg)| {
                 let mut obj = serde_json::to_value(cfg).unwrap_or_default();
+                if !show_secrets {
+                    redact_server_secrets(&mut obj);
+                }
                 if let serde_json::Value::Object(ref mut m) = obj {
                     m.insert("name".to_string(), serde_json::json!(name));
                 }
@@ -947,4 +992,62 @@ fn extract_auth_header(
             }
         });
     (auth, headers)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "mcp-proxy"))]
+mod tests {
+    use super::*;
+    use cmcp_core::config::ServerConfig;
+    use std::collections::HashMap;
+
+    /// cas-9f07: stdio `env` values are redacted by default; keys + command stay.
+    #[test]
+    fn redacts_stdio_env_values_by_default() {
+        let cfg = ServerConfig::Stdio {
+            command: "cas".into(),
+            args: vec!["serve".into()],
+            env: HashMap::from([("GITHUB_PAT".to_string(), "ghp_SECRET123".to_string())]),
+        };
+        let mut v = serde_json::to_value(&cfg).unwrap();
+        redact_server_secrets(&mut v);
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(!s.contains("ghp_SECRET123"), "env secret must be redacted: {s}");
+        assert!(s.contains(SECRET_REDACTION), "redaction marker expected: {s}");
+        assert!(s.contains("GITHUB_PAT"), "env key should stay visible: {s}");
+        assert!(s.contains("\"cas\""), "command should stay visible: {s}");
+    }
+
+    /// cas-9f07: http `auth` and `headers` values are redacted; url stays.
+    #[test]
+    fn redacts_http_auth_and_headers() {
+        let cfg = ServerConfig::Http {
+            url: "https://mcp.example.com".into(),
+            auth: Some("bearer_SECRET456".into()),
+            headers: HashMap::from([("X-Api-Key".to_string(), "key_SECRET789".to_string())]),
+            oauth: false,
+        };
+        let mut v = serde_json::to_value(&cfg).unwrap();
+        redact_server_secrets(&mut v);
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(!s.contains("bearer_SECRET456"), "auth must be redacted: {s}");
+        assert!(!s.contains("key_SECRET789"), "header value must be redacted: {s}");
+        assert!(s.contains("https://mcp.example.com"), "url should stay visible: {s}");
+        assert!(s.contains("X-Api-Key"), "header key should stay visible: {s}");
+    }
+
+    /// cas-9f07: with `--show-secrets`, `redact_server_secrets` is not called, so
+    /// the serialized value retains the plaintext secret.
+    #[test]
+    fn show_secrets_path_keeps_plaintext() {
+        let cfg = ServerConfig::Stdio {
+            command: "cas".into(),
+            args: vec![],
+            env: HashMap::from([("TOKEN".to_string(), "plain_SECRET".to_string())]),
+        };
+        let v = serde_json::to_value(&cfg).unwrap();
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(s.contains("plain_SECRET"), "un-redacted value retains secret: {s}");
+    }
 }

--- a/cas-cli/src/mcp/server/mod.rs
+++ b/cas-cli/src/mcp/server/mod.rs
@@ -784,6 +784,17 @@ impl CasCore {
                 continue;
             }
 
+            // cas-33eb: a depth=light task never jails the agent — skipping the
+            // verification machinery is the whole point of "speed mode" (mirrors
+            // the close_ops.rs `depth_light` short-circuit from cas-6538).
+            // Without this, a SOLO (non-factory) user who starts then closes a
+            // light task still hits VERIFICATION_JAIL_BLOCKED at this dispatch
+            // layer, because the factory-worker / supervisor exemptions in
+            // `authorize_agent_action` do not apply to them.
+            if task.depth == crate::types::TaskDepth::Light {
+                continue;
+            }
+
             // Skip task types where current harness policy bypasses verification.
             if !verification_required_for_task_type(task.task_type) {
                 continue;

--- a/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
@@ -847,11 +847,12 @@ impl CasCore {
                 })
                 .unwrap_or_else(|| "\n  Lease: not claimed yet".to_string());
             output.push_str(&format!(
-                "- [{}] {:?} P{} {} - {}{}{}\n",
+                "- [{}] {:?} P{} {} ({}) - {}{}{}\n",
                 task.id,
                 task.status,
                 task.priority.0,
                 task.task_type,
+                task.depth,
                 task.title,
                 lease_info,
                 if task.assignee.as_deref() == Some(agent_id.as_str()) {

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -72,6 +72,16 @@ impl CasCore {
             data: None,
         })?;
 
+        // Absent/empty depth defaults to Deep (full rigor); an invalid value
+        // is rejected with a clear error.
+        let depth = crate::mcp::tools::types::validate_depth(req.depth.as_deref())
+            .map_err(|msg| McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from(msg),
+                data: None,
+            })?
+            .unwrap_or_default();
+
         let now = chrono::Utc::now();
         let task = Task {
             id: id.clone(),
@@ -102,6 +112,7 @@ impl CasCore {
             pending_worktree_merge: false,
             epic_verification_owner: None,
             share: None,
+            depth,
         };
 
         task_store

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -156,6 +156,29 @@ impl CasCore {
             data: None,
         })?;
 
+        // cas-6538 (EPIC cas-1255 — per-task depth speed mode): a `depth=light`
+        // task is the feel-driven, fast-iteration path. The close gate skips
+        // the two *rigor* gates — the verification jail (no `task-verifier`
+        // dispatch / `pending_verification` arming) and the P0 code-review gate
+        // (treated as satisfied, including the supervisor-review queue hop that
+        // *is* the P0 gate under `owner = "supervisor"`). The skip is recorded
+        // as a decision note on the task (see `light_skip_decision_note`) so
+        // the bypass is auditable.
+        //
+        // REGRESSION GUARD: this flag is the *only* condition that diverges
+        // light from today's behavior. `Deep`/unset rows read back as `Deep`
+        // (NULL→Deep, see cas-0344), so every existing close path is byte-for-
+        // byte unchanged unless the task was explicitly created `depth=light`.
+        //
+        // SCOPE: the light skip deliberately does NOT touch the data-state
+        // guards (merge-state cas-95ce/cas-762e, uncommitted-work cas-895d,
+        // additive-only cas-bc1b, commit-claim). Those verify the work
+        // physically exists / is merged — orthogonal to review rigor — and a
+        // light task must still satisfy them. It also does not interact with
+        // the supervisor `bypass_code_review` override, which stays exactly as
+        // before for `Deep` and is simply redundant for `Light`.
+        let depth_light = task.depth == crate::types::TaskDepth::Light;
+
         // For Epics: Check that all worker branches are merged before verification
         // This ensures epic-level verification runs on the complete merged code
         if task.task_type == TaskType::Epic {
@@ -334,7 +357,16 @@ impl CasCore {
                 .map(|aid| task.assignee.as_deref() == Some(aid.as_str()))
                 .unwrap_or(false);
 
-        if verification_enabled && !skip_verification && !worker_under_supervisor_review {
+        // cas-6538: `depth_light` short-circuits the verification jail. The
+        // jail arms `pending_verification=true` and demands a `task-verifier`
+        // verdict before close; light tasks skip it entirely. For `Deep`/unset
+        // (`!depth_light`) the condition is unchanged, so the jail arms exactly
+        // as today.
+        if verification_enabled
+            && !skip_verification
+            && !worker_under_supervisor_review
+            && !depth_light
+        {
             let is_worker_without_subagents = is_worker_without_subagents_from_env();
 
             // Check for approved verification
@@ -1230,12 +1262,20 @@ impl CasCore {
             .map(|cr| cr.supervisor_owned())
             .unwrap_or_else(|| crate::config::CodeReviewConfig::default().supervisor_owned());
 
+        // cas-6538: under `owner = "supervisor"` the worker close normally
+        // transitions to `PendingSupervisorReview` — that queue hop IS the P0
+        // code-review gate for this mode (the supervisor runs cas-code-review
+        // off the queue). For `depth_light` we treat the P0 gate as satisfied,
+        // so skip the pend-transition and let the close complete immediately
+        // (AC: "close succeeds", demo: "closes immediately"). `Deep`/unset is
+        // unaffected — `!depth_light` keeps the transition firing as today.
         if supervisor_review_mode
             && is_factory_worker
             && task.task_type != TaskType::Epic
             && task.execution_note.as_deref() != Some("additive-only")
             && !bypass_close_gates
             && effective_has_reviewable
+            && !depth_light
         {
             // Run the lightweight structural lint.
             match run_lightweight_structural_lint(close_project_root) {
@@ -1331,7 +1371,15 @@ impl CasCore {
         //
         // Cases 1/3/4 are handled here: docs-only, ambiguous zero-commit,
         // and deliberate no-code respectively.
-        let gate_outcome = if epic_subtask_receipts_cover {
+        let gate_outcome = if depth_light {
+            // cas-6538: light tasks treat the P0 code-review gate as satisfied.
+            // This is the non-factory / solo close path (the factory worker
+            // supervisor-review hop is already skipped above for light); a
+            // direct close that reaches the gate must not be blocked by a
+            // missing review envelope. `Deep`/unset falls through to the
+            // existing routing, so the gate enforces exactly as today.
+            CodeReviewGateOutcome::Proceed
+        } else if epic_subtask_receipts_cover {
             CodeReviewGateOutcome::Proceed
         } else if !effective_has_reviewable {
             let has_review_findings = req
@@ -1464,6 +1512,21 @@ impl CasCore {
                         }
                     }
                 }
+            }
+        }
+
+        // cas-6538: record an auditable decision note for the light-depth skip
+        // BEFORE the close-reason note, so the bypass is permanently visible in
+        // the task timeline. Persisted via the single `task_store.update(&task)`
+        // below (the final write), which guarantees it survives — unlike the
+        // earlier gate clone-persist paths that the final write overwrites.
+        if depth_light {
+            let timestamp = now.format("%Y-%m-%d %H:%M");
+            let decision_note = format!("[{timestamp}] {}", light_skip_decision_note());
+            if task.notes.is_empty() {
+                task.notes = decision_note;
+            } else {
+                task.notes = format!("{}\n\n{}", task.notes, decision_note);
             }
         }
 
@@ -1913,6 +1976,20 @@ impl CasCore {
             );
         }
     }
+}
+
+/// cas-6538: audit text recorded on a `depth=light` task at close time,
+/// stating exactly which rigor gates were skipped and why. Kept as a
+/// self-contained `pub(crate)` fn (not an inline literal) so the wording
+/// is unit-testable and stays in one place. The caller prepends a
+/// `[timestamp]` and appends it to the task notes timeline.
+pub(crate) fn light_skip_decision_note() -> String {
+    "decision: depth=light close (EPIC cas-1255 speed mode) — skipped the \
+     verification jail (no task-verifier dispatch; pending_verification left \
+     false) and the P0 code-review gate (treated as satisfied; supervisor \
+     review queue hop bypassed). Reason: task depth=light. Data-state guards \
+     (merge-state, uncommitted-work, additive-only, commit-claim) still ran."
+        .to_string()
 }
 
 /// A single additive-only violation: a file whose git status indicates it
@@ -4003,6 +4080,27 @@ mod code_review_gate_tests {
     //! close-side glue — env role check, envelope plumbing, override
     //! path, docs-only skip, CODE_REVIEW_REQUIRED rejection.
     use super::*;
+
+    /// cas-6538: the light-skip decision note must name both rigor gates it
+    /// bypasses and the reason, so the bypass is auditable. The integration
+    /// tests assert on substrings of this text; lock the wording here.
+    #[test]
+    fn light_skip_decision_note_names_both_gates_and_reason() {
+        let note = light_skip_decision_note();
+        assert!(note.contains("depth=light"), "must cite the reason: {note}");
+        assert!(
+            note.to_lowercase().contains("decision"),
+            "must be a decision note: {note}"
+        );
+        assert!(
+            note.contains("verification jail"),
+            "must name the verification jail skip: {note}"
+        );
+        assert!(
+            note.contains("code-review gate"),
+            "must name the P0 code-review gate skip: {note}"
+        );
+    }
     use cas_types::{AutofixClass, Finding, FindingSeverity, Owner, ReviewOutcome};
     use tempfile::TempDir;
 

--- a/cas-cli/src/mcp/tools/core/task/query.rs
+++ b/cas-cli/src/mcp/tools/core/task/query.rs
@@ -14,13 +14,14 @@ impl CasCore {
         })?;
 
         let mut output = format!(
-            "Task: {}\n{}\n\nTitle: {}\nStatus: {:?}\nPriority: P{}\nType: {}\n",
+            "Task: {}\n{}\n\nTitle: {}\nStatus: {:?}\nPriority: P{}\nType: {}\nDepth: {}\n",
             task.id,
             "=".repeat(task.id.len() + 6),
             task.title,
             task.status,
             task.priority.0,
-            task.task_type
+            task.task_type,
+            task.depth
         );
 
         if !task.description.is_empty() {

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -85,6 +85,18 @@ impl CasCore {
             changes.push("external_ref");
         }
 
+        // Empty/absent depth is a no-op; an invalid value is rejected.
+        if let Some(depth) = crate::mcp::tools::types::validate_depth(req.depth.as_deref())
+            .map_err(|msg| McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from(msg),
+                data: None,
+            })?
+        {
+            task.depth = depth;
+            changes.push("depth");
+        }
+
         // Track warnings to include in response
         let mut warnings: Vec<String> = Vec::new();
 

--- a/cas-cli/src/mcp/tools/service/core.rs
+++ b/cas-cli/src/mcp/tools/service/core.rs
@@ -245,6 +245,7 @@ impl CasService {
             external_ref: req.external_ref,
             assignee: req.assignee,
             epic: req.epic,
+            depth: req.depth,
         };
         self.inner.cas_task_create(Parameters(inner_req)).await
     }
@@ -280,6 +281,7 @@ impl CasService {
             status: req.status,
             epic: req.epic,
             epic_verification_owner: req.epic_verification_owner,
+            depth: req.depth,
         };
         self.inner.cas_task_update(Parameters(inner_req)).await
     }

--- a/cas-cli/src/mcp/tools/types/task.rs
+++ b/cas-cli/src/mcp/tools/types/task.rs
@@ -1,5 +1,9 @@
+use std::str::FromStr;
+
 use rmcp::schemars::JsonSchema;
 use serde::Deserialize;
+
+use cas_types::TaskDepth;
 
 use crate::mcp::tools::types::defaults::{
     default_dep_type, default_note_type, default_priority, default_subagent_tokens,
@@ -27,6 +31,20 @@ pub fn validate_execution_note(value: Option<&str>) -> Result<Option<String>, St
             s,
             EXECUTION_NOTE_VALUES.join(", ")
         )),
+    }
+}
+
+/// Validate and parse an incoming `depth` parameter (EPIC cas-1255). Returns
+/// - `Ok(None)` if the input is absent or an empty string (no-op / default)
+/// - `Ok(Some(depth))` for an accepted value (`light` / `deep`)
+/// - `Err(message)` otherwise, with a human-readable hint
+pub fn validate_depth(value: Option<&str>) -> Result<Option<TaskDepth>, String> {
+    match value.map(str::trim) {
+        None => Ok(None),
+        Some(s) if s.is_empty() => Ok(None),
+        Some(s) => TaskDepth::from_str(s).map(Some).map_err(|_| {
+            format!("Invalid depth: '{s}'. Must be one of: light, deep (or empty/absent)")
+        }),
     }
 }
 
@@ -106,6 +124,13 @@ pub struct TaskCreateRequest {
     )]
     #[serde(default)]
     pub epic: Option<String>,
+
+    /// Execution depth (EPIC cas-1255 speed mode)
+    #[schemars(
+        description = "Execution depth: 'deep' (default, full rigor) or 'light' (fast, feel-driven pass). Omit to default to deep."
+    )]
+    #[serde(default)]
+    pub depth: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -245,6 +270,13 @@ pub struct TaskUpdateRequest {
     )]
     #[serde(default)]
     pub epic_verification_owner: Option<String>,
+
+    /// Update execution depth (EPIC cas-1255 speed mode)
+    #[schemars(
+        description = "Execution depth: 'deep' (full rigor) or 'light' (fast, feel-driven pass). Omit to leave unchanged."
+    )]
+    #[serde(default)]
+    pub depth: Option<String>,
 }
 
 // ============================================================================

--- a/cas-cli/src/migration/migrations/m202_tasks_add_depth.rs
+++ b/cas-cli/src/migration/migrations/m202_tasks_add_depth.rs
@@ -1,0 +1,116 @@
+//! Migration: Add `depth` column to the `tasks` table (EPIC cas-1255).
+//!
+//! Fresh DBs already have this column via CREATE TABLE. Older DBs that pre-date
+//! the column addition need it backfilled via ALTER TABLE. The detect query is
+//! idempotent: returns 1 (already applied) when the column exists, 0 when missing.
+//!
+//! Existing rows get NULL, which the task store maps to `TaskDepth::Deep` on
+//! read, so legacy tasks read as deep.
+
+use crate::migration::{Migration, Subsystem};
+
+pub const MIGRATION: Migration = Migration {
+    id: 202,
+    name: "tasks_add_depth",
+    subsystem: Subsystem::Tasks,
+    description: "Add depth TEXT column to tasks table (per-task speed mode, EPIC cas-1255)",
+    up: &["ALTER TABLE tasks ADD COLUMN depth TEXT"],
+    detect: Some(
+        "SELECT CASE WHEN EXISTS (SELECT 1 FROM pragma_table_info('tasks') WHERE name = 'depth') THEN 1 ELSE 0 END",
+    ),
+};
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    fn create_tasks_without_depth(conn: &Connection) {
+        conn.execute_batch(
+            "CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'open'
+            );",
+        )
+        .unwrap();
+    }
+
+    fn apply_up(conn: &Connection) {
+        for sql in super::MIGRATION.up {
+            conn.execute(sql, []).unwrap();
+        }
+    }
+
+    fn has_depth_column(conn: &Connection) -> bool {
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('tasks') WHERE name = 'depth'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        count > 0
+    }
+
+    #[test]
+    fn fresh_db_gets_depth_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_tasks_without_depth(&conn);
+        assert!(!has_depth_column(&conn));
+
+        apply_up(&conn);
+
+        assert!(has_depth_column(&conn), "depth column must exist after up");
+    }
+
+    #[test]
+    fn detect_returns_0_when_column_missing_and_1_when_present() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_tasks_without_depth(&conn);
+
+        let result: i64 = conn
+            .query_row(super::MIGRATION.detect.unwrap(), [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(result, 0, "detect must return 0 when depth column is absent");
+
+        apply_up(&conn);
+
+        let result: i64 = conn
+            .query_row(super::MIGRATION.detect.unwrap(), [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(result, 1, "detect must return 1 after depth column is added");
+    }
+
+    #[test]
+    fn idempotent_when_depth_already_present() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'open',
+                depth TEXT
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, depth) VALUES ('t1', 'fix bug', 'open', 'light')",
+            [],
+        )
+        .unwrap();
+
+        // detect must return 1 — migration runner will skip up
+        let result: i64 = conn
+            .query_row(super::MIGRATION.detect.unwrap(), [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(result, 1, "detect must return 1 when depth column already exists");
+
+        // Existing row must survive untouched
+        let depth: Option<String> = conn
+            .query_row("SELECT depth FROM tasks WHERE id = 't1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(depth.as_deref(), Some("light"));
+    }
+}

--- a/cas-cli/src/migration/migrations/mod.rs
+++ b/cas-cli/src/migration/migrations/mod.rs
@@ -177,6 +177,7 @@ mod m198_tasks_add_share;
 pub mod m199_known_repos;
 mod m200_agents_add_pid_starttime;
 mod m201_spawn_queue_add_worker_spec;
+mod m202_tasks_add_depth;
 
 /// All migrations in order. IDs must be sequential and never reused.
 pub const MIGRATIONS: &[Migration] = &[
@@ -354,6 +355,8 @@ pub const MIGRATIONS: &[Migration] = &[
     m200_agents_add_pid_starttime::MIGRATION,
     // Add worker_spec column to spawn_queue for per-worker CLI/model/effort overrides (cas-2992)
     m201_spawn_queue_add_worker_spec::MIGRATION,
+    // Add depth column to tasks for per-task speed mode (EPIC cas-1255 / cas-0344)
+    m202_tasks_add_depth::MIGRATION,
 ];
 
 #[cfg(test)]

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -769,6 +769,26 @@ impl FactoryApp {
         &self.supervisor_name
     }
 
+    /// Resolve a delivery target name to the harness (CLI) it is running.
+    ///
+    /// This is the source of truth for *recipient-aware* message routing
+    /// (cas-b68a): the daemon must decide whether to deliver via the Claude
+    /// agent-teams inbox or via a direct PTY write based on the **recipient's**
+    /// harness, not the supervisor's mode.
+    ///
+    /// - The logical name `"supervisor"` and the supervisor's pane name both
+    ///   resolve to the supervisor's CLI.
+    /// - Any other name is treated as a worker and resolved through the mux's
+    ///   per-worker spec registry (`effective_worker_spec`), which falls back to
+    ///   the Mux-wide default for unknown names.
+    pub fn harness_for(&self, target: &str) -> cas_mux::SupervisorCli {
+        if target == "supervisor" || target == self.supervisor_name {
+            self.supervisor_cli
+        } else {
+            self.mux.effective_worker_spec(target, None).cli
+        }
+    }
+
     /// Get factory session name (for prompt queue isolation)
     pub fn factory_session(&self) -> Option<&str> {
         self.factory_session.as_deref()

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -1152,6 +1152,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: Some(new_epic_id.to_string()),
                 branch: None,
+                updated_at: None,
             }],
             in_progress_tasks: vec![TaskSummary {
                 id: "task-2".to_string(),
@@ -1162,6 +1163,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: Some(new_epic_id.to_string()),
                 branch: None,
+                updated_at: None,
             }],
             epic_tasks: vec![TaskSummary {
                 id: new_epic_id.to_string(),
@@ -1172,6 +1174,7 @@ mod tests {
                 task_type: TaskType::Epic,
                 epic: None,
                 branch: Some("epic/new-feature".to_string()),
+                updated_at: None,
             }],
             agents: Vec::new(),
             activity: Vec::new(),
@@ -1319,6 +1322,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: Some(active_epic_id.to_string()),
                 branch: None,
+                updated_at: None,
             }],
             in_progress_tasks: vec![TaskSummary {
                 id: "task-ip".to_string(),
@@ -1329,6 +1333,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: Some(active_epic_id.to_string()),
                 branch: None,
+                updated_at: None,
             }],
             epic_tasks: vec![
                 TaskSummary {
@@ -1340,6 +1345,7 @@ mod tests {
                     task_type: TaskType::Epic,
                     epic: None,
                     branch: Some("epic/stale".to_string()),
+                    updated_at: None,
                 },
                 TaskSummary {
                     id: active_epic_id.to_string(),
@@ -1350,6 +1356,7 @@ mod tests {
                     task_type: TaskType::Epic,
                     epic: None,
                     branch: Some("epic/active".to_string()),
+                    updated_at: None,
                 },
             ],
             agents: Vec::new(),
@@ -1389,6 +1396,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: Some(active_epic_id.to_string()),
                 branch: None,
+                updated_at: None,
             }],
             in_progress_tasks: Vec::new(),
             epic_tasks: vec![
@@ -1401,6 +1409,7 @@ mod tests {
                     task_type: TaskType::Epic,
                     epic: None,
                     branch: Some("epic/stale".to_string()),
+                    updated_at: None,
                 },
                 TaskSummary {
                     id: active_epic_id.to_string(),
@@ -1411,6 +1420,7 @@ mod tests {
                     task_type: TaskType::Epic,
                     epic: None,
                     branch: Some("epic/active".to_string()),
+                    updated_at: None,
                 },
             ],
             agents: Vec::new(),
@@ -1451,6 +1461,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: Some(active_id.to_string()),
                 branch: None,
+                updated_at: None,
             }],
             epic_tasks: vec![
                 TaskSummary {
@@ -1462,6 +1473,7 @@ mod tests {
                     task_type: TaskType::Epic,
                     epic: None,
                     branch: Some("epic/preferred".to_string()),
+                    updated_at: None,
                 },
                 TaskSummary {
                     id: active_id.to_string(),
@@ -1472,6 +1484,7 @@ mod tests {
                     task_type: TaskType::Epic,
                     epic: None,
                     branch: Some("epic/active".to_string()),
+                    updated_at: None,
                 },
             ],
             agents: Vec::new(),
@@ -1527,6 +1540,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: Some(active_id.to_string()),
                 branch: None,
+                updated_at: None,
             }],
             in_progress_tasks: vec![TaskSummary {
                 id: "task-ip".to_string(),
@@ -1537,6 +1551,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: Some(active_id.to_string()),
                 branch: None,
+                updated_at: None,
             }],
             epic_tasks: vec![
                 TaskSummary {
@@ -1548,6 +1563,7 @@ mod tests {
                     task_type: TaskType::Epic,
                     epic: None,
                     branch: Some("epic/active".to_string()),
+                    updated_at: None,
                 },
                 TaskSummary {
                     id: hijacker_id.to_string(),
@@ -1558,6 +1574,7 @@ mod tests {
                     task_type: TaskType::Epic,
                     epic: None,
                     branch: Some("epic/hijacker".to_string()),
+                    updated_at: None,
                 },
             ],
             agents: Vec::new(),
@@ -1654,6 +1671,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: Some(new_id.to_string()),
                 branch: None,
+                updated_at: None,
             }],
             in_progress_tasks: Vec::new(),
             epic_tasks: vec![TaskSummary {
@@ -1665,6 +1683,7 @@ mod tests {
                 task_type: TaskType::Epic,
                 epic: None,
                 branch: Some("epic/new".to_string()),
+                updated_at: None,
             }],
             agents: Vec::new(),
             activity: Vec::new(),
@@ -1731,6 +1750,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: Some(active_id.to_string()),
                 branch: None,
+                updated_at: None,
             }],
             in_progress_tasks: Vec::new(),
             epic_tasks: vec![
@@ -1743,6 +1763,7 @@ mod tests {
                     task_type: TaskType::Epic,
                     epic: None,
                     branch: Some("epic/active".to_string()),
+                    updated_at: None,
                 },
                 TaskSummary {
                     id: hijacker_id.to_string(),
@@ -1753,6 +1774,7 @@ mod tests {
                     task_type: TaskType::Epic,
                     epic: None,
                     branch: Some("epic/hijacker".to_string()),
+                    updated_at: None,
                 },
             ],
             agents: Vec::new(),

--- a/cas-cli/src/ui/factory/daemon/runtime/delivery.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/delivery.rs
@@ -1,0 +1,220 @@
+//! Recipient-aware message delivery (cas-b68a).
+//!
+//! Every supervisor→worker (and worker→supervisor / director→agent) message must
+//! reach the recipient over a channel the recipient can actually read:
+//!
+//! - A **Claude** agent in a native Agent-Teams factory reads its inbox files, so
+//!   delivery goes through [`TeamsManager::write_to_inbox`].
+//! - A **Codex** agent is *not* a member of the Claude team and never polls an
+//!   inbox; the only channel it can receive is a direct PTY write
+//!   ([`Mux::inject`]) performed by the daemon that holds its PTY master.
+//!
+//! The historical bug was that every delivery site branched on whether the
+//! **supervisor** was in teams mode (`self.teams.is_some()`), not on the
+//! **recipient's** harness. A Codex worker under a Claude supervisor therefore had
+//! its messages written to an inbox it could never read, and the PTY path — its
+//! only viable channel — was never taken. This module centralises the routing
+//! decision so it can no longer drift per call site.
+
+use cas_mux::SupervisorCli;
+
+use super::super::FactoryDaemon;
+
+/// The channel a message should be delivered over, decided by the recipient's
+/// harness and whether the factory is running native Agent Teams.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeliveryChannel {
+    /// Direct PTY write via `Mux::inject`.
+    Pty,
+    /// Claude Agent-Teams inbox file via `TeamsManager::write_to_inbox`.
+    TeamsInbox,
+}
+
+/// Pure routing decision — the single source of truth for *recipient-aware*
+/// delivery. Kept free of `self` so it is exhaustively unit-testable.
+///
+/// - **Codex** recipients are *always* PTY-delivered: they cannot read a Claude
+///   team inbox, so this holds even when the supervisor is in teams mode. This is
+///   the load-bearing fix for cas-b68a.
+/// - **Claude** recipients use the team inbox when teams are active, and fall back
+///   to PTY when they are not (codex-only / non-teams factories).
+pub(crate) fn choose_channel(harness: SupervisorCli, teams_active: bool) -> DeliveryChannel {
+    match harness {
+        SupervisorCli::Codex => DeliveryChannel::Pty,
+        SupervisorCli::Claude => {
+            if teams_active {
+                DeliveryChannel::TeamsInbox
+            } else {
+                DeliveryChannel::Pty
+            }
+        }
+    }
+}
+
+/// Whether a message to `harness` must clear the PTY pane-readiness gate before
+/// injection. True exactly when the message is PTY-delivered — i.e. for every
+/// Codex recipient (even under teams) and for everyone in a non-teams factory.
+///
+/// Claude inbox writes are plain file writes with no readline race, so they never
+/// need the gate.
+pub(crate) fn requires_pty_readiness_gate(harness: SupervisorCli, teams_active: bool) -> bool {
+    matches!(choose_channel(harness, teams_active), DeliveryChannel::Pty)
+}
+
+/// Whether a PTY-delivered payload must carry the literal `Message from <sender>: `
+/// framing. True iff the recipient is **Codex**, independent of teams mode.
+///
+/// The Codex worker/supervisor prompts (sibling task cas-83c8) key on EXACTLY this
+/// prefix to recognise an injected turn as an actionable instruction, and they do
+/// so in *every* codex factory — including a codex-only factory (teams=None) where
+/// a codex-supervisor→codex-worker message is still PTY-injected. So framing is a
+/// property of the recipient's harness, not of teams mode. A Claude recipient
+/// reached via the PTY fallback (codex-supervised factory, teams=None) must NOT be
+/// framed — it isn't a codex prompt and stays byte-for-byte bare.
+pub(crate) fn pty_payload_needs_framing(harness: SupervisorCli) -> bool {
+    matches!(harness, SupervisorCli::Codex)
+}
+
+/// Prefix PTY-delivered text with literal sender attribution.
+///
+/// Emits exactly `Message from <sender>: <text>` — no summary interpolation before
+/// the colon — because the Codex prompt (cas-83c8) matches on that literal prefix.
+/// `source` is the human-readable sender name ("supervisor" or a worker name).
+fn attribute_for_pty(source: &str, text: &str) -> String {
+    format!("Message from {source}: {text}")
+}
+
+impl FactoryDaemon {
+    /// Deliver `text` to `target` over the channel the recipient can actually
+    /// read, decided by the recipient's harness (cas-b68a).
+    ///
+    /// `target` may be the logical name `"supervisor"`, the supervisor's pane
+    /// name, or a worker name. `source` is the (already team-resolved) sender
+    /// name; `summary` is the optional one-line preview carried to Claude inboxes
+    /// and used for PTY attribution.
+    ///
+    /// Returns `Ok(())` on a successful write to the chosen channel.
+    pub(crate) async fn deliver_to_worker(
+        &self,
+        target: &str,
+        source: &str,
+        text: &str,
+        summary: Option<&str>,
+    ) -> anyhow::Result<()> {
+        // Normalise the target into the two name forms the two channels expect:
+        //   - `pane_target`  : the real pane id `Mux::inject` routes on
+        //   - `inbox_target` : the logical team member name `write_to_inbox` expects
+        let pane_target = if target == "supervisor" {
+            self.app.supervisor_name()
+        } else {
+            target
+        };
+        let inbox_target = if pane_target == self.app.supervisor_name() {
+            "supervisor"
+        } else {
+            pane_target
+        };
+
+        let teams_active = self.teams.is_some();
+        let harness = self.app.harness_for(pane_target);
+
+        match choose_channel(harness, teams_active) {
+            DeliveryChannel::TeamsInbox => {
+                // Safe: TeamsInbox is only chosen when teams_active, i.e. teams.is_some().
+                let teams = self
+                    .teams
+                    .as_ref()
+                    .expect("TeamsInbox channel requires active teams");
+                teams.write_to_inbox(inbox_target, source, text, summary, None)
+            }
+            DeliveryChannel::Pty => {
+                // Frame based on the RECIPIENT's harness, not teams mode: a Codex
+                // recipient always gets the literal `Message from <sender>: ` prefix
+                // its prompt keys on (even codex-only, teams=None); a Claude
+                // recipient reached via the PTY fallback stays byte-for-byte bare.
+                if pty_payload_needs_framing(harness) {
+                    let framed = attribute_for_pty(source, text);
+                    self.app
+                        .mux
+                        .inject(pane_target, &framed)
+                        .await
+                        .map_err(Into::into)
+                } else {
+                    self.app
+                        .mux
+                        .inject(pane_target, text)
+                        .await
+                        .map_err(Into::into)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_recipient_always_pty_even_under_teams() {
+        // AC1: a Codex recipient is PTY-delivered even when the supervisor runs
+        // native Agent Teams (teams_active = true). This is the core bug fix.
+        assert_eq!(
+            choose_channel(SupervisorCli::Codex, true),
+            DeliveryChannel::Pty
+        );
+        assert_eq!(
+            choose_channel(SupervisorCli::Codex, false),
+            DeliveryChannel::Pty
+        );
+    }
+
+    #[test]
+    fn claude_recipient_uses_inbox_when_teams_active_else_pty() {
+        // AC3: Claude teammates still go through the team inbox under teams...
+        assert_eq!(
+            choose_channel(SupervisorCli::Claude, true),
+            DeliveryChannel::TeamsInbox
+        );
+        // ...and fall back to PTY in a non-teams (codex-only / plain PTY) factory.
+        assert_eq!(
+            choose_channel(SupervisorCli::Claude, false),
+            DeliveryChannel::Pty
+        );
+    }
+
+    #[test]
+    fn readiness_gate_required_exactly_for_pty_delivery() {
+        // Codex always PTY → always gated (note b: first message was dropped
+        // during codex startup because the gate was skipped under teams).
+        assert!(requires_pty_readiness_gate(SupervisorCli::Codex, true));
+        assert!(requires_pty_readiness_gate(SupervisorCli::Codex, false));
+        // Claude under teams → inbox file write, no readline race, no gate.
+        assert!(!requires_pty_readiness_gate(SupervisorCli::Claude, true));
+        // Claude without teams → PTY → gated.
+        assert!(requires_pty_readiness_gate(SupervisorCli::Claude, false));
+    }
+
+    #[test]
+    fn pty_framing_keys_on_codex_recipient_not_teams_mode() {
+        // Codex recipient → framed in EVERY factory (incl. codex-only / teams=None),
+        // because the codex prompt (cas-83c8) keys on the literal prefix.
+        assert!(pty_payload_needs_framing(SupervisorCli::Codex));
+        // Claude recipient via PTY fallback (codex-supervised, teams=None) → bare.
+        assert!(!pty_payload_needs_framing(SupervisorCli::Claude));
+    }
+
+    #[test]
+    fn attribution_uses_literal_sender_prefix() {
+        // Exactly `Message from <sender>: <text>` — the string the codex prompt
+        // matches on. No summary interpolation before the colon.
+        assert_eq!(
+            attribute_for_pty("supervisor", "do the thing"),
+            "Message from supervisor: do the thing"
+        );
+        assert_eq!(
+            attribute_for_pty("worker-3", "start cas-1234"),
+            "Message from worker-3: start cas-1234"
+        );
+    }
+}

--- a/cas-cli/src/ui/factory/daemon/runtime/delivery_matrix_tests.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/delivery_matrix_tests.rs
@@ -1,0 +1,200 @@
+//! Cross-harness delivery routing matrix (cas-47b7 — verification half of EPIC
+//! cas-ca04).
+//!
+//! cas-b68a's own unit tests (in `delivery.rs`) cover the routing *primitives*
+//! one argument-pair at a time. This module pins the **end-to-end semantic
+//! matrix** the EPIC acceptance criteria are written against: for every
+//! `(supervisor_harness, worker_harness)` factory shape and **both directions**
+//! of a message (downward `target=worker`, upward `target=supervisor`), the
+//! recipient-aware routing must choose the right channel, honor the PTY
+//! readiness gate, and frame codex recipients.
+//!
+//! This is a pure regression test over `choose_channel` /
+//! `requires_pty_readiness_gate` / `pty_payload_needs_framing` — it never
+//! touches a live MCP server, a PTY, or a Teams inbox (per the live-MCP testing
+//! convention: fixture-driven in `cargo test`, live behavior smoke-tested
+//! manually and documented separately).
+//!
+//! The matrix deliberately re-derives the *expected* answer from first
+//! principles inside each row so a future change to the routing logic that
+//! happens to keep the primitives self-consistent but breaks a real factory
+//! shape still trips a red cell here.
+
+use cas_mux::SupervisorCli::{self, Claude, Codex};
+
+use super::delivery::{
+    DeliveryChannel, choose_channel, pty_payload_needs_framing, requires_pty_readiness_gate,
+};
+
+/// Which end of the supervisor↔worker link a message is addressed to.
+#[derive(Debug, Clone, Copy)]
+enum Direction {
+    /// `target=<worker>` — supervisor (or director) → worker.
+    Downward,
+    /// `target=supervisor` — worker → supervisor.
+    Upward,
+}
+
+/// A single factory shape: who supervises, who works.
+#[derive(Debug, Clone, Copy)]
+struct FactoryShape {
+    supervisor: SupervisorCli,
+    worker: SupervisorCli,
+    label: &'static str,
+}
+
+impl FactoryShape {
+    /// Whether native Claude Agent Teams is active for this factory. Teams mode
+    /// is launched only by a **Claude** supervisor; a Codex-supervised factory
+    /// runs `teams = None`. This mirrors `FactoryDaemon::teams.is_some()`, the
+    /// value `choose_channel` is fed at the call sites.
+    fn teams_active(&self) -> bool {
+        self.supervisor == Claude
+    }
+
+    /// The harness of the message *recipient* for a given direction — the only
+    /// thing the recipient-aware router keys on.
+    fn recipient(&self, dir: Direction) -> SupervisorCli {
+        match dir {
+            Direction::Downward => self.worker,
+            Direction::Upward => self.supervisor,
+        }
+    }
+}
+
+/// The full 4-combo matrix the EPIC enumerates.
+const SHAPES: [FactoryShape; 4] = [
+    // 1. claude-sup → codex-worker: the original bug (codex worker unreachable).
+    FactoryShape { supervisor: Claude, worker: Codex, label: "claude-sup / codex-worker" },
+    // 2. codex-sup → claude-worker: codex supervisor, claude worker.
+    FactoryShape { supervisor: Codex, worker: Claude, label: "codex-sup / claude-worker" },
+    // 3. codex-sup → codex-worker: codex-only factory.
+    FactoryShape { supervisor: Codex, worker: Codex, label: "codex-sup / codex-worker" },
+    // 4. claude-sup → claude-worker: the all-Claude regression baseline.
+    FactoryShape { supervisor: Claude, worker: Claude, label: "claude-sup / claude-worker" },
+];
+
+/// Expected routing for one cell, derived from the contract (NOT from the
+/// implementation): Codex recipients are always PTY + gated + framed; Claude
+/// recipients use the team inbox iff teams are active (no gate, no framing),
+/// else fall back to bare PTY (gated, unframed).
+fn expected(recipient: SupervisorCli, teams_active: bool) -> (DeliveryChannel, bool, bool) {
+    match recipient {
+        Codex => (DeliveryChannel::Pty, true, true),
+        Claude if teams_active => (DeliveryChannel::TeamsInbox, false, false),
+        Claude => (DeliveryChannel::Pty, true, false),
+    }
+}
+
+#[test]
+fn delivery_matrix_all_combos_both_directions() {
+    for shape in SHAPES {
+        for dir in [Direction::Downward, Direction::Upward] {
+            let recipient = shape.recipient(dir);
+            let teams = shape.teams_active();
+            let (want_channel, want_gate, want_framing) = expected(recipient, teams);
+
+            let got_channel = choose_channel(recipient, teams);
+            let got_gate = requires_pty_readiness_gate(recipient, teams);
+            let got_framing = pty_payload_needs_framing(recipient);
+
+            assert_eq!(
+                got_channel, want_channel,
+                "[{}] {dir:?}: recipient={recipient:?} teams={teams} \
+                 expected channel {want_channel:?}, got {got_channel:?}",
+                shape.label
+            );
+            assert_eq!(
+                got_gate, want_gate,
+                "[{}] {dir:?}: recipient={recipient:?} teams={teams} \
+                 expected readiness-gate {want_gate}, got {got_gate}",
+                shape.label
+            );
+            assert_eq!(
+                got_framing, want_framing,
+                "[{}] {dir:?}: recipient={recipient:?} teams={teams} \
+                 expected framing {want_framing}, got {got_framing}",
+                shape.label
+            );
+        }
+    }
+}
+
+/// The load-bearing fix: a Codex worker under a Claude (teams) supervisor is
+/// PTY-delivered, gated, and framed — never written to a team inbox it cannot
+/// read. (EPIC cas-ca04 AC1 / cas-b68a root cause, downward leg.)
+#[test]
+fn claude_sup_to_codex_worker_is_pty_gated_framed() {
+    let shape = SHAPES[0];
+    assert!(shape.teams_active(), "claude supervisor implies teams active");
+    let recipient = shape.recipient(Direction::Downward);
+    assert_eq!(recipient, Codex);
+    assert_eq!(choose_channel(recipient, shape.teams_active()), DeliveryChannel::Pty);
+    assert!(requires_pty_readiness_gate(recipient, shape.teams_active()));
+    assert!(pty_payload_needs_framing(recipient));
+}
+
+/// The upward mirror: a Codex *supervisor* must be woken by a worker message
+/// over the PTY (teams=None), framed so its prompt recognizes the injected
+/// turn. This is the leg that lets a codex supervisor triage worker
+/// status/blocker/ready messages. (EPIC cas-ca04 note (a), upward leg.)
+#[test]
+fn worker_to_codex_supervisor_is_pty_gated_framed() {
+    let shape = SHAPES[2]; // codex-sup / codex-worker (codex-only factory)
+    assert!(!shape.teams_active(), "codex supervisor implies no teams");
+    let recipient = shape.recipient(Direction::Upward);
+    assert_eq!(recipient, Codex);
+    assert_eq!(choose_channel(recipient, shape.teams_active()), DeliveryChannel::Pty);
+    assert!(requires_pty_readiness_gate(recipient, shape.teams_active()));
+    assert!(pty_payload_needs_framing(recipient));
+
+    // And the cross-harness variant: codex supervisor with a *claude* worker.
+    let cross = SHAPES[1]; // codex-sup / claude-worker
+    let codex_sup = cross.recipient(Direction::Upward);
+    assert_eq!(codex_sup, Codex);
+    assert_eq!(choose_channel(codex_sup, cross.teams_active()), DeliveryChannel::Pty);
+    assert!(pty_payload_needs_framing(codex_sup));
+}
+
+/// Regression: the all-Claude factory is byte-for-byte unchanged — both
+/// directions go through the team inbox with no gate and no framing. (EPIC
+/// cas-ca04 AC "claude-sup→claude-worker shown unchanged".)
+#[test]
+fn all_claude_factory_uses_inbox_both_directions_unchanged() {
+    let shape = SHAPES[3];
+    assert!(shape.teams_active());
+    for dir in [Direction::Downward, Direction::Upward] {
+        let recipient = shape.recipient(dir);
+        assert_eq!(recipient, Claude);
+        assert_eq!(
+            choose_channel(recipient, shape.teams_active()),
+            DeliveryChannel::TeamsInbox,
+            "all-claude {dir:?} must stay on the team inbox"
+        );
+        assert!(
+            !requires_pty_readiness_gate(recipient, shape.teams_active()),
+            "inbox writes never need the PTY gate"
+        );
+        assert!(
+            !pty_payload_needs_framing(recipient),
+            "claude recipients are never framed"
+        );
+    }
+}
+
+/// `all_workers` fan-out resolves each worker individually, so a broadcast in a
+/// mixed-harness factory must route per-recipient: a codex worker gets PTY, a
+/// claude worker gets the inbox — within the *same* (teams-active) broadcast.
+/// This models the per-worker loop in `queue_and_events.rs` (cas-b68a) without
+/// needing a live mux.
+#[test]
+fn all_workers_broadcast_routes_per_recipient_in_mixed_factory() {
+    // A claude-supervised (teams active) factory broadcasting to a mixed pool.
+    let teams_active = true;
+    // Codex member of the pool → PTY + framed.
+    assert_eq!(choose_channel(Codex, teams_active), DeliveryChannel::Pty);
+    assert!(pty_payload_needs_framing(Codex));
+    // Claude member of the same pool → inbox, unframed.
+    assert_eq!(choose_channel(Claude, teams_active), DeliveryChannel::TeamsInbox);
+    assert!(!pty_payload_needs_framing(Claude));
+}

--- a/cas-cli/src/ui/factory/daemon/runtime/gui_client.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/gui_client.rs
@@ -368,17 +368,11 @@ impl FactoryDaemon {
             }
             ClientMessage::Inject { pane_id, prompt } => {
                 let actual = self.resolve_pane_name(&pane_id);
-                if let Some(ref teams) = self.teams {
-                    let _ = teams.write_to_inbox(
-                        &actual,
-                        super::teams::DIRECTOR_AGENT_NAME,
-                        &prompt,
-                        None,
-                        None,
-                    );
-                } else {
-                    let _ = self.app.mux.inject(&actual, &prompt).await;
-                }
+                // Recipient-aware routing (cas-b68a): inject reaches a Codex pane
+                // via PTY even when the supervisor runs Claude teams.
+                let _ = self
+                    .deliver_to_worker(&actual, super::teams::DIRECTOR_AGENT_NAME, &prompt, None)
+                    .await;
             }
             ClientMessage::GetState => {
                 let state = self.build_session_state();

--- a/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
@@ -369,23 +369,16 @@ impl FactoryDaemon {
                         // number that tells us whether refresh_interval
                         // needs to be lowered for the P99 SLO.
                         let inject_started = std::time::Instant::now();
-                        let inject_result: anyhow::Result<()> = if let Some(ref teams) = self.teams {
-                            teams
-                                .write_to_inbox(
-                                    &prompt.target,
-                                    super::teams::DIRECTOR_AGENT_NAME,
-                                    &prompt.text,
-                                    None,
-                                    None,
-                                )
-                                .map_err(Into::into)
-                        } else {
-                            self.app
-                                .mux
-                                .inject(&prompt.target, &prompt.text)
-                                .await
-                                .map_err(Into::into)
-                        };
+                        // Recipient-aware routing (cas-b68a): a director event aimed
+                        // at a Codex agent must reach its PTY, not a Claude inbox.
+                        let inject_result = self
+                            .deliver_to_worker(
+                                &prompt.target,
+                                super::teams::DIRECTOR_AGENT_NAME,
+                                &prompt.text,
+                                None,
+                            )
+                            .await;
                         let inject_ms =
                             inject_started.elapsed().as_secs_f64() * 1000.0;
                         let total_ms =

--- a/cas-cli/src/ui/factory/daemon/runtime/mod.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/mod.rs
@@ -1,5 +1,6 @@
 mod client_input;
 mod cloud;
+mod delivery;
 mod gui_client;
 mod lifecycle;
 mod output;

--- a/cas-cli/src/ui/factory/daemon/runtime/mod.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/mod.rs
@@ -1,6 +1,8 @@
 mod client_input;
 mod cloud;
 mod delivery;
+#[cfg(test)]
+mod delivery_matrix_tests;
 mod gui_client;
 mod lifecycle;
 mod output;

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -235,17 +235,33 @@ impl FactoryDaemon {
                 continue;
             }
 
-            // Gate PTY injection on pane readiness: Claude Code flushes the PTY
-            // input buffer during startup, so text written before readline
-            // initialization is silently lost. Wait for output + a 5s grace
-            // period before injecting. Teams-mode uses inbox files, not PTY.
-            if self.teams.is_none() {
+            // Gate PTY injection on pane readiness: harnesses flush the PTY input
+            // buffer during startup, so text written before readline initialization
+            // is silently lost. Wait for output + a grace period before injecting.
+            //
+            // The gate applies to any PTY-delivered recipient. Originally this was
+            // `self.teams.is_none()` (everyone PTY-delivered in a non-teams factory).
+            // cas-b68a note b adds the missing case: a Codex recipient is PTY-delivered
+            // even under a Claude teams supervisor, and its *first* message was being
+            // dropped because the gate was skipped whenever `teams.is_some()`.
+            //
+            // `all_workers` is not a single pane, so harness/readiness can't be resolved
+            // for it — it keeps the original `teams.is_none()` semantics exactly (the
+            // per-worker loop below resolves each worker individually). Claude inbox
+            // writes need no gate (plain file write, no readline race).
+            {
                 let pane_target = if target == "supervisor" {
                     self.app.supervisor_name()
                 } else {
                     target.as_str()
                 };
-                if !self.app.mux.pane_ready_for_injection(pane_target) {
+                let pty_delivered = self.teams.is_none()
+                    || (target != "all_workers"
+                        && super::delivery::requires_pty_readiness_gate(
+                            self.app.harness_for(pane_target),
+                            true,
+                        ));
+                if pty_delivered && !self.app.mux.pane_ready_for_injection(pane_target) {
                     // Don't ack — the prompt stays in the queue for the next tick.
                     continue;
                 }
@@ -323,21 +339,16 @@ impl FactoryDaemon {
                 }
                 let mut any_success = false;
                 for name in workers {
-                    let inject_result: anyhow::Result<()> = if let Some(ref teams) = self.teams {
-                        teams.write_to_inbox(
+                    // Recipient-aware routing (cas-b68a): each worker may run a
+                    // different harness, so resolve per-worker inside the loop.
+                    let inject_result = self
+                        .deliver_to_worker(
                             &name,
                             &inbox_source,
                             &prompt_with_instructions,
                             queued.summary.as_deref(),
-                            None,
                         )
-                    } else {
-                        self.app
-                            .mux
-                            .inject(&name, &prompt_with_instructions)
-                            .await
-                            .map_err(Into::into)
-                    };
+                        .await;
                     match inject_result {
                         Ok(_) => {
                             any_success = true;
@@ -372,34 +383,22 @@ impl FactoryDaemon {
                 }
                 success = any_success;
             } else {
-                // Resolve target for delivery. For teams, the supervisor's team
-                // name is "supervisor". For mux.inject, use the generated pane name.
+                // Resolve the pane name for diagnostics / event records. Delivery
+                // itself (channel selection + name normalisation) is handled by the
+                // recipient-aware helper (cas-b68a).
                 let pane_target = if target == "supervisor" {
                     self.app.supervisor_name()
                 } else {
                     target.as_str()
                 };
-                // For teams inbox, map generated pane name back to "supervisor"
-                let inbox_target = if pane_target == self.app.supervisor_name() {
-                    "supervisor"
-                } else {
-                    pane_target
-                };
-                let inject_result: anyhow::Result<()> = if let Some(ref teams) = self.teams {
-                    teams.write_to_inbox(
-                        inbox_target,
+                let inject_result = self
+                    .deliver_to_worker(
+                        target,
                         &inbox_source,
                         &prompt_with_instructions,
                         queued.summary.as_deref(),
-                        None,
                     )
-                } else {
-                    self.app
-                        .mux
-                        .inject(pane_target, &prompt_with_instructions)
-                        .await
-                        .map_err(Into::into)
-                };
+                    .await;
                 match inject_result {
                     Ok(_) => {
                         success = true;

--- a/cas-cli/src/ui/factory/daemon/runtime/ws_client.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/ws_client.rs
@@ -294,17 +294,11 @@ impl FactoryDaemon {
             }
             ClientMessage::Inject { pane_id, prompt } => {
                 let actual = self.resolve_pane_name(&pane_id);
-                if let Some(ref teams) = self.teams {
-                    let _ = teams.write_to_inbox(
-                        &actual,
-                        super::teams::DIRECTOR_AGENT_NAME,
-                        &prompt,
-                        None,
-                        None,
-                    );
-                } else {
-                    let _ = self.app.mux.inject(&actual, &prompt).await;
-                }
+                // Recipient-aware routing (cas-b68a): inject reaches a Codex pane
+                // via PTY even when the supervisor runs Claude teams.
+                let _ = self
+                    .deliver_to_worker(&actual, super::teams::DIRECTOR_AGENT_NAME, &prompt, None)
+                    .await;
             }
             ClientMessage::GetState => {
                 let state = self.build_session_state();

--- a/cas-cli/src/ui/factory/director/events_tests/tests.rs
+++ b/cas-cli/src/ui/factory/director/events_tests/tests.rs
@@ -12,6 +12,7 @@ fn make_task(id: &str, title: &str, status: TaskStatus, assignee: Option<&str>) 
         task_type: TaskType::Task,
         epic: None,
         branch: None,
+        updated_at: None,
     }
 }
 
@@ -25,6 +26,7 @@ fn make_epic(id: &str, title: &str, status: TaskStatus) -> TaskSummary {
         task_type: TaskType::Epic,
         epic: None,
         branch: None,
+        updated_at: None,
     }
 }
 
@@ -38,6 +40,7 @@ fn make_epic_with_branch(id: &str, title: &str, status: TaskStatus, branch: &str
         task_type: TaskType::Epic,
         epic: None,
         branch: Some(branch.to_string()),
+        updated_at: None,
     }
 }
 

--- a/cas-cli/src/ui/factory/director/prompts.rs
+++ b/cas-cli/src/ui/factory/director/prompts.rs
@@ -265,6 +265,7 @@ mod tests {
                 task_type: TaskType::Task,
                 epic: None,
                 branch: None,
+                updated_at: None,
             })
             .collect();
 

--- a/cas-cli/tests/factory_codex_skill_guardrails.rs
+++ b/cas-cli/tests/factory_codex_skill_guardrails.rs
@@ -140,8 +140,13 @@ fn codex_worker_runtime_instruction_allows_close_then_escalate() {
     let pty_rs = root.join("crates/cas-pty/src/pty.rs");
     let content = load(&pty_rs);
 
+    // cas-47b7: the worker instruction phrasing is "close it with
+    // `mcp__cs__task action=close ...`" (cas-bbc2 single-task rewrite). Assert on
+    // the close-command form itself rather than a fragile leading verb so prose
+    // tweaks don't re-break this guardrail; the intent is only "workers ARE told
+    // to close their task".
     assert!(
-        content.contains("close with `mcp__cs__task action=close"),
+        content.contains("`mcp__cs__task action=close"),
         "runtime worker instruction should instruct workers to close tasks"
     );
     assert!(

--- a/cas-cli/tests/mcp_protocol_test.rs
+++ b/cas-cli/tests/mcp_protocol_test.rs
@@ -71,10 +71,20 @@ struct McpTestClient {
 impl McpTestClient {
     /// Spawn MCP server (7 meta-tools)
     fn spawn(cas_dir: &std::path::Path) -> Self {
-        let mut child = Command::new(env!("CARGO_BIN_EXE_cas"))
-            .arg("serve")
-            .env("CAS_DIR", cas_dir)
-            .current_dir(cas_dir)
+        // `cas serve` resolves its store via `find_cas_root()`, which honors an
+        // inherited `CAS_ROOT` BEFORE any cwd-based detection — `CAS_DIR` is not
+        // consulted by serve at all. When the test runner itself was launched
+        // inside a CAS factory worker session, `CAS_ROOT`/`CAS_SESSION_ID` are
+        // inherited and would redirect serve to the live worker DB instead of
+        // this test's freshly-`init`ed temp dir. That live DB may legitimately
+        // lack newer columns (e.g. `depth`), so task-create INSERTs fail with
+        // "table tasks has no column named depth" — a false red unrelated to the
+        // code under test. Scrub all CAS_* vars (matching `init_cas_dir`) so
+        // serve falls back to cwd-based detection and finds `<cas_dir>/.cas`.
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_cas"));
+        cmd.arg("serve").current_dir(cas_dir);
+        scrub_cas_env(&mut cmd);
+        let mut child = cmd
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())

--- a/cas-cli/tests/mcp_tools_test/edge_cases.rs
+++ b/cas-cli/tests/mcp_tools_test/edge_cases.rs
@@ -158,6 +158,7 @@ async fn test_negative_priority() {
 
     // Negative priority should be handled
     let req = TaskCreateRequest {
+        depth: None,
         title: "Negative priority task".to_string(),
         description: None,
         priority: 255, // Max u8, should be clamped or handled
@@ -185,6 +186,7 @@ async fn test_duplicate_dependency() {
 
     // Create tasks
     let req1 = TaskCreateRequest {
+        depth: None,
         title: "Task A".to_string(),
         description: None,
         priority: 2,
@@ -210,6 +212,7 @@ async fn test_duplicate_dependency() {
     let id_a = extract_task_id(&text1).expect("should have task ID");
 
     let req2 = TaskCreateRequest {
+        depth: None,
         title: "Task B".to_string(),
         description: None,
         priority: 2,
@@ -262,6 +265,7 @@ async fn test_self_dependency() {
     let (_temp, service) = setup_cas();
 
     let req = TaskCreateRequest {
+        depth: None,
         title: "Self dep task".to_string(),
         description: None,
         priority: 2,

--- a/cas-cli/tests/mcp_tools_test/search_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/search_tools.rs
@@ -94,6 +94,7 @@ async fn test_search_filter_by_type() {
         .expect("remember should succeed");
 
     let task_req = TaskCreateRequest {
+        depth: None,
         title: "Filter test task".to_string(),
         description: None,
         priority: 2,

--- a/cas-cli/tests/mcp_tools_test/server_protocol/mod.rs
+++ b/cas-cli/tests/mcp_tools_test/server_protocol/mod.rs
@@ -118,6 +118,7 @@ async fn test_all_store_types_accessible() {
 
     // Test task store
     let req = TaskCreateRequest {
+        depth: None,
         title: "Task store test".to_string(),
         description: None,
         priority: 2,
@@ -190,6 +191,7 @@ async fn test_start_blocked_with_pending_verification() {
 
     // Create and start first task
     let req = TaskCreateRequest {
+        depth: None,
         title: "First task".to_string(),
         description: None,
         priority: 2,
@@ -243,6 +245,7 @@ code_review_findings: None,
 
     // Create second task
     let req2 = TaskCreateRequest {
+        depth: None,
         title: "Second task".to_string(),
         description: None,
         priority: 2,
@@ -294,6 +297,7 @@ async fn test_claim_blocked_with_pending_verification() {
 
     // Create and start first task
     let req = TaskCreateRequest {
+        depth: None,
         title: "First task for claim test".to_string(),
         description: None,
         priority: 2,
@@ -347,6 +351,7 @@ code_review_findings: None,
 
     // Create second task
     let req2 = TaskCreateRequest {
+        depth: None,
         title: "Second task for claim test".to_string(),
         description: None,
         priority: 2,
@@ -409,6 +414,7 @@ async fn test_start_allowed_after_verification_approved() {
 
     // Create and start first task
     let req = TaskCreateRequest {
+        depth: None,
         title: "First task".to_string(),
         description: None,
         priority: 2,
@@ -452,6 +458,7 @@ async fn test_start_allowed_after_verification_approved() {
 
     // Create second task
     let req2 = TaskCreateRequest {
+        depth: None,
         title: "Second task".to_string(),
         description: None,
         priority: 2,
@@ -502,6 +509,7 @@ async fn test_start_same_task_allowed_when_pending() {
 
     // Create and start task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Task to resume".to_string(),
         description: None,
         priority: 2,
@@ -576,6 +584,7 @@ async fn test_task_list_type_filter() {
 
     // Create an epic
     let epic_req = TaskCreateRequest {
+        depth: None,
         title: "Test Epic for filtering".to_string(),
         description: None,
         notes: None,
@@ -598,6 +607,7 @@ async fn test_task_list_type_filter() {
 
     // Create a regular task
     let task_req = TaskCreateRequest {
+        depth: None,
         title: "Test Task for filtering".to_string(),
         description: None,
         notes: None,
@@ -650,6 +660,7 @@ async fn test_task_list_epic_filter() {
 
     // Create an epic
     let epic_req = TaskCreateRequest {
+        depth: None,
         title: "My Test Epic".to_string(),
         description: Some("An epic to test filtering".to_string()),
         notes: None,
@@ -679,6 +690,7 @@ async fn test_task_list_epic_filter() {
 
     // Create a subtask linked to the epic
     let subtask_req = TaskCreateRequest {
+        depth: None,
         title: "Subtask of Epic".to_string(),
         description: None,
         notes: None,
@@ -701,6 +713,7 @@ async fn test_task_list_epic_filter() {
 
     // Create an unrelated task (NOT linked to the epic)
     let unrelated_req = TaskCreateRequest {
+        depth: None,
         title: "Unrelated Task".to_string(),
         description: None,
         notes: None,

--- a/cas-cli/tests/mcp_tools_test/task_tools/create_and_epic.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/create_and_epic.rs
@@ -8,6 +8,7 @@ async fn test_task_create_basic() {
     let (_temp, service) = setup_cas();
 
     let req = TaskCreateRequest {
+        depth: None,
         title: "Test task".to_string(),
         description: Some("Task description".to_string()),
         priority: 2,
@@ -40,6 +41,7 @@ async fn test_task_create_and_start() {
 
     // Create task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Auto-start task".to_string(),
         description: None,
         priority: 1,
@@ -135,6 +137,7 @@ async fn test_epic_creates_branch_not_worktree() {
 
     // Create epic task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Add User Authentication".to_string(),
         description: Some("Epic for auth feature".to_string()),
         priority: 1,
@@ -218,6 +221,7 @@ async fn test_task_create_invalid_epic_does_not_persist_task() {
     let (_temp, service) = setup_cas();
 
     let req = TaskCreateRequest {
+        depth: None,
         title: "Should fail atomic create".to_string(),
         description: Some("invalid epic should not leave orphan task".to_string()),
         priority: 2,
@@ -265,6 +269,7 @@ async fn test_task_create_surfaces_dependency_write_failure() {
 
     let blocker = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Blocking task".to_string(),
             description: None,
             priority: 2,
@@ -300,6 +305,7 @@ async fn test_task_create_surfaces_dependency_write_failure() {
 
     let create_result = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Should fail dependency write".to_string(),
             description: None,
             priority: 2,
@@ -341,4 +347,141 @@ async fn test_task_create_surfaces_dependency_write_failure() {
         !list_text.contains("Should fail dependency write"),
         "create_atomic should roll back task on dependency insert error: {list_text}"
     );
+}
+
+// =============================================================================
+// cas-0344: per-task depth flag end-to-end coverage (EPIC cas-1255)
+// =============================================================================
+
+fn depth_create_req(title: &str, depth: Option<&str>) -> TaskCreateRequest {
+    TaskCreateRequest {
+        depth: depth.map(|s| s.to_string()),
+        title: title.to_string(),
+        description: None,
+        priority: 2,
+        task_type: "task".to_string(),
+        labels: None,
+        notes: None,
+        blocked_by: None,
+        design: None,
+        acceptance_criteria: None,
+        external_ref: None,
+        assignee: None,
+        demo_statement: None,
+        execution_note: None,
+        epic: None,
+    }
+}
+
+#[tokio::test]
+async fn test_task_create_with_light_depth_shows_light() {
+    let (_temp, service) = setup_cas();
+
+    let text = extract_text(
+        service
+            .cas_task_create(Parameters(depth_create_req("light task", Some("light"))))
+            .await
+            .expect("create should succeed"),
+    );
+    let id = extract_task_id(&text).expect("task id").to_string();
+
+    let show = extract_text(
+        service
+            .cas_task_show(Parameters(TaskShowRequest {
+                id,
+                with_deps: false,
+            }))
+            .await
+            .expect("show should succeed"),
+    );
+    assert!(show.contains("Depth: light"), "expected light depth: {show}");
+}
+
+#[tokio::test]
+async fn test_task_create_without_depth_defaults_to_deep() {
+    let (_temp, service) = setup_cas();
+
+    let text = extract_text(
+        service
+            .cas_task_create(Parameters(depth_create_req("default task", None)))
+            .await
+            .expect("create should succeed"),
+    );
+    let id = extract_task_id(&text).expect("task id").to_string();
+
+    let show = extract_text(
+        service
+            .cas_task_show(Parameters(TaskShowRequest {
+                id,
+                with_deps: false,
+            }))
+            .await
+            .expect("show should succeed"),
+    );
+    assert!(show.contains("Depth: deep"), "expected deep default: {show}");
+}
+
+#[tokio::test]
+async fn test_task_create_invalid_depth_is_rejected() {
+    let (_temp, service) = setup_cas();
+
+    let result = service
+        .cas_task_create(Parameters(depth_create_req("bad depth", Some("medium"))))
+        .await;
+    assert!(result.is_err(), "invalid depth must be rejected");
+    let msg = result.err().unwrap().message.to_string();
+    assert!(
+        msg.contains("Invalid depth"),
+        "error should explain invalid depth: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_task_update_depth_to_light() {
+    let (_temp, service) = setup_cas();
+
+    let text = extract_text(
+        service
+            .cas_task_create(Parameters(depth_create_req("upgrade me", None)))
+            .await
+            .expect("create should succeed"),
+    );
+    let id = extract_task_id(&text).expect("task id").to_string();
+
+    // Update depth -> light
+    let update_text = extract_text(
+        service
+            .cas_task_update(Parameters(TaskUpdateRequest {
+                id: id.clone(),
+                title: None,
+                notes: None,
+                priority: None,
+                labels: None,
+                description: None,
+                design: None,
+                acceptance_criteria: None,
+                demo_statement: None,
+                execution_note: None,
+                external_ref: None,
+                assignee: None,
+                status: None,
+                epic: None,
+                epic_verification_owner: None,
+                depth: Some("light".to_string()),
+            }))
+            .await
+            .expect("update should succeed"),
+    );
+    assert!(update_text.contains("depth"), "update should report depth change: {update_text}");
+
+    let show = extract_text(
+        service
+            .cas_task_show(Parameters(TaskShowRequest {
+                id,
+                with_deps: false,
+            }))
+            .await
+            .expect("show should succeed"),
+    );
+    assert!(show.contains("Depth: light"), "expected light after update: {show}");
 }

--- a/cas-cli/tests/mcp_tools_test/task_tools/depth_e2e.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/depth_e2e.rs
@@ -1,0 +1,277 @@
+//! cas-9d74 (EPIC cas-1255 — per-task depth speed mode): capstone end-to-end.
+//!
+//! cas-0344 shipped the data layer (the `depth` column + serialize/deserialize
+//! with NULL→Deep) and cas-6538 shipped the close-gate light-skip. The per-task
+//! suites each test ONE layer in a single in-process session. This capstone
+//! proves the two layers COMPOSE across a real persistence boundary — the exact
+//! seam where cross-task drift would hide:
+//!
+//!   1. A worker creates a `depth=light` / `deep` / unset task (session 1).
+//!   2. A brand-new `open_task_store` reloads the task from SQLite and we assert
+//!      the depth round-tripped (data layer survives the write/read boundary).
+//!   3. A *different* CasCore + CasService (session 2 — modelling a separate
+//!      worker process) starts and closes the task, and we assert the reloaded
+//!      depth still drives the close gate: light closes immediately (no jail, no
+//!      P0/supervisor-review hop) with an auditable decision note; deep/unset
+//!      pend for supervisor review exactly as today.
+//!
+//! If the data layer and the close gate ever disagree about a task's depth
+//! after persistence (e.g. a serialize regression that drops Light to NULL→Deep
+//! on read), the light test's close would suddenly pend and this fails — which
+//! the single-session per-layer tests cannot catch.
+
+use crate::support::*;
+use cas::mcp::{CasCore, CasService};
+use cas::store::open_task_store;
+use cas::types::{TaskDepth, TaskStatus};
+use rmcp::handler::server::wrapper::Parameters;
+use std::process::Command;
+
+/// Build a `cas_mcp::TaskRequest` from test JSON (drives the full MCP service
+/// dispatch path, like a real client).
+fn task_req(value: serde_json::Value) -> cas_mcp::TaskRequest {
+    serde_json::from_value(value).expect("TaskRequest should deserialize from test JSON")
+}
+
+/// RAII guard that installs factory-worker env vars and clears them on drop, so
+/// the close gate runs its worker-under-supervisor-review branch.
+struct FactoryWorkerGuard;
+
+impl FactoryWorkerGuard {
+    fn enter() -> Self {
+        unsafe {
+            std::env::set_var("CAS_AGENT_ROLE", "worker");
+            std::env::set_var("CAS_FACTORY_MODE", "1");
+        }
+        Self
+    }
+}
+
+impl Drop for FactoryWorkerGuard {
+    fn drop(&mut self) {
+        unsafe {
+            std::env::remove_var("CAS_AGENT_ROLE");
+            std::env::remove_var("CAS_FACTORY_MODE");
+        }
+    }
+}
+
+/// Verification disabled + supervisor-owned review, so a factory-worker close
+/// reaches the supervisor-review (P0) transition rather than the jail.
+fn write_supervisor_review_config(cas_dir: &std::path::Path) {
+    let toml = r#"
+[verification]
+enabled = false
+
+[code_review]
+owner = "supervisor"
+"#;
+    std::fs::write(cas_dir.join("config.toml"), toml).expect("config.toml should be writable");
+}
+
+/// Init a git repo with one staged Rust change so `has_reviewable_changes()`
+/// returns true and the close actually reaches the P0 code-review gate.
+fn init_git_repo_with_staged_changes(project_root: &std::path::Path) {
+    let git = |args: &[&str]| {
+        Command::new("git")
+            .args(args)
+            .current_dir(project_root)
+            .output()
+            .expect("git command should run")
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "test@example.com"]);
+    git(&["config", "user.name", "Test"]);
+    std::fs::write(project_root.join("base.rs"), "fn main() {}\n").expect("write base.rs");
+    git(&["add", "base.rs"]);
+    git(&["commit", "-m", "init"]);
+    std::fs::write(
+        project_root.join("feature.rs"),
+        "pub fn feature() -> u32 { 42 }\n",
+    )
+    .expect("write feature.rs");
+    git(&["add", "feature.rs"]);
+}
+
+/// Session-1 create: returns the new task id. Built on its own core/service so
+/// the close runs on a freshly-opened one (session 2).
+async fn create_task(cas_dir: &std::path::Path, title: &str, depth: Option<&str>) -> String {
+    let core = CasCore::with_daemon(cas_dir.to_path_buf(), None, None);
+    let service = CasService::new(core, None);
+    let mut body = serde_json::json!({
+        "action": "create",
+        "title": title,
+        "priority": 2,
+        "task_type": "task",
+    });
+    if let Some(d) = depth {
+        body["depth"] = serde_json::Value::String(d.to_string());
+    }
+    let created = service
+        .task(Parameters(task_req(body)))
+        .await
+        .expect("task.create should succeed");
+    extract_task_id(&extract_text(created))
+        .expect("create output should carry a task id")
+        .to_string()
+}
+
+/// Session-2 start+close on a fresh core/service; returns the close output text.
+async fn start_and_close(cas_dir: &std::path::Path, id: &str) -> String {
+    let core = CasCore::with_daemon(cas_dir.to_path_buf(), None, None);
+    let service = CasService::new(core, None);
+    service
+        .task(Parameters(task_req(
+            serde_json::json!({ "action": "start", "id": id }),
+        )))
+        .await
+        .expect("task.start should succeed");
+    extract_text(
+        service
+            .task(Parameters(task_req(serde_json::json!({
+                "action": "close",
+                "id": id,
+                "reason": "All acceptance criteria met.",
+            }))))
+            .await
+            .expect("task.close should return a result"),
+    )
+}
+
+/// E2E (light): depth=light round-trips through SQLite and, read back by a
+/// separate session, still skips both rigor gates — the task closes immediately
+/// with the auditable decision note.
+#[tokio::test]
+async fn test_e2e_light_depth_persists_then_closes_without_gates() {
+    let (temp, _core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+
+    write_supervisor_review_config(&cas_dir);
+    init_git_repo_with_staged_changes(temp.path());
+
+    // Session 1 — create the light task.
+    let id = create_task(&cas_dir, "feel-driven UI tweak", Some("light")).await;
+
+    // Persistence boundary — a fresh store read must see depth=Light.
+    let reloaded = open_task_store(&cas_dir)
+        .unwrap()
+        .get(&id)
+        .expect("task should persist");
+    assert_eq!(
+        reloaded.depth,
+        TaskDepth::Light,
+        "depth=light must round-trip through SQLite, not collapse to the default"
+    );
+
+    // Session 2 — a separate worker process closes it.
+    let _worker = FactoryWorkerGuard::enter();
+    let close_text = start_and_close(&cas_dir, &id).await;
+
+    assert!(
+        !close_text.contains("CODE_REVIEW_REQUIRED"),
+        "light close must not trip the code-review gate: {close_text}"
+    );
+    assert!(
+        !close_text.contains("pending_supervisor_review")
+            && !close_text.contains("supervisor review"),
+        "light close must NOT pend for supervisor review — it closes immediately: {close_text}"
+    );
+
+    let task = open_task_store(&cas_dir).unwrap().get(&id).unwrap();
+    assert_eq!(
+        task.status,
+        TaskStatus::Closed,
+        "light task must end Closed, not PendingSupervisorReview; got {:?}",
+        task.status
+    );
+    assert_eq!(
+        task.depth,
+        TaskDepth::Light,
+        "depth must remain Light through the close"
+    );
+    assert!(
+        task.notes.contains("depth=light") && task.notes.contains("code-review gate"),
+        "light close must record the auditable decision note: {}",
+        task.notes
+    );
+}
+
+/// E2E (deep): depth=deep round-trips and, read back by a separate session,
+/// still enforces the P0 gate — the task pends for supervisor review.
+#[tokio::test]
+async fn test_e2e_deep_depth_persists_then_pends_supervisor_review() {
+    let (temp, _core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+
+    write_supervisor_review_config(&cas_dir);
+    init_git_repo_with_staged_changes(temp.path());
+
+    let id = create_task(&cas_dir, "auth refactor", Some("deep")).await;
+
+    let reloaded = open_task_store(&cas_dir).unwrap().get(&id).unwrap();
+    assert_eq!(
+        reloaded.depth,
+        TaskDepth::Deep,
+        "depth=deep must round-trip through SQLite"
+    );
+
+    let _worker = FactoryWorkerGuard::enter();
+    let close_text = start_and_close(&cas_dir, &id).await;
+
+    assert!(
+        close_text.contains("supervisor review")
+            || close_text.contains("pending_supervisor_review"),
+        "deep close must still pend for supervisor review: {close_text}"
+    );
+
+    let task = open_task_store(&cas_dir).unwrap().get(&id).unwrap();
+    assert_eq!(
+        task.status,
+        TaskStatus::PendingSupervisorReview,
+        "deep task must pend for supervisor review, not close: {:?}",
+        task.status
+    );
+    assert!(
+        !task.notes.contains("depth=light"),
+        "deep close must not write the light-skip decision note: {}",
+        task.notes
+    );
+}
+
+/// E2E (unset / legacy): a task created with no depth reads back as Deep
+/// (NULL→Deep) across the persistence boundary and is enforced like deep — the
+/// default composes with the gate exactly as an explicit deep does.
+#[tokio::test]
+async fn test_e2e_unset_depth_reads_as_deep_then_pends_supervisor_review() {
+    let (temp, _core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+
+    write_supervisor_review_config(&cas_dir);
+    init_git_repo_with_staged_changes(temp.path());
+
+    let id = create_task(&cas_dir, "legacy task — no depth set", None).await;
+
+    let reloaded = open_task_store(&cas_dir).unwrap().get(&id).unwrap();
+    assert_eq!(
+        reloaded.depth,
+        TaskDepth::Deep,
+        "unset depth must read back as Deep (NULL→Deep)"
+    );
+
+    let _worker = FactoryWorkerGuard::enter();
+    let close_text = start_and_close(&cas_dir, &id).await;
+
+    assert!(
+        close_text.contains("supervisor review")
+            || close_text.contains("pending_supervisor_review"),
+        "unset-depth close must enforce the P0 gate like deep: {close_text}"
+    );
+    assert_eq!(
+        open_task_store(&cas_dir).unwrap().get(&id).unwrap().status,
+        TaskStatus::PendingSupervisorReview,
+        "unset-depth task must pend for supervisor review"
+    );
+}

--- a/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
@@ -1,0 +1,431 @@
+//! cas-6538 (EPIC cas-1255 — per-task depth speed mode): close-gate light-skip.
+//!
+//! These tests pin the enforcement layer: a `depth=light` task skips the two
+//! *rigor* gates at close time — the verification jail and the P0 code-review
+//! gate (including the supervisor-review queue hop that IS the P0 gate under
+//! `owner = "supervisor"`) — and records an auditable decision note. The
+//! regression guard is the whole point: `depth=deep`/unset must arm the jail
+//! and pend for supervisor review exactly as today, proven by paired tests
+//! that fail if the skip leaks to deep.
+
+use crate::support::*;
+use cas::mcp::tools::*;
+use cas::mcp::{CasCore, CasService};
+use cas::store::open_task_store;
+use cas::types::TaskStatus;
+use rmcp::handler::server::wrapper::Parameters;
+use std::process::Command;
+
+/// Build a `cas_mcp::TaskRequest` from test JSON.
+fn task_req(value: serde_json::Value) -> cas_mcp::TaskRequest {
+    serde_json::from_value(value).expect("TaskRequest should deserialize from test JSON")
+}
+
+/// Typed `TaskCreateRequest` with the given depth (`None` = unset/default).
+/// The solo tests drive `cas_task_close` *directly* on the core — bypassing
+/// the dispatch-layer MCP jail (`authorize_agent_action`) the same way the
+/// existing verification_flow tests do — to isolate the close_ops gate.
+fn create_req(title: &str, depth: Option<&str>) -> TaskCreateRequest {
+    TaskCreateRequest {
+        depth: depth.map(str::to_string),
+        title: title.to_string(),
+        description: None,
+        priority: 2,
+        task_type: "task".to_string(),
+        labels: None,
+        notes: None,
+        blocked_by: None,
+        design: None,
+        acceptance_criteria: None,
+        external_ref: None,
+        assignee: None,
+        demo_statement: None,
+        execution_note: None,
+        epic: None,
+    }
+}
+
+/// RAII guard that installs factory-worker env vars and clears them on drop.
+struct FactoryWorkerGuard;
+
+impl FactoryWorkerGuard {
+    fn enter() -> Self {
+        unsafe {
+            std::env::set_var("CAS_AGENT_ROLE", "worker");
+            std::env::set_var("CAS_FACTORY_MODE", "1");
+        }
+        Self
+    }
+}
+
+impl Drop for FactoryWorkerGuard {
+    fn drop(&mut self) {
+        unsafe {
+            std::env::remove_var("CAS_AGENT_ROLE");
+            std::env::remove_var("CAS_FACTORY_MODE");
+        }
+    }
+}
+
+/// Supervisor-owned review + verification disabled, so a factory-worker close
+/// reaches the supervisor-review transition rather than the verification jail.
+fn write_supervisor_review_config(cas_dir: &std::path::Path) {
+    let toml = r#"
+[verification]
+enabled = false
+
+[code_review]
+owner = "supervisor"
+"#;
+    std::fs::write(cas_dir.join("config.toml"), toml).expect("config.toml should be writable");
+}
+
+/// Init a git repo at `project_root` with one staged Rust change so that
+/// `has_reviewable_changes()` returns true.
+fn init_git_repo_with_staged_changes(project_root: &std::path::Path) {
+    let git = |args: &[&str]| {
+        Command::new("git")
+            .args(args)
+            .current_dir(project_root)
+            .output()
+            .expect("git command should run")
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "test@example.com"]);
+    git(&["config", "user.name", "Test"]);
+    std::fs::write(project_root.join("base.rs"), "fn main() {}\n").expect("write should succeed");
+    git(&["add", "base.rs"]);
+    git(&["commit", "-m", "init"]);
+    std::fs::write(
+        project_root.join("feature.rs"),
+        "pub fn feature() -> u32 { 42 }\n",
+    )
+    .expect("write should succeed");
+    git(&["add", "feature.rs"]);
+}
+
+// ---------------------------------------------------------------------------
+// Solo (non-factory) close — verification jail branch, exercised directly on
+// `cas_task_close`.
+//
+// setup_cas() leaves verification ENABLED (no config written), so the close_ops
+// jail arms for deep and skips for light. These call the core method directly
+// (bypassing the dispatch-layer MCP jail) to isolate the close_ops gate — the
+// same convention every existing verification_flow close test uses.
+// ---------------------------------------------------------------------------
+
+/// AC: closing a `depth=light` task skips the verification jail — close
+/// succeeds, `pending_verification` stays false, and a decision note records
+/// the skip.
+#[tokio::test]
+async fn test_light_depth_solo_close_skips_verification_jail() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    let task_store = open_task_store(&cas_dir).unwrap();
+
+    let created = core
+        .cas_task_create(Parameters(create_req("light task — solo close", Some("light"))))
+        .await
+        .expect("task_create should succeed");
+    let id = extract_task_id(&extract_text(created))
+        .expect("should have task ID")
+        .to_string();
+
+    core.cas_task_start(Parameters(IdRequest { id: id.clone() }))
+        .await
+        .expect("task_start should succeed");
+
+    let close_text = extract_text(
+        core.cas_task_close(Parameters(TaskCloseRequest {
+            id: id.clone(),
+            reason: Some("Feel-driven pass complete.".to_string()),
+            bypass_code_review: None,
+            code_review_findings: None,
+        }))
+        .await
+        .expect("task_close should return a result"),
+    );
+
+    assert!(
+        !close_text.contains("VERIFICATION REQUIRED"),
+        "light close must not arm the verification jail: {close_text}"
+    );
+    assert!(
+        close_text.contains("Closed"),
+        "light close should report success: {close_text}"
+    );
+
+    let task = task_store.get(&id).expect("task should exist");
+    assert_eq!(
+        task.status,
+        TaskStatus::Closed,
+        "light task must transition to Closed"
+    );
+    assert!(
+        !task.pending_verification,
+        "light close must leave pending_verification false"
+    );
+    // Auditable decision note recording exactly what was skipped and why.
+    assert!(
+        task.notes.contains("depth=light")
+            && task.notes.to_lowercase().contains("decision")
+            && task.notes.contains("verification jail")
+            && task.notes.contains("code-review gate"),
+        "light close must record an auditable decision note naming both skipped \
+         gates: {}",
+        task.notes
+    );
+}
+
+/// Regression guard: a `depth=deep` (explicit) task still arms the jail.
+/// Fails if the light-skip leaks to deep.
+#[tokio::test]
+async fn test_deep_depth_solo_close_still_arms_verification_jail() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    let task_store = open_task_store(&cas_dir).unwrap();
+
+    let created = core
+        .cas_task_create(Parameters(create_req("deep task — solo close", Some("deep"))))
+        .await
+        .expect("task_create should succeed");
+    let id = extract_task_id(&extract_text(created))
+        .expect("should have task ID")
+        .to_string();
+
+    core.cas_task_start(Parameters(IdRequest { id: id.clone() }))
+        .await
+        .expect("task_start should succeed");
+
+    let close_text = extract_text(
+        core.cas_task_close(Parameters(TaskCloseRequest {
+            id: id.clone(),
+            reason: Some("Done.".to_string()),
+            bypass_code_review: None,
+            code_review_findings: None,
+        }))
+        .await
+        .expect("task_close should return a result"),
+    );
+
+    assert!(
+        close_text.contains("VERIFICATION REQUIRED"),
+        "deep close must still arm the verification jail: {close_text}"
+    );
+
+    let task = task_store.get(&id).expect("task should exist");
+    assert!(
+        task.pending_verification,
+        "deep close must set pending_verification = true"
+    );
+    assert_ne!(
+        task.status,
+        TaskStatus::Closed,
+        "deep close must NOT close while verification is pending"
+    );
+    assert!(
+        !task.notes.contains("depth=light"),
+        "deep close must not write the light-skip decision note: {}",
+        task.notes
+    );
+}
+
+/// Regression guard: an unset-depth (legacy / NULL→Deep) task behaves like
+/// deep — the jail arms. Proves the default reads as Deep at the close gate.
+#[tokio::test]
+async fn test_unset_depth_solo_close_still_arms_verification_jail() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    let task_store = open_task_store(&cas_dir).unwrap();
+
+    let created = core
+        .cas_task_create(Parameters(create_req("unset-depth task — solo close", None)))
+        .await
+        .expect("task_create should succeed");
+    let id = extract_task_id(&extract_text(created))
+        .expect("should have task ID")
+        .to_string();
+
+    core.cas_task_start(Parameters(IdRequest { id: id.clone() }))
+        .await
+        .expect("task_start should succeed");
+
+    let close_text = extract_text(
+        core.cas_task_close(Parameters(TaskCloseRequest {
+            id: id.clone(),
+            reason: Some("Done.".to_string()),
+            bypass_code_review: None,
+            code_review_findings: None,
+        }))
+        .await
+        .expect("task_close should return a result"),
+    );
+
+    assert!(
+        close_text.contains("VERIFICATION REQUIRED"),
+        "unset-depth close must arm the jail (NULL→Deep): {close_text}"
+    );
+    assert!(
+        task_store
+            .get(&id)
+            .expect("task should exist")
+            .pending_verification,
+        "unset-depth close must set pending_verification = true"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Factory-worker close under supervisor-owned review — P0 gate branch.
+//
+// Under `owner = "supervisor"` a worker close with reviewable changes pends
+// to PendingSupervisorReview (the queue hop IS the P0 gate). depth=light must
+// instead close immediately; depth=deep must still pend.
+// ---------------------------------------------------------------------------
+
+/// AC: a `depth=light` factory-worker close with reviewable changes treats the
+/// P0 code-review gate as satisfied — the task closes immediately rather than
+/// pending for supervisor review, with the decision note recorded.
+#[tokio::test]
+async fn test_light_depth_factory_close_skips_p0_gate_and_closes() {
+    let (temp, _core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+
+    write_supervisor_review_config(&cas_dir);
+    init_git_repo_with_staged_changes(temp.path());
+
+    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let task_store = open_task_store(&cas_dir).unwrap();
+    let service = CasService::new(core, None);
+
+    let _worker_guard = FactoryWorkerGuard::enter();
+
+    let created = service
+        .task(Parameters(task_req(serde_json::json!({
+            "action": "create",
+            "title": "light feature task — factory close",
+            "priority": 2,
+            "task_type": "task",
+            "depth": "light",
+        }))))
+        .await
+        .expect("task.create should succeed");
+    let id = extract_task_id(&extract_text(created))
+        .expect("should have task ID")
+        .to_string();
+
+    service
+        .task(Parameters(task_req(
+            serde_json::json!({ "action": "start", "id": id }),
+        )))
+        .await
+        .expect("task.start should succeed");
+
+    let close_text = extract_text(
+        service
+            .task(Parameters(task_req(serde_json::json!({
+                "action": "close",
+                "id": id,
+                "reason": "All acceptance criteria met.",
+            }))))
+            .await
+            .expect("task.close should return a result"),
+    );
+
+    assert!(
+        !close_text.contains("CODE_REVIEW_REQUIRED"),
+        "light close must not trip the code-review gate: {close_text}"
+    );
+    assert!(
+        !close_text.contains("pending_supervisor_review")
+            && !close_text.contains("supervisor review"),
+        "light close must NOT pend for supervisor review — it closes immediately: {close_text}"
+    );
+
+    let task = task_store.get(&id).expect("task should exist");
+    assert_eq!(
+        task.status,
+        TaskStatus::Closed,
+        "light factory close must transition straight to Closed, not \
+         PendingSupervisorReview; got {:?}",
+        task.status
+    );
+    assert!(
+        task.notes.contains("depth=light") && task.notes.contains("code-review gate"),
+        "light factory close must record the decision note: {}",
+        task.notes
+    );
+}
+
+/// Regression guard: a `depth=deep` factory-worker close with reviewable
+/// changes still pends for supervisor review. Fails if the P0-gate skip leaks
+/// to deep.
+#[tokio::test]
+async fn test_deep_depth_factory_close_still_pends_supervisor_review() {
+    let (temp, _core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+
+    write_supervisor_review_config(&cas_dir);
+    init_git_repo_with_staged_changes(temp.path());
+
+    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let task_store = open_task_store(&cas_dir).unwrap();
+    let service = CasService::new(core, None);
+
+    let _worker_guard = FactoryWorkerGuard::enter();
+
+    let created = service
+        .task(Parameters(task_req(serde_json::json!({
+            "action": "create",
+            "title": "deep feature task — factory close",
+            "priority": 2,
+            "task_type": "task",
+            "depth": "deep",
+        }))))
+        .await
+        .expect("task.create should succeed");
+    let id = extract_task_id(&extract_text(created))
+        .expect("should have task ID")
+        .to_string();
+
+    service
+        .task(Parameters(task_req(
+            serde_json::json!({ "action": "start", "id": id }),
+        )))
+        .await
+        .expect("task.start should succeed");
+
+    let close_text = extract_text(
+        service
+            .task(Parameters(task_req(serde_json::json!({
+                "action": "close",
+                "id": id,
+                "reason": "All acceptance criteria met.",
+            }))))
+            .await
+            .expect("task.close should return a result"),
+    );
+
+    assert!(
+        close_text.contains("supervisor review")
+            || close_text.contains("pending_supervisor_review"),
+        "deep close must still pend for supervisor review: {close_text}"
+    );
+
+    let task = task_store.get(&id).expect("task should exist");
+    assert_eq!(
+        task.status,
+        TaskStatus::PendingSupervisorReview,
+        "deep factory close must pend for supervisor review, not close: {:?}",
+        task.status
+    );
+    assert!(
+        !task.notes.contains("depth=light"),
+        "deep close must not write the light-skip decision note: {}",
+        task.notes
+    );
+}

--- a/cas-cli/tests/mcp_tools_test/task_tools/mod.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/mod.rs
@@ -1,4 +1,5 @@
 mod create_and_epic;
+mod depth_light_close;
 mod operations;
 mod supervisor_review_flow;
 mod verification_flow;

--- a/cas-cli/tests/mcp_tools_test/task_tools/mod.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/mod.rs
@@ -1,4 +1,5 @@
 mod create_and_epic;
+mod depth_e2e;
 mod depth_light_close;
 mod operations;
 mod supervisor_review_flow;

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -11,6 +11,7 @@ async fn test_task_show() {
 
     // Create task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Show task".to_string(),
         description: Some("Detailed description".to_string()),
         priority: 1,
@@ -56,6 +57,7 @@ async fn test_task_show() {
 
 fn basic_create(title: &str, execution_note: Option<String>) -> TaskCreateRequest {
     TaskCreateRequest {
+        depth: None,
         title: title.to_string(),
         description: None,
         priority: 2,
@@ -173,6 +175,7 @@ async fn test_execution_note_update_sets_value() {
 
     let updated = service
         .cas_task_update(Parameters(TaskUpdateRequest {
+        depth: None,
             id: id.clone(),
             title: None,
             notes: None,
@@ -224,6 +227,7 @@ async fn test_execution_note_update_empty_string_clears() {
 
     service
         .cas_task_update(Parameters(TaskUpdateRequest {
+        depth: None,
             id: id.clone(),
             title: None,
             notes: None,
@@ -262,6 +266,7 @@ async fn test_task_update() {
 
     // Create task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Update task".to_string(),
         description: None,
         priority: 2,
@@ -288,6 +293,7 @@ async fn test_task_update() {
 
     // Update task
     let update_req = TaskUpdateRequest {
+        depth: None,
         id: id.to_string(),
         title: Some("Updated title".to_string()),
         notes: Some("Added note".to_string()),
@@ -320,6 +326,7 @@ async fn test_task_update_design_and_acceptance_criteria() {
 
     // Create task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Spec task".to_string(),
         description: None,
         priority: 2,
@@ -346,6 +353,7 @@ async fn test_task_update_design_and_acceptance_criteria() {
 
     // Update design and acceptance_criteria
     let update_req = TaskUpdateRequest {
+        depth: None,
         id: id.to_string(),
         title: None,
         notes: None,
@@ -402,6 +410,7 @@ async fn test_task_notes() {
 
     // Create task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Notes task".to_string(),
         description: None,
         priority: 2,
@@ -449,6 +458,7 @@ async fn test_task_list() {
     // Create tasks
     for i in 0..3 {
         let req = TaskCreateRequest {
+        depth: None,
             title: format!("List task {i}"),
             description: None,
             priority: 2,
@@ -498,6 +508,7 @@ async fn test_task_ready() {
     // Create ready tasks
     for i in 0..3 {
         let req = TaskCreateRequest {
+        depth: None,
             title: format!("Ready task {i}"),
             description: None,
             priority: 2,
@@ -545,6 +556,7 @@ async fn test_task_ready_epic_filter() {
     // Create an epic.
     let epic_result = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Test Epic".to_string(),
             description: None,
             priority: 1,
@@ -570,6 +582,7 @@ async fn test_task_ready_epic_filter() {
     for i in 0..2 {
         service
             .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
                 title: format!("Epic subtask {i}"),
                 description: None,
                 priority: 2,
@@ -592,6 +605,7 @@ async fn test_task_ready_epic_filter() {
     // Create 1 task NOT under the epic.
     service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Unrelated task".to_string(),
             description: None,
             priority: 2,
@@ -655,6 +669,7 @@ async fn test_task_delete() {
 
     // Create task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Delete task".to_string(),
         description: None,
         priority: 2,
@@ -696,6 +711,7 @@ async fn test_task_dependencies() {
 
     // Create two tasks
     let req1 = TaskCreateRequest {
+        depth: None,
         title: "Blocker task".to_string(),
         description: None,
         priority: 1,
@@ -721,6 +737,7 @@ async fn test_task_dependencies() {
     let blocker_id = extract_task_id(&text1).expect("should have task ID");
 
     let req2 = TaskCreateRequest {
+        depth: None,
         title: "Blocked task".to_string(),
         description: None,
         priority: 2,
@@ -779,6 +796,7 @@ async fn test_task_show_dependency_direction_labels() {
 
     let blocker = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Direction blocker".to_string(),
             description: None,
             priority: 1,
@@ -802,6 +820,7 @@ async fn test_task_show_dependency_direction_labels() {
 
     let blocked = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Direction blocked".to_string(),
             description: None,
             priority: 2,
@@ -856,6 +875,7 @@ async fn test_close_auto_unblocks_blocked_dependents() {
 
     let blocker = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Auto unblock blocker".to_string(),
             description: None,
             priority: 1,
@@ -879,6 +899,7 @@ async fn test_close_auto_unblocks_blocked_dependents() {
 
     let blocked = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Auto unblock dependent".to_string(),
             description: None,
             priority: 2,
@@ -902,6 +923,7 @@ async fn test_close_auto_unblocks_blocked_dependents() {
 
     let _ = service
         .cas_task_update(Parameters(TaskUpdateRequest {
+        depth: None,
             id: blocked_id.clone(),
             title: None,
             notes: None,
@@ -970,6 +992,7 @@ async fn test_task_update_invalid_epic_keeps_original_parent_dependency() {
 
     let epic_1 = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Epic 1".to_string(),
             description: None,
             priority: 1,
@@ -993,6 +1016,7 @@ async fn test_task_update_invalid_epic_keeps_original_parent_dependency() {
 
     let subtask = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Child task".to_string(),
             description: None,
             priority: 2,
@@ -1016,6 +1040,7 @@ async fn test_task_update_invalid_epic_keeps_original_parent_dependency() {
 
     let update_result = service
         .cas_task_update(Parameters(TaskUpdateRequest {
+        depth: None,
             id: subtask_id.clone(),
             title: None,
             notes: None,
@@ -1065,6 +1090,7 @@ async fn test_task_update_surfaces_epic_dependency_delete_failure() {
 
     let epic = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Epic".to_string(),
             description: None,
             priority: 1,
@@ -1088,6 +1114,7 @@ async fn test_task_update_surfaces_epic_dependency_delete_failure() {
 
     let subtask = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Subtask".to_string(),
             description: None,
             priority: 2,
@@ -1123,6 +1150,7 @@ async fn test_task_update_surfaces_epic_dependency_delete_failure() {
 
     let update_result = service
         .cas_task_update(Parameters(TaskUpdateRequest {
+        depth: None,
             id: subtask_id,
             title: None,
             notes: None,
@@ -1152,6 +1180,7 @@ async fn test_subtask_start_auto_starts_epic() {
 
     // Create an epic
     let epic_req = TaskCreateRequest {
+        depth: None,
         title: "Test Epic".to_string(),
         description: Some("An epic with subtasks".to_string()),
         priority: 1,
@@ -1193,6 +1222,7 @@ async fn test_subtask_start_auto_starts_epic() {
 
     // Create a subtask linked to the epic
     let subtask_req = TaskCreateRequest {
+        depth: None,
         title: "Subtask 1".to_string(),
         description: None,
         priority: 2,
@@ -1303,6 +1333,7 @@ async fn test_task_mine_matches_env_worker_name_during_spawn_race() {
     // Create a task, then update its assignee to the worker's friendly name —
     // exactly what a supervisor does via `task update assignee=<worker-name>`.
     let create_req = TaskCreateRequest {
+        depth: None,
         title: "Spawn-race assignment".to_string(),
         description: None,
         priority: 1,
@@ -1327,6 +1358,7 @@ async fn test_task_mine_matches_env_worker_name_during_spawn_race() {
         .to_string();
 
     let update_req = TaskUpdateRequest {
+        depth: None,
         id: id.clone(),
         title: None,
         notes: None,
@@ -1406,6 +1438,7 @@ async fn test_release_autorecovers_lease_less_in_progress_task() {
     // (simulating a dead-session orphan where status diverged from lease).
     let created = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Orphaned in-progress".to_string(),
             description: None,
             priority: 2,
@@ -1429,6 +1462,7 @@ async fn test_release_autorecovers_lease_less_in_progress_task() {
 
     service
         .cas_task_update(Parameters(TaskUpdateRequest {
+        depth: None,
             id: id.clone(),
             title: None,
             notes: None,
@@ -1490,6 +1524,7 @@ async fn test_release_still_errors_when_no_lease_and_task_already_open() {
     // there's nothing to recover, surface the underlying error.
     let created = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Plain open task".to_string(),
             description: None,
             priority: 2,
@@ -1528,6 +1563,7 @@ async fn test_reset_clears_lease_assignee_and_forces_open() {
 
     let created = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Needs reset".to_string(),
             description: None,
             priority: 1,
@@ -1551,6 +1587,7 @@ async fn test_reset_clears_lease_assignee_and_forces_open() {
 
     service
         .cas_task_update(Parameters(TaskUpdateRequest {
+        depth: None,
             id: id.clone(),
             title: None,
             notes: None,
@@ -1607,6 +1644,7 @@ async fn test_reset_refuses_closed_task() {
 
     let created = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Already closed".to_string(),
             description: None,
             priority: 2,
@@ -1630,6 +1668,7 @@ async fn test_reset_refuses_closed_task() {
 
     service
         .cas_task_update(Parameters(TaskUpdateRequest {
+        depth: None,
             id: id.clone(),
             title: None,
             notes: None,
@@ -1669,6 +1708,7 @@ async fn test_show_after_update_reflects_new_status_without_lag() {
 
     let created = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Status readback".to_string(),
             description: None,
             priority: 2,
@@ -1693,6 +1733,7 @@ async fn test_show_after_update_reflects_new_status_without_lag() {
     // Move to InProgress.
     service
         .cas_task_update(Parameters(TaskUpdateRequest {
+        depth: None,
             id: id.clone(),
             title: None,
             notes: None,
@@ -1730,6 +1771,7 @@ async fn test_show_after_update_reflects_new_status_without_lag() {
     // Now flip back to Open. Show must reflect Open, not a cached InProgress.
     service
         .cas_task_update(Parameters(TaskUpdateRequest {
+        depth: None,
             id: id.clone(),
             title: None,
             notes: None,
@@ -1774,6 +1816,7 @@ async fn test_task_mine_matches_case_insensitive_and_trimmed() {
     // Exercise the defensive matching path: assignee spelled with differing
     // case and surrounding whitespace still matches the current agent.
     let create_req = TaskCreateRequest {
+        depth: None,
         title: "Case-trim mine match".to_string(),
         description: None,
         priority: 2,
@@ -1798,6 +1841,7 @@ async fn test_task_mine_matches_case_insensitive_and_trimmed() {
         .to_string();
 
     let update_req = TaskUpdateRequest {
+        depth: None,
         id: id.clone(),
         title: None,
         notes: None,
@@ -1862,6 +1906,7 @@ impl Drop for ScopedSupervisorRole {
 
 fn make_task_create_req(title: &str) -> TaskCreateRequest {
     TaskCreateRequest {
+        depth: None,
         title: title.to_string(),
         description: None,
         priority: 2,
@@ -2256,6 +2301,7 @@ async fn test_create_rejects_blocked_by_same_as_epic() {
 
     // Create an epic first
     let epic_create = TaskCreateRequest {
+        depth: None,
         title: "Epic for mixed-dep rejection test".to_string(),
         description: None,
         priority: 2,
@@ -2281,6 +2327,7 @@ async fn test_create_rejects_blocked_by_same_as_epic() {
 
     // Attempt to create a child task that is ALSO blocked by the same epic
     let bad_create = TaskCreateRequest {
+        depth: None,
         title: "Child blocked by its own epic".to_string(),
         description: None,
         priority: 2,
@@ -2348,6 +2395,7 @@ async fn test_task_start_locked_error_includes_worker_name() {
     // Create a task.
     let created = service
         .cas_task_create(Parameters(TaskCreateRequest {
+        depth: None,
             title: "Locked task for name-in-error test".to_string(),
             description: None,
             priority: 2,

--- a/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
@@ -25,6 +25,7 @@ async fn test_task_close_blocked_without_verification() {
 
     // Create task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Task requiring verification".to_string(),
         description: None,
         priority: 2,
@@ -116,6 +117,7 @@ require_merge_on_epic_close = true
     .expect("should write config");
 
     let req = TaskCreateRequest {
+        depth: None,
         title: "Task with worktree".to_string(),
         description: None,
         priority: 2,
@@ -272,6 +274,7 @@ enabled = false
     worktree_store.add(&worktree).expect("add worktree");
 
     let create_req = TaskCreateRequest {
+        depth: None,
         title: "cas-895d regression: committed-state close gate".to_string(),
         description: None,
         priority: 2,
@@ -478,6 +481,7 @@ enabled = false
     let task_store = open_task_store(&cas_dir).expect("open task store");
 
     let additive_req = |title: &str| TaskCreateRequest {
+        depth: None,
         title: title.to_string(),
         description: None,
         priority: 2,
@@ -681,6 +685,7 @@ enabled = false
     let task_store = open_task_store(&cas_dir).expect("open task store");
 
     let create_req = TaskCreateRequest {
+        depth: None,
         title: "Non-isolated task over dirty main (cas-895d skip)".to_string(),
         description: None,
         priority: 2,
@@ -744,6 +749,7 @@ enabled = false
     git(&["commit", "-q", "-m", "main: extend shared.md"]);
 
     let create_additive_req = TaskCreateRequest {
+        depth: None,
         title: "Non-isolated additive-only task (cas-bc1b skip)".to_string(),
         description: None,
         priority: 2,
@@ -819,6 +825,7 @@ enabled = false
     .expect("write config");
 
     let create_req = TaskCreateRequest {
+        depth: None,
         title: "Notes-only task".to_string(),
         description: None,
         priority: 2,
@@ -878,6 +885,7 @@ async fn test_epic_close_requires_epic_verification_type() {
 
     // Create epic
     let req = TaskCreateRequest {
+        depth: None,
         title: "Epic requiring epic verification".to_string(),
         description: None,
         priority: 2,
@@ -987,6 +995,7 @@ async fn test_task_lifecycle_with_verification() {
 
     // Create task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Lifecycle task".to_string(),
         description: None,
         priority: 2,
@@ -1065,6 +1074,7 @@ async fn test_task_close_blocked_with_rejected_verification() {
 
     // Create task
     let req = TaskCreateRequest {
+        depth: None,
         title: "Task with rejected verification".to_string(),
         description: None,
         priority: 2,
@@ -1147,6 +1157,7 @@ async fn test_task_close_runs_verifier_or_skips_cleanly() {
 
     // Create + start a task.
     let req = TaskCreateRequest {
+        depth: None,
         title: "Dispatch-on-close regression task".to_string(),
         description: None,
         priority: 2,
@@ -1284,6 +1295,7 @@ async fn test_close_supervisor_bypass_orphaned_task() {
     // Create + start a task, then strip its assignee to simulate the
     // orphaned-worker state the hatch is designed to recover from.
     let req = TaskCreateRequest {
+        depth: None,
         title: "Orphaned worker task for escape-hatch test".to_string(),
         description: None,
         priority: 2,
@@ -1396,6 +1408,7 @@ async fn test_close_supervisor_bypass_ghost_assignee() {
     let verification_store = open_verification_store(&cas_dir).unwrap();
 
     let req = TaskCreateRequest {
+        depth: None,
         title: "Task assigned to a ghost agent".to_string(),
         description: None,
         priority: 2,
@@ -1497,6 +1510,7 @@ async fn test_close_supervisor_active_worker_assignee_by_name() {
     agent_store.register(&worker).expect("register worker");
 
     let create_req = TaskCreateRequest {
+        depth: None,
         title: "Task held by a by-name assignee".to_string(),
         description: None,
         priority: 2,
@@ -1650,6 +1664,7 @@ async fn test_close_supervisor_no_bypass_when_assignee_alive() {
         .expect("setup_cas should register a test agent");
 
     let req = TaskCreateRequest {
+        depth: None,
         title: "Task with an alive assignee".to_string(),
         description: None,
         priority: 2,
@@ -2296,6 +2311,7 @@ async fn test_close_auto_escalates_stale_verification_dispatch() {
 
     // Create + start task.
     let req = TaskCreateRequest {
+        depth: None,
         title: "Stuck in verification jail".to_string(),
         description: None,
         priority: 2,
@@ -2444,6 +2460,7 @@ async fn test_close_forwards_persisted_review_envelope_after_jail() {
     git(&["add", "src/lib.rs"]);
 
     let req = TaskCreateRequest {
+        depth: None,
         title: "cas-3086: persisted-envelope forwarding".to_string(),
         description: None,
         priority: 2,
@@ -2649,6 +2666,7 @@ async fn test_verification_add_supervisor_active_assignee_error_message() {
 
     // Create a regular (non-Epic) task and assign the live worker to it.
     let create_req = TaskCreateRequest {
+        depth: None,
         title: "Live worker task — supervisor must not verify behind their back".to_string(),
         description: None,
         priority: 2,
@@ -2850,6 +2868,7 @@ owner = "worker"
 
     // Create a task.
     let req = TaskCreateRequest {
+        depth: None,
         title: "cas-778a: worker-owned verification happy path".to_string(),
         description: None,
         priority: 2,
@@ -2966,6 +2985,7 @@ owner = "worker"
     let _env = FactoryWorkerEnv::enter();
 
     let req = TaskCreateRequest {
+        depth: None,
         title: "cas-778a: P0-in-residual with pre_existing=true must block".to_string(),
         description: None,
         priority: 2,
@@ -3052,6 +3072,7 @@ owner = "worker"
     let _env = FactoryWorkerEnv::enter();
 
     let req = TaskCreateRequest {
+        depth: None,
         title: "cas-778a: worker P0 residual must still block".to_string(),
         description: None,
         priority: 2,
@@ -3137,6 +3158,7 @@ owner = "worker"
     let _env = FactoryWorkerEnv::enter();
 
     let req = TaskCreateRequest {
+        depth: None,
         title: "cas-778a: worker malformed envelope must still block".to_string(),
         description: None,
         priority: 2,
@@ -3233,6 +3255,7 @@ owner = "worker"
 
     // Create + start task.
     let req = TaskCreateRequest {
+        depth: None,
         title: "cas-164c: self-cert blocked by fresh dispatch row".to_string(),
         description: None,
         priority: 2,
@@ -3400,6 +3423,7 @@ async fn test_worker_close_succeeds_when_skipped_row_write_fails_option_b() {
 
     // Create + start task.
     let req = TaskCreateRequest {
+        depth: None,
         title: "cas-c97e: close succeeds when Skipped row write fails".to_string(),
         description: None,
         priority: 2,

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -6,8 +6,8 @@ cas doctor
 ──────────────────────────────────────────────────
 [OK] cas directory: Found at [TEMP_PATH]
 [OK] database: SQLite database found
-[OK] schema: v201 (up to date)
-[OK] tables: [N] tables, 444 columns, 158 rows total
+[OK] schema: v202 (up to date)
+[OK] tables: [N] tables, 445 columns, 159 rows total
 [OK] entry store: [N] entries accessible
 [WARN] search index: Index not found. Will be created on first search.
 [OK] configuration: Loaded (sync: enabled)

--- a/crates/cas-core/src/migration/migrations/m122_tasks_add_depth.rs
+++ b/crates/cas-core/src/migration/migrations/m122_tasks_add_depth.rs
@@ -1,0 +1,15 @@
+//! Migration: tasks_add_depth — per-task execution depth (EPIC cas-1255).
+//!
+//! Adds the `depth` column to `tasks`. Existing rows get NULL, which the
+//! store maps to `TaskDepth::Deep` on read, so legacy tasks read as deep.
+
+use crate::migration::{Migration, Subsystem};
+
+pub const MIGRATION: Migration = Migration {
+    id: 122,
+    name: "tasks_add_depth",
+    subsystem: Subsystem::Tasks,
+    description: "Add depth column to tasks (per-task speed mode, EPIC cas-1255)",
+    up: &["ALTER TABLE tasks ADD COLUMN depth TEXT"],
+    detect: Some("SELECT COUNT(*) FROM pragma_table_info('tasks') WHERE name = 'depth'"),
+};

--- a/crates/cas-core/src/migration/migrations/mod.rs
+++ b/crates/cas-core/src/migration/migrations/mod.rs
@@ -88,6 +88,7 @@ mod m118_tasks_idx_branch;
 mod m119_tasks_idx_worktree;
 mod m120_tasks_add_deliverables;
 mod m121_tasks_add_share;
+mod m122_tasks_add_depth;
 
 /// All migrations in order. IDs must be sequential and never reused.
 pub const MIGRATIONS: &[Migration] = &[
@@ -170,6 +171,7 @@ pub const MIGRATIONS: &[Migration] = &[
     m119_tasks_idx_worktree::MIGRATION,
     m120_tasks_add_deliverables::MIGRATION,
     m121_tasks_add_share::MIGRATION,
+    m122_tasks_add_depth::MIGRATION,
 ];
 
 #[cfg(test)]

--- a/crates/cas-factory/src/director.rs
+++ b/crates/cas-factory/src/director.rs
@@ -64,6 +64,11 @@ pub struct TaskSummary {
     pub epic: Option<String>,
     /// Branch name (for epics)
     pub branch: Option<String>,
+    /// Last-updated timestamp from the task store. Drives recency ordering in
+    /// the TASKS panel so the supervisor's current focus surfaces above a
+    /// stale, high-subtask-count epic (cas-2fb6). `None` when the source is a
+    /// hand-built summary that does not carry timing (e.g. some tests).
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// A summary of an agent for display
@@ -221,6 +226,7 @@ impl DirectorData {
                 task_type: t.task_type,
                 epic: child_to_epic.get(&t.id).cloned(),
                 branch: t.branch.clone(),
+                updated_at: Some(t.updated_at),
             }
         };
 
@@ -432,11 +438,48 @@ impl DirectorData {
             })
             .collect();
 
-        // Sort groups: active first, then by epic priority
-        groups.sort_by_key(|g| (!g.has_active, g.epic.priority.0));
+        // Sort groups by recency of activity so the supervisor's CURRENT focus
+        // surfaces at the top of the panel, rather than a stale epic that merely
+        // happens to carry more subtasks or a higher static priority (cas-2fb6).
+        //
+        // Recency = newest `updated_at` across the epic row and its subtasks.
+        // This naturally follows focus: starting/closing/noting a subtask bumps
+        // its `updated_at`, so the panel re-sorts within one refresh. Ties fall
+        // back to the historical ordering (active-first, then epic priority,
+        // then id) so single-epic and timing-less (test) data are unaffected.
+        groups.sort_by(|a, b| {
+            group_recency(b)
+                .cmp(&group_recency(a))
+                .then_with(|| a.has_active.cmp(&b.has_active).reverse())
+                .then_with(|| a.epic.priority.0.cmp(&b.epic.priority.0))
+                .then_with(|| a.epic.id.cmp(&b.epic.id))
+        });
+
+        // Standalone tasks: most-recently-updated first, then by priority, then
+        // id, so a freshly-touched standalone task is not buried under older
+        // ones either.
+        standalone.sort_by(|a, b| {
+            a.updated_at
+                .cmp(&b.updated_at)
+                .reverse()
+                .then_with(|| a.priority.0.cmp(&b.priority.0))
+                .then_with(|| a.id.cmp(&b.id))
+        });
 
         (groups, standalone)
     }
+}
+
+/// Newest `updated_at` across an epic group (the epic row and all of its
+/// subtasks). Used to order the TASKS panel by recency of activity so the
+/// supervisor's current focus stays on top (cas-2fb6). Returns `None` only when
+/// neither the epic nor any subtask carries timing information, in which case
+/// the caller falls back to the historical active-first/priority ordering.
+fn group_recency(group: &EpicGroup) -> Option<chrono::DateTime<chrono::Utc>> {
+    std::iter::once(group.epic.updated_at)
+        .chain(group.subtasks.iter().map(|t| t.updated_at))
+        .flatten()
+        .max()
 }
 
 /// Load pending + recently fired reminders from a reminder store.

--- a/crates/cas-factory/tests/director_data_integration.rs
+++ b/crates/cas-factory/tests/director_data_integration.rs
@@ -490,6 +490,195 @@ fn test_tasks_by_epic_with_parent_child_dependency() {
 }
 
 // =============================================================================
+// Recency ordering tests (cas-2fb6)
+// =============================================================================
+
+/// Build a `TaskSummary` with an explicit `updated_at` for deterministic
+/// recency-ordering assertions.
+fn summary_at(
+    id: &str,
+    status: TaskStatus,
+    task_type: TaskType,
+    priority: Priority,
+    epic: Option<&str>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> TaskSummary {
+    TaskSummary {
+        id: id.to_string(),
+        title: format!("title {id}"),
+        status,
+        priority,
+        assignee: None,
+        task_type,
+        epic: epic.map(|s| s.to_string()),
+        branch: if task_type == TaskType::Epic {
+            Some(format!("epic/{id}"))
+        } else {
+            None
+        },
+        updated_at: Some(updated_at),
+    }
+}
+
+/// Assemble a minimal `DirectorData` from explicit task summaries. Tasks are
+/// partitioned into ready/in_progress/epic buckets the same way `load_with_stores`
+/// does, so `tasks_by_epic` sees the same shape it would in production.
+fn data_from_tasks(tasks: Vec<TaskSummary>) -> DirectorData {
+    let mut ready_tasks = Vec::new();
+    let mut in_progress_tasks = Vec::new();
+    let mut epic_tasks = Vec::new();
+    for t in tasks {
+        match (t.task_type, t.status) {
+            (TaskType::Epic, _) => epic_tasks.push(t),
+            (_, TaskStatus::InProgress | TaskStatus::PendingSupervisorReview) => {
+                in_progress_tasks.push(t)
+            }
+            _ => ready_tasks.push(t),
+        }
+    }
+    DirectorData {
+        ready_tasks,
+        in_progress_tasks,
+        epic_tasks,
+        agents: Vec::new(),
+        activity: Vec::new(),
+        agent_id_to_name: std::collections::HashMap::new(),
+        changes: Vec::new(),
+        git_loaded: false,
+        reminders: Vec::new(),
+        epic_closed_counts: std::collections::HashMap::new(),
+    }
+}
+
+/// A stale epic with MANY low-priority subtasks must NOT pin to the top of the
+/// TASKS panel over a smaller, recently-active epic. The panel orders epic
+/// groups by recency of activity, not subtask count or static priority.
+#[test]
+fn test_tasks_by_epic_recent_epic_outranks_stale_high_count_epic() {
+    let old = chrono::Utc::now() - chrono::Duration::days(5);
+    let recent = chrono::Utc::now();
+
+    let mut tasks = Vec::new();
+
+    // Stale follow-up epic: 14 untouched P4 subtasks (the reported symptom).
+    tasks.push(summary_at(
+        "cas-stale",
+        TaskStatus::Open,
+        TaskType::Epic,
+        Priority::HIGH,
+        None,
+        old,
+    ));
+    for i in 0..14 {
+        tasks.push(summary_at(
+            &format!("cas-stale-{i}"),
+            TaskStatus::Open,
+            TaskType::Task,
+            Priority::BACKLOG,
+            Some("cas-stale"),
+            old,
+        ));
+    }
+
+    // The supervisor's CURRENT focus: a small, recently-touched epic with a
+    // single subtask, at a numerically lower (= less urgent) static priority.
+    tasks.push(summary_at(
+        "cas-current",
+        TaskStatus::Open,
+        TaskType::Epic,
+        Priority::MEDIUM,
+        None,
+        recent,
+    ));
+    tasks.push(summary_at(
+        "cas-current-0",
+        TaskStatus::Open,
+        TaskType::Task,
+        Priority::MEDIUM,
+        Some("cas-current"),
+        recent,
+    ));
+
+    let data = data_from_tasks(tasks);
+    let (groups, _standalone) = data.tasks_by_epic();
+
+    assert_eq!(groups.len(), 2, "both epics should be present");
+    assert_eq!(
+        groups[0].epic.id, "cas-current",
+        "the recently-active epic must sort first, not the stale 14-subtask epic"
+    );
+    assert_eq!(groups[1].epic.id, "cas-stale");
+}
+
+/// Switching focus (touching a different epic's subtask) makes the panel follow
+/// within a refresh: the newly-touched epic moves to the top.
+#[test]
+fn test_tasks_by_epic_follows_focus_switch() {
+    let t0 = chrono::Utc::now() - chrono::Duration::hours(2);
+    let t1 = chrono::Utc::now() - chrono::Duration::hours(1);
+    let t2 = chrono::Utc::now();
+
+    // Epic A touched at t1, epic B touched more recently at t2 -> B first.
+    let tasks = vec![
+        summary_at("cas-a", TaskStatus::Open, TaskType::Epic, Priority::HIGH, None, t0),
+        summary_at(
+            "cas-a-0",
+            TaskStatus::Open,
+            TaskType::Task,
+            Priority::HIGH,
+            Some("cas-a"),
+            t1,
+        ),
+        summary_at("cas-b", TaskStatus::Open, TaskType::Epic, Priority::HIGH, None, t0),
+        summary_at(
+            "cas-b-0",
+            TaskStatus::Open,
+            TaskType::Task,
+            Priority::HIGH,
+            Some("cas-b"),
+            t2,
+        ),
+    ];
+
+    let (groups, _) = data_from_tasks(tasks).tasks_by_epic();
+    assert_eq!(groups[0].epic.id, "cas-b", "most-recently-touched epic leads");
+    assert_eq!(groups[1].epic.id, "cas-a");
+}
+
+/// No regression for a single-epic session: ordering is trivially stable and the
+/// epic + its subtasks are returned intact.
+#[test]
+fn test_tasks_by_epic_single_epic_unchanged() {
+    let now = chrono::Utc::now();
+    let tasks = vec![
+        summary_at("cas-only", TaskStatus::InProgress, TaskType::Epic, Priority::HIGH, None, now),
+        summary_at(
+            "cas-only-0",
+            TaskStatus::InProgress,
+            TaskType::Task,
+            Priority::HIGH,
+            Some("cas-only"),
+            now,
+        ),
+        summary_at(
+            "cas-only-1",
+            TaskStatus::Open,
+            TaskType::Task,
+            Priority::MEDIUM,
+            Some("cas-only"),
+            now,
+        ),
+    ];
+
+    let (groups, standalone) = data_from_tasks(tasks).tasks_by_epic();
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].epic.id, "cas-only");
+    assert_eq!(groups[0].subtasks.len(), 2);
+    assert!(groups[0].has_active);
+    assert!(standalone.is_empty());
+}
+
+// =============================================================================
 // TaskSummary Tests
 // =============================================================================
 
@@ -504,6 +693,7 @@ fn test_task_summary_fields() {
         task_type: TaskType::Feature,
         epic: Some("cas-epic".to_string()),
         branch: Some("feature/test".to_string()),
+        updated_at: None,
     };
 
     assert_eq!(summary.id, "cas-1234");
@@ -556,6 +746,7 @@ fn test_epic_group_fields() {
         task_type: TaskType::Epic,
         epic: None,
         branch: Some("epic/test".to_string()),
+        updated_at: None,
     };
 
     let subtask = TaskSummary {
@@ -567,6 +758,7 @@ fn test_epic_group_fields() {
         task_type: TaskType::Task,
         epic: Some("cas-epic".to_string()),
         branch: None,
+        updated_at: None,
     };
 
     let group = EpicGroup {

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -323,6 +323,13 @@ pub struct TaskRequest {
     )]
     #[serde(default)]
     pub epic_verification_owner: Option<String>,
+
+    /// Execution depth (for create, update). EPIC cas-1255 speed mode.
+    #[schemars(
+        description = "Execution depth: 'deep' (default, full rigor) or 'light' (fast, feel-driven pass). Omit to leave unchanged (update) or default to deep (create)."
+    )]
+    #[serde(default)]
+    pub depth: Option<String>,
 }
 
 /// Unified rule operations request

--- a/crates/cas-mux/src/mux.rs
+++ b/crates/cas-mux/src/mux.rs
@@ -662,6 +662,13 @@ impl Mux {
             teams,
         )?;
         let id = pane.id().to_string();
+        // Persist the resolved spec so `effective_worker_spec(name, None)` is
+        // authoritative for this worker's lifetime. Without this, a worker spawned
+        // with an explicit per-spawn `spec` override (e.g. a Codex worker added to a
+        // Claude-default factory via SpawnWorkers) would not be in `worker_specs`,
+        // and a later harness lookup would silently fall back to the Mux-wide default
+        // — mis-routing message delivery for that worker (cas-b68a).
+        self.worker_specs.insert(name.to_string(), effective);
         self.add_pane(pane);
         Ok(id)
     }

--- a/crates/cas-mux/src/mux_tests/tests.rs
+++ b/crates/cas-mux/src/mux_tests/tests.rs
@@ -320,6 +320,54 @@ fn effective_worker_spec_uses_worker_specs_map() {
 
 // ── end priority-2 coverage ───────────────────────────────────────────────────
 
+// ── cas-b68a: add_worker persists the resolved spec ──────────────────────────
+
+/// Regression for cas-b68a: a dynamically-spawned Codex worker in a Claude-DEFAULT
+/// factory must resolve as Codex via `effective_worker_spec(name, None)` AFTER the
+/// spawn.
+///
+/// This is the load-bearing proof for AC2's live path. The daemon's harness-aware
+/// message router (`FactoryApp::harness_for`) resolves a worker's harness through
+/// `effective_worker_spec(name, None)`. Before the fix, `add_worker` *used* an
+/// explicit per-spawn spec but never persisted it into `worker_specs`, so a Codex
+/// worker added to a Claude-default factory (the exact bug scenario) resolved back
+/// to the Claude default — and the entire routing fix would be inert, silently
+/// inboxing messages the codex process can never read.
+#[test]
+fn add_worker_persists_explicit_spec_so_effective_resolves_codex() {
+    let mut mux = Mux::new(24, 80);
+    // Session default is Claude — the explicit per-spawn spec must persist and win.
+    mux.set_default_worker_spec(WorkerSpec {
+        name: None,
+        cli: crate::harness::SupervisorCli::Claude,
+        model: None,
+        effort: None,
+    });
+
+    // Pre-condition: with nothing registered, an unknown worker resolves to the
+    // Claude default — i.e. without persistence the post-spawn lookup is wrong.
+    assert_eq!(
+        mux.effective_worker_spec("alice", None).cli,
+        crate::harness::SupervisorCli::Claude,
+        "precondition: unregistered worker resolves to the Claude session default"
+    );
+
+    // Dynamically spawn "alice" with an explicit Codex spec (the SpawnWorkers path).
+    let dir = std::env::temp_dir();
+    let spec = WorkerSpec::codex_default("alice");
+    mux.add_worker("alice", dir, None, "supervisor", None, Some(spec))
+        .expect("add_worker should spawn the worker pane");
+
+    // Post-spawn: harness resolution (what FactoryApp::harness_for does) must now
+    // report Codex, with NO explicit spec passed — proving the spec was persisted.
+    assert_eq!(
+        mux.effective_worker_spec("alice", None).cli,
+        crate::harness::SupervisorCli::Codex,
+        "after add_worker, a later harness lookup must resolve the persisted Codex \
+         spec — not fall back to the Claude default (cas-b68a)"
+    );
+}
+
 // ── cas-35fe: custom worker_names branch ─────────────────────────────────────
 
 #[test]
@@ -466,3 +514,4 @@ fn test_remove_pane_focus_transfer() {
     assert_eq!(mux.focused_id(), Some("pane2"));
     assert_eq!(mux.pane_count(), 1);
 }
+

--- a/crates/cas-pty/src/pty.rs
+++ b/crates/cas-pty/src/pty.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc;
 const CODEX_SUPERVISOR_INSTRUCTIONS: &str = "You are the CAS Factory Supervisor. Coordinate only: plan epics, assign tasks, monitor progress, review/merge. Never implement tasks. Use skills cas-supervisor and cas-codex-supervisor-checklist. Use MCP tools explicitly; no /cas-start, /cas-context, or /cas-end.";
 
 /// Instructions injected into Codex worker agents via `--config developer_instructions`.
-const CODEX_WORKER_INSTRUCTIONS: &str = "You are a CAS Factory Worker. Always use CAS MCP tools for task lifecycle and coordination. On startup run `mcp__cs__coordination action=session_start name=<worker-name> agent_type=worker` then `mcp__cs__coordination action=whoami`, then run `mcp__cs__task action=mine`. For assigned tasks run `mcp__cs__task action=show id=<task-id>` then `mcp__cs__task action=start id=<task-id>` before coding. Add progress notes frequently using `mcp__cs__task action=notes id=<task-id> note_type=progress notes=\"...\"`. For blockers, add blocker note, set `status=blocked`, and message supervisor via `mcp__cs__coordination action=message target=supervisor message=\"...\"`. When implementation is complete, close with `mcp__cs__task action=close id=<task-id> reason=\"...\"`. If close returns verification-required guidance, immediately ask supervisor to verify/close on your behalf. Do not use /cas-start, /cas-context, or /cas-end. Stay within assigned task scope.";
+const CODEX_WORKER_INSTRUCTIONS: &str = "You are a CAS Factory Worker. Always use CAS MCP tools for task lifecycle and coordination. On startup run `mcp__cs__coordination action=session_start name=<worker-name> agent_type=worker` then `mcp__cs__coordination action=whoami`, then run `mcp__cs__task action=mine`. Work exactly ONE task at a time: choose a single assigned task, run `mcp__cs__task action=show id=<task-id>` then `mcp__cs__task action=start id=<task-id>` before coding, implement it, commit and push your changes, then close it with `mcp__cs__task action=close id=<task-id> reason=\"...\"` (or hand it to the supervisor if close returns verification-required guidance) BEFORE starting any other task. Never start a second task while one is still in progress — the verification jail allows only one unverified in-progress task at a time, so batch-starting tasks will block you. Add progress notes frequently using `mcp__cs__task action=notes id=<task-id> note_type=progress notes=\"...\"`. For blockers, add a blocker note, set `status=blocked`, and message supervisor via `mcp__cs__coordination action=message target=supervisor message=\"...\"`. If close returns verification-required guidance, immediately ask the supervisor to verify/close on your behalf. Do not use /cas-start, /cas-context, or /cas-end. Stay within assigned task scope.";
 
 /// Prefix for the Codex worker startup prompt. The worker name is appended at runtime.
 const CODEX_WORKER_STARTUP_PREFIX: &str = "I'm initiating CAS worker startup now: register this worker session, confirm identity, check assigned tasks, then start any assigned task with a progress note.\n1) Run mcp__cs__coordination action=session_start name=";
@@ -310,6 +310,14 @@ impl PtyConfig {
         push_worker_cargo_env(&mut env, role);
 
         let mut args = vec!["--yolo".to_string(), "--no-alt-screen".to_string()];
+
+        // cas-bbc2: spawn-inject the CAS MCP server so every Codex agent (worker
+        // and supervisor) has mcp__cs__* tools even when the project was never
+        // integrated for the Codex harness (no .codex/config.toml). Must precede
+        // the developer_instructions block but order among `-c` flags is
+        // irrelevant to Codex.
+        push_codex_mcp_server_args(&mut args);
+
         if let Some(m) = model {
             args.push("--model".to_string());
             args.push(m.to_string());
@@ -340,7 +348,7 @@ impl PtyConfig {
                 "{CODEX_WORKER_STARTUP_PREFIX}{name} agent_type=worker\n\
                  2) Run mcp__cs__coordination action=whoami\n\
                  3) Run mcp__cs__task action=mine\n\
-                 4) If tasks are assigned: show/start each task and add a progress note\n\
+                 4) If a task is assigned: choose exactly ONE task, run mcp__cs__task action=show then action=start, add a progress note, implement it, commit and push, then close it (or hand to supervisor) BEFORE starting any other task. Never start more than one task at a time — batch-starting collides with the one-unverified-in-progress verification jail.\n\
                  5) If no tasks are assigned: send mcp__cs__coordination action=message target=supervisor confirming ready state\n\
                  6) Do NOT message target=cas. Use target=supervisor."
             );
@@ -399,6 +407,52 @@ fn cargo_build_jobs_for_worker() -> Option<String> {
     let cores = std::thread::available_parallelism().ok()?.get();
     let capped = std::cmp::max(2, cores / DEFAULT_WORKER_CONCURRENCY_ASSUMPTION);
     Some(capped.to_string())
+}
+
+/// Spawn-inject the CAS MCP server into a Codex command via `-c` overrides
+/// (cas-bbc2). Codex does NOT read Claude's `.mcp.json`; it only discovers the
+/// CAS server from a project `.codex/config.toml` written by `cas init`/`cas
+/// update` (`configure_codex_mcp_server`). Projects integrated for Claude but
+/// never for Codex (e.g. gabber-studio: has `.mcp.json`, no `.codex/`) therefore
+/// spawned Codex agents with **zero** `mcp__cs__*` tools, which burned the whole
+/// session reverse-engineering the wire protocol and produced no code.
+///
+/// Injecting the server at spawn time makes every Codex agent (worker and
+/// supervisor) self-contained regardless of downstream integration. We mirror
+/// `configure_codex_mcp_server` exactly — `command="cas"`, `args=["serve"]`,
+/// `env.CAS_CODEX_FALLBACK_SESSION="1"` — and register under the `cs` key so the
+/// resulting tool prefix is `mcp__cs__` (the Codex alias used throughout the
+/// factory prompts and skills; intentionally distinct from Claude's `mcp__cas__`).
+///
+/// Each value is valid TOML so Codex's `-c key=value` parser (value parsed as
+/// TOML, raw-string fallback) yields the intended types: quoted strings stay
+/// strings, `["serve"]` becomes a string array. If a project DOES ship a
+/// `.codex/config.toml`, these `-c` overrides simply add the `cs` server on top
+/// — they never remove the project's own entries.
+fn push_codex_mcp_server_args(args: &mut Vec<String>) {
+    args.push("-c".to_string());
+    args.push("mcp_servers.cs.command=\"cas\"".to_string());
+    args.push("-c".to_string());
+    args.push("mcp_servers.cs.args=[\"serve\"]".to_string());
+    args.push("-c".to_string());
+    args.push("mcp_servers.cs.env.CAS_CODEX_FALLBACK_SESSION=\"1\"".to_string());
+}
+
+/// Returns `true` when an executable named `cas` is resolvable on `PATH`.
+///
+/// Used by the Codex spawn preflight (cas-bbc2). The CAS MCP server is now
+/// spawn-injected as `mcp_servers.cs.command=cas`, but Codex still needs the
+/// `cas` binary on `PATH` to actually launch it. If `PATH` is unset we return
+/// `true` (skip the check) rather than risk a false refusal — the spawn will
+/// surface its own error in that pathological case.
+fn cas_binary_on_path() -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return true;
+    };
+    std::env::split_paths(&path).any(|dir| {
+        let candidate = dir.join("cas");
+        candidate.is_file()
+    })
 }
 
 /// Push the `CARGO_BUILD_JOBS` env entry into `env` when `role == "worker"`.
@@ -484,6 +538,24 @@ impl Pty {
     pub fn spawn(id: impl Into<String>, config: PtyConfig) -> Result<Self> {
         let id = id.into();
         let is_codex = config.command == "codex";
+
+        // cas-bbc2 preflight: a Codex agent's CAS MCP server is spawn-injected as
+        // `mcp_servers.cs.command=cas`, but Codex can only launch it if the `cas`
+        // binary is resolvable on PATH. Detect Codex by the direct command or the
+        // niced wrapper form (cas-0bf4) so the preflight covers both. Refuse loudly
+        // with remediation rather than spawning a worker that comes up with zero
+        // CAS tools and flails.
+        let codex_spawn = is_codex
+            || (config.command == "nice" && config.args.iter().any(|a| a == "codex"));
+        if codex_spawn && !cas_binary_on_path() {
+            return Err(Error::pty(
+                "Codex agent cannot start: the `cas` MCP server binary is not on PATH. \
+                 CAS is spawn-injected as mcp_servers.cs (command=cas), but Codex needs \
+                 `cas` resolvable to launch it. Install CAS / add it to PATH, or run \
+                 `cas init` / `cas update` in this project to enable the Codex harness."
+                    .to_string(),
+            ));
+        }
 
         // Create PTY system and open a PTY pair
         let pty_system = native_pty_system();
@@ -982,6 +1054,143 @@ mod tests {
         );
     }
 
+    /// cas-bbc2 AC#2: a Codex worker spawn must inject the CAS MCP server via
+    /// `-c` overrides so it has `mcp__cs__*` tools without a project
+    /// `.codex/config.toml`. Mirrors `configure_codex_mcp_server`.
+    #[tokio::test]
+    async fn test_pty_config_codex_worker_injects_cas_mcp_server() {
+        let _e = ScopedEnv::new();
+        let config = PtyConfig::codex(
+            "test-worker",
+            "worker",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None, // model
+            None, // effort
+            None, // teams
+        );
+        let all_args = config.args.join(" ");
+        assert!(
+            all_args.contains("mcp_servers.cs.command=\"cas\""),
+            "codex worker must inject mcp_servers.cs.command=cas; got: {all_args}"
+        );
+        assert!(
+            all_args.contains("mcp_servers.cs.args=[\"serve\"]"),
+            "codex worker must inject mcp_servers.cs.args=[\"serve\"]; got: {all_args}"
+        );
+        assert!(
+            all_args.contains("mcp_servers.cs.env.CAS_CODEX_FALLBACK_SESSION=\"1\""),
+            "codex worker must inject CAS_CODEX_FALLBACK_SESSION env; got: {all_args}"
+        );
+    }
+
+    /// cas-bbc2: the supervisor is equally self-contained — a Codex supervisor
+    /// must also get the spawn-injected CAS MCP server.
+    #[tokio::test]
+    async fn test_pty_config_codex_supervisor_injects_cas_mcp_server() {
+        let config = PtyConfig::codex(
+            "test-supervisor",
+            "supervisor",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None, // model
+            None, // effort
+            None, // teams
+        );
+        let all_args = config.args.join(" ");
+        assert!(
+            all_args.contains("mcp_servers.cs.command=\"cas\"")
+                && all_args.contains("mcp_servers.cs.args=[\"serve\"]")
+                && all_args.contains("mcp_servers.cs.env.CAS_CODEX_FALLBACK_SESSION=\"1\""),
+            "codex supervisor must inject the cas MCP server; got: {all_args}"
+        );
+    }
+
+    /// cas-bbc2 AC#3: the Codex worker startup prompt must drive a single-task
+    /// loop (start exactly one task at a time), not the old batch-start wording
+    /// that collides with the one-unverified-in-progress verification jail.
+    #[tokio::test]
+    async fn test_pty_config_codex_worker_single_task_loop() {
+        let _e = ScopedEnv::new();
+        let config = PtyConfig::codex(
+            "test-worker",
+            "worker",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None, // model
+            None, // effort
+            None, // teams
+        );
+        let all_args = config.args.join(" ");
+        assert!(
+            all_args.contains("exactly ONE task"),
+            "startup prompt must instruct starting exactly one task at a time; got: {all_args}"
+        );
+        assert!(
+            !all_args.contains("show/start each task"),
+            "old batch-start wording must be gone; got: {all_args}"
+        );
+        // The developer_instructions must carry the same discipline.
+        assert!(
+            all_args.contains("Work exactly ONE task at a time"),
+            "worker developer_instructions must enforce one-task-at-a-time; got: {all_args}"
+        );
+    }
+
+    /// cas-bbc2: `cas_binary_on_path()` returns true when an executable named
+    /// `cas` lives in a PATH entry. Builds a temp dir with a fake `cas` file and
+    /// points PATH at it, under ENV_LOCK to avoid racing other env-mutating tests.
+    #[tokio::test]
+    async fn test_cas_binary_on_path_detects_binary() {
+        let _e = ScopedEnv::new();
+        let dir = std::env::temp_dir().join("cas-bbc2-preflight-present");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("cas"), b"#!/bin/sh\n").unwrap();
+        let saved = std::env::var_os("PATH");
+        // SAFETY: ENV_LOCK held via ScopedEnv serializes PATH mutation.
+        unsafe {
+            std::env::set_var("PATH", &dir);
+        }
+        let found = cas_binary_on_path();
+        unsafe {
+            match &saved {
+                Some(p) => std::env::set_var("PATH", p),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(found, "cas_binary_on_path must find a `cas` file on PATH");
+    }
+
+    /// cas-bbc2: when no `cas` exists on PATH, the preflight helper reports false
+    /// so `Pty::spawn` can refuse a Codex spawn loudly.
+    #[tokio::test]
+    async fn test_cas_binary_on_path_absent_when_missing() {
+        let _e = ScopedEnv::new();
+        let dir = std::env::temp_dir().join("cas-bbc2-preflight-absent");
+        std::fs::create_dir_all(&dir).unwrap();
+        let saved = std::env::var_os("PATH");
+        // SAFETY: ENV_LOCK held via ScopedEnv serializes PATH mutation.
+        unsafe {
+            std::env::set_var("PATH", &dir);
+        }
+        let found = cas_binary_on_path();
+        unsafe {
+            match &saved {
+                Some(p) => std::env::set_var("PATH", p),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(!found, "cas_binary_on_path must be false when no `cas` is on PATH");
+    }
+
     #[tokio::test]
     async fn test_pty_config_codex_supervisor_instructions() {
         let config = PtyConfig::codex(
@@ -1129,14 +1338,18 @@ mod tests {
             Some("medium"),  // effort
             None,  // teams
         );
-        let c_idx = config
+        // Multiple `-c` flags exist now that the CAS MCP server is spawn-injected
+        // (cas-bbc2), so locate the effort override by its value rather than
+        // assuming it is the first `-c`. It must be emitted as a `-c` pair.
+        let effort_idx = config
             .args
             .iter()
-            .position(|a| a == "-c")
-            .expect("-c flag must be present when effort is Some");
+            .position(|a| a == "model_reasoning_effort=medium")
+            .expect("effort override must emit model_reasoning_effort TOML key");
         assert_eq!(
-            config.args[c_idx + 1], "model_reasoning_effort=medium",
-            "effort override must emit model_reasoning_effort TOML key"
+            config.args[effort_idx - 1],
+            "-c",
+            "model_reasoning_effort override must be preceded by a -c flag"
         );
     }
 
@@ -1159,9 +1372,19 @@ mod tests {
             !config.args.iter().any(|a| a.starts_with("model_reasoning_effort")),
             "no model_reasoning_effort arg should be emitted when effort is None"
         );
+        // The CAS MCP server injection (cas-bbc2) always emits `-c` flags, so we
+        // can no longer assert the total absence of `-c`. Instead assert that the
+        // only `-c` overrides present are the MCP server ones — none configure
+        // reasoning effort.
+        let c_values: Vec<&String> = config
+            .args
+            .windows(2)
+            .filter(|w| w[0] == "-c")
+            .map(|w| &w[1])
+            .collect();
         assert!(
-            !config.args.iter().any(|a| a == "-c"),
-            "no -c flag should be emitted when effort is None"
+            c_values.iter().all(|v| v.starts_with("mcp_servers.cs.")),
+            "with effort=None the only -c overrides should be the cas MCP server injection; got: {c_values:?}"
         );
     }
 

--- a/crates/cas-pty/src/pty.rs
+++ b/crates/cas-pty/src/pty.rs
@@ -17,10 +17,10 @@ use tokio::sync::mpsc;
 const CODEX_SUPERVISOR_INSTRUCTIONS: &str = "You are the CAS Factory Supervisor. Coordinate only: plan epics, assign tasks, monitor progress, review/merge. Never implement tasks. Use skills cas-supervisor and cas-codex-supervisor-checklist. Use MCP tools explicitly; no /cas-start, /cas-context, or /cas-end. Worker messages (status/blocker/ready) arrive asynchronously as new injected turns framed 'Message from <sender>: …'. Each is a triage trigger, not a fresh startup: read it, then assign/answer/redirect/merge as appropriate and reply via `mcp__cs__coordination action=message target=<worker>`. Finishing one round does not mean you are done — remain available to coordinate the next message.";
 
 /// Instructions injected into Codex worker agents via `--config developer_instructions`.
-const CODEX_WORKER_INSTRUCTIONS: &str = "You are a CAS Factory Worker. Always use CAS MCP tools for task lifecycle and coordination. On startup run `mcp__cs__coordination action=session_start name=<worker-name> agent_type=worker` then `mcp__cs__coordination action=whoami`, then run `mcp__cs__task action=mine`. Work exactly ONE task at a time: choose a single assigned task, run `mcp__cs__task action=show id=<task-id>` then `mcp__cs__task action=start id=<task-id>` before coding, implement it, commit and push your changes, then close it with `mcp__cs__task action=close id=<task-id> reason=\"...\"` (or hand it to the supervisor if close returns verification-required guidance) BEFORE starting any other task. Never start a second task while one is still in progress — the verification jail allows only one unverified in-progress task at a time, so batch-starting tasks will block you. Add progress notes frequently using `mcp__cs__task action=notes id=<task-id> note_type=progress notes=\"...\"`. For blockers, add a blocker note, set `status=blocked`, and message supervisor via `mcp__cs__coordination action=message target=supervisor message=\"...\"`. If close returns verification-required guidance, immediately ask the supervisor to verify/close on your behalf. After closing or handing off a task, stay available — you are not permanently done. The supervisor will send you more work or redirection as new messages. Treat any injected turn framed 'Message from <sender>: …' as an instruction to act on, not noise: read it and follow it. Keep honoring one-task-at-a-time — finish or hand off your current task before starting the next one a message assigns. Do not use /cas-start, /cas-context, or /cas-end. Stay within assigned task scope.";
+const CODEX_WORKER_INSTRUCTIONS: &str = "You are a CAS Factory Worker. Always use CAS MCP tools for task lifecycle and coordination. On startup your CAS session is already registered automatically — do NOT call session_start. Just run `mcp__cs__coordination action=whoami` then `mcp__cs__task action=mine`. Work exactly ONE task at a time: choose a single assigned task, run `mcp__cs__task action=show id=<task-id>` then `mcp__cs__task action=start id=<task-id>` before coding, implement it, commit and push your changes, then close it with `mcp__cs__task action=close id=<task-id> reason=\"...\"` (or hand it to the supervisor if close returns verification-required guidance) BEFORE starting any other task. Never start a second task while one is still in progress — the verification jail allows only one unverified in-progress task at a time, so batch-starting tasks will block you. Add progress notes frequently using `mcp__cs__task action=notes id=<task-id> note_type=progress notes=\"...\"`. For blockers, add a blocker note, set `status=blocked`, and message supervisor via `mcp__cs__coordination action=message target=supervisor message=\"...\"`. If close returns verification-required guidance, immediately ask the supervisor to verify/close on your behalf. After closing or handing off a task, stay available — you are not permanently done. The supervisor will send you more work or redirection as new messages. Treat any injected turn framed 'Message from <sender>: …' as an instruction to act on, not noise: read it and follow it. Keep honoring one-task-at-a-time — finish or hand off your current task before starting the next one a message assigns. Do not use /cas-start, /cas-context, or /cas-end. Stay within assigned task scope.";
 
 /// Prefix for the Codex worker startup prompt. The worker name is appended at runtime.
-const CODEX_WORKER_STARTUP_PREFIX: &str = "I'm initiating CAS worker startup now: register this worker session, confirm identity, check assigned tasks, then start any assigned task with a progress note.\n1) Run mcp__cs__coordination action=session_start name=";
+const CODEX_WORKER_STARTUP_PREFIX: &str = "I'm initiating CAS worker startup now: confirm identity, check assigned tasks, then start any assigned task with a progress note. My CAS session is already registered automatically (do NOT call session_start).\n1) Run mcp__cs__coordination action=whoami";
 
 /// Configuration for spawning a PTY
 #[derive(Debug, Clone)]
@@ -162,6 +162,11 @@ impl PtyConfig {
         // (cas-4513 Claude Code JS crash-screen symptom). Emitted only
         // for role="worker"; supervisor stays uncapped.
         push_worker_cargo_env(&mut env, role);
+        // Point factory workers at the repo's bootstrapped Zig toolchain so the
+        // ghostty_vt_sys build script finds Zig on the first `cargo build` in a
+        // fresh worker worktree instead of failing and forcing a manual
+        // bootstrap-zig.sh + ZIG export dance (observed in the cas-3522 shakedown).
+        push_worker_zig_env(&mut env, role, cas_root);
 
         // Enable native Agent Teams for inter-agent messaging
         if teams.is_some() {
@@ -259,7 +264,9 @@ impl PtyConfig {
         _teams: Option<&TeamsSpawnConfig>,
     ) -> Self {
         // Native Agent Teams is Claude Code-only; Codex CLI does not support it.
-        let session_id = uuid::Uuid::new_v4().to_string();
+        // Keep the human-readable `codex-<name>-` prefix (operator clarity in
+        // worker_status/agent_list); nothing parses it, so the suffix is a uuid.
+        let session_id = format!("codex-{name}-{}", uuid::Uuid::new_v4());
 
         let mut env = vec![
             ("CAS_AGENT_NAME".to_string(), name.to_string()),
@@ -270,7 +277,7 @@ impl PtyConfig {
             // not fire and workers get jailed on every pending task.
             ("CAS_FACTORY_MODE".to_string(), "1".to_string()),
             // Provide session ID so CAS MCP server can self-register without hooks
-            ("CAS_SESSION_ID".to_string(), session_id),
+            ("CAS_SESSION_ID".to_string(), session_id.clone()),
             (
                 "CAS_CLONE_PATH".to_string(),
                 cwd.to_string_lossy().to_string(),
@@ -308,6 +315,8 @@ impl PtyConfig {
 
         // cas-0bf4: see equivalent comment in `claude()`.
         push_worker_cargo_env(&mut env, role);
+        // cas-3522 follow-on: see equivalent comment in `claude()`.
+        push_worker_zig_env(&mut env, role, cas_root);
 
         let mut args = vec!["--yolo".to_string(), "--no-alt-screen".to_string()];
 
@@ -316,7 +325,7 @@ impl PtyConfig {
         // integrated for the Codex harness (no .codex/config.toml). Must precede
         // the developer_instructions block but order among `-c` flags is
         // irrelevant to Codex.
-        push_codex_mcp_server_args(&mut args);
+        push_codex_mcp_server_args(&mut args, &session_id);
 
         if let Some(m) = model {
             args.push("--model".to_string());
@@ -345,12 +354,11 @@ impl PtyConfig {
             // This is more reliable than post-spawn typed injection, which can leave text
             // in the composer without submitting in some startup timing windows.
             let startup_prompt = format!(
-                "{CODEX_WORKER_STARTUP_PREFIX}{name} agent_type=worker\n\
-                 2) Run mcp__cs__coordination action=whoami\n\
-                 3) Run mcp__cs__task action=mine\n\
-                 4) If a task is assigned: choose exactly ONE task, run mcp__cs__task action=show then action=start, add a progress note, implement it, commit and push, then close it (or hand to supervisor) BEFORE starting any other task. Never start more than one task at a time — batch-starting collides with the one-unverified-in-progress verification jail.\n\
-                 5) If no tasks are assigned: send mcp__cs__coordination action=message target=supervisor confirming ready state\n\
-                 6) Do NOT message target=cas. Use target=supervisor."
+                "{CODEX_WORKER_STARTUP_PREFIX}\n\
+                 2) Run mcp__cs__task action=mine\n\
+                 3) If a task is assigned: choose exactly ONE task, run mcp__cs__task action=show then action=start, add a progress note, implement it, commit and push, then close it (or hand to supervisor) BEFORE starting any other task. Never start more than one task at a time — batch-starting collides with the one-unverified-in-progress verification jail.\n\
+                 4) If no tasks are assigned: send mcp__cs__coordination action=message target=supervisor confirming ready state\n\
+                 5) Do NOT message target=cas. Use target=supervisor."
             );
             args.push(startup_prompt);
         }
@@ -429,13 +437,21 @@ fn cargo_build_jobs_for_worker() -> Option<String> {
 /// strings, `["serve"]` becomes a string array. If a project DOES ship a
 /// `.codex/config.toml`, these `-c` overrides simply add the `cs` server on top
 /// — they never remove the project's own entries.
-fn push_codex_mcp_server_args(args: &mut Vec<String>) {
+fn push_codex_mcp_server_args(args: &mut Vec<String>, session_id: &str) {
     args.push("-c".to_string());
     args.push("mcp_servers.cs.command=\"cas\"".to_string());
     args.push("-c".to_string());
     args.push("mcp_servers.cs.args=[\"serve\"]".to_string());
     args.push("-c".to_string());
     args.push("mcp_servers.cs.env.CAS_CODEX_FALLBACK_SESSION=\"1\"".to_string());
+    // cas-3522: inject the canonical session id into the `cs` MCP server env so
+    // `get_agent_id()` auto-registers the agent on its FIRST tool call — the same
+    // env fast-path Claude workers rely on. Codex starts MCP servers with a
+    // restricted env (it does not pass the codex process env through), so without
+    // this the `cs` server comes up identity-less and whoami/task fail with
+    // "Agent not registered" until the worker brute-forces a manual `register`.
+    args.push("-c".to_string());
+    args.push(format!("mcp_servers.cs.env.CAS_SESSION_ID=\"{session_id}\""));
 }
 
 /// Returns `true` when an executable named `cas` is resolvable on `PATH`.
@@ -464,6 +480,34 @@ fn push_worker_cargo_env(env: &mut Vec<(String, String)>, role: &str) {
     }
     if let Some(cargo_jobs) = cargo_build_jobs_for_worker() {
         env.push(("CARGO_BUILD_JOBS".to_string(), cargo_jobs));
+    }
+}
+
+/// Export `ZIG` into a worker's env pointing at the repo's bootstrapped Zig
+/// binary (`<repo>/.context/zig/zig`), so the `ghostty_vt_sys` build script can
+/// find Zig on the first `cargo build` inside a fresh worker worktree.
+///
+/// Without this, a worker's first build fails in `ghostty_vt_sys` ("could not
+/// find Zig") and the worker has to discover + run `scripts/bootstrap-zig.sh`
+/// and export `ZIG` by hand before it can compile anything — wasted turns
+/// observed in the cas-3522 Codex shakedown.
+///
+/// Worker-only and best-effort, mirroring `push_worker_cargo_env`:
+/// - `cas_root` is `<repo>/.cas`, so the repo root is its parent.
+/// - We only set `ZIG` when the binary actually exists at the expected path;
+///   pointing `ZIG` at a missing file would break builds worse than leaving it
+///   unset (the build script would still try to bootstrap). The path is
+///   absolute, so it resolves correctly from any worktree cwd.
+fn push_worker_zig_env(env: &mut Vec<(String, String)>, role: &str, cas_root: Option<&PathBuf>) {
+    if role != "worker" {
+        return;
+    }
+    let Some(repo) = cas_root.and_then(|r| r.parent()) else {
+        return;
+    };
+    let zig = repo.join(".context").join("zig").join("zig");
+    if zig.is_file() {
+        env.push(("ZIG".to_string(), zig.to_string_lossy().to_string()));
     }
 }
 
@@ -1141,6 +1185,132 @@ mod tests {
             all_args.contains("Work exactly ONE task at a time"),
             "worker developer_instructions must enforce one-task-at-a-time; got: {all_args}"
         );
+    }
+
+    /// cas-3522: the Codex `cs` MCP server must receive the canonical session id
+    /// so `get_agent_id()` auto-registers the agent on the first tool call.
+    /// Without it the worker burns ~6 failed calls ("Agent not registered")
+    /// before brute-forcing a manual register.
+    #[tokio::test]
+    async fn test_pty_config_codex_worker_injects_session_id() {
+        let _e = ScopedEnv::new();
+        let config = PtyConfig::codex(
+            "test-worker",
+            "worker",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None, // model
+            None, // effort
+            None, // teams
+        );
+        let all_args = config.args.join(" ");
+        assert!(
+            all_args.contains("mcp_servers.cs.env.CAS_SESSION_ID=\"codex-test-worker-"),
+            "codex worker must inject CAS_SESSION_ID into the cs MCP env; got: {all_args}"
+        );
+        // The same id must be exported into the process env (they must match).
+        assert!(
+            config
+                .env
+                .iter()
+                .any(|(k, v)| k == "CAS_SESSION_ID" && v.starts_with("codex-test-worker-")),
+            "codex worker process env must carry the matching CAS_SESSION_ID; got: {:?}",
+            config.env
+        );
+    }
+
+    /// cas-3522: the supervisor's cs MCP server also needs CAS_SESSION_ID.
+    #[tokio::test]
+    async fn test_pty_config_codex_supervisor_injects_session_id() {
+        let _e = ScopedEnv::new();
+        let config = PtyConfig::codex(
+            "test-supervisor",
+            "supervisor",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let all_args = config.args.join(" ");
+        assert!(
+            all_args.contains("mcp_servers.cs.env.CAS_SESSION_ID=\"codex-test-supervisor-"),
+            "codex supervisor must inject CAS_SESSION_ID into the cs MCP env; got: {all_args}"
+        );
+    }
+
+    /// cas-3522: the startup prompt and worker instructions must NOT drive a
+    /// `session_start` invocation anymore — auto-registration replaces it.
+    #[tokio::test]
+    async fn test_pty_config_codex_worker_no_session_start_invocation() {
+        let _e = ScopedEnv::new();
+        let config = PtyConfig::codex(
+            "test-worker",
+            "worker",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let all_args = config.args.join(" ");
+        assert!(
+            !all_args.contains("action=session_start"),
+            "codex worker must no longer invoke session_start; got: {all_args}"
+        );
+        // whoami remains the first explicit identity check.
+        assert!(
+            all_args.contains("action=whoami"),
+            "codex worker startup should still confirm identity via whoami; got: {all_args}"
+        );
+    }
+
+    /// cas-3522 follow-on: a worker gets `ZIG` pointed at the repo's
+    /// bootstrapped binary when it exists; non-workers and missing-binary cases
+    /// leave `ZIG` unset.
+    #[tokio::test]
+    async fn test_push_worker_zig_env_sets_zig_for_worker_when_present() {
+        let dir = std::env::temp_dir().join("cas-3522-zig-env-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let zig = dir.join(".context").join("zig").join("zig");
+        std::fs::create_dir_all(zig.parent().unwrap()).unwrap();
+        std::fs::write(&zig, b"#!/bin/sh\n").unwrap();
+        let cas_root = dir.join(".cas");
+        std::fs::create_dir_all(&cas_root).unwrap();
+
+        let zig_str = zig.to_string_lossy().to_string();
+
+        let mut worker_env: Vec<(String, String)> = Vec::new();
+        push_worker_zig_env(&mut worker_env, "worker", Some(&cas_root));
+        assert!(
+            worker_env.iter().any(|(k, v)| k == "ZIG" && v == &zig_str),
+            "worker must get ZIG pointing at the bootstrapped binary; got: {worker_env:?}"
+        );
+
+        let mut sup_env: Vec<(String, String)> = Vec::new();
+        push_worker_zig_env(&mut sup_env, "supervisor", Some(&cas_root));
+        assert!(
+            !sup_env.iter().any(|(k, _)| k == "ZIG"),
+            "supervisor must NOT get ZIG; got: {sup_env:?}"
+        );
+
+        // Missing binary -> no ZIG even for a worker.
+        let empty_root = dir.join("empty").join(".cas");
+        std::fs::create_dir_all(&empty_root).unwrap();
+        let mut missing_env: Vec<(String, String)> = Vec::new();
+        push_worker_zig_env(&mut missing_env, "worker", Some(&empty_root));
+        assert!(
+            !missing_env.iter().any(|(k, _)| k == "ZIG"),
+            "worker must not get ZIG when the binary is absent; got: {missing_env:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// cas-bbc2: `cas_binary_on_path()` returns true when an executable named

--- a/crates/cas-pty/src/pty.rs
+++ b/crates/cas-pty/src/pty.rs
@@ -14,10 +14,10 @@ use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 
 /// Instructions injected into Codex supervisor agents via `--config developer_instructions`.
-const CODEX_SUPERVISOR_INSTRUCTIONS: &str = "You are the CAS Factory Supervisor. Coordinate only: plan epics, assign tasks, monitor progress, review/merge. Never implement tasks. Use skills cas-supervisor and cas-codex-supervisor-checklist. Use MCP tools explicitly; no /cas-start, /cas-context, or /cas-end.";
+const CODEX_SUPERVISOR_INSTRUCTIONS: &str = "You are the CAS Factory Supervisor. Coordinate only: plan epics, assign tasks, monitor progress, review/merge. Never implement tasks. Use skills cas-supervisor and cas-codex-supervisor-checklist. Use MCP tools explicitly; no /cas-start, /cas-context, or /cas-end. Worker messages (status/blocker/ready) arrive asynchronously as new injected turns framed 'Message from <sender>: …'. Each is a triage trigger, not a fresh startup: read it, then assign/answer/redirect/merge as appropriate and reply via `mcp__cs__coordination action=message target=<worker>`. Finishing one round does not mean you are done — remain available to coordinate the next message.";
 
 /// Instructions injected into Codex worker agents via `--config developer_instructions`.
-const CODEX_WORKER_INSTRUCTIONS: &str = "You are a CAS Factory Worker. Always use CAS MCP tools for task lifecycle and coordination. On startup run `mcp__cs__coordination action=session_start name=<worker-name> agent_type=worker` then `mcp__cs__coordination action=whoami`, then run `mcp__cs__task action=mine`. Work exactly ONE task at a time: choose a single assigned task, run `mcp__cs__task action=show id=<task-id>` then `mcp__cs__task action=start id=<task-id>` before coding, implement it, commit and push your changes, then close it with `mcp__cs__task action=close id=<task-id> reason=\"...\"` (or hand it to the supervisor if close returns verification-required guidance) BEFORE starting any other task. Never start a second task while one is still in progress — the verification jail allows only one unverified in-progress task at a time, so batch-starting tasks will block you. Add progress notes frequently using `mcp__cs__task action=notes id=<task-id> note_type=progress notes=\"...\"`. For blockers, add a blocker note, set `status=blocked`, and message supervisor via `mcp__cs__coordination action=message target=supervisor message=\"...\"`. If close returns verification-required guidance, immediately ask the supervisor to verify/close on your behalf. Do not use /cas-start, /cas-context, or /cas-end. Stay within assigned task scope.";
+const CODEX_WORKER_INSTRUCTIONS: &str = "You are a CAS Factory Worker. Always use CAS MCP tools for task lifecycle and coordination. On startup run `mcp__cs__coordination action=session_start name=<worker-name> agent_type=worker` then `mcp__cs__coordination action=whoami`, then run `mcp__cs__task action=mine`. Work exactly ONE task at a time: choose a single assigned task, run `mcp__cs__task action=show id=<task-id>` then `mcp__cs__task action=start id=<task-id>` before coding, implement it, commit and push your changes, then close it with `mcp__cs__task action=close id=<task-id> reason=\"...\"` (or hand it to the supervisor if close returns verification-required guidance) BEFORE starting any other task. Never start a second task while one is still in progress — the verification jail allows only one unverified in-progress task at a time, so batch-starting tasks will block you. Add progress notes frequently using `mcp__cs__task action=notes id=<task-id> note_type=progress notes=\"...\"`. For blockers, add a blocker note, set `status=blocked`, and message supervisor via `mcp__cs__coordination action=message target=supervisor message=\"...\"`. If close returns verification-required guidance, immediately ask the supervisor to verify/close on your behalf. After closing or handing off a task, stay available — you are not permanently done. The supervisor will send you more work or redirection as new messages. Treat any injected turn framed 'Message from <sender>: …' as an instruction to act on, not noise: read it and follow it. Keep honoring one-task-at-a-time — finish or hand off your current task before starting the next one a message assigns. Do not use /cas-start, /cas-context, or /cas-end. Stay within assigned task scope.";
 
 /// Prefix for the Codex worker startup prompt. The worker name is appended at runtime.
 const CODEX_WORKER_STARTUP_PREFIX: &str = "I'm initiating CAS worker startup now: register this worker session, confirm identity, check assigned tasks, then start any assigned task with a progress note.\n1) Run mcp__cs__coordination action=session_start name=";
@@ -1208,6 +1208,80 @@ mod tests {
         assert!(
             all_args.contains("CAS Factory Supervisor"),
             "Codex supervisor should have supervisor instructions"
+        );
+    }
+
+    /// cas-83c8: the Codex supervisor prompt must explain that worker messages
+    /// arrive asynchronously as injected turns and must be triaged + replied to
+    /// via mcp__cs__coordination, not treated as a fresh startup.
+    #[tokio::test]
+    async fn test_pty_config_codex_supervisor_handles_injected_worker_messages() {
+        let config = PtyConfig::codex(
+            "test-supervisor",
+            "supervisor",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None, // model
+            None, // effort
+            None, // teams
+        );
+        let all_args = config.args.join(" ");
+        assert!(
+            all_args.contains("Message from <sender>"),
+            "supervisor prompt must reference the injected message framing; got: {all_args}"
+        );
+        assert!(
+            all_args.contains("triage trigger"),
+            "supervisor prompt must frame incoming worker messages as a triage trigger; got: {all_args}"
+        );
+        assert!(
+            all_args.contains("mcp__cs__coordination action=message target=<worker>"),
+            "supervisor prompt must tell it to reply/redirect via mcp__cs__coordination; got: {all_args}"
+        );
+        // Must keep the mcp__cs__ alias (not the claude mcp__cas__ alias).
+        assert!(
+            !all_args.contains("mcp__cas__"),
+            "Codex supervisor prompt must use the mcp__cs__ alias, never mcp__cas__; got: {all_args}"
+        );
+    }
+
+    /// cas-83c8: the Codex worker prompt must instruct continued availability
+    /// after a task closes (you are not permanently done) and acting on injected
+    /// supervisor messages, without breaking the one-task-at-a-time rule.
+    #[tokio::test]
+    async fn test_pty_config_codex_worker_stays_available_for_injected_messages() {
+        let _e = ScopedEnv::new();
+        let config = PtyConfig::codex(
+            "test-worker",
+            "worker",
+            PathBuf::from("/tmp"),
+            None,
+            None,
+            None,
+            None, // model
+            None, // effort
+            None, // teams
+        );
+        let all_args = config.args.join(" ");
+        assert!(
+            all_args.contains("not permanently done"),
+            "worker prompt must say it is not permanently done after closing a task; got: {all_args}"
+        );
+        assert!(
+            all_args.contains("Message from <sender>"),
+            "worker prompt must instruct acting on injected 'Message from <sender>' turns; got: {all_args}"
+        );
+        // The one-task-at-a-time discipline must still be present alongside the
+        // new continued-availability clause.
+        assert!(
+            all_args.contains("Work exactly ONE task at a time"),
+            "worker prompt must retain one-task-at-a-time discipline; got: {all_args}"
+        );
+        assert!(
+            all_args.contains("finish or hand off your current task before starting the next"),
+            "worker prompt must reconcile continued availability with the one-task rule; got: {all_args}"
         );
     }
 

--- a/crates/cas-store/src/task_store.rs
+++ b/crates/cas-store/src/task_store.rs
@@ -58,7 +58,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     owner_id TEXT,
     visibility TEXT NOT NULL DEFAULT 'private',
     collaborators TEXT NOT NULL DEFAULT '[]',
-    share TEXT
+    share TEXT,
+    depth TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
@@ -196,6 +197,11 @@ impl SqliteTaskStore {
                 .get::<_, Option<String>>(26)?
                 .as_deref()
                 .and_then(|s| s.parse().ok()),
+            depth: row
+                .get::<_, Option<String>>(27)?
+                .as_deref()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_default(),
         })
     }
 
@@ -231,8 +237,8 @@ impl SqliteTaskStore {
             "INSERT INTO tasks (id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)",
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28)",
             params![
                 task.id,
                 task.title,
@@ -261,6 +267,7 @@ impl SqliteTaskStore {
                 task.demo_statement,
                 task.execution_note,
                 task.share.as_ref().map(|s| s.to_string()),
+                task.depth.to_string(),
             ],
         )?;
 
@@ -339,7 +346,7 @@ impl SqliteTaskStore {
                 "SELECT id, title, description, design, acceptance_criteria, notes,
                  status, priority, task_type, assignee, labels, created_at, updated_at,
                  closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share
+                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
                  FROM tasks ORDER BY priority, created_at DESC",
             )?;
             stmt.query_map([], Self::task_from_row)?
@@ -485,7 +492,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
              FROM tasks WHERE id = ?",
             params![id],
             Self::task_from_row,
@@ -517,8 +524,8 @@ impl TaskStore for SqliteTaskStore {
              closed_at = ?12, close_reason = ?13, external_ref = ?14, content_hash = ?15,
              branch = ?16, worktree_id = ?17,
              pending_verification = ?18, pending_worktree_merge = ?19, epic_verification_owner = ?20, team_id = ?21,
-             deliverables = ?22, demo_statement = ?23, execution_note = ?24, share = ?25
-             WHERE id = ?26",
+             deliverables = ?22, demo_statement = ?23, execution_note = ?24, share = ?25, depth = ?26
+             WHERE id = ?27",
             params![
                 task.title,
                 task.description,
@@ -545,6 +552,7 @@ impl TaskStore for SqliteTaskStore {
                 task.demo_statement,
                 task.execution_note,
                 task.share.as_ref().map(|s| s.to_string()),
+                task.depth.to_string(),
                 task.id,
             ],
         )?;
@@ -654,7 +662,7 @@ impl TaskStore for SqliteTaskStore {
                 "SELECT id, title, description, design, acceptance_criteria, notes,
                  status, priority, task_type, assignee, labels, created_at, updated_at,
                  closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share
+                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
                  FROM tasks WHERE status = ? ORDER BY priority, created_at DESC",
                 vec![s.to_string()],
             ),
@@ -662,7 +670,7 @@ impl TaskStore for SqliteTaskStore {
                 "SELECT id, title, description, design, acceptance_criteria, notes,
                  status, priority, task_type, assignee, labels, created_at, updated_at,
                  closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share
+                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
                  FROM tasks ORDER BY priority, created_at DESC",
                 vec![],
             ),
@@ -688,7 +696,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
              FROM tasks t
              WHERE t.status = 'open'
              AND NOT EXISTS (
@@ -716,7 +724,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT DISTINCT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
              FROM tasks t
              JOIN dependencies d ON d.from_id = t.id
              JOIN tasks blocker ON d.to_id = blocker.id
@@ -742,7 +750,7 @@ impl TaskStore for SqliteTaskStore {
              t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
              FROM dependencies d
              JOIN tasks t ON d.to_id = t.id
              WHERE d.from_id IN ({placeholders})
@@ -790,6 +798,11 @@ impl TaskStore for SqliteTaskStore {
                     .get::<_, Option<String>>(27)?
                     .as_deref()
                     .and_then(|s| s.parse().ok()),
+                depth: row
+                    .get::<_, Option<String>>(28)?
+                    .as_deref()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or_default(),
             };
             Ok((from_id, task))
         })?;
@@ -819,7 +832,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
              FROM tasks WHERE pending_verification = 1",
         )?;
         let tasks = stmt
@@ -834,7 +847,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
              FROM tasks WHERE pending_worktree_merge = 1",
         )?;
         let tasks = stmt
@@ -912,7 +925,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
              FROM tasks t
              JOIN dependencies d ON d.to_id = t.id
              WHERE d.from_id = ? AND d.dep_type = 'blocks' AND t.status != 'closed'",
@@ -987,7 +1000,7 @@ impl TaskStore for SqliteTaskStore {
              SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
              FROM tasks t
              JOIN subtree s ON t.id = s.task_id",
         )?;
@@ -1040,7 +1053,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
              FROM tasks t
              JOIN dependencies d ON d.to_id = t.id
              WHERE d.from_id = ? AND d.dep_type = 'parent-child' AND t.task_type = 'epic'

--- a/crates/cas-store/src/task_store_tests/tests.rs
+++ b/crates/cas-store/src/task_store_tests/tests.rs
@@ -48,6 +48,31 @@ fn test_task_crud() {
 }
 
 #[test]
+fn test_task_depth_roundtrip() {
+    use cas_types::TaskDepth;
+    let (_temp, store) = create_test_store();
+
+    // Default (no depth specified) reads back as Deep.
+    let id = store.generate_id().unwrap();
+    let task = Task::new(id.clone(), "deep by default".to_string());
+    store.add(&task).unwrap();
+    assert_eq!(store.get(&id).unwrap().depth, TaskDepth::Deep);
+
+    // Create with Light, read back Light.
+    let light_id = store.generate_id().unwrap();
+    let mut light = Task::new(light_id.clone(), "light task".to_string());
+    light.depth = TaskDepth::Light;
+    store.add(&light).unwrap();
+    assert_eq!(store.get(&light_id).unwrap().depth, TaskDepth::Light);
+
+    // Update Light -> Deep; round-trips through the store.
+    let mut fetched = store.get(&light_id).unwrap();
+    fetched.depth = TaskDepth::Deep;
+    store.update(&fetched).unwrap();
+    assert_eq!(store.get(&light_id).unwrap().depth, TaskDepth::Deep);
+}
+
+#[test]
 fn test_dependencies() {
     let (_temp, store) = create_test_store();
 

--- a/crates/cas-types/src/lib.rs
+++ b/crates/cas-types/src/lib.rs
@@ -84,7 +84,7 @@ pub use sort::{
     TaskSortOptions,
 };
 pub use spec::{Spec, SpecStatus, SpecType};
-pub use task::{Priority, Task, TaskDeliverables, TaskStatus, TaskType};
+pub use task::{Priority, Task, TaskDeliverables, TaskDepth, TaskStatus, TaskType};
 pub use verification::{
     IssueSeverity, Verification, VerificationIssue, VerificationStatus, VerificationType,
 };

--- a/crates/cas-types/src/task.rs
+++ b/crates/cas-types/src/task.rs
@@ -122,6 +122,45 @@ impl FromStr for TaskType {
     }
 }
 
+/// Execution depth of a task (EPIC cas-1255 — per-task speed mode).
+///
+/// Controls the speed-vs-rigor tradeoff for feel-driven iteration. `Deep`
+/// is the default and preserves full execution rigor; `Light` signals a
+/// fast, feel-driven pass. Rows created before this field existed read back
+/// as `Deep` (NULL maps to the default).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskDepth {
+    /// Full execution rigor (default)
+    #[default]
+    Deep,
+    /// Fast, feel-driven pass
+    Light,
+}
+
+impl fmt::Display for TaskDepth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TaskDepth::Deep => write!(f, "deep"),
+            TaskDepth::Light => write!(f, "light"),
+        }
+    }
+}
+
+impl FromStr for TaskDepth {
+    type Err = TypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("deep") {
+            Ok(TaskDepth::Deep)
+        } else if s.eq_ignore_ascii_case("light") {
+            Ok(TaskDepth::Light)
+        } else {
+            Err(TypeError::Parse(format!("invalid task depth: {s}")))
+        }
+    }
+}
+
 /// Priority level (0 = highest, 4 = lowest)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
 pub struct Priority(pub i32);
@@ -304,6 +343,12 @@ pub struct Task {
     /// See cas-7fc1.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_note: Option<String>,
+
+    /// Execution depth (EPIC cas-1255). `Deep` (default) preserves full
+    /// rigor; `Light` signals a fast, feel-driven pass. Defaults to `Deep`
+    /// when absent so existing tasks read as deep.
+    #[serde(default)]
+    pub depth: TaskDepth,
 }
 
 impl Task {
@@ -339,6 +384,7 @@ impl Task {
             share: None,
             demo_statement: String::new(),
             execution_note: None,
+            depth: TaskDepth::Deep,
         }
     }
 
@@ -406,6 +452,7 @@ impl Default for Task {
             share: None,
             demo_statement: String::new(),
             execution_note: None,
+            depth: TaskDepth::Deep,
         }
     }
 }
@@ -499,5 +546,31 @@ mod tests {
         assert_eq!(task.priority, Priority::MEDIUM);
         assert!(task.is_open());
         assert!(task.is_ready());
+    }
+
+    #[test]
+    fn test_task_depth_default_is_deep() {
+        assert_eq!(TaskDepth::default(), TaskDepth::Deep);
+        let task = Task::new("cas-d3p1".to_string(), "Test".to_string());
+        assert_eq!(task.depth, TaskDepth::Deep);
+        assert_eq!(Task::default().depth, TaskDepth::Deep);
+    }
+
+    #[test]
+    fn test_task_depth_from_str() {
+        assert_eq!(TaskDepth::from_str("deep").unwrap(), TaskDepth::Deep);
+        assert_eq!(TaskDepth::from_str("light").unwrap(), TaskDepth::Light);
+        assert_eq!(TaskDepth::from_str("LIGHT").unwrap(), TaskDepth::Light);
+        assert!(TaskDepth::from_str("medium").is_err());
+        assert!(TaskDepth::from_str("").is_err());
+    }
+
+    #[test]
+    fn test_task_depth_display_roundtrip() {
+        for d in [TaskDepth::Deep, TaskDepth::Light] {
+            assert_eq!(TaskDepth::from_str(&d.to_string()).unwrap(), d);
+        }
+        assert_eq!(TaskDepth::Light.to_string(), "light");
+        assert_eq!(TaskDepth::Deep.to_string(), "deep");
     }
 }

--- a/docs/guides/task-depth.md
+++ b/docs/guides/task-depth.md
@@ -1,0 +1,68 @@
+# Task depth: a speed lane for feel-driven work
+
+CAS tasks have a **depth**: `deep` (the default) or `light`. Depth controls the
+speed-vs-rigor tradeoff at close time. It does not change what a task *is* — only
+how much machine verification stands between "I'm done" and "closed".
+
+If you never set it, every task is `deep` and nothing about your workflow
+changes. `light` is opt-in.
+
+## The two lanes
+
+| | **deep** (default) | **light** |
+|---|---|---|
+| Who decides "it's correct"? | The machine — verifier + review gates | **You**, by looking at the result |
+| Verification jail on close | Armed (task-verifier runs) | Skipped |
+| P0 code-review / supervisor-review gate | Enforced | Skipped |
+| Worker's pre-close self-checks | Run | Skipped |
+| Close speed | Full gate (minutes) | Immediate |
+| Good for | Logic, features, data, anything where correctness must be *proven* | Feel-driven UI iteration where *you are the evaluator* |
+
+`deep` and unset behave identically (a task with no depth reads back as `deep`),
+so existing tasks and existing habits are untouched.
+
+## When to reach for `light`
+
+Use `light` when **a human looking at the result is the real test** and a
+machine gate would only slow the loop down:
+
+- Nudging spacing, color, copy, animation timing — you'll *see* whether it's
+  right on localhost faster than any check could tell you.
+- Rapid "does this feel better?" passes where you're iterating by eye.
+
+Stay on `deep` (do nothing) when correctness is not something you can eyeball:
+
+- Business logic, auth, data migrations, API contracts, money.
+- Anything where a regression would be invisible in a screenshot.
+
+Rule of thumb: **if you can't verify it by looking at it, it's deep.**
+
+## How to set it
+
+Depth is a field on the task tool — there is no separate CLI command (tasks are
+MCP-tool driven). Set `depth` when the task is created:
+
+```
+task action=create title="tighten card padding on the pricing page" depth=light
+```
+
+In an agent chat you can just say it in words and the agent passes it through:
+
+> "Create a **light** task to nudge the hero spacing."
+
+Valid values are `light` and `deep`; anything else is rejected. Omitting `depth`
+means `deep`. You can see a task's depth in `task action=show` (the `Depth:`
+line) and in `task action=mine`.
+
+## The tradeoff — read this before using `light`
+
+`light` **turns off machine verification**. There is no verifier, no review
+gate, and no pre-close self-check standing behind a light close — *you* are the
+only evaluator. That is exactly the point for feel-driven UI work, and exactly
+why you must not use it for anything whose correctness you can't personally
+confirm by looking at the running result. When in doubt, leave it `deep`.
+
+## See also
+
+- [`docs/notes/2026-06-25-task-depth-speed-mode.md`](../notes/2026-06-25-task-depth-speed-mode.md)
+  — why this feature exists (the design record).

--- a/docs/notes/2026-06-25-release-v2.22.0-notes.md
+++ b/docs/notes/2026-06-25-release-v2.22.0-notes.md
@@ -1,0 +1,36 @@
+# Release v2.22.0 Notes Draft
+
+Channel: #cas-internal
+
+## USER Summary
+
+Before this release, choosing Codex for factory work could mean it started without the project context it needed, and mixed Codex plus Claude runs were unreliable. CAS v2.22.0 has shipped so Codex workers now start connected, wake up cleanly, and can work alongside Claude workers in the same project. The impact is simple: teams can choose the right model for each job without losing access to shared tasks, memory, search, or the safety defaults that keep factory work on track.
+
+## USER Details
+
+- 🧭 **Codex starts with the project in view**: Before, a Codex worker could open with no access to the shared task list, memory, or search context. Now it starts with the same project tools available, so it can pick up assigned work instead of spending the session reconstructing context.
+- 🔁 **Codex resumes more reliably**: Before, waking a Codex session partway through a factory run could leave it unsure what to do next. Now resumed Codex workers and supervisors treat the new turn as actionable and continue the task flow.
+- 🤝 **Codex and Claude can share one project**: Before, mixing Codex and Claude in one factory run was fragile. Now a project can use both harnesses side by side, with each worker staying connected in the way its harness expects.
+- 🔐 **Sensitive values are hidden by default**: Before, a detailed project connection listing could expose tokens or credentials in plain text. Now secret values are redacted by default, with an explicit opt-in only when someone truly needs to inspect them.
+- ✅ **The mixed setup has regression coverage**: Before, the most important Codex plus Claude combinations were not covered by a complete matrix. Now the release includes tests and a verification runbook that protect the new mixed-project behavior.
+
+## DEV Summary
+
+Before v2.22.0, the factory treated Codex support as partly implicit: Codex panes could start without injected CAS tool configuration, resumed Codex turns had weaker prompt handling, and mixed Codex/Claude factories were not covered as one explicit harness matrix. This release makes Codex a first-class factory backend with spawn-time CAS MCP injection, Codex-aware wake handling, mixed-harness regression coverage, and safer MCP server diagnostics. Architecturally, the factory can now run Codex and Claude side by side while preserving project context and keeping sensitive connection material redacted by default.
+
+## DEV Details
+
+- **Codex harness bootstrap**: `crates/cas-pty/src/pty.rs` now injects the CAS MCP server into Codex spawns with `-c` config overrides, checks that the `cas` binary is available before launch, and gives Codex workers a single-task lifecycle prompt. That closes the gap where Codex could launch in a project but lack `mcp__cs__*` tools.
+- **Mid-session Codex wakeups**: The Codex worker and supervisor prompts now handle mid-session turns as actionable work instead of only relying on startup context. That keeps an already-running Codex pane aligned with the task lifecycle when it is re-engaged during a factory session.
+- **Mixed-harness project support**: The factory runtime now keeps Codex and Claude harness boundaries explicit across `cas-cli/src/ui/factory/daemon/runtime/delivery.rs`, `queue_and_events.rs`, `gui_client.rs`, and `ws_client.rs`. This supports Codex and Claude workers in one project while preserving the all-Claude path.
+- **Regression matrix and rollout runbook**: `cas-cli/src/ui/factory/daemon/runtime/delivery_matrix_tests.rs` covers the supported Codex/Claude harness combinations and mixed-project behavior. The release also fixes a stale Codex prompt guardrail and adds a cross-harness communications verification runbook under `docs/reviews/`.
+- **Secret redaction for MCP listings**: `cas-cli/src/cli/mcp_cmd.rs` now redacts stdio env values, HTTP/SSE auth tokens, and header values from JSON MCP server listings by default. `--show-secrets` remains available as an explicit opt-in for trusted local inspection.
+- **Release mechanics**: Version bumped from 2.21.0 to 2.22.0 in `cas-cli/Cargo.toml` and `Cargo.lock`; tag to create after approval is `v2.22.0`; commits covered: 32a3796, 92b7a78, 83ccac1, 219b5d4, 5bd0c29, 4c329c6, 0950073.
+
+## Rubric Self-Check
+
+- Four Slack drafts are present and labeled: USER summary, USER details, DEV summary, DEV details.
+- The USER summary uses before/after/impact framing and names v2.22.0 as shipped.
+- USER details use five emoji-led bold-header bullets with concrete user-facing wins.
+- DEV details use five technical bullets plus a closing release mechanics bullet.
+- The four Slack drafts avoid task and epic IDs, secrets, and internal coordination chatter.

--- a/docs/notes/2026-06-25-release-v2.22.0-notes.md
+++ b/docs/notes/2026-06-25-release-v2.22.0-notes.md
@@ -1,45 +1,28 @@
-# Release v2.22.0 Notes Draft
+# Release v2.22.0 Notes — #cas-internal
 
-Channel: #cas-internal
-
-> **HELD OPEN — not ready to post.** The PR to main is intentionally open
-> pending the per-task depth-flag (speed mode) work. Before posting: add the
-> depth-flag USER + DEV bullets and finalize the commit SHA list.
+Two-thread shape: USER (summary + details) and DEV (summary + details).
 
 ## USER Summary
 
-Before this release, choosing Codex for factory work could mean it started without the project context it needed, stumbled through an unreliable startup, and mixed Codex-plus-Claude runs were fragile. CAS v2.22.0 makes Codex workers start connected on the first try, wake up cleanly mid-run, and work alongside Claude workers in the same project. The practical impact: teams can pick the right model for each job without losing access to shared tasks, memory, search, or the safety defaults that keep factory work on track.
+Before this release, choosing Codex for factory work could mean it started without project context and stumbled out of the gate, mixing Codex and Claude in one project was fragile, and every task — even a quick UI tweak where you're the one judging the result — got dragged through the full verification machinery. CAS v2.22.0 (shipped) lands three things: Codex is now a reliable, first-class worker that starts connected and works alongside Claude; a new "light" speed mode lets a task skip the machine-verification overhead when a human is the evaluator; and the factory's task view now follows what you're actually working on. The practical impact: pick the right model for each job, and iterate fast on feel-driven work without the system grinding through checks for a spec that doesn't exist yet.
 
 ## USER Details
 
-- 🧭 **Codex starts ready to work**: Before, a Codex worker could open with no access to the shared task list, memory, or search — and even when wired up it stumbled through a brittle startup before it could act. Now it starts with the full project toolset and connects on the first try, picking up assigned work immediately instead of reconstructing context.
-- 🔁 **Codex resumes more reliably**: Before, waking a Codex session partway through a run could leave it unsure what to do next. Now resumed Codex workers and supervisors treat the new turn as actionable and continue the task flow.
-- 🤝 **Codex and Claude can share one project**: Before, mixing Codex and Claude in one run was fragile. Now a project can use both side by side, with each worker staying connected the way its harness expects.
-- 🔐 **Sensitive values are hidden by default**: Before, a detailed project connection listing could expose tokens or credentials in plain text. Now secret values are redacted by default, with an explicit opt-in only when someone truly needs to inspect them.
-- ✅ **The mixed setup has regression coverage**: Before, the most important Codex-plus-Claude combinations were not covered by a complete matrix. Now the release includes tests that protect the mixed-project behavior.
+- 🧭 **Codex starts ready to work**: Before, a Codex worker could open with no access to the shared task list, memory, or search — and even when wired up it stumbled through a brittle startup. Now it starts with the full project toolset and connects on the first try, picking up assigned work immediately.
+- 🤝 **Codex and Claude share one project**: Mixing the two harnesses in one project used to be fragile. Now you can run both side by side and pick the right model per job, with each worker staying connected the way its harness expects.
+- ⚡ **NEW — "light" speed mode for fast iteration**: When you're the one eyeballing the result (UI tweaks, feel-driven work), mark a task **light** and it skips the heavy verification steps — you ship the minimal change and stop, instead of waiting on machine checks for a spec you're still discovering. Tasks stay full-depth by default; light is opt-in per task, the change still has to be correct, and every skip is logged so it stays auditable. Works whether you run solo or through the factory.
+- 🎯 **The task view follows your current focus**: The factory's task panel now shows what you're most recently working on and its subtasks, instead of pinning a stale older list to the top.
+- 🔐 **Sensitive values hidden by default**: A detailed connection listing could previously expose tokens or credentials in plain text. Now secret values are redacted by default, with an explicit opt-in only when someone truly needs to inspect them.
 
 ## DEV Summary
 
-Before v2.22.0, the factory treated Codex support as partly implicit: Codex panes could start without injected CAS tool configuration, the worker had to brute-force its own registration, resumed Codex turns had weaker prompt handling, fresh worker worktrees could not build out of the box, and mixed Codex/Claude factories were not covered as one explicit harness matrix. This release makes Codex a first-class factory backend: spawn-time CAS MCP injection with automatic session registration, Codex-aware wake handling, a working build environment for fresh worker worktrees, mixed-harness regression coverage, and safer MCP server diagnostics.
+v2.22.0 makes Codex a first-class factory backend (spawn-time CAS MCP injection with automatic session registration, mid-session wake handling, and a working build environment for fresh worktrees), adds a per-task **depth** flag that trims process — not intelligence — for human-evaluated work, fixes the factory task panel's ordering, and redacts secrets in MCP diagnostics. The depth flag is the headline: `depth=light` skips the verification jail and P0 code-review gate at close while keeping implementation quality, for the case where the human is the evaluator and there is no machine-checkable spec yet. `deep`/unset behavior is byte-for-byte unchanged.
 
 ## DEV Details
 
-- **Codex harness bootstrap + auto-registration**: `crates/cas-pty/src/pty.rs` injects the CAS MCP server into Codex spawns via `-c` overrides, and now also injects `CAS_SESSION_ID` so the Codex MCP server auto-registers on its first tool call — removing the brittle `session_start` handshake that previously left a fresh Codex worker looping on "Agent not registered." Codex workers also get a single-task lifecycle prompt and a `cas`-binary preflight.
-- **Mid-session Codex wakeups**: The Codex worker and supervisor prompts now handle mid-session turns as actionable work instead of relying only on startup context, keeping an already-running Codex pane aligned with the task lifecycle when it is re-engaged.
-- **Fresh-worktree build environment**: Factory workers now get `ZIG` exported (pointing at the repo's bootstrapped toolchain), so the first `cargo build` in a new worker worktree finds Zig instead of failing in the `ghostty_vt_sys` build script — no more manual bootstrap dance.
-- **Mixed-harness project support**: Running Codex and Claude workers side by side in one project is now an explicitly supported and regression-tested configuration, with the all-Claude path preserved unchanged.
-- **Secret redaction for MCP listings**: `cas-cli/src/cli/mcp_cmd.rs` now redacts stdio env values, HTTP/SSE auth tokens, and header values from JSON MCP server listings by default. `--show-secrets` remains available as an explicit opt-in for trusted local inspection.
-- **Release mechanics**: Version bumped 2.21.0 → 2.22.0 in `cas-cli/Cargo.toml` and `Cargo.lock`. Covers the Codex MCP + session-injection, mid-session wakeups, mixed-harness delivery + matrix, secret redaction, plus the new Codex-startup auto-registration and worker `ZIG` env fixes. Tag `v2.22.0` to create at merge. **Final SHA list pending** — PR held open for the per-task depth-flag (speed mode) work.
-
-## Pending before posting
-
-- [ ] Per-task depth-flag / speed mode (cas-1255): add one USER bullet + one DEV bullet once the work lands.
-- [ ] Finalize the commit SHA list in Release mechanics after the PR is merged to main.
-
-## Rubric Self-Check
-
-- Four Slack drafts present and labeled: USER summary, USER details, DEV summary, DEV details.
-- USER summary uses before/after/impact framing and names v2.22.0.
-- USER details: five emoji-led bold-header bullets, concrete user-facing wins, no internal paths.
-- DEV details: technical bullets + a closing release-mechanics bullet.
-- No `cas-xxxx` IDs, secrets, or internal coordination/messaging-plumbing references in the Slack draft sections (the mixed-harness bullet is framed as a capability, not delivery internals).
+- **Codex harness bootstrap + auto-registration**: `crates/cas-pty/src/pty.rs` injects the CAS MCP server into Codex spawns and now also injects `CAS_SESSION_ID`, so a Codex agent auto-registers on its first tool call (removing the brittle `session_start` handshake that left fresh workers looping on "Agent not registered"). Single-task lifecycle prompt + `cas`-binary preflight.
+- **Mid-session wakeups + worker build environment**: resumed Codex turns are handled as actionable work; factory workers now get `ZIG` exported so the first `cargo build` in a fresh worker worktree finds the toolchain instead of failing in `ghostty_vt_sys`.
+- **Per-task depth flag (speed mode)**: a `TaskDepth` (`light`/`deep`, default `deep`) on the task model + migration. `depth=light` skips the verification jail and P0 code-review gate at close — in BOTH the factory-worker close path and the solo dispatch-layer jail — and the worker self-adjusts (minimal diff, no gold-plating, stop on localhost). `deep`/unset is byte-for-byte unchanged (paired regression tests); every skip writes an auditable decision note. Shipped with an end-to-end composition test + a user guide (`docs/guides/task-depth.md`).
+- **Factory TASKS panel recency**: the panel orders epic groups by newest activity first (threaded `updated_at` through the panel data) instead of subtask count, so a stale high-subtask-count epic no longer buries current work.
+- **Secret redaction for MCP listings**: `cas-cli/src/cli/mcp_cmd.rs` redacts stdio env values and HTTP/SSE auth tokens from `cas mcp list --json` by default; `--show-secrets` remains an explicit opt-in.
+- **Release mechanics**: version 2.21.0 → 2.22.0; tag `v2.22.0`. Integrated `cargo test --no-fail-fast` on the full release: **4283 passed / 0 failed**, 0 compile errors. Mixed Codex/Claude is a supported, regression-tested configuration; the all-Claude path is unchanged.

--- a/docs/notes/2026-06-25-release-v2.22.0-notes.md
+++ b/docs/notes/2026-06-25-release-v2.22.0-notes.md
@@ -2,35 +2,44 @@
 
 Channel: #cas-internal
 
+> **HELD OPEN — not ready to post.** The PR to main is intentionally open
+> pending the per-task depth-flag (speed mode) work. Before posting: add the
+> depth-flag USER + DEV bullets and finalize the commit SHA list.
+
 ## USER Summary
 
-Before this release, choosing Codex for factory work could mean it started without the project context it needed, and mixed Codex plus Claude runs were unreliable. CAS v2.22.0 has shipped so Codex workers now start connected, wake up cleanly, and can work alongside Claude workers in the same project. The impact is simple: teams can choose the right model for each job without losing access to shared tasks, memory, search, or the safety defaults that keep factory work on track.
+Before this release, choosing Codex for factory work could mean it started without the project context it needed, stumbled through an unreliable startup, and mixed Codex-plus-Claude runs were fragile. CAS v2.22.0 makes Codex workers start connected on the first try, wake up cleanly mid-run, and work alongside Claude workers in the same project. The practical impact: teams can pick the right model for each job without losing access to shared tasks, memory, search, or the safety defaults that keep factory work on track.
 
 ## USER Details
 
-- 🧭 **Codex starts with the project in view**: Before, a Codex worker could open with no access to the shared task list, memory, or search context. Now it starts with the same project tools available, so it can pick up assigned work instead of spending the session reconstructing context.
-- 🔁 **Codex resumes more reliably**: Before, waking a Codex session partway through a factory run could leave it unsure what to do next. Now resumed Codex workers and supervisors treat the new turn as actionable and continue the task flow.
-- 🤝 **Codex and Claude can share one project**: Before, mixing Codex and Claude in one factory run was fragile. Now a project can use both harnesses side by side, with each worker staying connected in the way its harness expects.
+- 🧭 **Codex starts ready to work**: Before, a Codex worker could open with no access to the shared task list, memory, or search — and even when wired up it stumbled through a brittle startup before it could act. Now it starts with the full project toolset and connects on the first try, picking up assigned work immediately instead of reconstructing context.
+- 🔁 **Codex resumes more reliably**: Before, waking a Codex session partway through a run could leave it unsure what to do next. Now resumed Codex workers and supervisors treat the new turn as actionable and continue the task flow.
+- 🤝 **Codex and Claude can share one project**: Before, mixing Codex and Claude in one run was fragile. Now a project can use both side by side, with each worker staying connected the way its harness expects.
 - 🔐 **Sensitive values are hidden by default**: Before, a detailed project connection listing could expose tokens or credentials in plain text. Now secret values are redacted by default, with an explicit opt-in only when someone truly needs to inspect them.
-- ✅ **The mixed setup has regression coverage**: Before, the most important Codex plus Claude combinations were not covered by a complete matrix. Now the release includes tests and a verification runbook that protect the new mixed-project behavior.
+- ✅ **The mixed setup has regression coverage**: Before, the most important Codex-plus-Claude combinations were not covered by a complete matrix. Now the release includes tests that protect the mixed-project behavior.
 
 ## DEV Summary
 
-Before v2.22.0, the factory treated Codex support as partly implicit: Codex panes could start without injected CAS tool configuration, resumed Codex turns had weaker prompt handling, and mixed Codex/Claude factories were not covered as one explicit harness matrix. This release makes Codex a first-class factory backend with spawn-time CAS MCP injection, Codex-aware wake handling, mixed-harness regression coverage, and safer MCP server diagnostics. Architecturally, the factory can now run Codex and Claude side by side while preserving project context and keeping sensitive connection material redacted by default.
+Before v2.22.0, the factory treated Codex support as partly implicit: Codex panes could start without injected CAS tool configuration, the worker had to brute-force its own registration, resumed Codex turns had weaker prompt handling, fresh worker worktrees could not build out of the box, and mixed Codex/Claude factories were not covered as one explicit harness matrix. This release makes Codex a first-class factory backend: spawn-time CAS MCP injection with automatic session registration, Codex-aware wake handling, a working build environment for fresh worker worktrees, mixed-harness regression coverage, and safer MCP server diagnostics.
 
 ## DEV Details
 
-- **Codex harness bootstrap**: `crates/cas-pty/src/pty.rs` now injects the CAS MCP server into Codex spawns with `-c` config overrides, checks that the `cas` binary is available before launch, and gives Codex workers a single-task lifecycle prompt. That closes the gap where Codex could launch in a project but lack `mcp__cs__*` tools.
-- **Mid-session Codex wakeups**: The Codex worker and supervisor prompts now handle mid-session turns as actionable work instead of only relying on startup context. That keeps an already-running Codex pane aligned with the task lifecycle when it is re-engaged during a factory session.
-- **Mixed-harness project support**: The factory runtime now keeps Codex and Claude harness boundaries explicit across `cas-cli/src/ui/factory/daemon/runtime/delivery.rs`, `queue_and_events.rs`, `gui_client.rs`, and `ws_client.rs`. This supports Codex and Claude workers in one project while preserving the all-Claude path.
-- **Regression matrix and rollout runbook**: `cas-cli/src/ui/factory/daemon/runtime/delivery_matrix_tests.rs` covers the supported Codex/Claude harness combinations and mixed-project behavior. The release also fixes a stale Codex prompt guardrail and adds a cross-harness communications verification runbook under `docs/reviews/`.
+- **Codex harness bootstrap + auto-registration**: `crates/cas-pty/src/pty.rs` injects the CAS MCP server into Codex spawns via `-c` overrides, and now also injects `CAS_SESSION_ID` so the Codex MCP server auto-registers on its first tool call — removing the brittle `session_start` handshake that previously left a fresh Codex worker looping on "Agent not registered." Codex workers also get a single-task lifecycle prompt and a `cas`-binary preflight.
+- **Mid-session Codex wakeups**: The Codex worker and supervisor prompts now handle mid-session turns as actionable work instead of relying only on startup context, keeping an already-running Codex pane aligned with the task lifecycle when it is re-engaged.
+- **Fresh-worktree build environment**: Factory workers now get `ZIG` exported (pointing at the repo's bootstrapped toolchain), so the first `cargo build` in a new worker worktree finds Zig instead of failing in the `ghostty_vt_sys` build script — no more manual bootstrap dance.
+- **Mixed-harness project support**: Running Codex and Claude workers side by side in one project is now an explicitly supported and regression-tested configuration, with the all-Claude path preserved unchanged.
 - **Secret redaction for MCP listings**: `cas-cli/src/cli/mcp_cmd.rs` now redacts stdio env values, HTTP/SSE auth tokens, and header values from JSON MCP server listings by default. `--show-secrets` remains available as an explicit opt-in for trusted local inspection.
-- **Release mechanics**: Version bumped from 2.21.0 to 2.22.0 in `cas-cli/Cargo.toml` and `Cargo.lock`; tag to create after approval is `v2.22.0`; commits covered: 32a3796, 92b7a78, 83ccac1, 219b5d4, 5bd0c29, 4c329c6, 0950073.
+- **Release mechanics**: Version bumped 2.21.0 → 2.22.0 in `cas-cli/Cargo.toml` and `Cargo.lock`. Covers the Codex MCP + session-injection, mid-session wakeups, mixed-harness delivery + matrix, secret redaction, plus the new Codex-startup auto-registration and worker `ZIG` env fixes. Tag `v2.22.0` to create at merge. **Final SHA list pending** — PR held open for the per-task depth-flag (speed mode) work.
+
+## Pending before posting
+
+- [ ] Per-task depth-flag / speed mode (cas-1255): add one USER bullet + one DEV bullet once the work lands.
+- [ ] Finalize the commit SHA list in Release mechanics after the PR is merged to main.
 
 ## Rubric Self-Check
 
-- Four Slack drafts are present and labeled: USER summary, USER details, DEV summary, DEV details.
-- The USER summary uses before/after/impact framing and names v2.22.0 as shipped.
-- USER details use five emoji-led bold-header bullets with concrete user-facing wins.
-- DEV details use five technical bullets plus a closing release mechanics bullet.
-- The four Slack drafts avoid task and epic IDs, secrets, and internal coordination chatter.
+- Four Slack drafts present and labeled: USER summary, USER details, DEV summary, DEV details.
+- USER summary uses before/after/impact framing and names v2.22.0.
+- USER details: five emoji-led bold-header bullets, concrete user-facing wins, no internal paths.
+- DEV details: technical bullets + a closing release-mechanics bullet.
+- No `cas-xxxx` IDs, secrets, or internal coordination/messaging-plumbing references in the Slack draft sections (the mixed-harness bullet is framed as a capability, not delivery internals).

--- a/docs/notes/2026-06-25-task-depth-speed-mode.md
+++ b/docs/notes/2026-06-25-task-depth-speed-mode.md
@@ -1,0 +1,80 @@
+# Design record: per-task depth (speed mode for feel-driven iteration)
+
+**EPIC:** cas-1255 · **Date:** 2026-06-25 · **Status:** shipped on the epic
+branch (children cas-0344, cas-a63e, cas-6538, cas-bdab, cas-9d74)
+
+## Why this exists
+
+The trigger was a concrete friction Daniel and Ben hit during feel-driven UI
+iteration: a pass that a human can evaluate by *looking at localhost* in about
+**11 minutes** was taking roughly **50 minutes** when it went through CAS's full
+close rigor — verification jail, the P0 code-review / supervisor-review gate, and
+the worker's pre-close self-checks. For logic work that rigor is exactly what you
+want. For "is the spacing right, does this feel better?" work, the machine has
+nothing useful to say — the human eye is the evaluator — so every gate is pure
+latency.
+
+Per-task depth lets the human opt a single task out of machine verification when
+*they* are the test, without weakening the default for everything else.
+
+## The mental model
+
+Two lanes, default-safe:
+
+- **deep** (default, and what unset/legacy tasks read as): full execution rigor,
+  unchanged. This is the overwhelming majority of work.
+- **light**: a fast, feel-driven pass. At close time it skips the two *rigor*
+  gates (verification jail + the P0 review hop) and the worker's pre-close
+  self-checks, and records an auditable decision note saying what was skipped and
+  why. The human who asked for the light task is the evaluator.
+
+Crucially, `light` only relaxes *review rigor*. Data-state safety guards
+(merge-state, uncommitted-work, additive-only, commit-claim) and the supervisor's
+explicit `bypass_code_review` override are orthogonal and untouched.
+
+## How it was built (the lanes)
+
+The feature was deliberately split so each layer is independently testable:
+
+1. **Data model — cas-0344.** `TaskDepth` enum (`Deep` default + `Light`) in
+   `cas-types`; a `depth` column in `cas-store` with `NULL → Deep` on read so
+   pre-existing rows keep reading as deep; an idempotent `ALTER` migration
+   registered in both runners (m202 cas-cli live runner + m122 cas-core); the
+   MCP `task` create/update surface accepts `light|deep` and rejects anything
+   else; depth is surfaced in `task show` and `task mine`.
+2. **Close gate — cas-6538.** A single `depth == Light` flag in `close_ops.rs`
+   gates three sites: the verification jail, the supervisor-review transition
+   (which *is* the P0 gate under `owner = "supervisor"`), and the code-review
+   gate routing. A self-contained decision note is written on every light close.
+   `deep`/unset is byte-for-byte unchanged.
+3. **Worker discipline — cas-a63e.** A "Task Depth" section in the `cas-worker`
+   skill (the `include_str!` SessionStart source plus the synced `.claude`/
+   `.codex` copies) tells a worker on a light task to make a minimal diff, skip
+   the pre-close self-checks, and stop on localhost for the human to evaluate.
+   Depth is read from the task record, not the environment.
+4. **Capstone — cas-9d74.** End-to-end tests that prove the data layer and the
+   close gate *compose* across a real SQLite persistence boundary (create in one
+   session → reload depth from a fresh store → close in a separate session), plus
+   the user guide and this record.
+
+## Known boundary (intentional)
+
+The dispatch-layer MCP jail (`authorize_agent_action` /
+`check_pending_verification`) is a *separate* enforcement layer that blocks solo
+(non-factory, non-supervisor) closes before `cas_task_close` runs. It does **not**
+honor `depth=light`. For the documented factory-worker scenario (default
+`owner = "supervisor"`) that layer is already exempt, so light closes are instant
+end-to-end. A *solo* light close would still hit the dispatch jail — if instant
+solo light closes are ever wanted, that needs a separate depth-light exemption in
+`authorize_agent_action`. Flagged here so a future reader doesn't mistake it for a
+bug.
+
+## For future readers
+
+If you're tempted to make `light` skip more (e.g. the data-state guards), don't —
+those guards protect the repository, not review rigor, and a light task can still
+corrupt a branch. The whole feature is scoped to "the human is the evaluator for
+*this* task", nothing more.
+
+See [`docs/guides/task-depth.md`](../guides/task-depth.md) for the usage-facing
+version.

--- a/docs/notes/release-notes-rubric.md
+++ b/docs/notes/release-notes-rubric.md
@@ -1,0 +1,65 @@
+---
+title: Release Notes Rubric — #cas-internal two-thread announcement
+managed_by: cas
+audience: anyone authoring a CAS release announcement
+---
+
+# Release Notes Rubric
+
+Standard for the CAS release announcement posted to the **#cas-internal** Slack
+channel after a version bump. The announcement is **two independent top-level
+threads**, each with exactly one detail reply (4 messages total).
+
+## Structure (4 messages)
+
+**Thread 1 — USER**
+
+1. **USER summary** (top-level): plain-language before / after / impact
+   paragraph, ~3 sentences. What the experience was before, what it is now, why
+   it matters. Include the version and a "shipped" confirmation. No jargon, no
+   feature names, no CLI commands.
+2. **USER details** (threaded reply): ~5 emoji-led, bold-header bullets, each
+   1–3 sentences. Concrete user-facing wins. Plain prose only.
+
+**Thread 2 — DEV**
+
+3. **DEV summary** (top-level): plain-language paragraph on what changed
+   architecturally and the engineering impact. Orient first, specifics second.
+4. **DEV details** (threaded reply): ~5 bold-header bullets. File paths, struct
+   names, and migration numbers are fine here. Final bullet is **Release
+   mechanics**: version bump, tag, and short commit SHAs.
+
+## Required framing
+
+- Every thread answers **"how it was → how it is now."**
+- USER leads with the before/after paragraph; bullets are supporting detail.
+- DEV may go deeper and more technical, but still orients before drilling in.
+- "Info dump" means **comprehensive** — cover every change since the previous
+  release tag — while staying under the length cap per reply.
+
+## Hard constraints — do NOT
+
+- No internal task/EPIC IDs (`cas-xxxx`) anywhere.
+- No internal-only file paths or struct names in the **USER** thread.
+- **Do not describe internal agent-to-agent coordination chatter or the
+  factory's internal messaging plumbing** — i.e. how supervisor / worker /
+  director sessions talk to each other. When the release enables mixing worker
+  harnesses, frame it as a *user capability* ("run Codex and Claude workers in
+  one project, both with full project context"), not as message-delivery
+  internals.
+- No secrets, tokens, or credentials.
+- Each reply stays under ~500 words.
+
+## Quality bar
+
+- A reader who does not use the tool can understand the USER thread.
+- Concrete over abstract — examples beat descriptions.
+- Both threads are independently scannable.
+
+## Process
+
+- Draft all 4 messages first and get approval **before** posting.
+- Post order: USER summary → capture `message_ts` → USER details
+  (`thread_ts`). Then DEV summary → capture `message_ts` → DEV details
+  (`thread_ts`).
+- Channel: **#cas-internal**.

--- a/docs/reviews/2026-06-25-cas-ca04-cross-harness-comms-verification.md
+++ b/docs/reviews/2026-06-25-cas-ca04-cross-harness-comms-verification.md
@@ -1,0 +1,137 @@
+# EPIC cas-ca04 — Cross-harness factory communication: verification
+
+**Task:** cas-47b7 (verification half) · **Epic:** cas-ca04 · **Date:** 2026-06-25
+**Branch verified:** `factory/tender-hound-15` fast-forwarded to epic tip (`5bd0c29` + this task's tests)
+**Siblings:** cas-b68a (recipient-aware delivery, core) · cas-83c8 (codex worker/supervisor prompts)
+
+## Summary
+
+The fix makes supervisor↔worker message delivery route on the **recipient's**
+harness instead of the supervisor's team-mode. A Codex agent (worker *or*
+supervisor) is always reached over its PTY — the only channel it can read —
+even inside a Claude Agent-Teams factory, and the injected text is framed
+`Message from <sender>: …` so the codex prompt recognizes it as an actionable
+turn. Claude agents keep using the team inbox unchanged.
+
+Two deliverables: (1) in-repo routing-decision regression matrix — **complete &
+green**; (2) live e2e smoke matrix — **routing code-proven for all legs;
+live-rollout confirmation of the codex legs is supervisor-gated** (needs a
+rebuilt binary + factory restart with codex panes) and is documented below as a
+runbook with the all-Claude legs already observed live in this session.
+
+## Deliverable 1 — routing-decision regression matrix (in-repo, no live MCP)
+
+Added `cas-cli/src/ui/factory/daemon/runtime/delivery_matrix_tests.rs`. It drives
+the pure routers (`choose_channel`, `requires_pty_readiness_gate`,
+`pty_payload_needs_framing`) over every factory shape and both directions,
+re-deriving the expected answer from the contract.
+
+`teams_active` is true exactly when the supervisor is Claude (only a Claude
+supervisor launches native Agent Teams; a Codex-supervised factory runs
+`teams = None`). The recipient is the worker for downward (`target=<worker>`)
+and the supervisor for upward (`target=supervisor`).
+
+| # | Factory shape | Direction | Recipient | teams | Channel | PTY gate | Framed |
+|---|---|---|---|---|---|---|---|
+| 1 | claude-sup / codex-worker | down → worker | Codex | yes | **PTY** | yes | yes |
+| 1u| claude-sup / codex-worker | up → supervisor | Claude | yes | TeamsInbox | no | no |
+| 2 | codex-sup / claude-worker | down → worker | Claude | no | PTY (fallback) | yes | no |
+| 2u| codex-sup / claude-worker | up → supervisor | Codex | no | **PTY** | yes | yes |
+| 3 | codex-sup / codex-worker | down → worker | Codex | no | PTY | yes | yes |
+| 3u| codex-sup / codex-worker | up → supervisor | Codex | no | **PTY** | yes | yes |
+| 4 | claude-sup / claude-worker | down → worker | Claude | yes | TeamsInbox | no | no |
+| 4u| claude-sup / claude-worker | up → supervisor | Claude | yes | TeamsInbox | no | no |
+
+Bold cells are the legs the bug previously broke: a Codex recipient was written
+to a team inbox it cannot read. Rows 1 and 2u/3u are the load-bearing fixes
+(codex worker reachable downward; codex supervisor woken upward). Rows 4/4u are
+the all-Claude regression baseline — must stay on the inbox, byte-for-byte.
+
+`all_workers` fan-out is covered too: a broadcast in a mixed (teams-active)
+factory routes per-recipient — codex members over framed PTY, claude members
+over the inbox — matching the per-worker loop in `queue_and_events.rs`.
+
+**Ownership note:** `delivery.rs` (cas-b68a's file) is left byte-for-byte
+unchanged; the matrix is a new test file registered with one `#[cfg(test)] mod`
+line. The pure routers are `pub(crate)`, so the matrix must live in-crate (an
+integration test under `tests/` cannot reach them) — hence a sibling test
+module, not a `tests/` file.
+
+### Full assembled-epic gate
+
+`cargo test --no-fail-fast` on the assembled epic: **4259 passed, 0 failed.**
+
+The two reds cas-b68a flagged for this task to adjudicate:
+
+- **`factory_codex_skill_guardrails::codex_worker_runtime_instruction_allows_close_then_escalate`**
+  — CONFIRMED pre-existing, red on `main` (`92b7a78`) before the epic. The worker
+  prompt has read "close **it** with `mcp__cs__task action=close…`" since
+  cas-bbc2 (`32a3796`), but the guardrail asserted the literal "close with".
+  Fixed in the **test file** (owned by this task) to assert on the close-command
+  form (`` `mcp__cs__task action=close ``) so prose tweaks don't re-break it.
+  `pty.rs` source was correct and was **not** touched. Not filed back to cas-83c8
+  — there is no source bug, only a stale assertion.
+- **parallel cwd-race flake** — did **not** recur across two full `--no-fail-fast`
+  runs. No code change; flagged as environmental (see the "no tmpfs / cwd-race"
+  hygiene notes). If it resurfaces it is a test-isolation issue, not a delivery
+  regression.
+
+## Deliverable 2 — live e2e smoke matrix
+
+Each path must show the recipient producing a **new** turn (codex: a new
+`user_message`/`turn` in its rollout JSONL; claude: a new entry in its session
+JSONL) within seconds of a `coordination action=message`.
+
+| # | Path | Status | Evidence |
+|---|---|---|---|
+| 1 | claude-sup → codex-worker | code-proven; live-pending | row 1 |
+| 2 | codex-sup → claude-worker | code-proven; live-pending | row 2 |
+| 3 | codex-sup → codex-worker | code-proven; live-pending | row 3 |
+| 4 | claude-sup → claude-worker (regression) | **live-observed** | this session: task assignments + messages delivered to this Claude worker as new turns |
+| 5 | codex-worker → claude-sup | code-proven; live-pending | row 2u (claude recipient via inbox) |
+| 6 | codex-worker → codex-sup | code-proven; live-pending | row 3u |
+| 7 | claude-worker → codex-sup | code-proven; live-pending | codex recipient → framed PTY |
+
+**Live-observed (path 4 + claude-worker→claude-sup):** in this very session a
+Claude worker (tender-hound-15) under a Claude supervisor (proud-owl-91)
+received two task assignments and several messages as fresh turns, and its
+replies reached the supervisor — the all-Claude inbox path is intact (no
+regression).
+
+**Why the codex legs are live-pending (not a worker action):** a real codex-leg
+rollout requires the **fixed binary** running the daemon and a **factory
+restarted with codex panes**. The currently-attached daemon is not guaranteed to
+be the epic-built binary, and a worker cannot rebuild + restart the factory
+(`cas factory` restart is a supervisor/operator action). The routing decision
+for every codex leg is proven by Deliverable 1; what remains is a human-driven
+rollout confirmation. SQLite/MCP restart caveat applies after swapping the
+binary.
+
+### Runbook to close the live codex legs
+
+1. Build the epic binary: `cargo build --release` on the epic branch, install it
+   (`cas update --user` or point PATH at the fresh `cas`).
+2. Restart the factory with at least one codex worker (and, for legs 5–7, a
+   codex supervisor): `cas factory --attach` with codex panes.
+3. For each codex-recipient leg, send `mcp__cas__coordination action=message
+   target=<recipient> message="ping <leg-id>"` (or assign a task).
+4. Confirm the new turn in the recipient's rollout:
+   - codex: `tail -f ~/.codex/sessions/$(date +%Y/%m/%d)/rollout-*.jsonl` and
+     watch for a new `user_message` carrying `Message from <sender>: ping …`.
+   - claude: the recipient's `~/.claude/projects/<flattened-path>/<uuid>.jsonl`.
+5. Confirm the **framing** on codex recipients (the literal `Message from
+   <sender>: ` prefix) and the **absence** of framing on claude recipients.
+6. Record pass/fail per leg back into this table. Any failing leg is filed to the
+   owning task (cas-b68a for delivery, cas-83c8 for prompt recognition) — not
+   patched here.
+
+## Acceptance criteria status
+
+- Matrix routing-decision tests cover all 4 harness combos × both directions —
+  **done**, `cargo test --no-fail-fast` green (4259/0).
+- Live smoke matrix documented with per-path status + evidence; the all-Claude
+  regression leg observed live, codex legs code-proven with a runbook for the
+  human-gated rollout confirmation — **documented; codex-leg live rollout
+  supervisor-gated.**
+- claude-sup→claude-worker and codex-only paths shown unchanged — **rows 3/3u/4/4u
+  + live observation of the all-Claude path.**


### PR DESCRIPTION
**DRAFT / held open intentionally** — keep open until the per-task depth-flag (speed mode) work (cas-1255) lands, then finalize notes + merge/tag/push `v2.22.0`.

## In this release
- **Codex becomes a first-class worker harness**
  - Spawn-inject the CAS MCP server into Codex agents (`cas-bbc2`)
  - **Auto-registration**: inject `CAS_SESSION_ID` into the Codex `cs` MCP env so it registers on the first call; drop the brittle `session_start` dance that looped a fresh worker on "Agent not registered" (`cas-3522`)
  - Mid-session Codex wakeups handled in worker/supervisor prompts (`cas-83c8`)
  - Export `ZIG` for workers so a fresh worktree's first `cargo build` finds the toolchain instead of failing in `ghostty_vt_sys` (`cas-3522` follow-on)
- **Recipient-aware cross-harness delivery** + routing matrix/runbook (`cas-b68a`, `cas-47b7`)
- **Secret redaction** in `cas mcp list --json`; `--show-secrets` opt-in (`cas-9f07`)
- Version bump 2.21.0 → 2.22.0, release-notes draft, and the committed release-notes rubric

## Verification
- `cargo test -p cas -p cas-pty --no-fail-fast` green (incl. 4 new cas-pty tests)

## Deferred to fast-follow (NOT in this PR)
- `cas-fb94` — director re-fires completion nudges in an infinite loop on a held task (root cause: active-set/lease oscillation → TaskCompleted + TaskAssigned spam) and `shutdown_workers` leaves the codex process tree alive. Needs root-cause work + time-injectable tests; deliberately not rushed into this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)