### PR TITLE
fix(factory): reconcile liveness signals (cas-e98e)

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor.md
@@ -31,20 +31,11 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Counter-propose when you see a better path.** Three anchors required: (a) a specific citable source — pattern, library, prior incident, commit, measured characteristic; (b) a concrete cost of the current approach; (c) a concrete benefit of the alternative. No anchors → no counter-proposal; execute or ask a clarifying question.
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 - **Tier every spawn — never fleet-default.** Explicit `model=`/`effort=` every spawn. Four tiers: **light** `grok/grok-composer-2.5-fast`; **standard** `grok/grok-4.5/medium` (floor); **heavy** `grok/grok-4.5/high`; **frontier** `claude/opus/high` (sparingly). Deep-dive: [model-selection.md](cas-supervisor/references/model-selection.md).
-
-### Worker liveness (authoritative signals) — cas-e98e / cas-3e56
-
-**Authoritative formula** (shared by `worker_status`, `agent_list`, FACTORY pane):
-
-> Live = (Active/Idle + heartbeat &lt; 30s) **OR** live OS harness process for that agent.
-
-1. **Process presence** is the mid-turn life signal — dual-signal labels when heartbeat lags but process is up.
-2. **Supporting:** last activity / transcript age, worktree dirty, active leases.
-3. **Shutdown / re-spawn:** never act on `Workers: None active` alone — confirm `ps`/worktree/`is-wedged` first.
+- **Worker liveness (cas-e98e):** live = fresh heartbeat **or** live OS process. Never shut down on `None active` alone — see [worker-recovery.md](cas-supervisor/references/worker-recovery.md#authoritative-liveness-cas-e98e).
 
 ### End your turn
 
-After you assign tasks and send context to workers, **produce no more output**. No `git log`, no `task list`, no `worker_status`. Your next action only happens in response to a worker message or a user prompt.
+After assigning tasks, **produce no more output**. Wait for worker messages or a user prompt.
 
 ## Quick Start
 

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/worker-recovery.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/worker-recovery.md
@@ -1,5 +1,18 @@
 # Worker Recovery — Triage and Failure Modes
 
+## Authoritative liveness (cas-e98e)
+
+`worker_status`, `agent_list`, and the FACTORY pane share one dual-signal classifier:
+
+> **Live = (Active/Idle + heartbeat &lt; 30s) OR live OS harness process for that agent.**
+
+**Authoritative for shutdown / re-spawn decisions:**
+
+1. **OS process** (highest) — if Grok/Claude/Codex is still running, the worker is alive even when heartbeat lagged (`[alive — heartbeat stale]` / `active,alive-heartbeat-stale`). Do **not** shut down, unregister, or re-spawn.
+2. **Heartbeat freshness** — within ~30s → live. Past that with no process → not live.
+3. **Supporting:** last activity / transcript age, worktree dirty, active leases, `is-wedged`.
+4. **Never** act on `Workers: None active` or `Filtered stale` alone — confirm `ps`/worktree/`is-wedged` first (cas-3e56 residual: false-empty roster nearly killed mid-turn Grok). Use `gc_cleanup` to purge dead registry rows.
+
 ## Is the worker actually dead? (cas-4513 triage)
 
 Before you run `shutdown_workers` on a pane that *looks* broken, spend 60 seconds on triage. The supervisor TUI is not ground truth for worker liveness — the most common false-positive failure mode is a worker that's mid-way through a long tool call or showing Claude Code's Bun/React-Ink crash screen (which leaves the process alive with an unresponsive UI). Destructive recovery on a live worker rips its worktree out from under itself and turns a recoverable hang into a real crash.
@@ -22,9 +35,9 @@ The Bun/React-Ink crash signature is the visual fingerprint captured in the cas-
 
 **Step 3: recovery.** Only after `is-wedged` reports `wedged` or `dead` — never off `unverified`:
 
-- **Wedged:** `cas factory kill <worker>` — SIGKILL (SIGTERM is observed not to exit cleanly on the Bun wedge) and reset any leased tasks (release lease + status→Open + clear assignee, same semantics as `mcp__cs__task action=reset`). Idempotent on an already-dead process. Then respawn.
+- **Wedged:** `cas factory kill <worker>` — SIGKILL (SIGTERM is observed not to exit cleanly on the Bun wedge) and reset any leased tasks (release lease + status→Open + clear assignee, same semantics as `mcp__cas__task action=reset`). Idempotent on an already-dead process. Then respawn.
 - **Starved:** do not kill. Come back in 2 minutes; if it re-classifies as `wedged`, proceed to the kill path.
-- **Dead:** no kill needed. The `kill` verb is still safe to run (`skipping SIGKILL` + task reset runs); or manually `mcp__cs__task action=reset id=<task>`.
+- **Dead:** no kill needed. The `kill` verb is still safe to run (`skipping SIGKILL` + task reset runs); or manually `mcp__cas__task action=reset id=<task>`.
 - **Unverified:** do not kill and do not reset the lease. Run `cas factory debug <worker>` and inspect the worktree manually; re-run `is-wedged` once you've confirmed which process is actually the worker.
 
 **Process resolution (cas-f781).** `cas factory kill` does not blindly trust the agent store's tracked pid — that value can be stale or wrong (the MCP-server-child self-registration bug above). Before killing, it scans the live process table for a process whose own argv (`--agent-name <worker>`) or environment (`CAS_AGENT_NAME=<worker>`, for Codex workers) identifies it as the target worker, and prefers that resolved pid over the tracked one. The summary line calls this out explicitly: `process-table scan resolved a live process for `<worker>` at pid N (agent-name match) — overriding stale tracked pid M`. The kill itself targets the process **group**, not a single pid, since workers are spawned as session leaders and may have forked children of their own.
@@ -39,9 +52,9 @@ The Bun/React-Ink crash signature is the visual fingerprint captured in the cas-
 
 Director and task-lifecycle notifications are hints, not ground truth. A known bug (tracking pointer `cas-dbbe`) produced false `task_completed` notifications around task start, including five false completions in one session. Before closing, reassigning, respawning, or merging because of a notification:
 
-- Run `mcp__cs__task action=show id=<task-id>` and trust the task status over the notification text.
+- Run `mcp__cas__task action=show id=<task-id>` and trust the task status over the notification text.
 - Check the worker branch tip or worktree commits before assuming work exists: `git -C .cas/worktrees/<worker> log --oneline -5`.
-- Check liveness with `mcp__cs__coordination action=worker_status` before declaring a worker idle or dead.
+- Check liveness with `mcp__cas__coordination action=worker_status` before declaring a worker idle or dead.
 
 ## Worker Failure Recovery
 
@@ -52,16 +65,16 @@ Workers fail in production. These are recurring observed failure modes and their
 **Signature:** Worker stops responding to messages. No progress notes, no commits, no heartbeat updates. Task stays `in_progress` indefinitely.
 
 **Diagnosis:**
-1. Check worker status: `mcp__cs__coordination action=worker_status`
-2. Look for stale heartbeat (last activity timestamp far in the past) or missing entry
-3. Check worker activity log: `mcp__cs__coordination action=worker_activity`
+1. Check worker status: `mcp__cas__coordination action=worker_status`
+2. Look for stale heartbeat (last activity timestamp far in the past) or missing entry — but **do not treat `Workers: None active` or `Filtered stale` as death alone** (cas-3e56: live Grok workers were omitted while mid-turn; prefer `[alive — heartbeat stale]` + OS/`ps`/worktree check before re-spawn)
+3. Check worker activity log: `mcp__cas__coordination action=worker_activity`
 
 **Recovery:**
 1. Check the worker's worktree for partial work: `git -C .cas/worktrees/<worker> log --oneline main..HEAD`
 2. If commits exist, cherry-pick salvageable work to the base branch before cleanup
-3. Release the dead worker's lease: `mcp__cs__task action=release id=<task-id>`
-4. Shut down the dead worker: `mcp__cs__coordination action=shutdown_workers count=0` (then respawn the count you need)
-5. Spawn a fresh worker: `mcp__cs__coordination action=spawn_workers count=1 isolate=true`
+3. Release the dead worker's lease: `mcp__cas__task action=release id=<task-id>`
+4. Shut down the dead worker: `mcp__cas__coordination action=shutdown_workers count=0` (then respawn the count you need)
+5. Spawn a fresh worker: `mcp__cas__coordination action=spawn_workers count=1 isolate=true`
 6. Reassign the task to the new worker. If partial work was cherry-picked, include that context in the assignment message so the new worker builds on it rather than redoing it.
 
 ### Injected but Unwoken Worker
@@ -69,7 +82,7 @@ Workers fail in production. These are recurring observed failure modes and their
 **Signature:** Heartbeat is fresh, worktree is clean, and there is zero activity for 10+ minutes after a supervisor message. The prompt was injected into the worker session, but the worker did not acknowledge or act. This is most often triggered by long multi-line payloads sent to Codex workers.
 
 **Diagnosis:**
-1. Confirm a fresh heartbeat with `mcp__cs__coordination action=worker_status`
+1. Confirm a fresh heartbeat with `mcp__cas__coordination action=worker_status`
 2. Confirm no work started: `git -C .cas/worktrees/<worker> status --short`
 3. Check prompt delivery state:
    ```bash
@@ -81,13 +94,13 @@ Workers fail in production. These are recurring observed failure modes and their
 1. Ensure the work exists as an assigned task with full spec and acceptance criteria.
 2. Send a short urgent wake that points only at the task:
    ```
-   mcp__cs__coordination action=message target=<worker> urgent=true summary="Task <id> assigned" message="Task <id> is assigned. Run mcp__cs__task action=show id=<id>."
+   mcp__cas__coordination action=message target=<worker> urgent=true summary="Task <id> assigned" message="Task <id> is assigned. Run mcp__cas__task action=show id=<id>."
    ```
 3. Do not kill or respawn. There is no evidence of a dead process or dirty worktree; the fix is a durable task plus a short wake.
 
 ### Pre-compaction Triage via worker_status context indicator (cas-573c)
 
-`mcp__cs__coordination action=worker_status` now includes a `context:` line per worker:
+`mcp__cas__coordination action=worker_status` now includes a `context:` line per worker:
 
 ```
   • bright-leopard-9 (heartbeat: 8s ago)
@@ -104,8 +117,8 @@ Workers fail in production. These are recurring observed failure modes and their
 | `near-limit` | ≥ 160k | Act immediately — see recovery steps below. |
 
 **Pre-compaction recovery (context: near-limit):**
-1. Send: `mcp__cs__coordination action=message target=<worker> message="Your context is near the limit. Commit any in-progress work immediately (git add / git commit), then report what you committed."`
-2. Wait for the commit confirmation (watch `mcp__cs__coordination action=worker_activity`).
+1. Send: `mcp__cas__coordination action=message target=<worker> message="Your context is near the limit. Commit any in-progress work immediately (git add / git commit), then report what you committed."`
+2. Wait for the commit confirmation (watch `mcp__cas__coordination action=worker_activity`).
 3. If the worker is mid-task and not responding: check the worktree manually: `git -C .cas/worktrees/<worker> log --oneline HEAD~5..HEAD`
 4. Once work is committed: shut down the worker cleanly and respawn with a fresh context.
 
@@ -140,7 +153,7 @@ Workers fail in production. These are recurring observed failure modes and their
 2. Respawn workers — they will pick up the new binary
 
 **Recovery (binary is outdated or rebuild is not feasible mid-session):**
-1. Close the jailed task with an audit trail: `mcp__cs__task action=close id=<task-id> reason="Supervisor close — verification jail deadlock. Work verified at <commit-sha>. Worker jailed, CAS binary predates bba6fbf exemption fix."`
+1. Close the jailed task with an audit trail: `mcp__cas__task action=close id=<task-id> reason="Supervisor close — verification jail deadlock. Work verified at <commit-sha>. Worker jailed, CAS binary predates bba6fbf exemption fix."`
 2. If `close` is also blocked, use direct sqlite as last resort:
    ```sql
    UPDATE tasks SET status='closed', pending_verification=0 WHERE id='cas-XXXX';

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor.md
@@ -31,20 +31,11 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Counter-propose when you see a better path.** Three anchors required: (a) a specific citable source — pattern, library, prior incident, commit, measured characteristic; (b) a concrete cost of the current approach; (c) a concrete benefit of the alternative. No anchors → no counter-proposal; execute or ask a clarifying question.
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 - **Tier every spawn — never fleet-default.** Explicit `model=`/`effort=` every spawn. Four tiers: **light** `grok/grok-composer-2.5-fast`; **standard** `grok/grok-4.5/medium` (floor); **heavy** `grok/grok-4.5/high`; **frontier** `claude/opus/high` (sparingly). Deep-dive: [model-selection.md](cas-supervisor/references/model-selection.md).
-
-### Worker liveness (authoritative signals) — cas-e98e / cas-3e56
-
-**Authoritative formula** (shared by `worker_status`, `agent_list`, FACTORY pane):
-
-> Live = (Active/Idle + heartbeat &lt; 30s) **OR** live OS harness process for that agent.
-
-1. **Process presence** is the mid-turn life signal — dual-signal labels when heartbeat lags but process is up.
-2. **Supporting:** last activity / transcript age, worktree dirty, active leases.
-3. **Shutdown / re-spawn:** never act on `Workers: None active` alone — confirm `ps`/worktree/`is-wedged` first.
+- **Worker liveness (cas-e98e):** live = fresh heartbeat **or** live OS process. Never shut down on `None active` alone — see [worker-recovery.md](cas-supervisor/references/worker-recovery.md#authoritative-liveness-cas-e98e).
 
 ### End your turn
 
-After you assign tasks and send context to workers, **produce no more output**. No `git log`, no `task list`, no `worker_status`. Your next action only happens in response to a worker message or a user prompt.
+After assigning tasks, **produce no more output**. Wait for worker messages or a user prompt.
 
 ## Quick Start
 

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor/references/worker-recovery.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor/references/worker-recovery.md
@@ -1,5 +1,18 @@
 # Worker Recovery — Triage and Failure Modes
 
+## Authoritative liveness (cas-e98e)
+
+`worker_status`, `agent_list`, and the FACTORY pane share one dual-signal classifier:
+
+> **Live = (Active/Idle + heartbeat &lt; 30s) OR live OS harness process for that agent.**
+
+**Authoritative for shutdown / re-spawn decisions:**
+
+1. **OS process** (highest) — if Grok/Claude/Codex is still running, the worker is alive even when heartbeat lagged (`[alive — heartbeat stale]` / `active,alive-heartbeat-stale`). Do **not** shut down, unregister, or re-spawn.
+2. **Heartbeat freshness** — within ~30s → live. Past that with no process → not live.
+3. **Supporting:** last activity / transcript age, worktree dirty, active leases, `is-wedged`.
+4. **Never** act on `Workers: None active` or `Filtered stale` alone — confirm `ps`/worktree/`is-wedged` first (cas-3e56 residual: false-empty roster nearly killed mid-turn Grok). Use `gc_cleanup` to purge dead registry rows.
+
 ## Is the worker actually dead? (cas-4513 triage)
 
 Before you run `shutdown_workers` on a pane that *looks* broken, spend 60 seconds on triage. The supervisor TUI is not ground truth for worker liveness — the most common false-positive failure mode is a worker that's mid-way through a long tool call or showing Claude Code's Bun/React-Ink crash screen (which leaves the process alive with an unresponsive UI). Destructive recovery on a live worker rips its worktree out from under itself and turns a recoverable hang into a real crash.
@@ -22,9 +35,9 @@ The Bun/React-Ink crash signature is the visual fingerprint captured in the cas-
 
 **Step 3: recovery.** Only after `is-wedged` reports `wedged` or `dead` — never off `unverified`:
 
-- **Wedged:** `cas factory kill <worker>` — SIGKILL (SIGTERM is observed not to exit cleanly on the Bun wedge) and reset any leased tasks (release lease + status→Open + clear assignee, same semantics as `cas__task action=reset`). Idempotent on an already-dead process. Then respawn.
+- **Wedged:** `cas factory kill <worker>` — SIGKILL (SIGTERM is observed not to exit cleanly on the Bun wedge) and reset any leased tasks (release lease + status→Open + clear assignee, same semantics as `mcp__cas__task action=reset`). Idempotent on an already-dead process. Then respawn.
 - **Starved:** do not kill. Come back in 2 minutes; if it re-classifies as `wedged`, proceed to the kill path.
-- **Dead:** no kill needed. The `kill` verb is still safe to run (`skipping SIGKILL` + task reset runs); or manually `cas__task action=reset id=<task>`.
+- **Dead:** no kill needed. The `kill` verb is still safe to run (`skipping SIGKILL` + task reset runs); or manually `mcp__cas__task action=reset id=<task>`.
 - **Unverified:** do not kill and do not reset the lease. Run `cas factory debug <worker>` and inspect the worktree manually; re-run `is-wedged` once you've confirmed which process is actually the worker.
 
 **Process resolution (cas-f781).** `cas factory kill` does not blindly trust the agent store's tracked pid — that value can be stale or wrong (the MCP-server-child self-registration bug above). Before killing, it scans the live process table for a process whose own argv (`--agent-name <worker>`) or environment (`CAS_AGENT_NAME=<worker>`, for Codex workers) identifies it as the target worker, and prefers that resolved pid over the tracked one. The summary line calls this out explicitly: `process-table scan resolved a live process for `<worker>` at pid N (agent-name match) — overriding stale tracked pid M`. The kill itself targets the process **group**, not a single pid, since workers are spawned as session leaders and may have forked children of their own.
@@ -39,9 +52,9 @@ The Bun/React-Ink crash signature is the visual fingerprint captured in the cas-
 
 Director and task-lifecycle notifications are hints, not ground truth. A known bug (tracking pointer `cas-dbbe`) produced false `task_completed` notifications around task start, including five false completions in one session. Before closing, reassigning, respawning, or merging because of a notification:
 
-- Run `cas__task action=show id=<task-id>` and trust the task status over the notification text.
+- Run `mcp__cas__task action=show id=<task-id>` and trust the task status over the notification text.
 - Check the worker branch tip or worktree commits before assuming work exists: `git -C .cas/worktrees/<worker> log --oneline -5`.
-- Check liveness with `cas__coordination action=worker_status` before declaring a worker idle or dead.
+- Check liveness with `mcp__cas__coordination action=worker_status` before declaring a worker idle or dead.
 
 ## Worker Failure Recovery
 
@@ -52,16 +65,16 @@ Workers fail in production. These are recurring observed failure modes and their
 **Signature:** Worker stops responding to messages. No progress notes, no commits, no heartbeat updates. Task stays `in_progress` indefinitely.
 
 **Diagnosis:**
-1. Check worker status: `cas__coordination action=worker_status`
-2. Look for stale heartbeat (last activity timestamp far in the past) or missing entry
-3. Check worker activity log: `cas__coordination action=worker_activity`
+1. Check worker status: `mcp__cas__coordination action=worker_status`
+2. Look for stale heartbeat (last activity timestamp far in the past) or missing entry — but **do not treat `Workers: None active` or `Filtered stale` as death alone** (cas-3e56: live Grok workers were omitted while mid-turn; prefer `[alive — heartbeat stale]` + OS/`ps`/worktree check before re-spawn)
+3. Check worker activity log: `mcp__cas__coordination action=worker_activity`
 
 **Recovery:**
 1. Check the worker's worktree for partial work: `git -C .cas/worktrees/<worker> log --oneline main..HEAD`
 2. If commits exist, cherry-pick salvageable work to the base branch before cleanup
-3. Release the dead worker's lease: `cas__task action=release id=<task-id>`
-4. Shut down the dead worker: `cas__coordination action=shutdown_workers count=0` (then respawn the count you need)
-5. Spawn a fresh worker: `cas__coordination action=spawn_workers count=1 isolate=true`
+3. Release the dead worker's lease: `mcp__cas__task action=release id=<task-id>`
+4. Shut down the dead worker: `mcp__cas__coordination action=shutdown_workers count=0` (then respawn the count you need)
+5. Spawn a fresh worker: `mcp__cas__coordination action=spawn_workers count=1 isolate=true`
 6. Reassign the task to the new worker. If partial work was cherry-picked, include that context in the assignment message so the new worker builds on it rather than redoing it.
 
 ### Injected but Unwoken Worker
@@ -69,7 +82,7 @@ Workers fail in production. These are recurring observed failure modes and their
 **Signature:** Heartbeat is fresh, worktree is clean, and there is zero activity for 10+ minutes after a supervisor message. The prompt was injected into the worker session, but the worker did not acknowledge or act. This is most often triggered by long multi-line payloads sent to Codex workers.
 
 **Diagnosis:**
-1. Confirm a fresh heartbeat with `cas__coordination action=worker_status`
+1. Confirm a fresh heartbeat with `mcp__cas__coordination action=worker_status`
 2. Confirm no work started: `git -C .cas/worktrees/<worker> status --short`
 3. Check prompt delivery state:
    ```bash
@@ -81,13 +94,13 @@ Workers fail in production. These are recurring observed failure modes and their
 1. Ensure the work exists as an assigned task with full spec and acceptance criteria.
 2. Send a short urgent wake that points only at the task:
    ```
-   cas__coordination action=message target=<worker> urgent=true summary="Task <id> assigned" message="Task <id> is assigned. Run cas__task action=show id=<id>."
+   mcp__cas__coordination action=message target=<worker> urgent=true summary="Task <id> assigned" message="Task <id> is assigned. Run mcp__cas__task action=show id=<id>."
    ```
 3. Do not kill or respawn. There is no evidence of a dead process or dirty worktree; the fix is a durable task plus a short wake.
 
 ### Pre-compaction Triage via worker_status context indicator (cas-573c)
 
-`cas__coordination action=worker_status` now includes a `context:` line per worker:
+`mcp__cas__coordination action=worker_status` now includes a `context:` line per worker:
 
 ```
   • bright-leopard-9 (heartbeat: 8s ago)
@@ -104,8 +117,8 @@ Workers fail in production. These are recurring observed failure modes and their
 | `near-limit` | ≥ 160k | Act immediately — see recovery steps below. |
 
 **Pre-compaction recovery (context: near-limit):**
-1. Send: `cas__coordination action=message target=<worker> message="Your context is near the limit. Commit any in-progress work immediately (git add / git commit), then report what you committed."`
-2. Wait for the commit confirmation (watch `cas__coordination action=worker_activity`).
+1. Send: `mcp__cas__coordination action=message target=<worker> message="Your context is near the limit. Commit any in-progress work immediately (git add / git commit), then report what you committed."`
+2. Wait for the commit confirmation (watch `mcp__cas__coordination action=worker_activity`).
 3. If the worker is mid-task and not responding: check the worktree manually: `git -C .cas/worktrees/<worker> log --oneline HEAD~5..HEAD`
 4. Once work is committed: shut down the worker cleanly and respawn with a fresh context.
 
@@ -140,7 +153,7 @@ Workers fail in production. These are recurring observed failure modes and their
 2. Respawn workers — they will pick up the new binary
 
 **Recovery (binary is outdated or rebuild is not feasible mid-session):**
-1. Close the jailed task with an audit trail: `cas__task action=close id=<task-id> reason="Supervisor close — verification jail deadlock. Work verified at <commit-sha>. Worker jailed, CAS binary predates bba6fbf exemption fix."`
+1. Close the jailed task with an audit trail: `mcp__cas__task action=close id=<task-id> reason="Supervisor close — verification jail deadlock. Work verified at <commit-sha>. Worker jailed, CAS binary predates bba6fbf exemption fix."`
 2. If `close` is also blocked, use direct sqlite as last resort:
    ```sql
    UPDATE tasks SET status='closed', pending_verification=0 WHERE id='cas-XXXX';

--- a/cas-cli/src/builtins/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor.md
@@ -31,20 +31,11 @@ You are a senior engineer who loves their craft and has zero patience for bad de
 - **Counter-propose when you see a better path.** Three anchors required: (a) a specific citable source — pattern, library, prior incident, commit, measured characteristic; (b) a concrete cost of the current approach; (c) a concrete benefit of the alternative. No anchors → no counter-proposal; execute or ask a clarifying question.
 - **Self-challenge before touching shared surfaces.** Before editing any skill, agent, hook, shared config, or distributed template: "who reads this file after my edit, and does this change fit all of them?" Catches scope errors before they ship to every consumer.
 - **Tier every spawn — never fleet-default.** Explicit `model=`/`effort=` every spawn. Four tiers: **light** `grok/grok-composer-2.5-fast`; **standard** `grok/grok-4.5/medium` (floor); **heavy** `grok/grok-4.5/high`; **frontier** `claude/opus/high` (sparingly). Details: [model-selection.md](cas-supervisor/references/model-selection.md).
-
-### Worker liveness (authoritative signals) — cas-e98e / cas-3e56
-
-**Authoritative formula** (shared by `worker_status`, `agent_list`, FACTORY pane):
-
-> Live = (Active/Idle + heartbeat &lt; 30s) **OR** live OS harness process for that agent.
-
-1. **Process presence** is the mid-turn life signal — `worker_status` / `agent_list` show `alive-heartbeat-stale` / `[alive — heartbeat stale]` when heartbeat lags but the process is up.
-2. **Supporting:** last activity / transcript age, worktree dirty, active leases.
-3. **Shutdown / re-spawn:** never act on `Workers: None active` or `Filtered stale` alone — confirm `ps`/worktree/`is-wedged` first. Use `gc_cleanup` to purge dead registry rows, not `shutdown_workers` on a false-empty roster.
+- **Worker liveness (cas-e98e):** live = fresh heartbeat **or** live OS process. Never shut down on `None active` alone — see [worker-recovery.md](cas-supervisor/references/worker-recovery.md#authoritative-liveness-cas-e98e).
 
 ### End your turn
 
-After you assign tasks and send context to workers, **produce no more output**. No `git log`, no `task list`, no `worker_status`. Your next action only happens in response to a worker message or a user prompt.
+After assigning tasks, **produce no more output**. Wait for worker messages or a user prompt.
 
 ## Quick Start
 

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/worker-recovery.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/worker-recovery.md
@@ -1,5 +1,18 @@
 # Worker Recovery — Triage and Failure Modes
 
+## Authoritative liveness (cas-e98e)
+
+`worker_status`, `agent_list`, and the FACTORY pane share one dual-signal classifier:
+
+> **Live = (Active/Idle + heartbeat &lt; 30s) OR live OS harness process for that agent.**
+
+**Authoritative for shutdown / re-spawn decisions:**
+
+1. **OS process** (highest) — if Grok/Claude/Codex is still running, the worker is alive even when heartbeat lagged (`[alive — heartbeat stale]` / `active,alive-heartbeat-stale`). Do **not** shut down, unregister, or re-spawn.
+2. **Heartbeat freshness** — within ~30s → live. Past that with no process → not live.
+3. **Supporting:** last activity / transcript age, worktree dirty, active leases, `is-wedged`.
+4. **Never** act on `Workers: None active` or `Filtered stale` alone — confirm `ps`/worktree/`is-wedged` first (cas-3e56 residual: false-empty roster nearly killed mid-turn Grok). Use `gc_cleanup` to purge dead registry rows.
+
 ## Is the worker actually dead? (cas-4513 triage)
 
 Before you run `shutdown_workers` on a pane that *looks* broken, spend 60 seconds on triage. The supervisor TUI is not ground truth for worker liveness — the most common false-positive failure mode is a worker that's mid-way through a long tool call or showing Claude Code's Bun/React-Ink crash screen (which leaves the process alive with an unresponsive UI). Destructive recovery on a live worker rips its worktree out from under itself and turns a recoverable hang into a real crash.

--- a/cas-cli/src/mcp/tools/service/agent_liveness.rs
+++ b/cas-cli/src/mcp/tools/service/agent_liveness.rs
@@ -124,6 +124,24 @@ pub fn is_live_factory_worker(agent: &Agent) -> bool {
     agent.role == AgentRole::Worker && evaluate_supervision_liveness(agent).is_live()
 }
 
+/// Whether a worker pane named `name` should remain given registry agents.
+///
+/// cas-e98e AC3 phantom-pane rule: keep when still registering (no rows) or
+/// any matching row is supervision-live; drop when every matching row is
+/// non-live (dead process + stale/shutdown registry).
+pub fn should_keep_worker_pane<'a>(
+    name: &str,
+    agents: impl IntoIterator<Item = &'a Agent>,
+) -> bool {
+    let matching: Vec<&Agent> = agents.into_iter().filter(|a| a.name == name).collect();
+    if matching.is_empty() {
+        return true;
+    }
+    matching
+        .iter()
+        .any(|a| evaluate_supervision_liveness(a).is_live())
+}
+
 /// `agent_list` status token using authoritative liveness.
 pub fn agent_list_status_label(agent: &Agent) -> String {
     match evaluate_supervision_liveness(agent) {
@@ -207,5 +225,20 @@ mod tests {
         a.pid = Some(9);
         assert!(agent_process_is_alive_with(&a, |p| p == 9, |_, _| false));
         assert!(!agent_process_is_alive_with(&a, |_| false, |_, _| true));
+    }
+
+    #[test]
+    fn pane_kept_when_unregistered_or_live() {
+        assert!(should_keep_worker_pane("spawning", std::iter::empty()));
+        let live = worker(AgentStatus::Active, 5);
+        assert!(should_keep_worker_pane("w1", std::iter::once(&live)));
+    }
+
+    #[test]
+    fn pane_dropped_when_all_matching_not_live() {
+        let dead = worker(AgentStatus::Stale, 120);
+        assert!(!should_keep_worker_pane("w1", std::iter::once(&dead)));
+        let shutdown = worker(AgentStatus::Shutdown, 0);
+        assert!(!should_keep_worker_pane("w1", std::iter::once(&shutdown)));
     }
 }

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -809,6 +809,14 @@ impl FactoryApp {
         self.sync_session_mappings();
         self.apply_session_metadata_focus();
 
+        // cas-e98e AC3: drop phantom worker panes when registry says the
+        // worker is no longer supervision-live (Shutdown, or Stale/dead with
+        // no live process). Keeps panes for still-registering names and for
+        // process-alive dual-signal workers.
+        if db_changed {
+            self.reconcile_phantom_worker_panes();
+        }
+
         // Detect state changes against the UNFILTERED snapshot (cas-dbbe) so new
         // epics are visible to the event detector, and so a second epic worked
         // concurrently in this session is never epic-scoped out of the
@@ -828,6 +836,47 @@ impl FactoryApp {
         }
 
         Ok(events)
+    }
+
+    /// Drop worker panes whose registry rows are all non-live (cas-e98e AC3).
+    ///
+    /// Uses the shared [`crate::mcp::tools::service::agent_liveness`] classifier
+    /// so pane grid, worker_status, and agent_list cannot disagree about dead
+    /// workers. Names with **no** registry row yet are kept (spawn race).
+    fn reconcile_phantom_worker_panes(&mut self) {
+        use crate::mcp::tools::service::agent_liveness::should_keep_worker_pane;
+        use crate::store::open_agent_store;
+
+        let Ok(agent_store) = open_agent_store(&self.cas_dir) else {
+            return;
+        };
+        let Ok(all_agents) = agent_store.list(None) else {
+            return;
+        };
+
+        let to_drop: Vec<String> = self
+            .worker_names
+            .iter()
+            .filter(|name| !should_keep_worker_pane(name, all_agents.iter()))
+            .cloned()
+            .collect();
+
+        if to_drop.is_empty() {
+            return;
+        }
+
+        for name in &to_drop {
+            tracing::info!(
+                worker = %name,
+                "cas-e98e: dropping phantom worker pane (registry non-live)"
+            );
+            self.worker_names.retain(|n| n != name);
+            self.event_detector.remove_worker(name);
+        }
+
+        self.pane_grid = PaneGrid::new(&self.worker_names, &self.supervisor_name, self.is_tabbed);
+        self.clamp_selected_worker_tab();
+        let _ = self.sync_pane_sizes();
     }
 
     fn set_active_epic(

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -1072,7 +1072,11 @@ async fn test_worker_status_and_agent_list_agree_on_live_workers() {
             .expect("agent_list"),
     );
 
-    // Live identities from worker_status (named bullets).
+    // Live identities from worker_status (named bullets) — AC2 count + identity.
+    assert!(
+        status_text.contains("Workers (2)"),
+        "worker_status operational count must be 2. Got:\n{status_text}"
+    );
     for name in ["live-fresh", "live-stale-hb"] {
         assert!(
             status_text.contains(name),
@@ -1084,8 +1088,12 @@ async fn test_worker_status_and_agent_list_agree_on_live_workers() {
         );
     }
     assert!(
+        list_text.contains("Live factory workers (authoritative): 2"),
+        "agent_list live footer must agree on count 2. Got:\n{list_text}"
+    );
+    assert!(
         list_text.contains("active,alive-heartbeat-stale")
-            || status_text.contains("alive") && status_text.contains("heartbeat stale"),
+            || (status_text.contains("alive") && status_text.contains("heartbeat stale")),
         "dual-signal must appear for process-alive stale-hb worker.\nstatus:\n{status_text}\nlist:\n{list_text}"
     );
     assert!(


### PR DESCRIPTION
## Summary
- Define one authoritative dual-signal liveness classifier (`agent_liveness`: fresh heartbeat **or** live OS harness process) shared by `worker_status`, `agent_list`, and the FACTORY pane.
- `agent_list` uses dual-signal status labels + live-worker footer so it agrees with `worker_status` on operational count/identity.
- FACTORY director keeps process-alive Stale agents (no false `not registered`); phantom worker panes are dropped on refresh when registry is non-live.
- Supervisor skill documents shutdown authority (OS process wins over empty roster); detail in `worker-recovery.md` without blowing the 8KB SessionStart cap.

Does **not** re-do cas-3e56 (already on main); builds on that process-alive prune suppress.

## Test plan
- [x] `cargo test -p cas --lib agent_liveness` (9 ok)
- [x] `cargo test -p cas --test factory_mcp_ops_test worker_status -- --test-threads=1` (9 ok, includes agreement test)
- [x] `cargo test -p cas --lib test_supervisor_guidance_under_8kb` (ok)

## Commits
- `19a7121` unify supervision liveness across status surfaces
- `3c5353c` phantom pane reconcile + skill budget

Task: cas-e98e