### PR TITLE
fix(tests): seed agent identity on rebuilt CasCore fixtures (cas-48e6)

### DIFF
--- a/cas-cli/tests/mcp_tools_test/support.rs
+++ b/cas-cli/tests/mcp_tools_test/support.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use tempfile::TempDir;
 
@@ -81,17 +83,59 @@ pub(crate) fn setup_cas() -> (TempDir, CasCore) {
     let agent_store = open_agent_store(&cas_dir).expect("agent store should open");
     agent_store.init().expect("agent store should initialize");
 
-    // In production, daemon setup handles session registration.
+    // Stable id format `test-session-{pid}` — several tests hardcode this
+    // (e.g. operations force-transfer, verification cas-7998 self-assignee).
+    // Secondary/rebuilt cores must use `core_with_test_agent` instead of bare
+    // `CasCore::with_daemon` (cas-48e6).
     let session_id = format!("test-session-{}", std::process::id());
     let agent = Agent::new(session_id.clone(), "test-agent".to_string());
     agent_store
         .register(&agent)
         .expect("test agent should register");
 
-    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let core = CasCore::with_daemon(cas_dir, None, None);
     core.set_agent_id_for_testing(session_id);
 
     (temp, core)
+}
+
+/// Build a `CasCore` on an existing `.cas` directory with a **registered** test
+/// agent identity.
+///
+/// Use this whenever a test rebuilds a core after `setup_cas()` (e.g. after
+/// writing `config.toml` so `OnceLock` config reloads, or to model a second
+/// worker process). Bare `CasCore::with_daemon` has no `agent_id` and no
+/// SessionStart mapping file, so `task.start` fails with:
+///
+/// ```text
+/// Agent not registered. … Original error: No such file or directory (os error 2)
+/// ```
+///
+/// when `CAS_SESSION_ID` is unset (cas-48e6). The ENOENT is from
+/// `agent_id::read_session_for_mcp` — the production SessionStart hook path.
+/// Ambient `CAS_SESSION_ID` masks the bug via env auto-register, which is why
+/// the suite can stay green inside a factory session and red on a clean
+/// checkout.
+pub(crate) fn core_with_test_agent(cas_dir: impl AsRef<Path>) -> CasCore {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let cas_dir: PathBuf = cas_dir.as_ref().to_path_buf();
+    let session_id = format!(
+        "test-session-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    );
+
+    let agent_store = open_agent_store(&cas_dir).expect("agent store should open");
+    // Idempotent if setup_cas already initialized the store.
+    let _ = agent_store.init();
+    let agent = Agent::new(session_id.clone(), "test-agent".to_string());
+    agent_store
+        .register(&agent)
+        .expect("test agent should register");
+
+    let core = CasCore::with_daemon(cas_dir, None, None);
+    core.set_agent_id_for_testing(session_id);
+    core
 }
 
 /// Extract text from a tool result.

--- a/cas-cli/tests/mcp_tools_test/task_tools/depth_e2e.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/depth_e2e.rs
@@ -21,7 +21,7 @@
 //! the single-session per-layer tests cannot catch.
 
 use crate::support::*;
-use cas::mcp::{CasCore, CasService};
+use cas::mcp::CasService;
 use cas::store::open_task_store;
 use cas::types::{TaskDepth, TaskStatus};
 use rmcp::handler::server::wrapper::Parameters;
@@ -96,7 +96,7 @@ fn init_git_repo_with_staged_changes(project_root: &std::path::Path) {
 /// Session-1 create: returns the new task id. Built on its own core/service so
 /// the close runs on a freshly-opened one (session 2).
 async fn create_task(cas_dir: &std::path::Path, title: &str, depth: Option<&str>) -> String {
-    let core = CasCore::with_daemon(cas_dir.to_path_buf(), None, None);
+    let core = core_with_test_agent(cas_dir);
     let service = CasService::new(core, None);
     let mut body = serde_json::json!({
         "action": "create",
@@ -118,7 +118,9 @@ async fn create_task(cas_dir: &std::path::Path, title: &str, depth: Option<&str>
 
 /// Session-2 start+close on a fresh core/service; returns the close output text.
 async fn start_and_close(cas_dir: &std::path::Path, id: &str) -> String {
-    let core = CasCore::with_daemon(cas_dir.to_path_buf(), None, None);
+    // Fresh session (second worker process) — must seed agent identity itself
+    // (cas-48e6); bare with_daemon has no SessionStart mapping / agent_id.
+    let core = core_with_test_agent(cas_dir);
     let service = CasService::new(core, None);
     service
         .task(Parameters(task_req(

--- a/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
@@ -10,7 +10,7 @@
 
 use crate::support::*;
 use cas::mcp::tools::*;
-use cas::mcp::{CasCore, CasService};
+use cas::mcp::CasService;
 use cas::store::open_task_store;
 use cas::types::TaskStatus;
 use rmcp::handler::server::wrapper::Parameters;
@@ -297,7 +297,7 @@ async fn test_light_depth_factory_close_skips_p0_gate_and_closes() {
     write_supervisor_review_config(&cas_dir);
     init_git_repo_with_staged_changes(temp.path());
 
-    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let core = core_with_test_agent(&cas_dir);
     let task_store = open_task_store(&cas_dir).unwrap();
     let service = CasService::new(core, None);
 
@@ -372,7 +372,7 @@ async fn test_deep_depth_factory_close_still_pends_supervisor_review() {
     write_supervisor_review_config(&cas_dir);
     init_git_repo_with_staged_changes(temp.path());
 
-    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let core = core_with_test_agent(&cas_dir);
     let task_store = open_task_store(&cas_dir).unwrap();
     let service = CasService::new(core, None);
 

--- a/cas-cli/tests/mcp_tools_test/task_tools/supervisor_review_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/supervisor_review_flow.rs
@@ -8,7 +8,7 @@
 /// - AC5: all 5 named test functions listed in spec
 use crate::support::*;
 use cas::config::{CodeReviewConfig, Config};
-use cas::mcp::{CasCore, CasService};
+use cas::mcp::CasService;
 use cas::store::{open_agent_store, open_task_store, open_verification_store};
 use cas::types::{TaskStatus, Verification, VerificationStatus};
 use rmcp::handler::server::wrapper::Parameters;
@@ -137,7 +137,7 @@ async fn test_worker_close_in_supervisor_mode_skips_cas_code_review() {
     init_git_repo_with_staged_changes(temp.path());
 
     // Rebuild CasCore so it reads from our config.toml.
-    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let core = core_with_test_agent(&cas_dir);
     let task_store = open_task_store(&cas_dir).unwrap();
     let service = CasService::new(core, None);
 
@@ -215,7 +215,7 @@ async fn test_worker_close_in_worker_mode_runs_cas_code_review_unchanged() {
     // Init git repo so has_reviewable_changes() = true.
     init_git_repo_with_staged_changes(temp.path());
 
-    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let core = core_with_test_agent(&cas_dir);
     let service = CasService::new(core, None);
 
     let _worker_guard = FactoryWorkerGuard::enter();
@@ -415,7 +415,7 @@ async fn test_lint_fail_close_blocked_before_pending_supervisor_review() {
     // Create a git repo whose staged diff includes a `todo!()` so the lint fires.
     init_git_repo_with_lint_violation(temp.path());
 
-    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let core = core_with_test_agent(&cas_dir);
     let task_store = open_task_store(&cas_dir).unwrap();
     let service = CasService::new(core, None);
 
@@ -509,7 +509,7 @@ async fn test_worker_close_absent_code_review_section_defaults_to_supervisor_mod
     // Init git repo at the project root so has_reviewable_changes() returns true.
     init_git_repo_with_staged_changes(temp.path());
 
-    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let core = core_with_test_agent(&cas_dir);
     let task_store = open_task_store(&cas_dir).unwrap();
     let service = CasService::new(core, None);
 
@@ -595,7 +595,7 @@ async fn test_start_on_pending_supervisor_review_task_is_rejected() {
     task.status = TaskStatus::PendingSupervisorReview;
     task_store.add(&task).expect("task.add should succeed");
 
-    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let core = core_with_test_agent(&cas_dir);
     let service = CasService::new(core, None);
 
     // Attempt to start the PSR task — must be rejected.
@@ -652,7 +652,7 @@ async fn test_release_orphan_recovery_does_not_reset_psr_to_open() {
     task.status = TaskStatus::PendingSupervisorReview;
     task_store.add(&task).expect("task.add should succeed");
 
-    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let core = core_with_test_agent(&cas_dir);
     let service = CasService::new(core, None);
 
     // Call action=release with no active lease — triggers the orphan-recovery
@@ -703,7 +703,7 @@ async fn test_psr_transition_releases_worker_lease() {
     write_supervisor_review_config(&cas_dir);
     init_git_repo_with_staged_changes(temp.path());
 
-    let core = CasCore::with_daemon(cas_dir.clone(), None, None);
+    let core = core_with_test_agent(&cas_dir);
     let task_store = open_task_store(&cas_dir).unwrap();
     let service = CasService::new(core, None);
 


### PR DESCRIPTION
## Summary
- `mcp_tools_test` had 10 failures on clean main when `CAS_SESSION_ID` unset: depth_e2e (3), depth_light_close (2), supervisor_review_flow (5).
- Root cause: fixtures rebuilt `CasCore::with_daemon` without seeding agent identity; `get_agent_id` hit `read_session_for_mcp` → ENOENT (os error 2). Ambient factory `CAS_SESSION_ID` masked it.
- Fix: `support::core_with_test_agent()` registers agent + `set_agent_id_for_testing`; secondary cores use it. `setup_cas` keeps stable `test-session-{pid}`.

## Proof
```
env -u CAS_SESSION_ID … cargo test -p cas --test mcp_tools_test --no-fail-fast -- --test-threads=1
→ ok. 208 passed; 0 failed
```

Task: cas-48e6