### PR TITLE
fix(sync): pull apply skips SyncQueue re-enqueue (cas-7fbb)

### DIFF
--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -18,8 +18,9 @@ use crate::ui::theme::ActiveTheme;
 
 use crate::store::{
     SqliteStore, open_commit_link_store, open_event_store, open_file_change_store,
-    open_prompt_store, open_rule_store, open_skill_store, open_spec_store, open_store,
-    open_task_store, open_worktree_store,
+    open_prompt_store, open_rule_store, open_rule_store_local, open_skill_store,
+    open_skill_store_local, open_spec_store, open_store, open_store_local, open_task_store,
+    open_task_store_local, open_worktree_store,
 };
 
 #[derive(Subcommand)]
@@ -1916,10 +1917,13 @@ fn execute_pull(args: &CloudPullArgs, cli: &Cli, cas_root: &Path) -> anyhow::Res
     // cas-bba4 re-adds the remaining 5 entity kinds (specs/events/prompts/
     // file_changes/commit_links) — also scoped — so `cas cloud pull` once
     // again imports the full set without re-introducing the leak.
-    let store = open_store(cas_root)?;
-    let task_store = open_task_store(cas_root)?;
-    let rule_store = open_rule_store(cas_root)?;
-    let skill_store = open_skill_store(cas_root)?;
+    //
+    // cas-7fbb: use *_local openers so pull apply does not re-enqueue into
+    // SyncQueue (open_store wraps Syncing* when logged in → push↔pull loop).
+    let store = open_store_local(cas_root)?;
+    let task_store = open_task_store_local(cas_root)?;
+    let rule_store = open_rule_store_local(cas_root)?;
+    let skill_store = open_skill_store_local(cas_root)?;
     let spec_store = open_spec_store(cas_root)?;
     let event_store = open_event_store(cas_root)?;
     let prompt_store = open_prompt_store(cas_root)?;
@@ -2471,28 +2475,30 @@ pub fn execute_team_pull(
     // Per cas-6ec7 spec, this is intentional parity with the current
     // `pull_team` signature — adding the remaining 5 entity kinds is a
     // separate scope expansion.
-    let store = match open_store(cas_root) {
+    //
+    // cas-7fbb: *_local openers — pull must not re-enqueue pulled rows.
+    let store = match open_store_local(cas_root) {
         Ok(s) => s,
         Err(e) => {
             let _ = report_team_pull_error(cli, &format!("Could not open entry store: {e}"));
             return Ok(());
         }
     };
-    let task_store = match open_task_store(cas_root) {
+    let task_store = match open_task_store_local(cas_root) {
         Ok(s) => s,
         Err(e) => {
             let _ = report_team_pull_error(cli, &format!("Could not open task store: {e}"));
             return Ok(());
         }
     };
-    let rule_store = match open_rule_store(cas_root) {
+    let rule_store = match open_rule_store_local(cas_root) {
         Ok(s) => s,
         Err(e) => {
             let _ = report_team_pull_error(cli, &format!("Could not open rule store: {e}"));
             return Ok(());
         }
     };
-    let skill_store = match open_skill_store(cas_root) {
+    let skill_store = match open_skill_store_local(cas_root) {
         Ok(s) => s,
         Err(e) => {
             let _ = report_team_pull_error(cli, &format!("Could not open skill store: {e}"));
@@ -2979,10 +2985,11 @@ fn execute_team_memories(
         return Ok(());
     }
 
-    // Merge into local stores using LWW
-    let store = open_store(cas_root)?;
-    let rule_store = open_rule_store(cas_root)?;
-    let skill_store = open_skill_store(cas_root)?;
+    // Merge into local stores using LWW.
+    // cas-7fbb: apply remote team memories without re-enqueueing to SyncQueue.
+    let store = open_store_local(cas_root)?;
+    let rule_store = open_rule_store_local(cas_root)?;
+    let skill_store = open_skill_store_local(cas_root)?;
 
     let mut entries_merged = 0usize;
     let mut entries_skipped = 0usize;
@@ -3119,10 +3126,12 @@ fn execute_purge_foreign(
     let project_id = get_project_canonical_id()
         .ok_or_else(|| anyhow::anyhow!("Cannot determine project ID. Not inside a CAS project?"))?;
 
-    let store = open_store(cas_root)?;
-    let task_store = open_task_store(cas_root)?;
-    let rule_store = open_rule_store(cas_root)?;
-    let skill_store = open_skill_store(cas_root)?;
+    // cas-7fbb: delete + re-pull must use local openers so the re-pull does
+    // not re-feed SyncQueue.
+    let store = open_store_local(cas_root)?;
+    let task_store = open_task_store_local(cas_root)?;
+    let rule_store = open_rule_store_local(cas_root)?;
+    let skill_store = open_skill_store_local(cas_root)?;
     // cas-bba4: extra stores required by the extended `CloudSyncer::pull`
     // signature. purge-foreign only deletes content entities (entries/tasks/
     // rules/skills), so these are passed through purely to satisfy the

--- a/cas-cli/src/mcp/daemon.rs
+++ b/cas-cli/src/mcp/daemon.rs
@@ -32,8 +32,8 @@ use crate::orchestration::names as friendly_names;
 use crate::store::open_agent_store;
 use crate::store::{
     SqliteStore, open_commit_link_store, open_event_store, open_file_change_store,
-    open_prompt_store, open_rule_store, open_skill_store, open_spec_store, open_store,
-    open_task_store,
+    open_prompt_store, open_rule_store_local, open_skill_store_local, open_spec_store,
+    open_store_local, open_task_store_local,
 };
 use crate::types::{Agent, AgentRole};
 
@@ -1092,15 +1092,18 @@ impl EmbeddedDaemon {
                 }
             }
 
-            // Open stores without cloud sync wrappers (to avoid recursion)
-            // We use the base stores here since we're doing the sync ourselves
-            let store = open_store(&cas_root)?;
-            let task_store = open_task_store(&cas_root)?;
-            let rule_store = open_rule_store(&cas_root)?;
-            let skill_store = open_skill_store(&cas_root)?;
+            // cas-7fbb: open_*_local skips Syncing* / SyncQueue wrappers so
+            // pull apply does not re-enqueue remote rows (which would feed
+            // push → pull forever). Local edits still use open_store (etc.)
+            // and correctly enqueue.
+            let store = open_store_local(&cas_root)?;
+            let task_store = open_task_store_local(&cas_root)?;
+            let rule_store = open_rule_store_local(&cas_root)?;
+            let skill_store = open_skill_store_local(&cas_root)?;
             // cas-bba4: extra stores for the extended pull surface (specs +
             // events + prompts + file_changes + commit_links). The auto-sync
             // path now imports the full content set just like `cas cloud pull`.
+            // These kinds are not wrapped by Syncing* openers today.
             let spec_store = open_spec_store(&cas_root)?;
             let event_store = open_event_store(&cas_root)?;
             let prompt_store = open_prompt_store(&cas_root)?;

--- a/cas-cli/src/store/detect.rs
+++ b/cas-cli/src/store/detect.rs
@@ -221,8 +221,9 @@ pub fn detect_store_type(cas_dir: &Path) -> StoreType {
     StoreType::Sqlite
 }
 
-/// Open the appropriate store based on what exists
-pub fn open_store(cas_dir: &Path) -> Result<Arc<dyn Store>> {
+/// Open base entry store (sqlite/markdown + optional notifier).
+/// Never wraps with [`SyncingEntryStore`] — safe for pull/apply-remote.
+fn open_store_base(cas_dir: &Path) -> Result<Arc<dyn Store>> {
     let store_type = detect_store_type(cas_dir);
     let config = Config::load(cas_dir).unwrap_or_default();
 
@@ -240,11 +241,24 @@ pub fn open_store(cas_dir: &Path) -> Result<Arc<dyn Store>> {
     };
 
     // Wrap with notifying store if TUI notifier is active
-    let base_store: Arc<dyn Store> = if has_notifier() && config.notifications_enabled() {
-        Arc::new(NotifyingEntryStore::new(base_store, config.notifications()))
+    if has_notifier() && config.notifications_enabled() {
+        Ok(Arc::new(NotifyingEntryStore::new(
+            base_store,
+            config.notifications(),
+        )))
     } else {
-        base_store
-    };
+        Ok(base_store)
+    }
+}
+
+/// Open the appropriate store based on what exists.
+///
+/// When logged in, wraps writes with [`SyncingEntryStore`] so local edits
+/// enqueue to the cloud SyncQueue. For pull / apply-remote paths use
+/// [`open_store_local`] instead — otherwise every pulled row re-enters the
+/// queue and push↔pull never settles (cas-7fbb).
+pub fn open_store(cas_dir: &Path) -> Result<Arc<dyn Store>> {
+    let base_store = open_store_base(cas_dir)?;
 
     // Wrap with cloud sync if logged in
     if let Ok(cloud_config) = CloudConfig::load_from_cas_dir(cas_dir) {
@@ -262,20 +276,36 @@ pub fn open_store(cas_dir: &Path) -> Result<Arc<dyn Store>> {
     Ok(base_store)
 }
 
-/// Open the task store
-pub fn open_task_store(cas_dir: &Path) -> Result<Arc<dyn TaskStore>> {
+/// Open entry store without cloud SyncQueue wrappers.
+///
+/// Use on pull / team-pull / daemon cloud-sync apply paths so remote rows
+/// are written locally without re-enqueueing (cas-7fbb).
+pub fn open_store_local(cas_dir: &Path) -> Result<Arc<dyn Store>> {
+    open_store_base(cas_dir)
+}
+
+/// Open base task store (+ optional notifier). No SyncingTaskStore.
+fn open_task_store_base(cas_dir: &Path) -> Result<Arc<dyn TaskStore>> {
     let config = Config::load(cas_dir).unwrap_or_default();
 
     let store = SqliteTaskStore::open(cas_dir)?;
     store.init()?;
     let base_store: Arc<dyn TaskStore> = Arc::new(store);
 
-    // Wrap with notifying store if TUI notifier is active
-    let base_store: Arc<dyn TaskStore> = if has_notifier() && config.notifications_enabled() {
-        Arc::new(NotifyingTaskStore::new(base_store, config.notifications()))
+    if has_notifier() && config.notifications_enabled() {
+        Ok(Arc::new(NotifyingTaskStore::new(
+            base_store,
+            config.notifications(),
+        )))
     } else {
-        base_store
-    };
+        Ok(base_store)
+    }
+}
+
+/// Open the task store (cloud-sync wrap when logged in).
+/// Prefer [`open_task_store_local`] for pull/apply-remote paths.
+pub fn open_task_store(cas_dir: &Path) -> Result<Arc<dyn TaskStore>> {
+    let base_store = open_task_store_base(cas_dir)?;
 
     // Wrap with cloud sync if logged in
     if let Ok(cloud_config) = CloudConfig::load_from_cas_dir(cas_dir) {
@@ -293,20 +323,33 @@ pub fn open_task_store(cas_dir: &Path) -> Result<Arc<dyn TaskStore>> {
     Ok(base_store)
 }
 
-/// Open the skill store
-pub fn open_skill_store(cas_dir: &Path) -> Result<Arc<dyn SkillStore>> {
+/// Open task store without cloud SyncQueue wrappers (cas-7fbb).
+pub fn open_task_store_local(cas_dir: &Path) -> Result<Arc<dyn TaskStore>> {
+    open_task_store_base(cas_dir)
+}
+
+/// Open base skill store (+ optional notifier). No SyncingSkillStore.
+fn open_skill_store_base(cas_dir: &Path) -> Result<Arc<dyn SkillStore>> {
     let config = Config::load(cas_dir).unwrap_or_default();
 
     let store = SqliteSkillStore::open(cas_dir)?;
     store.init()?;
     let base_store: Arc<dyn SkillStore> = Arc::new(store);
 
-    // Wrap with notifying store if TUI notifier is active
-    let base_store: Arc<dyn SkillStore> = if has_notifier() && config.notifications_enabled() {
-        Arc::new(NotifyingSkillStore::new(base_store, config.notifications()))
+    if has_notifier() && config.notifications_enabled() {
+        Ok(Arc::new(NotifyingSkillStore::new(
+            base_store,
+            config.notifications(),
+        )))
     } else {
-        base_store
-    };
+        Ok(base_store)
+    }
+}
+
+/// Open the skill store (cloud-sync wrap when logged in).
+/// Prefer [`open_skill_store_local`] for pull/apply-remote paths.
+pub fn open_skill_store(cas_dir: &Path) -> Result<Arc<dyn SkillStore>> {
+    let base_store = open_skill_store_base(cas_dir)?;
 
     // Wrap with cloud sync if logged in
     if let Ok(cloud_config) = CloudConfig::load_from_cas_dir(cas_dir) {
@@ -322,6 +365,11 @@ pub fn open_skill_store(cas_dir: &Path) -> Result<Arc<dyn SkillStore>> {
     }
 
     Ok(base_store)
+}
+
+/// Open skill store without cloud SyncQueue wrappers (cas-7fbb).
+pub fn open_skill_store_local(cas_dir: &Path) -> Result<Arc<dyn SkillStore>> {
+    open_skill_store_base(cas_dir)
 }
 
 /// Open the entity store for knowledge graph
@@ -436,8 +484,8 @@ pub fn open_spec_store(cas_dir: &Path) -> Result<Arc<dyn SpecStore>> {
     Ok(Arc::new(store))
 }
 
-/// Open the appropriate rule store
-pub fn open_rule_store(cas_dir: &Path) -> Result<Arc<dyn RuleStore>> {
+/// Open base rule store (+ optional notifier). No SyncingRuleStore / SyncQueue.
+fn open_rule_store_base(cas_dir: &Path) -> Result<Arc<dyn RuleStore>> {
     let store_type = detect_store_type(cas_dir);
     let config = Config::load(cas_dir).unwrap_or_default();
 
@@ -454,12 +502,21 @@ pub fn open_rule_store(cas_dir: &Path) -> Result<Arc<dyn RuleStore>> {
         }
     };
 
-    // Wrap with notifying store if TUI notifier is active
-    let base_store: Arc<dyn RuleStore> = if has_notifier() && config.notifications_enabled() {
-        Arc::new(NotifyingRuleStore::new(base_store, config.notifications()))
+    if has_notifier() && config.notifications_enabled() {
+        Ok(Arc::new(NotifyingRuleStore::new(
+            base_store,
+            config.notifications(),
+        )))
     } else {
-        base_store
-    };
+        Ok(base_store)
+    }
+}
+
+/// Open the appropriate rule store (file + cloud sync wrappers when enabled).
+/// Prefer [`open_rule_store_local`] for pull/apply-remote paths.
+pub fn open_rule_store(cas_dir: &Path) -> Result<Arc<dyn RuleStore>> {
+    let config = Config::load(cas_dir).unwrap_or_default();
+    let base_store = open_rule_store_base(cas_dir)?;
 
     // Wrap with syncing store if sync is enabled
     if config.sync.enabled && !Config::is_sync_disabled() {
@@ -502,6 +559,15 @@ pub fn open_rule_store(cas_dir: &Path) -> Result<Arc<dyn RuleStore>> {
     }
 
     Ok(base_store)
+}
+
+/// Open rule store without SyncingRuleStore / SyncQueue wrappers (cas-7fbb).
+///
+/// Skips both cloud enqueue and local `.claude/rules` file sync so pull
+/// apply does not re-feed the queue. Local rule-file sync still runs on
+/// normal edit paths via [`open_rule_store`].
+pub fn open_rule_store_local(cas_dir: &Path) -> Result<Arc<dyn RuleStore>> {
+    open_rule_store_base(cas_dir)
 }
 
 /// Initialize a new .cas directory

--- a/cas-cli/src/store/mod.rs
+++ b/cas-cli/src/store/mod.rs
@@ -156,9 +156,10 @@ pub use detect::{
     StoreType, detect_store_type, find_cas_root, find_cas_root_from, has_project_cas, init_cas_dir,
     open_agent_store, open_code_store, open_commit_link_store, open_entity_store, open_event_store,
     open_file_change_store, open_loop_store, open_prompt_queue_store, open_prompt_store,
-    open_recording_store, open_reminder_store, open_rule_store, open_skill_store,
-    open_spawn_queue_store, open_spec_store, open_store, open_supervisor_queue_store,
-    open_task_store, open_verification_store, open_worktree_store,
+    open_recording_store, open_reminder_store, open_rule_store, open_rule_store_local,
+    open_skill_store, open_skill_store_local, open_spawn_queue_store, open_spec_store, open_store,
+    open_store_local, open_supervisor_queue_store, open_task_store, open_task_store_local,
+    open_verification_store, open_worktree_store,
 };
 pub use notifying_entry::NotifyingEntryStore;
 pub use notifying_rule::NotifyingRuleStore;

--- a/cas-cli/tests/pull_no_reenqueue_test.rs
+++ b/cas-cli/tests/pull_no_reenqueue_test.rs
@@ -1,0 +1,332 @@
+//! Regression for cas-7fbb: pull must not re-enqueue pulled rows.
+//!
+//! Root cause: `open_store` / `open_task_store` / etc. wrap writes in
+//! Syncing* when logged in. Pull used those openers, so every remote
+//! upsert re-entered SyncQueue → push → (echo) pull → unbounded growth.
+//!
+//! Fix: pull / team-pull / daemon cloud-sync apply via `open_*_local`.
+//! These tests lock in:
+//! 1. Behavioral: CloudSyncer::pull of N entries via local openers does
+//!    not grow SyncQueue pending count by N.
+//! 2. Behavioral: open_store (syncing wrap) still enqueues local edits.
+//! 3. Source-level: execute_pull / execute_team_pull / daemon run_cloud_sync
+//!    call the *_local openers (not the wrapping ones) for apply stores.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use cas::cloud::{CloudConfig, CloudSyncer, CloudSyncerConfig, SyncQueue, get_project_canonical_id};
+use cas::store::{
+    open_commit_link_store, open_event_store, open_file_change_store, open_prompt_store,
+    open_rule_store_local, open_skill_store_local, open_spec_store, open_store, open_store_local,
+    open_task_store_local,
+};
+use cas::types::{Entry, EntryType, Scope};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const MAX_RETRIES: i32 = 5;
+
+fn production_source_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn make_logged_in_cas_root(endpoint: &str) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let cas_root = tmp.path();
+    // Force SQLite store files into existence.
+    let _ = open_store_local(cas_root).unwrap();
+    let _ = open_task_store_local(cas_root).unwrap();
+    let _ = open_rule_store_local(cas_root).unwrap();
+    let _ = open_skill_store_local(cas_root).unwrap();
+
+    let queue = SyncQueue::open(cas_root).unwrap();
+    queue.init().unwrap();
+
+    let mut cfg = CloudConfig::default();
+    cfg.endpoint = endpoint.to_string();
+    cfg.token = Some("test-token".to_string());
+    cfg.save_to_cas_dir(cas_root).unwrap();
+
+    tmp
+}
+
+fn entry_payload(id: &str, project_id: &str) -> serde_json::Value {
+    let entry = Entry {
+        id: id.to_string(),
+        scope: Scope::Project,
+        entry_type: EntryType::Context,
+        content: format!("remote content for {id}"),
+        ..Default::default()
+    };
+    let mut v = serde_json::to_value(&entry).unwrap();
+    v["project_id"] = serde_json::json!(project_id);
+    v["project_canonical_id"] = serde_json::json!(project_id);
+    v
+}
+
+/// cas-7fbb AC2: pull of N remote rows must not grow SyncQueue by N.
+#[tokio::test]
+async fn pull_via_local_openers_does_not_grow_sync_queue() {
+    let server = MockServer::start().await;
+    let project_id = get_project_canonical_id()
+        .expect("get_project_canonical_id should succeed inside cas-src checkout");
+
+    let n = 5usize;
+    let entries: Vec<serde_json::Value> = (0..n)
+        .map(|i| entry_payload(&format!("remote-entry-{i:03}"), &project_id))
+        .collect();
+
+    Mock::given(method("GET"))
+        .and(path("/api/sync/pull"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": entries,
+            "tasks": [],
+            "rules": [],
+            "skills": [],
+            "events": [],
+            "prompts": [],
+            "file_changes": [],
+            "commit_links": [],
+            "pulled_at": chrono::Utc::now().to_rfc3339(),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = make_logged_in_cas_root(&server.uri());
+    let cas_root = tmp.path();
+
+    // Logged-in so open_store *would* wrap — but pull uses local openers.
+    let cfg = CloudConfig::load_from_cas_dir(cas_root).unwrap();
+    assert!(cfg.is_logged_in(), "fixture must be logged in");
+
+    let queue = SyncQueue::open(cas_root).unwrap();
+    let pending_before = queue.pending_count(MAX_RETRIES).unwrap();
+    assert_eq!(pending_before, 0, "queue starts empty");
+
+    let store = open_store_local(cas_root).unwrap();
+    let task_store = open_task_store_local(cas_root).unwrap();
+    let rule_store = open_rule_store_local(cas_root).unwrap();
+    let skill_store = open_skill_store_local(cas_root).unwrap();
+    let spec_store = open_spec_store(cas_root).unwrap();
+    let event_store = open_event_store(cas_root).unwrap();
+    let prompt_store = open_prompt_store(cas_root).unwrap();
+    let file_change_store = open_file_change_store(cas_root).unwrap();
+    let commit_link_store = open_commit_link_store(cas_root).unwrap();
+
+    let syncer = CloudSyncer::new(
+        Arc::new(SyncQueue::open(cas_root).unwrap()),
+        cfg,
+        CloudSyncerConfig::default(),
+    );
+
+    let result = syncer
+        .pull(
+            store.as_ref(),
+            task_store.as_ref(),
+            rule_store.as_ref(),
+            skill_store.as_ref(),
+            spec_store.as_ref(),
+            event_store.as_ref(),
+            prompt_store.as_ref(),
+            file_change_store.as_ref(),
+            commit_link_store.as_ref(),
+        )
+        .expect("pull should succeed");
+
+    assert!(
+        result.errors.is_empty(),
+        "pull errors: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        result.pulled_entries, n,
+        "expected {n} entries pulled, got {}",
+        result.pulled_entries
+    );
+
+    // Rows landed locally.
+    let landed = open_store_local(cas_root).unwrap().list().unwrap();
+    assert!(
+        landed.len() >= n,
+        "expected at least {n} local entries, got {}",
+        landed.len()
+    );
+
+    let pending_after = SyncQueue::open(cas_root)
+        .unwrap()
+        .pending_count(MAX_RETRIES)
+        .unwrap();
+    assert_eq!(
+        pending_after, pending_before,
+        "cas-7fbb: pull of {n} rows must not grow SyncQueue (before={pending_before}, after={pending_after})"
+    );
+}
+
+/// cas-7fbb AC5: legitimate local edits still enqueue when logged in.
+#[test]
+fn open_store_still_enqueues_local_writes_when_logged_in() {
+    let tmp = TempDir::new().unwrap();
+    let cas_root = tmp.path();
+    let _ = open_store_local(cas_root).unwrap();
+
+    let mut cfg = CloudConfig::default();
+    cfg.endpoint = "http://127.0.0.1:9".to_string();
+    cfg.token = Some("test-token".to_string());
+    cfg.save_to_cas_dir(cas_root).unwrap();
+
+    let queue = SyncQueue::open(cas_root).unwrap();
+    queue.init().unwrap();
+    let before = queue.pending_count(MAX_RETRIES).unwrap();
+
+    let store = open_store(cas_root).unwrap();
+    let entry = Entry {
+        id: "local-edit-001".to_string(),
+        scope: Scope::Project,
+        entry_type: EntryType::Context,
+        content: "local user edit".to_string(),
+        ..Default::default()
+    };
+    store.add(&entry).unwrap();
+
+    let after = SyncQueue::open(cas_root)
+        .unwrap()
+        .pending_count(MAX_RETRIES)
+        .unwrap();
+    assert!(
+        after > before,
+        "local edit via open_store must enqueue (before={before}, after={after})"
+    );
+    assert!(
+        after >= before + 1,
+        "expected at least one new queue row for local edit"
+    );
+}
+
+/// Contrast: using wrapping open_store for pull *would* re-enqueue (documents
+/// the pre-fix failure mode). Guarded so we never ship a silent no-op local
+/// opener that actually still wraps.
+#[tokio::test]
+async fn wrapping_open_store_would_reenqueue_on_pull_apply() {
+    let server = MockServer::start().await;
+    let project_id = get_project_canonical_id()
+        .expect("get_project_canonical_id should succeed inside cas-src checkout");
+
+    let entry = entry_payload("echo-bait-001", &project_id);
+    Mock::given(method("GET"))
+        .and(path("/api/sync/pull"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": [entry],
+            "tasks": [],
+            "rules": [],
+            "skills": [],
+            "pulled_at": chrono::Utc::now().to_rfc3339(),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = make_logged_in_cas_root(&server.uri());
+    let cas_root = tmp.path();
+    let cfg = CloudConfig::load_from_cas_dir(cas_root).unwrap();
+
+    let pending_before = SyncQueue::open(cas_root)
+        .unwrap()
+        .pending_count(MAX_RETRIES)
+        .unwrap();
+
+    // Deliberately use the *wrapping* opener — the pre-cas-7fbb bug path.
+    let store = open_store(cas_root).unwrap();
+    let task_store = open_task_store_local(cas_root).unwrap();
+    let rule_store = open_rule_store_local(cas_root).unwrap();
+    let skill_store = open_skill_store_local(cas_root).unwrap();
+    let spec_store = open_spec_store(cas_root).unwrap();
+    let event_store = open_event_store(cas_root).unwrap();
+    let prompt_store = open_prompt_store(cas_root).unwrap();
+    let file_change_store = open_file_change_store(cas_root).unwrap();
+    let commit_link_store = open_commit_link_store(cas_root).unwrap();
+
+    let syncer = CloudSyncer::new(
+        Arc::new(SyncQueue::open(cas_root).unwrap()),
+        cfg,
+        CloudSyncerConfig::default(),
+    );
+    let result = syncer
+        .pull(
+            store.as_ref(),
+            task_store.as_ref(),
+            rule_store.as_ref(),
+            skill_store.as_ref(),
+            spec_store.as_ref(),
+            event_store.as_ref(),
+            prompt_store.as_ref(),
+            file_change_store.as_ref(),
+            commit_link_store.as_ref(),
+        )
+        .expect("pull should succeed");
+    assert_eq!(result.pulled_entries, 1);
+
+    let pending_after = SyncQueue::open(cas_root)
+        .unwrap()
+        .pending_count(MAX_RETRIES)
+        .unwrap();
+    assert!(
+        pending_after > pending_before,
+        "wrapping open_store must still re-enqueue on pull apply (proves Syncing* is live); before={pending_before} after={pending_after}"
+    );
+}
+
+/// Source guard: production pull apply sites must use *_local openers.
+#[test]
+fn pull_apply_sites_use_local_openers() {
+    let cloud_rs = production_source_root().join("cli/cloud.rs");
+    let daemon_rs = production_source_root().join("mcp/daemon.rs");
+    let cloud = fs::read_to_string(&cloud_rs).expect("read cloud.rs");
+    let daemon = fs::read_to_string(&daemon_rs).expect("read daemon.rs");
+
+    // execute_pull + execute_team_pull must mention local openers.
+    assert!(
+        cloud.contains("open_store_local"),
+        "cli/cloud.rs must call open_store_local for pull apply (cas-7fbb)"
+    );
+    assert!(
+        cloud.contains("open_task_store_local"),
+        "cli/cloud.rs must call open_task_store_local for pull apply (cas-7fbb)"
+    );
+    assert!(
+        cloud.contains("open_rule_store_local"),
+        "cli/cloud.rs must call open_rule_store_local for pull apply (cas-7fbb)"
+    );
+    assert!(
+        cloud.contains("open_skill_store_local"),
+        "cli/cloud.rs must call open_skill_store_local for pull apply (cas-7fbb)"
+    );
+
+    // Daemon cloud sync must use local openers and must not claim wrappers
+    // while calling wrapping openers.
+    assert!(
+        daemon.contains("open_store_local"),
+        "mcp/daemon.rs run_cloud_sync must use open_store_local (cas-7fbb)"
+    );
+    assert!(
+        daemon.contains("open_task_store_local"),
+        "mcp/daemon.rs must use open_task_store_local (cas-7fbb)"
+    );
+    // Stale comment must not claim "without cloud sync wrappers" while
+    // calling open_store (the pre-fix lie). After the fix we either use
+    // local openers or an accurate comment — both required.
+    let stale = "Open stores without cloud sync wrappers (to avoid recursion)";
+    assert!(
+        !daemon.contains(stale),
+        "stale daemon comment must be removed/rewritten (cas-7fbb AC3)"
+    );
+
+    // Local edit / push paths should still use open_store (enqueue).
+    assert!(
+        cloud.contains("open_store("),
+        "push/local paths should still reference open_store"
+    );
+}


### PR DESCRIPTION
## Summary
- Pull/team-pull/daemon cloud-sync were applying remote rows through `open_store` etc., which wrap `Syncing*` when logged in — every pulled row re-entered SyncQueue → self-feeding push↔pull growth.
- Adds `open_*_local` openers (no SyncQueue wrap) and wires them into `execute_pull`, `execute_team_pull`, daemon `run_cloud_sync`, plus purge-foreign / team-memories merge.
- Fixes stale daemon comment that claimed no-wrapper openers while calling wrapping ones.
- Local edits via `open_store` still enqueue (AC5).

## Test plan
- [x] `cargo test --test pull_no_reenqueue_test` — 4/4 (pull does not grow queue; local edit enqueues; wrapping contrast; source guard)
- [x] `cargo test --test team_pull_wiring_test --test pull_scoping_regression_test` — still green

Closes cas-7fbb.