### PR TITLE
fix(factory): director assignment guidance + idle/close suppression (cas-dbbb + cas-6aaf)

### DIFF
--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -101,26 +101,51 @@ impl CasCore {
         let mut warnings: Vec<String> = Vec::new();
 
         if let Some(ref assignee) = req.assignee {
-            // Check worktree staleness when assigning in factory mode
+            // In factory mode: normalize and validate the assignee value.
+            //
+            // cas-dbbb: `task mine` matches assignees against agent_name (the
+            // display name) and CAS_AGENT_NAME env var. Assigning by session UUID /
+            // agent ID is silently accepted but the task never appears in the target
+            // worker's `task mine` list — observed in the 2026-06-30 smoke test
+            // where director-provided session IDs left tasks in Ready/Open with no
+            // visible assignee, while worker names dispatched correctly.
+            //
+            // Resolution order:
+            //   1. Assignee matches agent.name → canonical, store as-is.
+            //   2. Assignee matches agent.id  → normalize to agent.name, warn.
+            //   3. No match                   → warn; store as-is (agent may not yet
+            //                                   be registered, e.g. pre-spawn).
+            let mut canonical_assignee = assignee.clone();
             if std::env::var("CAS_FACTORY_MODE").is_ok() {
                 let config = self.load_config();
                 let factory_config = config.factory();
 
-                if factory_config.warn_stale_assignment || factory_config.block_stale_assignment {
-                    // Look up the worker agent by name to get their clone_path
-                    if let Ok(agent_store) = self.open_agent_store() {
-                        if let Ok(agents) = agent_store.list(None) {
-                            if let Some(worker) = agents.iter().find(|a| &a.name == assignee) {
+                if let Ok(agent_store) = self.open_agent_store() {
+                    if let Ok(agents) = agent_store.list(None) {
+                        // Find by name first (canonical path).
+                        let by_name = agents.iter().find(|a| a.name == *assignee);
+                        // Fall back to ID lookup (supervisor may have copy-pasted session UUID).
+                        let by_id = if by_name.is_none() {
+                            agents.iter().find(|a| a.id == *assignee)
+                        } else {
+                            None
+                        };
+
+                        if let Some(worker) = by_name {
+                            // Canonical — no normalization needed.
+                            // Worktree staleness check.
+                            if factory_config.warn_stale_assignment
+                                || factory_config.block_stale_assignment
+                            {
                                 if let Some(clone_path) = worker.metadata.get("clone_path") {
                                     if let Some((behind_count, branch)) =
                                         check_worktree_staleness(clone_path)
                                     {
                                         if behind_count > 0 {
                                             let warning_msg = format!(
-                                                "⚠️ Worker '{assignee}' is {behind_count} commit(s) behind {branch}. Consider syncing first."
+                                                "⚠️ Worker '{assignee}' is {behind_count} commit(s) \
+                                                 behind {branch}. Consider syncing first."
                                             );
-
-                                            // Block if configured and above threshold
                                             if factory_config.block_stale_assignment
                                                 && behind_count
                                                     >= factory_config.stale_threshold_commits
@@ -128,7 +153,9 @@ impl CasCore {
                                                 return Err(McpError {
                                                     code: ErrorCode::INVALID_PARAMS,
                                                     message: Cow::from(format!(
-                                                        "Cannot assign to worker '{}': {} commits behind {} (threshold: {}). Ask the worker to rebase: `git rebase {}`",
+                                                        "Cannot assign to worker '{}': {} commits \
+                                                         behind {} (threshold: {}). Ask the worker \
+                                                         to rebase: `git rebase {}`",
                                                         assignee,
                                                         behind_count,
                                                         branch,
@@ -138,18 +165,37 @@ impl CasCore {
                                                     data: None,
                                                 });
                                             }
-
                                             warnings.push(warning_msg);
                                         }
                                     }
                                 }
                             }
+                        } else if let Some(worker) = by_id {
+                            // Assignee is a session UUID — normalize to display name
+                            // so `task mine` can find it.
+                            let worker_name = worker.name.clone();
+                            warnings.push(format!(
+                                "⚠️ Assignee '{assignee}' is a session ID. \
+                                 Normalized to display name '{worker_name}' so \
+                                 `task mine` can find this task. \
+                                 Use '{worker_name}' directly to avoid this warning."
+                            ));
+                            canonical_assignee = worker_name;
+                        } else {
+                            // No agent found by name or ID — warn but allow (agent
+                            // may not yet be registered, e.g. spawning in progress).
+                            warnings.push(format!(
+                                "⚠️ No registered factory agent found for assignee '{assignee}'. \
+                                 Verify the worker name with `mcp__cas__system action=worker_status`. \
+                                 Use the worker's display name (e.g. 'codex-jester'), not their \
+                                 session UUID, for reliable `task mine` dispatch."
+                            ));
                         }
                     }
                 }
             }
 
-            task.assignee = Some(assignee.clone());
+            task.assignee = Some(canonical_assignee);
             changes.push("assignee");
         }
 

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -123,10 +123,13 @@ impl CasCore {
                 if let Ok(agent_store) = self.open_agent_store() {
                     if let Ok(agents) = agent_store.list(None) {
                         // Find by name first (canonical path).
-                        let by_name = agents.iter().find(|a| a.name == *assignee);
+                        // cas-dbbb P2: use case-insensitive compare to match
+                        // `task mine`'s own identity matching logic.
+                        let by_name =
+                            agents.iter().find(|a| a.name.eq_ignore_ascii_case(assignee));
                         // Fall back to ID lookup (supervisor may have copy-pasted session UUID).
                         let by_id = if by_name.is_none() {
-                            agents.iter().find(|a| a.id == *assignee)
+                            agents.iter().find(|a| a.id.eq_ignore_ascii_case(assignee))
                         } else {
                             None
                         };
@@ -180,7 +183,43 @@ impl CasCore {
                                  `task mine` can find this task. \
                                  Use '{worker_name}' directly to avoid this warning."
                             ));
-                            canonical_assignee = worker_name;
+                            canonical_assignee = worker_name.clone();
+                            // cas-dbbb P1: run the same staleness check as the by_name
+                            // branch. The original code skipped this after normalization,
+                            // leaving stale-worktree blocking disabled for UUID assignees.
+                            if factory_config.warn_stale_assignment
+                                || factory_config.block_stale_assignment
+                            {
+                                if let Some(clone_path) = worker.metadata.get("clone_path") {
+                                    if let Some((behind_count, branch)) =
+                                        check_worktree_staleness(clone_path)
+                                    {
+                                        if behind_count > 0 {
+                                            let staleness_msg = format!(
+                                                "⚠️ Worker '{worker_name}' is {behind_count} \
+                                                 commit(s) behind {branch}. Consider syncing first."
+                                            );
+                                            if factory_config.block_stale_assignment
+                                                && behind_count
+                                                    >= factory_config.stale_threshold_commits
+                                            {
+                                                return Err(McpError {
+                                                    code: ErrorCode::INVALID_PARAMS,
+                                                    message: Cow::from(format!(
+                                                        "Cannot assign to worker '{worker_name}': \
+                                                         {behind_count} commits behind {branch} \
+                                                         (threshold: {}). Ask the worker to rebase: \
+                                                         `git rebase {branch}`",
+                                                        factory_config.stale_threshold_commits,
+                                                    )),
+                                                    data: None,
+                                                });
+                                            }
+                                            warnings.push(staleness_msg);
+                                        }
+                                    }
+                                }
+                            }
                         } else {
                             // No agent found by name or ID — warn but allow (agent
                             // may not yet be registered, e.g. spawning in progress).

--- a/cas-cli/src/ui/factory/director/prompts.rs
+++ b/cas-cli/src/ui/factory/director/prompts.rs
@@ -165,35 +165,29 @@ pub fn generate_prompt(
                 return None;
             }
 
-            // Guard (cas-889d): suppress idle nudge if the worker already has an
-            // active in_progress task in the current snapshot. This defends against
-            // the window where the event slips through the event-level gate (e.g.
-            // the consecutive-tick debounce fired just before the worker claimed a
-            // task). Checking by both session-ID assignee (standard DB path) and
-            // display-name assignee (legacy manual assignment path) makes this
-            // robust to either storage convention.
-            let worker_is_busy = data.in_progress_tasks.iter().any(|t| {
-                t.assignee.as_deref() == Some(worker.as_str())
-                    || data
-                        .agent_id_to_name
-                        .iter()
-                        .any(|(id, name)| name == worker && t.assignee.as_deref() == Some(id))
-            });
+            // Guard (cas-889d / cas-dbbb): suppress idle nudge if the worker already
+            // has an active in_progress task OR an assigned-but-not-yet-started Open
+            // task in the current snapshot. Checking in_progress_tasks alone misses
+            // the window between `task.update assignee=<name>` (status stays Open)
+            // and the worker calling `task start` (status becomes InProgress) — the
+            // director would incorrectly re-fire WorkerIdle during that gap.
+            //
+            // Checking by both display-name assignee (canonical DB path) and session-ID
+            // assignee (legacy assignment path) makes this robust to either convention.
+            let worker_is_busy = data
+                .in_progress_tasks
+                .iter()
+                .chain(data.ready_tasks.iter())
+                .any(|t| {
+                    t.assignee.as_deref() == Some(worker.as_str())
+                        || data
+                            .agent_id_to_name
+                            .iter()
+                            .any(|(id, name)| name == worker && t.assignee.as_deref() == Some(id))
+                });
             if worker_is_busy {
                 return None;
             }
-
-            // cas-889d: `task action=update assignee=<name>` is wrong — `task mine`
-            // resolves on SESSION ID, so names are invisible to the worker. Look up
-            // the session ID from the already-filtered agent_id_to_name map (which
-            // maps session-ID → display-name). Fall back to the display name only if
-            // the lookup fails (e.g. agent left the session between snapshot and now).
-            let worker_session_id = data
-                .agent_id_to_name
-                .iter()
-                .find(|(_, name)| name.as_str() == worker.as_str())
-                .map(|(id, _)| id.as_str())
-                .unwrap_or(worker.as_str());
 
             // Count only truly-dispatchable tasks (Open + unassigned). See
             // `dispatchable_ready_count` for why `ready_tasks.len()` is wrong.
@@ -210,10 +204,16 @@ pub fn generate_prompt(
                 // gap. Advertising a stale number causes the supervisor to
                 // under-assign or over-assign, so we remove the specific count and
                 // direct them to the live command instead.
+                //
+                // cas-dbbb: use the worker's display name (not session ID) for
+                // `assignee=`. `task mine` matches on agent_name (the display
+                // name) and CAS_AGENT_NAME env — worker display names dispatch
+                // correctly. Session IDs stored as `assignee` are silently accepted
+                // by `task update` but do NOT match `task mine`'s identity set.
                 format!(
                     "Worker {worker} is idle with no assigned tasks.\n\
                      Ready tasks exist — check live: `{supervisor_prefix}task action=ready`\n\
-                     Assign work: {supervisor_prefix}task action=update id=<task-id> assignee={worker_session_id}"
+                     Assign work: {supervisor_prefix}task action=update id=<task-id> assignee={worker}"
                 )
             } else {
                 // Do NOT suggest "closing the epic" here — the task snapshot may
@@ -248,25 +248,34 @@ pub fn generate_prompt(
                 return None;
             }
 
-            // Guard (cas-889d): suppress registration nudge if the newly-registered
-            // worker already has an active in_progress task (e.g. a reconnect after
-            // a session restart). Use both ID-keyed and name-keyed assignee checks
-            // for the same reason as WorkerIdle above.
-            let worker_already_busy = data.in_progress_tasks.iter().any(|t| {
-                t.assignee.as_deref() == Some(agent_id.as_str())
-                    || t.assignee.as_deref() == Some(agent_name.as_str())
-            });
+            // Guard (cas-889d / cas-dbbb): suppress registration nudge if the
+            // newly-registered worker already has an active in_progress task OR an
+            // assigned-but-not-yet-started Open task (reconnect after session restart,
+            // or assignment during the registration window). Check both ID-keyed and
+            // name-keyed assignees for the same reason as WorkerIdle above.
+            let worker_already_busy = data
+                .in_progress_tasks
+                .iter()
+                .chain(data.ready_tasks.iter())
+                .any(|t| {
+                    t.assignee.as_deref() == Some(agent_id.as_str())
+                        || t.assignee.as_deref() == Some(agent_name.as_str())
+                });
             if worker_already_busy {
                 return None;
             }
 
             let ready_count = dispatchable_ready_count(data);
 
+            // cas-dbbb: use agent_name (display name) for `assignee=`, not agent_id
+            // (session UUID). `task mine` matches on agent_name and CAS_AGENT_NAME
+            // env var. Assigning by session UUID is silently accepted by `task update`
+            // but does NOT appear in `task mine` for the target worker.
             let text = if ready_count > 0 {
                 format!(
                     "Worker {agent_name} is ready and waiting for tasks.\n\
                      There are {ready_count} ready tasks available.\n\
-                     Assign work: {supervisor_prefix}task action=update id=<task-id> assignee={agent_id}"
+                     Assign work: {supervisor_prefix}task action=update id=<task-id> assignee={agent_name}"
                 )
             } else {
                 format!(
@@ -666,17 +675,19 @@ mod tests {
         }
     }
 
-    /// cas-889d: WorkerIdle assignee template must use the worker's session ID, not
-    /// the display name. `task mine` resolves on session ID; display names are
-    /// invisible. The `agent_id_to_name` map (session_id → display_name) is used to
-    /// reverse-look up the session ID.
+    /// cas-dbbb: WorkerIdle assignee template must use the worker's display name
+    /// (not the session ID). `task mine` matches on agent_name and CAS_AGENT_NAME
+    /// env var — worker names dispatch correctly. Session IDs are silently accepted
+    /// by `task update` but do NOT appear in `task mine` for the target worker
+    /// (confirmed in smoke test 2026-06-30: session-ID assignments left tasks in
+    /// Ready/Open with no visible assignee; name-based assignments dispatched).
     #[test]
-    fn test_889d_worker_idle_assignee_uses_session_id() {
+    fn test_dbbb_worker_idle_assignee_uses_display_name() {
         let event = DirectorEvent::WorkerIdle {
             worker: "swift-fox".to_string(),
         };
 
-        // Populate agent_id_to_name so the reverse-lookup succeeds.
+        // Populate agent_id_to_name — the display name must be used regardless.
         let mut data = make_data(2);
         data.agent_id_to_name
             .insert("sess-id-abc123".to_string(), "swift-fox".to_string());
@@ -685,15 +696,15 @@ mod tests {
         let prompt =
             generate_prompt(&event, &data, "supervisor", &config, codex(), codex()).unwrap();
 
-        // The assignee= value must be the session ID, not the display name.
+        // The assignee= value must be the display name, not the session ID.
         assert!(
-            prompt.text.contains("assignee=sess-id-abc123"),
-            "cas-889d: WorkerIdle must use session ID in assignee field, got: {}",
+            prompt.text.contains("assignee=swift-fox"),
+            "cas-dbbb: WorkerIdle must use display name in assignee field, got: {}",
             prompt.text
         );
         assert!(
-            !prompt.text.contains("assignee=swift-fox"),
-            "cas-889d: WorkerIdle must NOT use display name in assignee field, got: {}",
+            !prompt.text.contains("assignee=sess-id-abc123"),
+            "cas-dbbb: WorkerIdle must NOT use session ID in assignee field, got: {}",
             prompt.text
         );
     }
@@ -742,10 +753,13 @@ mod tests {
         );
     }
 
-    /// cas-889d: AgentRegistered assignee template must use the session ID
-    /// (`agent_id` from the event), not the display name (`agent_name`).
+    /// cas-dbbb: AgentRegistered assignee template must use the display name
+    /// (`agent_name`), not the session ID (`agent_id`). `task mine` matches on
+    /// agent_name and CAS_AGENT_NAME env var. Session-ID assignments are silently
+    /// accepted by `task update` but the task does not appear in `task mine` for
+    /// the target worker (confirmed in 2026-06-30 smoke test).
     #[test]
-    fn test_889d_agent_registered_assignee_uses_session_id() {
+    fn test_dbbb_agent_registered_assignee_uses_display_name() {
         let event = DirectorEvent::AgentRegistered {
             agent_id: "sess-id-abc123".to_string(),
             agent_name: "calm-owl".to_string(),
@@ -756,13 +770,13 @@ mod tests {
             generate_prompt(&event, &data, "supervisor", &config, codex(), codex()).unwrap();
 
         assert!(
-            prompt.text.contains("assignee=sess-id-abc123"),
-            "cas-889d: AgentRegistered must use session ID in assignee field, got: {}",
+            prompt.text.contains("assignee=calm-owl"),
+            "cas-dbbb: AgentRegistered must use display name in assignee field, got: {}",
             prompt.text
         );
         assert!(
-            !prompt.text.contains("assignee=calm-owl"),
-            "cas-889d: AgentRegistered must NOT use display name in assignee field, got: {}",
+            !prompt.text.contains("assignee=sess-id-abc123"),
+            "cas-dbbb: AgentRegistered must NOT use session ID in assignee field, got: {}",
             prompt.text
         );
     }
@@ -785,6 +799,66 @@ mod tests {
             prompt.is_none(),
             "cas-889d: AgentRegistered must be suppressed when worker already has active task, got: {:?}",
             prompt.map(|p| p.text)
+        );
+    }
+
+    /// cas-dbbb: AgentRegistered and WorkerIdle must be suppressed when the worker
+    /// has an assigned Open (not yet InProgress) task. Without this, the director
+    /// fires idle/registration nudges in the window between `task update assignee=X`
+    /// (task stays Open) and the worker calling `task start` (task becomes InProgress).
+    #[test]
+    fn test_dbbb_idle_suppressed_when_worker_has_assigned_ready_task() {
+        // ready_tasks (Open) with worker as the assignee — simulates the post-assign,
+        // pre-start window.
+        let task = TaskSummary {
+            id: "task-assigned".to_string(),
+            title: "Assigned Task".to_string(),
+            status: TaskStatus::Open,
+            priority: Priority::MEDIUM,
+            assignee: Some("swift-fox".to_string()),
+            task_type: TaskType::Task,
+            epic: None,
+            branch: None,
+            updated_at: None,
+        };
+        let data = DirectorData {
+            ready_tasks: vec![task],
+            in_progress_tasks: vec![],
+            epic_tasks: vec![],
+            agents: vec![],
+            activity: vec![],
+            agent_id_to_name: HashMap::new(),
+            changes: vec![],
+            git_loaded: true,
+            reminders: vec![],
+            epic_closed_counts: HashMap::new(),
+        };
+        let config = default_config();
+
+        // WorkerIdle must be suppressed.
+        let idle_event = DirectorEvent::WorkerIdle {
+            worker: "swift-fox".to_string(),
+        };
+        let prompt = generate_prompt(&idle_event, &data, "supervisor", &config, codex(), codex());
+        assert!(
+            prompt.is_none(),
+            "cas-dbbb: WorkerIdle must be suppressed when worker has an assigned Open task \
+             (post-assign, pre-start window): got {:?}",
+            prompt.map(|p| p.text)
+        );
+
+        // AgentRegistered must also be suppressed.
+        let reg_event = DirectorEvent::AgentRegistered {
+            agent_id: "sess-id-xyz".to_string(),
+            agent_name: "swift-fox".to_string(),
+        };
+        let prompt2 =
+            generate_prompt(&reg_event, &data, "supervisor", &config, codex(), codex());
+        assert!(
+            prompt2.is_none(),
+            "cas-dbbb: AgentRegistered must be suppressed when worker has an assigned Open task: \
+             got {:?}",
+            prompt2.map(|p| p.text)
         );
     }
 

--- a/cas-cli/src/ui/factory/director/prompts.rs
+++ b/cas-cli/src/ui/factory/director/prompts.rs
@@ -210,12 +210,22 @@ pub fn generate_prompt(
             // and the worker calling `task start` (status becomes InProgress) — the
             // director would incorrectly re-fire WorkerIdle during that gap.
             //
+            // Blocked tasks are EXCLUDED: `ready_tasks` contains both Open and Blocked
+            // tasks, but a worker with only a Blocked task is genuinely stalled and may
+            // still need an idle nudge. Including Blocked tasks here would suppress
+            // WorkerIdle indefinitely for stalled workers.
+            //
             // Checking by both display-name assignee (canonical DB path) and session-ID
-            // assignee (legacy assignment path) makes this robust to either convention.
+            // assignee (legacy assignment path via agent_id_to_name) makes this robust
+            // to either convention.
             let worker_is_busy = data
                 .in_progress_tasks
                 .iter()
-                .chain(data.ready_tasks.iter())
+                .chain(
+                    data.ready_tasks
+                        .iter()
+                        .filter(|t| t.status == TaskStatus::Open),
+                )
                 .any(|t| {
                     t.assignee.as_deref() == Some(worker.as_str())
                         || data
@@ -291,10 +301,16 @@ pub fn generate_prompt(
             // assigned-but-not-yet-started Open task (reconnect after session restart,
             // or assignment during the registration window). Check both ID-keyed and
             // name-keyed assignees for the same reason as WorkerIdle above.
+            //
+            // Blocked tasks are EXCLUDED (see WorkerIdle guard comment above).
             let worker_already_busy = data
                 .in_progress_tasks
                 .iter()
-                .chain(data.ready_tasks.iter())
+                .chain(
+                    data.ready_tasks
+                        .iter()
+                        .filter(|t| t.status == TaskStatus::Open),
+                )
                 .any(|t| {
                     t.assignee.as_deref() == Some(agent_id.as_str())
                         || t.assignee.as_deref() == Some(agent_name.as_str())
@@ -1007,6 +1023,140 @@ mod tests {
             "cas-dbbb: AgentRegistered must be suppressed when worker has an assigned Open task: \
              got {:?}",
             prompt2.map(|p| p.text)
+        );
+    }
+
+    /// cas-dbbb P2: WorkerIdle must NOT be suppressed when the worker's only task
+    /// is Blocked. A Blocked task means the worker is genuinely stalled; the
+    /// supervisor still needs an idle nudge so they can resolve the blocker or
+    /// assign new work. Including Blocked tasks in the busy-guard would suppress
+    /// the nudge indefinitely.
+    #[test]
+    fn test_dbbb_idle_not_suppressed_when_worker_only_has_blocked_task() {
+        let blocked_task = TaskSummary {
+            id: "task-blocked".to_string(),
+            title: "Blocked Task".to_string(),
+            status: TaskStatus::Blocked,
+            priority: Priority::MEDIUM,
+            assignee: Some("swift-fox".to_string()),
+            task_type: TaskType::Task,
+            epic: None,
+            branch: None,
+            updated_at: None,
+        };
+        let data = DirectorData {
+            // Blocked task is in ready_tasks (Open|Blocked both land here).
+            ready_tasks: vec![blocked_task],
+            in_progress_tasks: vec![],
+            epic_tasks: vec![],
+            agents: vec![],
+            activity: vec![],
+            agent_id_to_name: HashMap::new(),
+            changes: vec![],
+            git_loaded: true,
+            reminders: vec![],
+            epic_closed_counts: HashMap::new(),
+        };
+
+        let event = DirectorEvent::WorkerIdle {
+            worker: "swift-fox".to_string(),
+        };
+        let config = default_config();
+        let prompt = generate_prompt(&event, &data, "supervisor", &config, codex(), codex());
+        assert!(
+            prompt.is_some(),
+            "cas-dbbb P2: WorkerIdle must NOT be suppressed when worker has only a Blocked task \
+             (blocked ≠ busy). Got: None"
+        );
+    }
+
+    /// cas-dbbb P2: WorkerIdle must be suppressed when the worker has a session-ID
+    /// assignee on an Open task in ready_tasks, with agent_id_to_name mapping the
+    /// session ID to the worker's display name. This covers the chain()
+    /// + session-ID path added in cas-dbbb.
+    #[test]
+    fn test_dbbb_idle_suppressed_via_session_id_in_ready_open_task() {
+        let open_task = TaskSummary {
+            id: "task-open-session-id".to_string(),
+            title: "Session-ID assigned Open task".to_string(),
+            status: TaskStatus::Open,
+            priority: Priority::MEDIUM,
+            assignee: Some("sess-id-abc123".to_string()),
+            task_type: TaskType::Task,
+            epic: None,
+            branch: None,
+            updated_at: None,
+        };
+        let mut data = DirectorData {
+            ready_tasks: vec![open_task],
+            in_progress_tasks: vec![],
+            epic_tasks: vec![],
+            agents: vec![],
+            activity: vec![],
+            agent_id_to_name: HashMap::new(),
+            changes: vec![],
+            git_loaded: true,
+            reminders: vec![],
+            epic_closed_counts: HashMap::new(),
+        };
+        // The reverse-lookup maps session ID → display name.
+        data.agent_id_to_name
+            .insert("sess-id-abc123".to_string(), "swift-fox".to_string());
+
+        let event = DirectorEvent::WorkerIdle {
+            worker: "swift-fox".to_string(),
+        };
+        let config = default_config();
+        let prompt = generate_prompt(&event, &data, "supervisor", &config, codex(), codex());
+        assert!(
+            prompt.is_none(),
+            "cas-dbbb P2: WorkerIdle must be suppressed when worker has a session-ID assigned \
+             Open task in ready_tasks (agent_id_to_name reverse-lookup path). Got: {:?}",
+            prompt.map(|p| p.text)
+        );
+    }
+
+    /// cas-dbbb P2: AgentRegistered must be suppressed when the worker's session ID
+    /// matches an assignee on an Open task in ready_tasks. This verifies the
+    /// chain() + agent_id path added in cas-dbbb.
+    #[test]
+    fn test_dbbb_agent_registered_suppressed_via_session_id_in_ready_open_task() {
+        let open_task = TaskSummary {
+            id: "task-reg-session-id".to_string(),
+            title: "Session-ID assigned for registration test".to_string(),
+            status: TaskStatus::Open,
+            priority: Priority::MEDIUM,
+            // Assignee is the session UUID (agent_id), not the display name.
+            assignee: Some("sess-id-abc123".to_string()),
+            task_type: TaskType::Task,
+            epic: None,
+            branch: None,
+            updated_at: None,
+        };
+        let data = DirectorData {
+            ready_tasks: vec![open_task],
+            in_progress_tasks: vec![],
+            epic_tasks: vec![],
+            agents: vec![],
+            activity: vec![],
+            agent_id_to_name: HashMap::new(),
+            changes: vec![],
+            git_loaded: true,
+            reminders: vec![],
+            epic_closed_counts: HashMap::new(),
+        };
+
+        let event = DirectorEvent::AgentRegistered {
+            agent_id: "sess-id-abc123".to_string(),
+            agent_name: "calm-owl".to_string(),
+        };
+        let config = default_config();
+        let prompt = generate_prompt(&event, &data, "supervisor", &config, codex(), codex());
+        assert!(
+            prompt.is_none(),
+            "cas-dbbb P2: AgentRegistered must be suppressed when session ID (agent_id) is the \
+             assignee of an Open task in ready_tasks. Got: {:?}",
+            prompt.map(|p| p.text)
         );
     }
 

--- a/cas-cli/src/ui/factory/director/prompts.rs
+++ b/cas-cli/src/ui/factory/director/prompts.rs
@@ -115,15 +115,53 @@ pub fn generate_prompt(
                 return None;
             }
 
-            let text = format!(
-                "Worker {worker} has completed task {task_id} ({task_title}).\n\n\
-                 Next steps:\n\
-                 - Tell the worker to close their own task: {worker_prefix}task action=close id={task_id}\n\
-                 - If close triggers verification, the worker handles it (not you)\n\
-                 - Then assign another task to this worker, OR\n\
-                 - If all subtasks are done, YOU verify and close the epic\n\n\
-                 Remember: workers close their own tasks, supervisors close epics."
-            );
+            // cas-6aaf: check current task state before emitting guidance.
+            //
+            // `TaskCompleted` fires when a task disappears from `in_progress_tasks`,
+            // which happens when it transitions to `Closed`. However, lease churn
+            // can also cause a task to temporarily regress to `Open` (lease expired
+            // → status reset to Open). We check the current snapshot to distinguish
+            // the two cases and avoid emitting "please close" guidance for a task
+            // the worker has already closed.
+            //
+            // State resolution:
+            //   - task absent from ready+in_progress → closed (expected path)
+            //   - task in ready_tasks as Open       → lease expired, still needs close
+            //   - task in in_progress_tasks         → still being worked (edge case)
+            let in_ready = data
+                .ready_tasks
+                .iter()
+                .any(|t| t.id == *task_id && t.status == cas_types::TaskStatus::Open);
+            let in_progress = data
+                .in_progress_tasks
+                .iter()
+                .any(|t| t.id == *task_id);
+
+            let text = if in_ready {
+                // Task regressed to Open (lease expired) — worker needs to close it.
+                format!(
+                    "Worker {worker} was working on task {task_id} ({task_title}) but \
+                     it is now Open (lease may have expired).\n\n\
+                     Next steps:\n\
+                     - Ask the worker to close: {worker_prefix}task action=close id={task_id}\n\
+                     - If they have uncommitted work, they should commit first, then close\n\
+                     - If close triggers verification, the worker handles it (not you)\n\n\
+                     Remember: workers close their own tasks, supervisors close epics."
+                )
+            } else if in_progress {
+                // Still in progress — stale event, nothing to do.
+                return None;
+            } else {
+                // Task is already closed (the normal path after a successful close).
+                // Do NOT instruct the supervisor to ask the worker to close it again.
+                format!(
+                    "Worker {worker} has closed task {task_id} ({task_title}).\n\n\
+                     Next steps:\n\
+                     - Assign another task to this worker, OR\n\
+                     - If all subtasks are done, verify and close the epic\n\n\
+                     Remember: workers close their own tasks, supervisors close epics."
+                )
+            };
 
             Some(Prompt {
                 target: supervisor_name.to_string(),
@@ -397,13 +435,17 @@ mod tests {
         assert!(prompt.text.contains("target=supervisor"));
     }
 
+    /// cas-6aaf: TaskCompleted with task already closed (the normal path).
+    /// The prompt must NOT instruct the supervisor to ask the worker to close
+    /// the task — it was already closed when the event fired.
     #[test]
-    fn test_task_completed_prompt() {
+    fn test_task_completed_prompt_already_closed() {
         let event = DirectorEvent::TaskCompleted {
             task_id: "task-123".to_string(),
             task_title: "Implement feature X".to_string(),
             worker: "swift-fox".to_string(),
         };
+        // Task not present in any active set = already closed.
         let data = make_data(0);
         let config = default_config();
 
@@ -413,13 +455,119 @@ mod tests {
         assert_eq!(prompt.target, "supervisor");
         assert!(prompt.text.contains("swift-fox"));
         assert!(prompt.text.contains("task-123"));
-        assert!(prompt.text.contains("completed"));
-        // Should clarify verification ownership
+        // Must say "closed" not "completed" — reflects actual final state.
+        assert!(
+            prompt.text.contains("closed"),
+            "cas-6aaf: TaskCompleted prompt must say 'closed' (task is already closed): {}",
+            prompt.text
+        );
+        // Must NOT instruct supervisor to close an already-closed task.
+        assert!(
+            !prompt.text.to_lowercase().contains("task action=close"),
+            "cas-6aaf: TaskCompleted must not emit close instruction for already-closed task: {}",
+            prompt.text
+        );
+        // Should clarify verification ownership.
         assert!(prompt.text.contains("workers close their own tasks"));
         assert!(prompt.text.contains("supervisors close epics"));
-        // Response instructions should point to the worker
+        // Response instructions should point to the worker.
         assert!(prompt.text.contains("To respond to this message, use:"));
         assert!(prompt.text.contains("target=swift-fox"));
+    }
+
+    /// cas-6aaf: TaskCompleted when task regressed to Open (lease expired).
+    /// The supervisor SHOULD be asked to have the worker close it — the task
+    /// is still open and needs attention.
+    #[test]
+    fn test_task_completed_prompt_lease_expired_still_open() {
+        let event = DirectorEvent::TaskCompleted {
+            task_id: "task-123".to_string(),
+            task_title: "Implement feature X".to_string(),
+            worker: "swift-fox".to_string(),
+        };
+        // Task is in ready_tasks as Open — lease expired, not yet closed.
+        let task = TaskSummary {
+            id: "task-123".to_string(),
+            title: "Implement feature X".to_string(),
+            status: TaskStatus::Open,
+            priority: Priority::MEDIUM,
+            assignee: Some("swift-fox".to_string()),
+            task_type: TaskType::Task,
+            epic: None,
+            branch: None,
+            updated_at: None,
+        };
+        let data = DirectorData {
+            ready_tasks: vec![task],
+            in_progress_tasks: vec![],
+            epic_tasks: vec![],
+            agents: vec![],
+            activity: vec![],
+            agent_id_to_name: HashMap::new(),
+            changes: vec![],
+            git_loaded: true,
+            reminders: vec![],
+            epic_closed_counts: HashMap::new(),
+        };
+        let config = default_config();
+
+        let prompt =
+            generate_prompt(&event, &data, "supervisor", &config, codex(), codex()).unwrap();
+
+        // When lease expired and task regressed to Open, supervisor should ask worker to close.
+        assert!(
+            prompt.text.to_lowercase().contains("task action=close"),
+            "cas-6aaf: TaskCompleted for lease-expired Open task must include close instruction: {}",
+            prompt.text
+        );
+        assert!(
+            prompt.text.contains("task-123"),
+            "Prompt must identify the task: {}",
+            prompt.text
+        );
+    }
+
+    /// cas-6aaf: TaskCompleted when task is still InProgress returns None
+    /// (stale event, nothing actionable).
+    #[test]
+    fn test_task_completed_prompt_still_in_progress_suppressed() {
+        let event = DirectorEvent::TaskCompleted {
+            task_id: "task-123".to_string(),
+            task_title: "Implement feature X".to_string(),
+            worker: "swift-fox".to_string(),
+        };
+        // Task is still in in_progress — stale event.
+        let task = TaskSummary {
+            id: "task-123".to_string(),
+            title: "Implement feature X".to_string(),
+            status: TaskStatus::InProgress,
+            priority: Priority::MEDIUM,
+            assignee: Some("swift-fox".to_string()),
+            task_type: TaskType::Task,
+            epic: None,
+            branch: None,
+            updated_at: None,
+        };
+        let data = DirectorData {
+            ready_tasks: vec![],
+            in_progress_tasks: vec![task],
+            epic_tasks: vec![],
+            agents: vec![],
+            activity: vec![],
+            agent_id_to_name: HashMap::new(),
+            changes: vec![],
+            git_loaded: true,
+            reminders: vec![],
+            epic_closed_counts: HashMap::new(),
+        };
+        let config = default_config();
+
+        let prompt = generate_prompt(&event, &data, "supervisor", &config, codex(), codex());
+        assert!(
+            prompt.is_none(),
+            "cas-6aaf: TaskCompleted must be suppressed when task is still in_progress: {:?}",
+            prompt.map(|p| p.text)
+        );
     }
 
     #[test]

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -2662,3 +2662,103 @@ async fn test_reset_alive_worker_task_with_force_succeeds_and_logs_audit() {
         "audit note must mention force/bypassed; notes: {notes}"
     );
 }
+
+// =============================================================================
+// cas-dbbb: factory-mode session UUID → display-name normalization in task.update
+// =============================================================================
+
+/// When CAS_FACTORY_MODE is set and a supervisor assigns a task using a
+/// worker's session UUID instead of their display name, `task.update` must
+/// automatically normalize the assignee to the display name so `task mine`
+/// can dispatch correctly.
+///
+/// Smoke-test evidence (2026-06-30): director auto-prompts were using session
+/// IDs as the `assignee=` value. `task.update` silently accepted them, but
+/// `task mine` on the target worker returned nothing because it matches against
+/// display name / CAS_AGENT_NAME, not agent IDs.
+#[tokio::test]
+async fn test_factory_mode_normalizes_session_uuid_assignee_to_display_name() {
+    let (temp, service) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    let agent_store = open_agent_store(&cas_dir).expect("open agent store");
+    let task_store = cas::store::open_task_store(&cas_dir).expect("open task store");
+
+    // Register a worker with a distinct session ID and display name.
+    const WORKER_SESSION: &str = "sess-uuid-abcdef-1234";
+    const WORKER_NAME: &str = "calm-owl";
+
+    let worker =
+        cas::types::Agent::new(WORKER_SESSION.to_string(), WORKER_NAME.to_string());
+    agent_store.register(&worker).expect("register worker");
+
+    // Set CAS_FACTORY_MODE so the normalization branch activates.
+    // SAFETY: we hold the process-wide env lock for the full test body.
+    unsafe { std::env::set_var("CAS_FACTORY_MODE", "1") }
+
+    // Create a task.
+    let created = service
+        .cas_task_create(Parameters(make_task_create_req(
+            "UUID-normalization test (cas-dbbb)",
+        )))
+        .await
+        .expect("create task");
+    let task_id = extract_task_id(&extract_text(created))
+        .expect("task id")
+        .to_string();
+
+    // Assign by session UUID — mimics a director prompt that used the wrong identifier.
+    let update_result = service
+        .cas_task_update(Parameters(TaskUpdateRequest {
+            depth: None,
+            id: task_id.clone(),
+            title: None,
+            notes: None,
+            priority: None,
+            labels: None,
+            description: None,
+            design: None,
+            acceptance_criteria: None,
+            demo_statement: None,
+            execution_note: None,
+            external_ref: None,
+            assignee: Some(WORKER_SESSION.to_string()),
+            status: None,
+            epic: None,
+            epic_verification_owner: None,
+        }))
+        .await
+        .expect("task update with session UUID must succeed");
+
+    // Restore env before assertions so a panic doesn't poison sibling tests.
+    // SAFETY: still holding env lock.
+    unsafe { std::env::remove_var("CAS_FACTORY_MODE") }
+
+    let text = extract_text(update_result);
+
+    // Response must warn that the value was normalized.
+    assert!(
+        text.to_lowercase().contains("session id") || text.contains("Normalized"),
+        "cas-dbbb: update with session UUID must emit normalization warning; got: {text}"
+    );
+    assert!(
+        text.contains(WORKER_NAME),
+        "cas-dbbb: normalization warning must include display name '{WORKER_NAME}'; got: {text}"
+    );
+
+    // The stored assignee must be the display name, not the session UUID.
+    // (task show does not render the assignee field; read from store directly.)
+    let task = task_store.get(&task_id).expect("get task after update");
+    assert_eq!(
+        task.assignee.as_deref(),
+        Some(WORKER_NAME),
+        "cas-dbbb: stored assignee must be display name '{WORKER_NAME}' after normalization; \
+         got: {:?}",
+        task.assignee
+    );
+    assert_ne!(
+        task.assignee.as_deref(),
+        Some(WORKER_SESSION),
+        "cas-dbbb: stored assignee must NOT retain session UUID '{WORKER_SESSION}' after normalization"
+    );
+}


### PR DESCRIPTION
## Summary

- **cas-dbbb**: Director prompts now use worker display names (not session IDs) for `assignee=` in WorkerIdle/AgentRegistered auto-prompts. `task.update` in factory mode normalizes session UUIDs to display names with a warning.
- **cas-6aaf**: TaskCompleted prompt now checks current task state — suppresses if still in_progress (stale event), skips close instruction if already closed, only asks for close when lease expired and task regressed to Open.
- **Code-review follow-ups**: P1 staleness bypass fixed (by_id branch now runs staleness guard), P2 case-insensitive lookup, P2 Blocked tasks excluded from busy-guard chain.

## Test plan

- [ ] `cargo test --lib -p cas -- ui::factory::director` → 55 tests pass
- [ ] `cargo test --test mcp_tools_test task_tools` → 94 tests pass
- [ ] New regression tests: display-name assignment, blocked-task not-suppressed, session-ID-in-ready-tasks suppression, normalization integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)