### PR TITLE
fix(factory): stop false-stale worker_status for live Grok mid-turn (cas-3e56)

### DIFF
--- a/cas-cli/src/agent_id.rs
+++ b/cas-cli/src/agent_id.rs
@@ -238,54 +238,102 @@ pub fn get_cc_pid_for_mcp() -> u32 {
     std::process::id()
 }
 
-/// Get Claude Code's PID from hook context
+/// Get the interactive harness PID from hook context (Claude / Codex / Grok).
 ///
 /// Hooks can run in two modes:
-/// 1. Direct: Claude Code → cas hook (PPID = Claude Code)
-/// 2. Via shell: Claude Code → shell → cas hook (grandparent = Claude Code)
+/// 1. Direct: harness → cas hook (PPID = harness)
+/// 2. Via shell: harness → shell → cas hook (grandparent = harness)
 ///
-/// We detect which mode by checking if our parent's name contains "claude".
+/// We detect which mode by checking whether the parent is a known harness
+/// process (`claude`, `codex`, or `grok`). Pre-cas-3e56 this only matched
+/// `"claude"`, so Grok SessionStart hooks walked up to the *grandparent*
+/// (often a short-lived factory wrapper) and stored the wrong PID. The
+/// daemon liveness gate then declared the agent dead while the real Grok
+/// process was mid-turn — worker_status showed "None active".
 #[cfg(unix)]
 pub fn get_cc_pid_for_hook() -> u32 {
     let ppid = std::os::unix::process::parent_id();
 
-    // Check if parent is Claude Code directly
-    if is_claude_code_process(ppid) {
+    // Parent is the harness itself (direct hook spawn).
+    if is_harness_process(ppid) {
         return ppid;
     }
 
-    // Otherwise assume we're in a shell, get grandparent
-    get_parent_of_pid(ppid).unwrap_or(ppid)
+    // Parent is a shell/wrapper — prefer grandparent when it is a harness.
+    if let Some(gpid) = get_parent_of_pid(ppid) {
+        if is_harness_process(gpid) {
+            return gpid;
+        }
+    }
+
+    // Fallback: parent if we cannot identify a harness (legacy behavior for
+    // unknown wrappers). Prefer ppid over grandparent so we at least track
+    // the immediate invoker rather than an unrelated ancestor.
+    ppid
 }
 
-/// Check if a process is Claude Code by examining its command name
+/// Whether `pid` looks like a supported interactive harness process.
+///
+/// Matches command names containing `claude`, `codex`, or `grok` (case-
+/// insensitive). Public for tests and for callers that need the same
+/// recognition as SessionStart PID stamping (cas-3e56).
 #[cfg(target_os = "macos")]
-fn is_claude_code_process(pid: u32) -> bool {
+pub fn is_harness_process(pid: u32) -> bool {
     use std::process::Command;
     if let Ok(output) = Command::new("ps")
         .args(["-o", "comm=", "-p", &pid.to_string()])
         .output()
     {
-        let comm = String::from_utf8_lossy(&output.stdout);
-        let comm_lower = comm.trim().to_lowercase();
-        return comm_lower.contains("claude");
+        return comm_looks_like_harness(String::from_utf8_lossy(&output.stdout).trim());
     }
     false
 }
 
 #[cfg(target_os = "linux")]
-fn is_claude_code_process(pid: u32) -> bool {
-    // Read /proc/{pid}/comm
-    if let Ok(comm) = std::fs::read_to_string(format!("/proc/{}/comm", pid)) {
-        let comm_lower = comm.trim().to_lowercase();
-        return comm_lower.contains("claude");
+pub fn is_harness_process(pid: u32) -> bool {
+    // Prefer /proc/{pid}/comm; also check cmdline basename so renamed
+    // binaries (e.g. `node` wrapping a harness) can still match argv0.
+    if let Ok(comm) = std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+        if comm_looks_like_harness(comm.trim()) {
+            return true;
+        }
+    }
+    if let Ok(cmdline) = std::fs::read(format!("/proc/{pid}/cmdline")) {
+        // First NUL-separated token is argv0.
+        let argv0 = cmdline
+            .split(|&b| b == 0)
+            .next()
+            .map(|b| String::from_utf8_lossy(b))
+            .unwrap_or_default();
+        let base = std::path::Path::new(argv0.as_ref())
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(argv0.as_ref());
+        if comm_looks_like_harness(base) {
+            return true;
+        }
     }
     false
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn is_claude_code_process(_pid: u32) -> bool {
+pub fn is_harness_process(_pid: u32) -> bool {
     false
+}
+
+/// Shared name matcher for harness process detection (cas-3e56).
+pub(crate) fn comm_looks_like_harness(comm: &str) -> bool {
+    let c = comm.to_ascii_lowercase();
+    // Substring match: covers `claude`, `claude-code`, `grok`, full paths
+    // already basenamed by callers, and `codex` / `codex-cli`.
+    c.contains("claude") || c.contains("codex") || c.contains("grok")
+}
+
+/// Back-compat alias used by older call sites / tests.
+#[cfg(any(test, unix))]
+#[allow(dead_code)]
+fn is_claude_code_process(pid: u32) -> bool {
+    is_harness_process(pid)
 }
 
 #[cfg(not(unix))]
@@ -303,6 +351,22 @@ mod tests {
         let hash2 = compute_machine_hash();
         assert_eq!(hash1, hash2);
         assert_eq!(hash1.len(), 8); // 8 hex chars
+    }
+
+    /// cas-3e56: harness recognition must cover Claude, Codex, and Grok so
+    /// SessionStart stores the real interactive PID (not grandparent).
+    #[test]
+    fn comm_looks_like_harness_matches_all_supported_clis() {
+        assert!(comm_looks_like_harness("claude"));
+        assert!(comm_looks_like_harness("Claude"));
+        assert!(comm_looks_like_harness("claude-code"));
+        assert!(comm_looks_like_harness("codex"));
+        assert!(comm_looks_like_harness("codex-cli"));
+        assert!(comm_looks_like_harness("grok"));
+        assert!(comm_looks_like_harness("Grok"));
+        assert!(!comm_looks_like_harness("bash"));
+        assert!(!comm_looks_like_harness("cargo"));
+        assert!(!comm_looks_like_harness("node"));
     }
 
     #[test]
@@ -332,14 +396,10 @@ mod tests {
         let pid: u32 = pid_str.parse().unwrap();
         #[cfg(unix)]
         {
+            // compute_agent_id_for_hook always uses grandparent (shell wrapper
+            // model). get_cc_pid_for_hook is the harness-aware path (cas-3e56).
             let ppid = std::os::unix::process::parent_id();
-            // In test, parent is cargo/test runner, not Claude Code
-            // So we use grandparent
-            let expected = if is_claude_code_process(ppid) {
-                ppid
-            } else {
-                get_parent_of_pid(ppid).unwrap_or(ppid)
-            };
+            let expected = get_parent_of_pid(ppid).unwrap_or(ppid);
             assert_eq!(pid, expected);
         }
         #[cfg(not(unix))]

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor.md
@@ -32,6 +32,14 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 - **Tier every spawn — never fleet-default.** Explicit `model=`/`effort=` every spawn. Four tiers: **light** `grok/grok-composer-2.5-fast`; **standard** `grok/grok-4.5/medium` (floor); **heavy** `grok/grok-4.5/high`; **frontier** `claude/opus/high` (sparingly). Deep-dive: [model-selection.md](cas-supervisor/references/model-selection.md).
 
+### Worker liveness (authoritative signals)
+
+`worker_status` / `agent_list` are **not** sole authority for “is this worker dead?”:
+
+1. **Authoritative for mid-turn life:** OS process for that worker (Grok/Claude/Codex) still running — `worker_status` surfaces `[alive — heartbeat stale]` when heartbeat lags but the process is up (cas-3e56).
+2. **Supporting:** last activity / transcript age, worktree dirty, active leases.
+3. **Never re-spawn or re-assign** solely because `worker_status` says `Workers: None active` or `Filtered stale` — confirm process/`ps`/worktree first. False-empty roster was observed for live Grok workers before cas-3e56.
+
 ### End your turn
 
 After you assign tasks and send context to workers, **produce no more output**. No `git log`, no `task list`, no `worker_status`. Your next action only happens in response to a worker message or a user prompt.

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor.md
@@ -32,6 +32,14 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 - **Tier every spawn — never fleet-default.** Explicit `model=`/`effort=` every spawn. Four tiers: **light** `grok/grok-composer-2.5-fast`; **standard** `grok/grok-4.5/medium` (floor); **heavy** `grok/grok-4.5/high`; **frontier** `claude/opus/high` (sparingly). Deep-dive: [model-selection.md](cas-supervisor/references/model-selection.md).
 
+### Worker liveness (authoritative signals)
+
+`worker_status` / `agent_list` are **not** sole authority for “is this worker dead?”:
+
+1. **Authoritative for mid-turn life:** OS process for that worker (Grok/Claude/Codex) still running — `worker_status` surfaces `[alive — heartbeat stale]` when heartbeat lags but the process is up (cas-3e56).
+2. **Supporting:** last activity / transcript age, worktree dirty, active leases.
+3. **Never re-spawn or re-assign** solely because `worker_status` says `Workers: None active` or `Filtered stale` — confirm process/`ps`/worktree first. False-empty roster was observed for live Grok workers before cas-3e56.
+
 ### End your turn
 
 After you assign tasks and send context to workers, **produce no more output**. No `git log`, no `task list`, no `worker_status`. Your next action only happens in response to a worker message or a user prompt.

--- a/cas-cli/src/builtins/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor.md
@@ -32,6 +32,14 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 - **Tier every spawn — never fleet-default.** Explicit `model=`/`effort=` every spawn. Four tiers: **light** `grok/grok-composer-2.5-fast`; **standard** `grok/grok-4.5/medium` (floor); **heavy** `grok/grok-4.5/high`; **frontier** `claude/opus/high` (sparingly). Details: [model-selection.md](cas-supervisor/references/model-selection.md).
 
+### Worker liveness (authoritative signals)
+
+`worker_status` / `agent_list` are **not** sole authority for “is this worker dead?”:
+
+1. **Authoritative for mid-turn life:** OS process for that worker (Grok/Claude/Codex) still running — `worker_status` surfaces `[alive — heartbeat stale]` when heartbeat lags but the process is up (cas-3e56).
+2. **Supporting:** last activity / transcript age, worktree dirty, active leases.
+3. **Never re-spawn or re-assign** solely because `worker_status` says `Workers: None active` or `Filtered stale` — confirm process/`ps`/worktree first. False-empty roster was observed for live Grok workers before cas-3e56.
+
 ### End your turn
 
 After you assign tasks and send context to workers, **produce no more output**. No `git log`, no `task list`, no `worker_status`. Your next action only happens in response to a worker message or a user prompt.

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/worker-recovery.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/worker-recovery.md
@@ -53,7 +53,7 @@ Workers fail in production. These are recurring observed failure modes and their
 
 **Diagnosis:**
 1. Check worker status: `mcp__cas__coordination action=worker_status`
-2. Look for stale heartbeat (last activity timestamp far in the past) or missing entry
+2. Look for stale heartbeat (last activity timestamp far in the past) or missing entry — but **do not treat `Workers: None active` or `Filtered stale` as death alone** (cas-3e56: live Grok workers were omitted while mid-turn; prefer `[alive — heartbeat stale]` + OS/`ps`/worktree check before re-spawn)
 3. Check worker activity log: `mcp__cas__coordination action=worker_activity`
 
 **Recovery:**

--- a/cas-cli/src/mcp/daemon.rs
+++ b/cas-cli/src/mcp/daemon.rs
@@ -953,18 +953,46 @@ impl EmbeddedDaemon {
                             cc_pid,
                             fingerprint_checked,
                         } => {
-                            tracing::info!(
-                                agent_id = %short_id,
-                                cc_pid = cc_pid,
-                                fingerprint_checked = fingerprint_checked,
-                                "Claude Code client process is gone (or PID recycled to \
-                                 a different process) — marking agent stale and stopping \
-                                 heartbeat (cas-2749/cas-ea46 liveness gate)"
+                            // cas-3e56: registered pid may be wrong (pre-fix
+                            // SessionStart only matched "claude" and walked to
+                            // grandparent for Grok). Before mark_stale, scan the
+                            // live process table for this agent name — if the
+                            // real harness is mid-turn, keep heartbeating.
+                            let live_pid = crate::cli::factory::wedged::find_worker_pid(
+                                &crate::cli::factory::wedged::RealProcessTable,
+                                &agent.name,
                             );
-                            let _ = store.mark_stale(&id);
-                            let mut guard = self.agent_id.write().await;
-                            *guard = None;
-                            return;
+                            if let Some(resolved) = live_pid {
+                                tracing::warn!(
+                                    agent_id = %short_id,
+                                    registered_cc_pid = cc_pid,
+                                    resolved_pid = resolved,
+                                    fingerprint_checked = fingerprint_checked,
+                                    "Registered harness PID dead/recycled but live \
+                                     process found by agent name — continuing heartbeat \
+                                     (cas-3e56)"
+                                );
+                                // Best-effort: re-stamp the correct pid so
+                                // subsequent ticks use the strict path.
+                                if let Ok(mut refreshed) = store.get(&id) {
+                                    refreshed.pid = Some(resolved);
+                                    stamp_pid_fingerprint(&mut refreshed, resolved);
+                                    let _ = store.update(&refreshed);
+                                }
+                            } else {
+                                tracing::info!(
+                                    agent_id = %short_id,
+                                    cc_pid = cc_pid,
+                                    fingerprint_checked = fingerprint_checked,
+                                    "Harness client process is gone (or PID recycled to \
+                                     a different process) — marking agent stale and stopping \
+                                     heartbeat (cas-2749/cas-ea46/cas-3e56 liveness gate)"
+                                );
+                                let _ = store.mark_stale(&id);
+                                let mut guard = self.agent_id.write().await;
+                                *guard = None;
+                                return;
+                            }
                         }
                     }
                 }

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -553,9 +553,12 @@ impl CasService {
                 .unwrap_or_default()
         };
 
-        // Agents suppressed from pruning due to recent I/O activity. Used in
-        // the render loop to show the dual-signal annotation.
+        // Agents suppressed from pruning due to recent I/O activity or a live
+        // harness PID. Used in the render loop to show the dual-signal
+        // annotation (cas-1ec7 I/O / cas-3e56 process-alive).
         let mut active_io_suppressed: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        let mut process_alive_suppressed: std::collections::HashSet<String> =
             std::collections::HashSet::new();
         let mut stale_pruned = 0usize;
         let factory_session = current_factory_session();
@@ -570,6 +573,13 @@ impl CasService {
                 // cas-1ec7: suppress stale-prune when observable I/O is recent.
                 if has_recent_worker_io_activity(&recent_io_events, &agent.id) {
                     active_io_suppressed.insert(agent.id.clone());
+                    continue;
+                }
+                // cas-3e56: suppress when the registered harness process is
+                // still live. Never drop a mid-turn Grok/Claude/Codex worker
+                // as "None active" solely because heartbeat lagged.
+                if agent_process_is_alive(&agent) {
+                    process_alive_suppressed.insert(agent.id.clone());
                     continue;
                 }
                 if store.mark_stale(&agent.id).is_ok() {
@@ -644,8 +654,14 @@ impl CasService {
                 // recent WorkerFileEdited/WorkerGitCommit event confirms they are
                 // still making progress despite a heartbeat lapse (e.g. during a
                 // long cargo build/test run).
+                //
+                // cas-3e56: "[alive — heartbeat stale]" when the registered
+                // harness PID is still live. Honest dual-signal so supervisors
+                // never re-spawn solely on heartbeat age.
                 let liveness_label = if active_io_suppressed.contains(&agent.id) {
                     " [heartbeat stale, active I/O]"
+                } else if process_alive_suppressed.contains(&agent.id) {
+                    " [alive — heartbeat stale]"
                 } else {
                     liveness_label_for(elapsed)
                 };
@@ -1718,6 +1734,59 @@ pub(crate) fn has_recent_worker_io_activity(events: &[cas_types::Event], agent_i
             EventType::WorkerFileEdited | EventType::WorkerGitCommit
         ) && e.session_id.as_deref() == Some(agent_id)
     })
+}
+
+/// cas-3e56: whether this agent still has a live harness process.
+///
+/// Used by `factory_worker_status` to suppress the opportunistic stale prune
+/// when heartbeat age alone would drop a worker that is still mid-turn. The
+/// classic failure mode is a Grok worker whose SessionStart stored a wrong
+/// ancestor PID (pre-cas-3e56) OR whose heartbeat lapsed while the real
+/// process kept working — supervisors saw "Workers: None active" and nearly
+/// re-spawned.
+///
+/// Probe order:
+/// 1. Registered `agent.pid` (+ optional starttime fingerprint) via the
+///    daemon liveness helpers.
+/// 2. Live process-table scan by agent name (`find_worker_pid`) — recovers
+///    when the store pid is wrong/stale but the real harness is still up
+///    (Grok workers identity via `CAS_AGENT_NAME` environ).
+pub(crate) fn agent_process_is_alive(agent: &cas_types::Agent) -> bool {
+    if agent_process_is_alive_with(
+        agent,
+        crate::mcp::daemon::pid_alive,
+        crate::mcp::daemon::pid_matches_fingerprint,
+    ) {
+        return true;
+    }
+    // Fallback: scan /proc for a process that identifies as this worker.
+    // Cheap enough for a status poll (is-wedged already does this on kill).
+    crate::cli::factory::wedged::find_worker_pid(
+        &crate::cli::factory::wedged::RealProcessTable,
+        &agent.name,
+    )
+    .is_some()
+}
+
+/// Injected-probe variant of the registered-pid check for unit tests.
+pub(crate) fn agent_process_is_alive_with(
+    agent: &cas_types::Agent,
+    pid_alive_fn: impl Fn(u32) -> bool,
+    fingerprint_matches_fn: impl Fn(u32, u64) -> bool,
+) -> bool {
+    let Some(pid) = agent.pid else {
+        return false;
+    };
+    let expected_starttime = agent.pid_starttime.or_else(|| {
+        agent
+            .metadata
+            .get(crate::mcp::daemon::PID_STARTTIME_KEY)
+            .and_then(|s| s.parse::<u64>().ok())
+    });
+    match expected_starttime {
+        Some(st) => fingerprint_matches_fn(pid, st),
+        None => pid_alive_fn(pid),
+    }
 }
 
 /// Return the age (seconds) and a short phase label of the worker's most recent
@@ -3329,6 +3398,52 @@ effort = "high"
             !has_recent_worker_io_activity(&[e], "ses-abc-123"),
             "event without session_id must not match (matching is by session_id, not entity_id)"
         );
+    }
+
+    // ---- cas-3e56: process-alive prune suppress ---------------------------
+
+    #[test]
+    fn agent_process_is_alive_with_no_pid_is_false() {
+        let agent = cas_types::Agent::new("id-1".into(), "worker".into());
+        assert!(
+            !agent_process_is_alive_with(&agent, |_| true, |_, _| true),
+            "no registered pid → cannot prove process alive"
+        );
+    }
+
+    #[test]
+    fn agent_process_is_alive_with_pid_only_uses_pid_alive_probe() {
+        let mut agent = cas_types::Agent::new("id-1".into(), "worker".into());
+        agent.pid = Some(4242);
+        assert!(agent_process_is_alive_with(
+            &agent,
+            |p| p == 4242,
+            |_, _| false
+        ));
+        assert!(!agent_process_is_alive_with(
+            &agent,
+            |_| false,
+            |_, _| true
+        ));
+    }
+
+    #[test]
+    fn agent_process_is_alive_with_fingerprint_prefers_strict_check() {
+        let mut agent = cas_types::Agent::new("id-1".into(), "worker".into());
+        agent.pid = Some(7);
+        agent.pid_starttime = Some(99);
+        // Fingerprint says alive even if pid_alive would say dead.
+        assert!(agent_process_is_alive_with(
+            &agent,
+            |_| false,
+            |p, st| p == 7 && st == 99
+        ));
+        // Fingerprint says dead even if pid_alive would say alive.
+        assert!(!agent_process_is_alive_with(
+            &agent,
+            |_| true,
+            |_, _| false
+        ));
     }
 
     // ---- cas-573c: context-usage band + tail reader -----------------------

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -1031,6 +1031,61 @@ async fn test_worker_status_scopes_agents_to_factory_session() {
     );
 }
 
+/// cas-3e56: heartbeat past WORKER_STALE_SECS but registered harness PID still
+/// alive → worker_status must keep the worker listed as active with the
+/// "[alive — heartbeat stale]" dual-signal, never omit as "None active".
+///
+/// This is the supervision-truth residual after Grok liveness work: false
+/// "None active" while a Grok worker is mid-turn nearly caused a re-spawn.
+#[tokio::test]
+async fn test_worker_status_keeps_heartbeat_stale_process_alive_worker() {
+    let _guard = EnvGuard::set(&[]);
+    let env = FactoryTestEnv::new();
+
+    let store = env.agent_store();
+    let id = Agent::generate_fallback_id();
+    let mut agent = Agent::new(id.clone(), "mid-turn-grok".to_string());
+    agent.role = AgentRole::Worker;
+    agent
+        .metadata
+        .insert("worker_cli".to_string(), "grok".to_string());
+    // Heartbeat is "stale" by the 30s prune threshold.
+    let staleness = chrono::Duration::seconds(40);
+    agent.last_heartbeat = chrono::Utc::now() - staleness;
+    agent.registered_at = chrono::Utc::now() - staleness;
+    // Registered PID = this test process (alive). No fingerprint → pid-only
+    // liveness (kill 0) still proves the process is up.
+    agent.pid = Some(std::process::id());
+    store
+        .register(&agent)
+        .expect("register heartbeat-stale process-alive worker");
+
+    let req = factory_req("worker_status");
+    let result = env
+        .service
+        .factory(Parameters(req))
+        .await
+        .expect("worker_status call should succeed");
+    let text = get_text(&result);
+
+    assert!(
+        text.contains("mid-turn-grok"),
+        "process-alive worker must stay in Active listing despite stale heartbeat. Got:\n{text}"
+    );
+    assert!(
+        !text.contains("Workers: None active"),
+        "must not report empty roster when a process-alive worker exists. Got:\n{text}"
+    );
+    assert!(
+        text.contains("alive") && text.contains("heartbeat stale"),
+        "must surface dual-signal '[alive — heartbeat stale]'. Got:\n{text}"
+    );
+    assert!(
+        !text.contains("Filtered stale agent record(s)"),
+        "process-alive worker must not be pruned. Got:\n{text}"
+    );
+}
+
 /// cas-5b1c integration coverage: a worker whose heartbeat is older than
 /// `WORKER_STALE_SECS` (30s) is pruned out of the Active listing on the
 /// next `factory_worker_status` call and reported in the "Filtered stale


### PR DESCRIPTION
## Summary
- **Bug:** `worker_status` reported `Workers: None active` / filtered stale while a Grok worker was mid-turn (live process + dirty worktree).
- **Root cause:** SessionStart PID stamping only matched `claude` in `/proc/comm`, so Grok hooks stored grandparent PID; daemon liveness gate mark_stale'd the agent; status prune dropped it.
- **Fix:** harness-aware PID (`claude|codex|grok`); process-alive prune suppress + `[alive — heartbeat stale]`; daemon re-resolve by agent name before mark_stale; supervisor skill note.

## Proof
```
cargo test -p cas --lib agent_id::tests  # 8 ok
cargo test -p cas --lib agent_process_is_alive  # 3 ok
cargo test -p cas --test factory_mcp_ops_test -- worker_status  # 8 ok incl. cas-3e56
```

Task: cas-3e56 (related cas-e98e remains broader multi-signal reconciliation)