### PR TITLE
fix(factory): unify supervision liveness across status surfaces (cas-e98e)

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor.md
@@ -32,13 +32,15 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 - **Tier every spawn — never fleet-default.** Explicit `model=`/`effort=` every spawn. Four tiers: **light** `grok/grok-composer-2.5-fast`; **standard** `grok/grok-4.5/medium` (floor); **heavy** `grok/grok-4.5/high`; **frontier** `claude/opus/high` (sparingly). Deep-dive: [model-selection.md](cas-supervisor/references/model-selection.md).
 
-### Worker liveness (authoritative signals)
+### Worker liveness (authoritative signals) — cas-e98e / cas-3e56
 
-`worker_status` / `agent_list` are **not** sole authority for “is this worker dead?”:
+**Authoritative formula** (shared by `worker_status`, `agent_list`, FACTORY pane):
 
-1. **Authoritative for mid-turn life:** OS process for that worker (Grok/Claude/Codex) still running — `worker_status` surfaces `[alive — heartbeat stale]` when heartbeat lags but the process is up (cas-3e56).
+> Live = (Active/Idle + heartbeat &lt; 30s) **OR** live OS harness process for that agent.
+
+1. **Process presence** is the mid-turn life signal — dual-signal labels when heartbeat lags but process is up.
 2. **Supporting:** last activity / transcript age, worktree dirty, active leases.
-3. **Never re-spawn or re-assign** solely because `worker_status` says `Workers: None active` or `Filtered stale` — confirm process/`ps`/worktree first. False-empty roster was observed for live Grok workers before cas-3e56.
+3. **Shutdown / re-spawn:** never act on `Workers: None active` alone — confirm `ps`/worktree/`is-wedged` first.
 
 ### End your turn
 

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor.md
@@ -32,13 +32,15 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 - **Tier every spawn — never fleet-default.** Explicit `model=`/`effort=` every spawn. Four tiers: **light** `grok/grok-composer-2.5-fast`; **standard** `grok/grok-4.5/medium` (floor); **heavy** `grok/grok-4.5/high`; **frontier** `claude/opus/high` (sparingly). Deep-dive: [model-selection.md](cas-supervisor/references/model-selection.md).
 
-### Worker liveness (authoritative signals)
+### Worker liveness (authoritative signals) — cas-e98e / cas-3e56
 
-`worker_status` / `agent_list` are **not** sole authority for “is this worker dead?”:
+**Authoritative formula** (shared by `worker_status`, `agent_list`, FACTORY pane):
 
-1. **Authoritative for mid-turn life:** OS process for that worker (Grok/Claude/Codex) still running — `worker_status` surfaces `[alive — heartbeat stale]` when heartbeat lags but the process is up (cas-3e56).
+> Live = (Active/Idle + heartbeat &lt; 30s) **OR** live OS harness process for that agent.
+
+1. **Process presence** is the mid-turn life signal — dual-signal labels when heartbeat lags but process is up.
 2. **Supporting:** last activity / transcript age, worktree dirty, active leases.
-3. **Never re-spawn or re-assign** solely because `worker_status` says `Workers: None active` or `Filtered stale` — confirm process/`ps`/worktree first. False-empty roster was observed for live Grok workers before cas-3e56.
+3. **Shutdown / re-spawn:** never act on `Workers: None active` alone — confirm `ps`/worktree/`is-wedged` first.
 
 ### End your turn
 

--- a/cas-cli/src/builtins/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor.md
@@ -32,13 +32,15 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 - **Tier every spawn — never fleet-default.** Explicit `model=`/`effort=` every spawn. Four tiers: **light** `grok/grok-composer-2.5-fast`; **standard** `grok/grok-4.5/medium` (floor); **heavy** `grok/grok-4.5/high`; **frontier** `claude/opus/high` (sparingly). Details: [model-selection.md](cas-supervisor/references/model-selection.md).
 
-### Worker liveness (authoritative signals)
+### Worker liveness (authoritative signals) — cas-e98e / cas-3e56
 
-`worker_status` / `agent_list` are **not** sole authority for “is this worker dead?”:
+**Authoritative formula** (shared by `worker_status`, `agent_list`, FACTORY pane):
 
-1. **Authoritative for mid-turn life:** OS process for that worker (Grok/Claude/Codex) still running — `worker_status` surfaces `[alive — heartbeat stale]` when heartbeat lags but the process is up (cas-3e56).
+> Live = (Active/Idle + heartbeat &lt; 30s) **OR** live OS harness process for that agent.
+
+1. **Process presence** is the mid-turn life signal — `worker_status` / `agent_list` show `alive-heartbeat-stale` / `[alive — heartbeat stale]` when heartbeat lags but the process is up.
 2. **Supporting:** last activity / transcript age, worktree dirty, active leases.
-3. **Never re-spawn or re-assign** solely because `worker_status` says `Workers: None active` or `Filtered stale` — confirm process/`ps`/worktree first. False-empty roster was observed for live Grok workers before cas-3e56.
+3. **Shutdown / re-spawn:** never act on `Workers: None active` or `Filtered stale` alone — confirm `ps`/worktree/`is-wedged` first. Use `gc_cleanup` to purge dead registry rows, not `shutdown_workers` on a false-empty roster.
 
 ### End your turn
 

--- a/cas-cli/src/mcp/tools/core/agent_coordination/agent_management.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/agent_management.rs
@@ -162,15 +162,27 @@ impl CasCore {
             format!("Agents ({} total):\n\n", agents.len())
         };
 
+        // cas-e98e: status token comes from authoritative supervision
+        // liveness (heartbeat + OS process), not the raw registry row alone
+        // — so process-alive mid-turn workers agree with worker_status.
+        use crate::mcp::tools::service::agent_liveness::{
+            agent_list_status_label, is_live_factory_worker,
+        };
         for agent in agents.iter().take(limit) {
+            let status_label = agent_list_status_label(agent);
             output.push_str(&format!(
-                "[{}] {} - {} ({}/{}) - {} tasks\n",
-                agent.status,
+                "[{status_label}] {} - {} ({}/{}) - {} tasks\n",
                 agent.id,
                 agent.name,
                 agent.agent_type,
                 agent.role,
                 agent.active_tasks
+            ));
+        }
+        let live_worker_count = agents.iter().filter(|a| is_live_factory_worker(a)).count();
+        if live_worker_count > 0 {
+            output.push_str(&format!(
+                "\nLive factory workers (authoritative): {live_worker_count}\n"
             ));
         }
 

--- a/cas-cli/src/mcp/tools/service/agent_liveness.rs
+++ b/cas-cli/src/mcp/tools/service/agent_liveness.rs
@@ -1,0 +1,211 @@
+//! Authoritative factory agent liveness (cas-e98e).
+//!
+//! Supervisors previously saw **four disagreeing answers** to "who is alive?":
+//! `worker_status`, `agent_list`, the FACTORY pane, and the OS process table.
+//! cas-3e56 fixed the high-severity Grok false-stale path on `worker_status`.
+//! This module is the **single source of truth** those surfaces should share:
+//!
+//! **Authoritative formula:** an agent is *supervision-live* if either
+//! (a) heartbeat is fresher than [`WORKER_STALE_SECS`] while Active/Idle, or
+//! (b) the OS still has a live harness process for that agent
+//!     (even when heartbeat lagged or the registry row is Stale).
+//!
+//! Shutdown decisions must use this dual signal — never `worker_status`
+//! "None active" alone (see cas-supervisor skill note).
+
+use cas_types::{Agent, AgentRole, AgentStatus};
+
+/// Heartbeat age at which a worker is considered **stale** for supervision
+/// prune / dual-signal (same constant as `factory_ops::WORKER_STALE_SECS`).
+pub const WORKER_STALE_SECS: i64 = 30;
+
+/// Effective liveness for supervisor tooling (cas-e98e).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SupervisionLiveness {
+    /// Registry Active/Idle and heartbeat within [`WORKER_STALE_SECS`].
+    Live,
+    /// Process proves mid-turn despite lagged heartbeat or Stale registry.
+    AliveHeartbeatStale,
+    /// Not live for supervision (no fresh heartbeat, no process).
+    NotLive,
+}
+
+impl SupervisionLiveness {
+    pub fn is_live(self) -> bool {
+        !matches!(self, Self::NotLive)
+    }
+}
+
+/// Seconds since last heartbeat.
+pub fn agent_heartbeat_age_secs(agent: &Agent) -> i64 {
+    (chrono::Utc::now() - agent.last_heartbeat)
+        .num_seconds()
+        .max(0)
+}
+
+/// cas-3e56/cas-e98e: whether this agent still has a live harness process.
+pub fn agent_process_is_alive(agent: &Agent) -> bool {
+    if agent_process_is_alive_with(
+        agent,
+        crate::mcp::daemon::pid_alive,
+        crate::mcp::daemon::pid_matches_fingerprint,
+    ) {
+        return true;
+    }
+    crate::cli::factory::wedged::find_worker_pid(
+        &crate::cli::factory::wedged::RealProcessTable,
+        &agent.name,
+    )
+    .is_some()
+}
+
+/// Injected-probe registered-pid check (unit tests).
+pub fn agent_process_is_alive_with(
+    agent: &Agent,
+    pid_alive_fn: impl Fn(u32) -> bool,
+    fingerprint_matches_fn: impl Fn(u32, u64) -> bool,
+) -> bool {
+    let Some(pid) = agent.pid else {
+        return false;
+    };
+    let expected_starttime = agent.pid_starttime.or_else(|| {
+        agent
+            .metadata
+            .get(crate::mcp::daemon::PID_STARTTIME_KEY)
+            .and_then(|s| s.parse::<u64>().ok())
+    });
+    match expected_starttime {
+        Some(st) => fingerprint_matches_fn(pid, st),
+        None => pid_alive_fn(pid),
+    }
+}
+
+/// Evaluate authoritative supervision liveness (`process_alive` injected).
+pub fn evaluate_supervision_liveness_with(
+    agent: &Agent,
+    process_alive: bool,
+    stale_secs: i64,
+) -> SupervisionLiveness {
+    match agent.status {
+        AgentStatus::Shutdown => {
+            if process_alive {
+                SupervisionLiveness::AliveHeartbeatStale
+            } else {
+                SupervisionLiveness::NotLive
+            }
+        }
+        AgentStatus::Stale => {
+            if process_alive {
+                SupervisionLiveness::AliveHeartbeatStale
+            } else {
+                SupervisionLiveness::NotLive
+            }
+        }
+        AgentStatus::Active | AgentStatus::Idle => {
+            let age = agent_heartbeat_age_secs(agent);
+            if age < stale_secs {
+                SupervisionLiveness::Live
+            } else if process_alive {
+                SupervisionLiveness::AliveHeartbeatStale
+            } else {
+                SupervisionLiveness::NotLive
+            }
+        }
+    }
+}
+
+/// Production path.
+pub fn evaluate_supervision_liveness(agent: &Agent) -> SupervisionLiveness {
+    evaluate_supervision_liveness_with(agent, agent_process_is_alive(agent), WORKER_STALE_SECS)
+}
+
+/// Live factory worker for roster agreement (`worker_status` ↔ `agent_list`).
+pub fn is_live_factory_worker(agent: &Agent) -> bool {
+    agent.role == AgentRole::Worker && evaluate_supervision_liveness(agent).is_live()
+}
+
+/// `agent_list` status token using authoritative liveness.
+pub fn agent_list_status_label(agent: &Agent) -> String {
+    match evaluate_supervision_liveness(agent) {
+        SupervisionLiveness::Live => match agent.status {
+            AgentStatus::Idle => "idle".to_string(),
+            _ => "active".to_string(),
+        },
+        SupervisionLiveness::AliveHeartbeatStale => {
+            "active,alive-heartbeat-stale".to_string()
+        }
+        SupervisionLiveness::NotLive => format!("{}", agent.status).to_lowercase(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn worker(status: AgentStatus, hb_age_secs: i64) -> Agent {
+        let mut a = Agent::new("id-1".into(), "w1".into());
+        a.role = AgentRole::Worker;
+        a.status = status;
+        a.last_heartbeat = chrono::Utc::now() - chrono::Duration::seconds(hb_age_secs);
+        a
+    }
+
+    #[test]
+    fn live_fresh_heartbeat_is_live() {
+        let a = worker(AgentStatus::Active, 5);
+        assert_eq!(
+            evaluate_supervision_liveness_with(&a, false, WORKER_STALE_SECS),
+            SupervisionLiveness::Live
+        );
+    }
+
+    #[test]
+    fn stale_heartbeat_without_process_is_not_live() {
+        let a = worker(AgentStatus::Active, 60);
+        assert_eq!(
+            evaluate_supervision_liveness_with(&a, false, WORKER_STALE_SECS),
+            SupervisionLiveness::NotLive
+        );
+    }
+
+    #[test]
+    fn stale_heartbeat_with_process_is_alive_stale() {
+        let a = worker(AgentStatus::Active, 60);
+        assert_eq!(
+            evaluate_supervision_liveness_with(&a, true, WORKER_STALE_SECS),
+            SupervisionLiveness::AliveHeartbeatStale
+        );
+    }
+
+    #[test]
+    fn registry_stale_with_process_is_alive_stale() {
+        let a = worker(AgentStatus::Stale, 120);
+        assert_eq!(
+            evaluate_supervision_liveness_with(&a, true, WORKER_STALE_SECS),
+            SupervisionLiveness::AliveHeartbeatStale
+        );
+    }
+
+    #[test]
+    fn shutdown_without_process_is_not_live() {
+        let a = worker(AgentStatus::Shutdown, 0);
+        assert_eq!(
+            evaluate_supervision_liveness_with(&a, false, WORKER_STALE_SECS),
+            SupervisionLiveness::NotLive
+        );
+    }
+
+    #[test]
+    fn agent_process_is_alive_with_no_pid_is_false() {
+        let a = Agent::new("id".into(), "n".into());
+        assert!(!agent_process_is_alive_with(&a, |_| true, |_, _| true));
+    }
+
+    #[test]
+    fn agent_process_is_alive_with_pid_only() {
+        let mut a = Agent::new("id".into(), "n".into());
+        a.pid = Some(9);
+        assert!(agent_process_is_alive_with(&a, |p| p == 9, |_, _| false));
+        assert!(!agent_process_is_alive_with(&a, |_| false, |_, _| true));
+    }
+}

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -3,18 +3,10 @@ use crate::mcp::tools::service::imports::*;
 /// Heartbeat age at which a worker is considered **stale** and becomes
 /// eligible for the opportunistic prune in `factory_worker_status`.
 ///
-/// A stale worker is dropped from the Active listing on the next status
-/// call (see the `list_stale` + `mark_stale` loop). If the prune succeeds
-/// — the overwhelmingly common path — the worker never reaches the
-/// render-time liveness-label branch at all.
-///
-/// Bumped from 120s to 30s by cas-2749 so a crashed CC client is
-/// detected within roughly one supervisor status poll. The 30s number is
-/// load-bearing: callers in tests assert the exact value via
-/// [`worker_stale_secs_is_pinned_at_30`] (cas-8240 AC anchor) so a drift
-/// fix in one place that forgets to update the other cannot silently
-/// regress the UX.
-pub(crate) const WORKER_STALE_SECS: i64 = 30;
+/// Re-exported from [`super::agent_liveness`] (cas-e98e single source of
+/// truth). Callers/tests that assert the 30s pin continue to use this
+/// name.
+pub(crate) use super::agent_liveness::WORKER_STALE_SECS;
 
 /// Heartbeat age at which a worker is escalated to **dead** in the
 /// supervisor-facing render: hard `[DEAD]` label + transcript-path
@@ -575,11 +567,12 @@ impl CasService {
                     active_io_suppressed.insert(agent.id.clone());
                     continue;
                 }
-                // cas-3e56: suppress when the registered harness process is
-                // still live. Never drop a mid-turn Grok/Claude/Codex worker
-                // as "None active" solely because heartbeat lagged.
+                // cas-3e56 / cas-e98e: suppress when process proves mid-turn.
+                // Prefer revive of already-Stale rows so agent_list and
+                // worker_status agree on Active identity.
                 if agent_process_is_alive(&agent) {
                     process_alive_suppressed.insert(agent.id.clone());
+                    let _ = store.revive(&agent.id);
                     continue;
                 }
                 if store.mark_stale(&agent.id).is_ok() {
@@ -1736,58 +1729,9 @@ pub(crate) fn has_recent_worker_io_activity(events: &[cas_types::Event], agent_i
     })
 }
 
-/// cas-3e56: whether this agent still has a live harness process.
-///
-/// Used by `factory_worker_status` to suppress the opportunistic stale prune
-/// when heartbeat age alone would drop a worker that is still mid-turn. The
-/// classic failure mode is a Grok worker whose SessionStart stored a wrong
-/// ancestor PID (pre-cas-3e56) OR whose heartbeat lapsed while the real
-/// process kept working — supervisors saw "Workers: None active" and nearly
-/// re-spawned.
-///
-/// Probe order:
-/// 1. Registered `agent.pid` (+ optional starttime fingerprint) via the
-///    daemon liveness helpers.
-/// 2. Live process-table scan by agent name (`find_worker_pid`) — recovers
-///    when the store pid is wrong/stale but the real harness is still up
-///    (Grok workers identity via `CAS_AGENT_NAME` environ).
-pub(crate) fn agent_process_is_alive(agent: &cas_types::Agent) -> bool {
-    if agent_process_is_alive_with(
-        agent,
-        crate::mcp::daemon::pid_alive,
-        crate::mcp::daemon::pid_matches_fingerprint,
-    ) {
-        return true;
-    }
-    // Fallback: scan /proc for a process that identifies as this worker.
-    // Cheap enough for a status poll (is-wedged already does this on kill).
-    crate::cli::factory::wedged::find_worker_pid(
-        &crate::cli::factory::wedged::RealProcessTable,
-        &agent.name,
-    )
-    .is_some()
-}
-
-/// Injected-probe variant of the registered-pid check for unit tests.
-pub(crate) fn agent_process_is_alive_with(
-    agent: &cas_types::Agent,
-    pid_alive_fn: impl Fn(u32) -> bool,
-    fingerprint_matches_fn: impl Fn(u32, u64) -> bool,
-) -> bool {
-    let Some(pid) = agent.pid else {
-        return false;
-    };
-    let expected_starttime = agent.pid_starttime.or_else(|| {
-        agent
-            .metadata
-            .get(crate::mcp::daemon::PID_STARTTIME_KEY)
-            .and_then(|s| s.parse::<u64>().ok())
-    });
-    match expected_starttime {
-        Some(st) => fingerprint_matches_fn(pid, st),
-        None => pid_alive_fn(pid),
-    }
-}
+// Process-alive probes live in `agent_liveness` (cas-e98e). Re-export so
+// existing call sites and tests keep compiling.
+pub(crate) use super::agent_liveness::agent_process_is_alive;
 
 /// Return the age (seconds) and a short phase label of the worker's most recent
 /// observable activity event (cas-86c5).
@@ -3400,51 +3344,7 @@ effort = "high"
         );
     }
 
-    // ---- cas-3e56: process-alive prune suppress ---------------------------
-
-    #[test]
-    fn agent_process_is_alive_with_no_pid_is_false() {
-        let agent = cas_types::Agent::new("id-1".into(), "worker".into());
-        assert!(
-            !agent_process_is_alive_with(&agent, |_| true, |_, _| true),
-            "no registered pid → cannot prove process alive"
-        );
-    }
-
-    #[test]
-    fn agent_process_is_alive_with_pid_only_uses_pid_alive_probe() {
-        let mut agent = cas_types::Agent::new("id-1".into(), "worker".into());
-        agent.pid = Some(4242);
-        assert!(agent_process_is_alive_with(
-            &agent,
-            |p| p == 4242,
-            |_, _| false
-        ));
-        assert!(!agent_process_is_alive_with(
-            &agent,
-            |_| false,
-            |_, _| true
-        ));
-    }
-
-    #[test]
-    fn agent_process_is_alive_with_fingerprint_prefers_strict_check() {
-        let mut agent = cas_types::Agent::new("id-1".into(), "worker".into());
-        agent.pid = Some(7);
-        agent.pid_starttime = Some(99);
-        // Fingerprint says alive even if pid_alive would say dead.
-        assert!(agent_process_is_alive_with(
-            &agent,
-            |_| false,
-            |p, st| p == 7 && st == 99
-        ));
-        // Fingerprint says dead even if pid_alive would say alive.
-        assert!(!agent_process_is_alive_with(
-            &agent,
-            |_| true,
-            |_, _| false
-        ));
-    }
+    // Process-alive unit tests live in agent_liveness::tests (cas-e98e).
 
     // ---- cas-573c: context-usage band + tail reader -----------------------
 

--- a/cas-cli/src/mcp/tools/service/mod.rs
+++ b/cas-cli/src/mcp/tools/service/mod.rs
@@ -1102,6 +1102,7 @@ impl CasService {
 // ============================================================================
 
 mod agent_search_system;
+pub(crate) mod agent_liveness;
 mod core;
 pub(crate) mod factory_ops;
 mod factory_remind;

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -1031,6 +1031,69 @@ async fn test_worker_status_scopes_agents_to_factory_session() {
     );
 }
 
+/// cas-e98e AC2: for the same registry state, the set of live factory worker
+/// identities from `worker_status` must agree with `agent_list` effective
+/// liveness labels (active / active,alive-heartbeat-stale).
+#[tokio::test]
+async fn test_worker_status_and_agent_list_agree_on_live_workers() {
+    let _guard = EnvGuard::set(&[]);
+    let env = FactoryTestEnv::new();
+
+    env.register_worker("live-fresh");
+    let store = env.agent_store();
+
+    // Heartbeat-stale + process-alive (this test process).
+    let id_alive = Agent::generate_fallback_id();
+    let mut alive = Agent::new(id_alive.clone(), "live-stale-hb".to_string());
+    alive.role = AgentRole::Worker;
+    let staleness = chrono::Duration::seconds(40);
+    alive.last_heartbeat = chrono::Utc::now() - staleness;
+    alive.registered_at = chrono::Utc::now() - staleness;
+    alive.pid = Some(std::process::id());
+    store.register(&alive).expect("register process-alive stale-hb worker");
+
+    // Truly dead stale (no pid) — must not appear as live.
+    env.register_stale_worker_with_clone_path("dead-stale", "/tmp/cas-wt-dead", 40);
+
+    let status_text = get_text(
+        &env.service
+            .factory(Parameters(factory_req("worker_status")))
+            .await
+            .expect("worker_status"),
+    );
+    let list_req: CoordinationRequest = serde_json::from_value(serde_json::json!({
+        "action": "agent_list"
+    }))
+    .expect("CoordinationRequest");
+    let list_text = get_text(
+        &env.service
+            .coordination(Parameters(list_req))
+            .await
+            .expect("agent_list"),
+    );
+
+    // Live identities from worker_status (named bullets).
+    for name in ["live-fresh", "live-stale-hb"] {
+        assert!(
+            status_text.contains(name),
+            "worker_status must list {name}. Got:\n{status_text}"
+        );
+        assert!(
+            list_text.contains(name),
+            "agent_list must list {name}. Got:\n{list_text}"
+        );
+    }
+    assert!(
+        list_text.contains("active,alive-heartbeat-stale")
+            || status_text.contains("alive") && status_text.contains("heartbeat stale"),
+        "dual-signal must appear for process-alive stale-hb worker.\nstatus:\n{status_text}\nlist:\n{list_text}"
+    );
+    assert!(
+        !status_text.contains("dead-stale"),
+        "dead worker must not be in worker_status Active roster. Got:\n{status_text}"
+    );
+}
+
 /// cas-3e56: heartbeat past WORKER_STALE_SECS but registered harness PID still
 /// alive → worker_status must keep the worker listed as active with the
 /// "[alive — heartbeat stale]" dual-signal, never omit as "None active".

--- a/crates/cas-factory/src/director.rs
+++ b/crates/cas-factory/src/director.rs
@@ -18,6 +18,24 @@ use cas_types::{
 
 use crate::changes::{FileChangeInfo, GitFileStatus, SourceChangesInfo};
 
+/// cas-e98e: lightweight PID liveness for FACTORY pane reconciliation.
+/// Linux: `/proc/<pid>` exists. Other platforms: conservatively false
+/// (no false "live" without a real probe).
+fn agent_pid_looks_alive(pid: Option<u32>) -> bool {
+    let Some(pid) = pid else {
+        return false;
+    };
+    #[cfg(target_os = "linux")]
+    {
+        std::path::Path::new(&format!("/proc/{pid}")).exists()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
 /// Cached store handles to avoid re-opening on every refresh cycle.
 ///
 /// Each `open()` call does path canonicalization + global hashmap lookup.
@@ -394,12 +412,22 @@ impl DirectorData {
         let mut agent_id_to_name = HashMap::new();
         let agents: Vec<AgentSummary> = agents_list
             .into_iter()
-            // Only show factory-relevant agents (not CLI agents with Standard role)
+            // Factory-relevant agents only. cas-e98e: also keep Stale rows
+            // whose registered PID is still live so FACTORY does not show
+            // "not registered" for a mid-turn agent that lost its heartbeat
+            // (same dual-signal as worker_status process-alive suppress).
             .filter(|a| {
-                (a.status == AgentStatus::Active || a.status == AgentStatus::Idle)
-                    && (a.role == AgentRole::Supervisor
-                        || a.role == AgentRole::Worker
-                        || a.role == AgentRole::Director)
+                let role_ok = a.role == AgentRole::Supervisor
+                    || a.role == AgentRole::Worker
+                    || a.role == AgentRole::Director;
+                if !role_ok {
+                    return false;
+                }
+                match a.status {
+                    AgentStatus::Active | AgentStatus::Idle => true,
+                    AgentStatus::Stale => agent_pid_looks_alive(a.pid),
+                    _ => false,
+                }
             })
             .map(|a| {
                 agent_id_to_name.insert(a.id.clone(), a.name.clone());
@@ -448,10 +476,19 @@ impl DirectorData {
                             .get(&(a.id.clone(), task.id.clone()))
                             .cloned(),
                     });
+                // Surface process-alive Stale rows as Active so icons/counts
+                // match worker_status dual-signal (cas-e98e).
+                let display_status = if a.status == AgentStatus::Stale
+                    && agent_pid_looks_alive(a.pid)
+                {
+                    AgentStatus::Active
+                } else {
+                    a.status
+                };
                 AgentSummary {
                     id: a.id,
                     name: a.name,
-                    status: a.status,
+                    status: display_status,
                     current_task,
                     latest_activity,
                     last_heartbeat: Some(a.last_heartbeat),


### PR DESCRIPTION
## Summary
Broader multi-signal liveness reconciliation after cas-3e56:

- **Authoritative formula:** Live = (Active/Idle + heartbeat &lt; 30s) OR live OS harness process
- Shared `agent_liveness` module used by `worker_status` + `agent_list` (+ director/FACTORY)
- FACTORY no longer drops process-alive Stale agents as "not registered"
- Agreement test: `test_worker_status_and_agent_list_agree_on_live_workers`
- Supervisor skill documents shutdown authority

## Proof
```
cargo test -p cas --lib agent_liveness           # 7 ok
cargo test -p cas --test factory_mcp_ops_test -- worker_status  # 9 ok
cargo test -p cas-factory --lib                  # 93 ok
```

Task: cas-e98e