### PR TITLE
docs: harness changelog diaries — Claude 2.1.203–209, Codex 0.143–0.144.4, seed Grok

### DIFF
--- a/docs/notes/claude-code-changelog-diary.md
+++ b/docs/notes/claude-code-changelog-diary.md
@@ -7,7 +7,8 @@ require a CAS change, and if so, where's the proof?"*
 This is the index layer. Deep per-EPIC working notes live in their own dated files
 (e.g. `2026-06-02-cc160-hook-surface.md`); this diary links out to them.
 
-Sibling ledger for the other supported harness: `codex-changelog-diary.md`.
+Sibling ledgers for the other supported harnesses: `codex-changelog-diary.md` and
+`grok-changelog-diary.md`.
 
 ## How to update
 

--- a/docs/notes/claude-code-changelog-diary.md
+++ b/docs/notes/claude-code-changelog-diary.md
@@ -39,6 +39,13 @@ When a new Claude Code version ships:
 
 | CC version | Headline | CAS verdict | Pointer |
 |------------|----------|-------------|---------|
+| 2.1.209 | `/model` + dialogs unblocked in `claude agents` background sessions | ⏭ n/a | — |
+| 2.1.208 | **catastrophic `rm` still prompts under `--dangerously-skip-permissions` when command has `$(…)`** · long-session hook/MCP memory leaks fixed · MCP tool-pool cache | 👀 watch / ✅ | this doc |
+| 2.1.207 | **agent-teams mailbox crash-loop fixed** · skill/worktree bracket-glob parse fixes · plugin shell-form `${user_config.*}` rejected | 🟢 win / ✅ | this doc |
+| 2.1.206 | **MCP per-server `request_timeout_ms` honored** · OAuth MCP refresh recovery · `EnterWorktree` confirm outside `.claude/worktrees/` | ✅ / 👀 | this doc |
+| 2.1.205 | **background notifications deny fabricated human-approval** · `--json-schema` invalid-schema no longer silent · verify-skills rewrite thrash fixed | 🟢 / ✅ | this doc |
+| 2.1.204 | **SessionStart hook streaming in headless — no more mid-hook idle-reap** | 🟢 direct win | this doc |
+| 2.1.203 | **Bash "arg list too long" with many git worktrees fixed** · worktree-isolated subagent cwd fix · subagents less re-delegate | 🟢 wins | this doc |
 | 2.1.202 | Workflow script parse fixes · **re-invoked skill no longer duplicates instructions** · resume-picker slow with many worktrees fixed · `/review` back to single-pass | ✅ no action (wins ride free) | this doc |
 | 2.1.201 | Sonnet 5 sessions drop mid-conversation system role for harness reminders | ✅ no action | this doc |
 | 2.1.200 | **`AskUserQuestion` no longer auto-continues by default** · "default" mode renamed "Manual" · tmux 3.4+ flicker fix | 👀 watch | this doc |
@@ -72,6 +79,145 @@ When a new Claude Code version ships:
 ---
 
 ## Entries
+
+### 2.1.209 — dialogs unblocked in `claude agents` background sessions
+
+Reviewed 2026-07-14 (w-claude-diary / cas-aeec9). Host on **2.1.209**.
+
+- **"Fixed /model and other dialogs being blocked in `claude agents` background sessions (reverts an
+  overly broad guard)."** → ⏭ **n/a for CAS factory.** Factory workers are CC instances in **tmux
+  panes**, not the `claude agents` background-daemon surface. No CAS change.
+
+### 2.1.208 — DSP catastrophic-rm prompt · hook/MCP long-session leaks · MCP tool-pool cache
+
+Reviewed 2026-07-14.
+
+- **"Catastrophic removals (e.g. `rm -rf ~`) in commands containing `$(…)`/backticks/`<(…)` now prompt
+  in `--dangerously-skip-permissions` and auto mode, matching the plain form."** → 👀 **watch —
+  factory permission surface.** Factory workers spawn with `--permission-mode bypassPermissions` /
+  `--dangerously-skip-permissions` (`cas-pty` worker args). Plain catastrophic `rm` already prompted;
+  substitution-wrapped forms now do too. Expected effect: a worker that builds `rm -rf $(…)` toward a
+  home-path-ish target can stall on a permission dialog even under DSP — stall detection is the
+  backstop. Not a break of the DSP path for normal work; recorded as the failure shape if a pane
+  freezes on shell cleanup.
+- **"Fixed several memory leaks in long sessions: MCP stdio server stderr accumulating up to 64 MB per
+  server, … async hook output retained after backgrounding, …"** → ✅ **no action — direct win.** CAS
+  rides SessionStart/SubagentStart/Stop hooks + multi-server MCP for the whole factory lifetime;
+  unbounded hook-output + MCP-stderr retention was exactly the long-session memory shape. Rides free.
+- **"Reduced per-tool-call CPU overhead in print/SDK sessions with many MCP tools by caching tool-pool
+  assembly (up to 7x faster tool rounds at high tool counts)."** → ✅ no action; CAS sessions expose a
+  large MCP tool surface (`cas__*`, plus host MCPs). Pure perf.
+- **"Fixed the Agent tool launching with no tools when a subagent's `tools` list resolves to nothing —
+  it now returns a clear error naming the unrecognized entries."** → ✅ no action; clearer failure for
+  `cas-code-review` Workflow persona dispatch / named Agent spawns with bad tool allowlists.
+- **"Fixed multi-second per-turn slowdowns in sessions with many permission deny/ask rules — rule
+  matchers are now compiled once and cached."** → ✅ no action; host-side if anyone runs dense deny
+  rules outside DSP.
+- Screen reader / vim remaps / mouse / Remote Control / Bedrock SSO / large-table render → ⏭ n/a.
+
+### 2.1.207 — agent-teams mailbox crash-loop · skill/worktree glob parse · plugin hook shell form
+
+Reviewed 2026-07-14.
+
+- **"Fixed a crash loop in agent teams where a malformed teammate mailbox message caused repeated
+  errors every second until the mailbox file was manually deleted."** → 🟢 **direct factory win.** CAS
+  factory rides CC agent teams (memory `reference_cas_factory_uses_cc_agent_teams_cli_flags`); a
+  corrupted mailbox previously required manual file surgery to unstick a pane. No CAS change;
+  shrinks a known zombie-team failure class (pairs with 2.1.198 teammate-"failed" reporting).
+- **"Fixed malformed bracket patterns in rules globs, skill paths, `.ignore`, and `.worktreeinclude`
+  breaking file reads, file suggestions, and worktree creation."** → ✅ **no action — de-flake.** CAS
+  ships skill paths and worktree isolation; bad bracket globs previously could break reads / worktree
+  create rather than failing clearly. Rides free.
+- **Plugin hooks/monitors/MCP headersHelper: `${user_config.*}` in shell-form commands is now rejected
+  (shell-injection fix).** → ✅ **no action.** CAS hooks are installed as shell-form `cas hook
+  <Event>` without `${user_config.*}` interpolation (`cas init` SessionStart path). Plugin-authored
+  hooks that did use that expansion must migrate to exec form / `$CLAUDE_PLUGIN_OPTION_*` — not a CAS
+  surface.
+- Auto-mode default-on for Bedrock/Vertex/Foundry; `autoMode` no longer read from
+  `.claude/settings.local.json` → ⏭ for factory (workers are DSP/bypassPermissions, not auto mode).
+- Terminal freezes on long lists/tables, Remote Control, Bedrock SSO, Opus 4.8 cloud defaults → ⏭ /
+  ✅ host-only.
+
+### 2.1.206 — MCP request_timeout_ms · OAuth MCP refresh · EnterWorktree outside `.claude/worktrees/`
+
+Reviewed 2026-07-14.
+
+- **"Fixed MCP servers configured via `--mcp-config` or `.mcp.json` ignoring a per-server
+  `request_timeout_ms`, which caused long-running MCP tool calls to time out at the 60s default in
+  fresh sessions."** → ✅ **no action — reliability win.** CAS MCP tools (search, task list, heavy
+  coordination) can exceed 60s on large stores; hosts that set a higher per-server timeout now get
+  the configured value instead of a silent 60s clip. No CAS code change.
+- **"Fixed OAuth MCP servers requiring manual re-authentication after a single failed token refresh."**
+  → ✅ no action; de-flakes host MCP OAuth (GitHub, etc.) mid-factory.
+- **"`EnterWorktree` now asks for confirmation before entering a git worktree outside the project's
+  `.claude/worktrees/` directory."** → 👀 **watch — path-shape note.** CAS factory worktrees live under
+  `.cas/worktrees/…`, not `.claude/worktrees/`. CAS creates/isolates via its own worktree coordination
+  path, not CC's `EnterWorktree` tool, so the confirm should not gate normal factory spawn. Residual
+  risk: an agent that *calls* `EnterWorktree` into a CAS worktree path may now get a human confirm
+  prompt — same unattended-pane hang class as the 2.1.200 `AskUserQuestion` note. No CAS change unless
+  that shape shows up in the wild.
+- Background-agent auto-upgrade after CC update, `/code-review` opus quality, agents-view Ctrl+X →
+  ⏭ / adjacent (built-in `/code-review`, not `cas-code-review`).
+
+### 2.1.205 — fabricated-approval denial · json-schema validity · verify-skills rewrite thrash
+
+Reviewed 2026-07-14.
+
+- **"Background task notifications now explicitly state that no human input has occurred, preventing
+  fabricated in-transcript approvals from being acted on."** → 🟢 **authority-model win.** Same family
+  as 2.1.166 SendMessage hardening and 2.1.198 "launcher messages ≠ user approval." CAS factory already
+  treats agent-to-agent direction as non-approval; this closes a background-notification path that could
+  look like a human yes. No CAS change.
+- **"Fixed `--json-schema` silently producing unstructured output when the schema was invalid, and
+  schemas using the `format` keyword being rejected."** → ✅ no action / residual of 2.1.187
+  structured-output hardening. Helps Workflow `agent({schema})` paths used by `cas-code-review`
+  (Phase C) fail loudly on bad schemas instead of returning free-form prose.
+- **"Fixed project verify skills being rewritten on every session instead of only when a documented
+  command changed."** → ✅ no action; skill hot-reload thrash reduction (pairs with 2.1.174
+  re-announce-only-changed). CAS skill sync already prefers stable skill bodies.
+- **"Fixed background agents staying shown as 'failed' or 'completed' in the agent list after being
+  resumed with `SendMessage`."** → ✅ no action for tmux factory; residual native agent-list correctness
+  when anyone uses CC background agents + SendMessage.
+- Auto-mode transcript-tamper block / `rm -rf` on unresolved vars → ⏭ (auto mode, not DSP factory).
+- Reserved "Claude Browser" MCP name → ⏭ unless a host MCP collides on that exact name.
+
+### 2.1.204 — SessionStart hook streaming in headless (idle-reap mid-hook)
+
+Reviewed 2026-07-14. **Small release, high CAS signal.**
+
+- **"Fixed hook events not streaming during SessionStart hooks in headless sessions, which could cause
+  remote workers to be idle-reaped mid-hook."** → 🟢 **direct win on the load-bearing CAS surface.**
+  SessionStart is how CAS injects factory supervisor/worker guidance, task context, and session
+  mapping (`cas hook SessionStart`). A headless/remote worker that looked idle while SessionStart was
+  still running could be reaped before the hook finished — exactly the "worker died before it ever
+  talked" shape. Interactive tmux factory panes were less exposed, but any headless/`claude -p`/remote
+  CAS path was. No CAS change; rides free on the host bump. Pairs with 2.1.199 SessionStart stderr-on-
+  exit-2 visibility for hook debuggability.
+
+### 2.1.203 — many-worktree Bash · subagent worktree cwd · re-delegation reduction
+
+Reviewed 2026-07-14.
+
+- **"Fixed Bash failing with 'argument list too long' in repos with many git worktrees."** → 🟢
+  **direct factory win.** Factory hosts accumulate `.cas/worktrees/*` (and related) by design; the
+  same class of "many worktrees" pain as the 2.1.202 resume-picker fix. Shell ops that expanded
+  worktree lists no longer blow `ARG_MAX`. No CAS change.
+- **"Fixed worktree-isolated subagents sometimes running shell commands in the parent checkout instead
+  of their own worktree."** → 🟢 **isolation correctness win.** CAS worktree-isolated workers and
+  subagents depend on cwd staying inside the assigned tree; parent-checkout leakage is a silent
+  cross-worker corruption risk. Rides free.
+- **"Improved subagent behavior: agents are now less likely to re-delegate their entire task to another
+  subagent."** → ✅ no action; quality win for task-verifier / `cas-code-review` persona fan-out (less
+  nested Agent thrash).
+- **"Fixed `TaskStop` and `TaskOutput` failing to find background agents spawned by another agent —
+  errors now list running agents by id and description."** → ✅ no action; clearer nested-agent
+  control surface.
+- **"Added the session's additional working directories to MCP `roots/list`, with
+  `notifications/roots/list_changed` when the set changes."** → ✅ no action / minor MCP correctness
+  for multi-root sessions; CAS MCP servers that honor roots see the fuller set.
+- Manual-mode footer ⏸ badge, background-session daemon recovery, `claude agents` UI polish → ✅ /
+  ⏭ (badge is cosmetic for Manual mode; factory is DSP).
+- Login-expiry warning before background sessions drop → ✅ host hygiene, not CAS-owned.
 
 ### 2.1.202 — Workflow parse fixes · re-invoked skill dedup · worktree-heavy resume perf
 

--- a/docs/notes/codex-changelog-diary.md
+++ b/docs/notes/codex-changelog-diary.md
@@ -1,8 +1,8 @@
 # Codex CLI Changelog Diary — CAS Response Ledger
 
 A living, **newest-first** ledger of OpenAI Codex CLI releases and how CAS responded to
-each. Sibling to `claude-code-changelog-diary.md` — CAS supports both harnesses
-(`--worker-cli codex` / `--supervisor-cli codex`), so we track Codex drift too.
+each. Sibling to `claude-code-changelog-diary.md` and `grok-changelog-diary.md` —
+CAS supports three harnesses (`cli=claude` / `cli=codex` / `cli=grok`), so we track Codex drift too.
 
 Codex has no `CHANGELOG.md`; release notes live on the GitHub **releases page**.
 

--- a/docs/notes/codex-changelog-diary.md
+++ b/docs/notes/codex-changelog-diary.md
@@ -26,14 +26,16 @@ verify on upgrade) · 🔧 fix shipped · 🏗 EPIC · ⏭ n/a
 
 - **CAS validated against:** Codex CLI **0.128.0** (the `crates/cas-pty/src/pty.rs` effort-approach
   comment pins to 0.128).
-- **Locally installed:** **0.142.5** (`codex-cli 0.142.5`, checked 2026-07-07).
-- **Latest stable:** **0.142.5** (2026-07-01). **0.143.0** still in alpha (alpha.38 as of 2026-07-07).
-- **Gap:** ~14 minor versions between the validated pin (0.128) and what's installed/latest (0.142).
+- **Locally installed:** **0.144.4** (`codex-cli 0.144.4`, checked 2026-07-14).
+- **Latest stable:** **0.144.4** (2026-07-14). **0.145.0** in alpha only (alpha.10 as of 2026-07-14) —
+  index note only; not tracked until stable.
+- **Gap:** ~16 minor versions between the validated pin (0.128) and what's installed/latest (0.144).
   The entries below are a *triage pass* against the touchpoints, not a per-item code audit —
   upgrade-time re-verification is the trigger for promoting any 👀 to a task. (Contrast the Claude
   Code diary's .166/.162 entries, which were deep-verified for specific user questions.) The
   **0.130–0.135 block is a backfill** (lighter fidelity, consolidated) added 2026-06-30 to extend
-  coverage below the original 0.136 seed floor.
+  coverage below the original 0.136 seed floor. The **0.143–0.144.4 block is a backfill**
+  (2026-07-14) catching the diary up from the previous 0.142.5 ceiling to the host install.
 
 ## CAS ↔ Codex touchpoints (what a release can break)
 
@@ -64,7 +66,10 @@ The load-bearing surface, all in `crates/cas-pty/src/pty.rs::PtyConfig::codex` u
 
 | Codex version | Headline | CAS verdict | Pointer |
 |---------------|----------|-------------|---------|
-| 0.143.0-alpha | (pre-release; not tracked until stable) | — | — |
+| 0.145.0-alpha | (pre-release; alpha.10 as of 2026-07-14 — not tracked until stable) | — | — |
+| 0.144.1–.4 | Installer/code-mode reliability · Guardian auto-review prompt revert · two empty patch releases | ✅ no action | this doc |
+| 0.144.0 | **`writes` app-approval mode** · MCP auth elicitation default · plugin skill-loading perf · Ultra+multi-agent usage warn | 👀 watch | this doc |
+| 0.143.0 | **`max` first-class reasoning effort** · MCP tool search by default · rmcp 1.8.0 · AGENTS.md env-reactive + skills/delegation · sandbox profile flag rename | 👀 watch | this doc |
 | 0.142.5 | Single backport: WebSocket request payloads no longer written to trace logs | ✅ no action | this doc |
 | 0.142.0–.4 | **Rollout token budgets (turns abort when exhausted)** · env-scoped command/network approvals · AGENTS.md from foreign envs · `SkillsManager→SkillsService` + skill-frontmatter repair | 👀 watch | this doc |
 | 0.141.0 | **Hook trust bypass persists through `codex exec`; blocking PostToolUse rejects code-mode** · per-thread plugin stdio MCP activation · MCP tool timeout→300s | 👀 watch | this doc |
@@ -78,6 +83,98 @@ The load-bearing surface, all in `crates/cas-pty/src/pty.rs::PtyConfig::codex` u
 ---
 
 ## Entries
+
+### 0.144.1–.4 — installer/code-mode · Guardian review revert · empty patches
+
+Reviewed 2026-07-14 (w-codex-diary / cas-64d6). Host is `codex-cli 0.144.4`. Consolidated: no CAS-touchpoint
+signal in the patch band after 0.144.0.
+
+- **0.144.4 (2026-07-14):** "No user-facing changes in this patch release." → ✅ **no action.**
+- **0.144.3 (2026-07-13):** Version-only release; no merged PR changes since 0.144.2. → ✅ **no action.**
+- **0.144.2 (2026-07-13):** "Restored the previous Guardian auto-review policy, request format, and tool
+  behavior after rolling back a prompting regression" (#32672). → ✅ **no action** for factory. Guardian
+  auto-review is Codex's review product surface, not CAS's `--yolo` worker launch path.
+- **0.144.1 (2026-07-09):** Standalone-install GitHub metadata robustness + macOS code-mode host packaging
+  + embedded runtime fallback when companion host binary missing (#31913). → ⏭ n/a (installer/code-mode
+  packaging; CAS factory launches `codex` via PTY, not the standalone installer path).
+
+### 0.144.0 — `writes` app-approval · MCP auth elicitation default · skills plugin ns · Ultra concurrency warn
+
+Reviewed 2026-07-14 (w-codex-diary / cas-64d6). Triage pass vs touchpoints. Sources: `gh release view
+rust-v0.144.0 --repo openai/codex`.
+
+- **"Added a `writes` app-approval mode that allows declared read-only actions while prompting for
+  writes" (#30482).** → 👀 **touchpoint: `--yolo`/approval.** New approval-mode vocabulary on the
+  app-approval axis. CAS workers bypass via `--yolo` and do not set app-approval modes; still **verify
+  on upgrade** that the new mode is not a default that reintroduces prompts under `--yolo`, and that
+  any host-level defaults in `.codex/config.toml` don't pin `writes` for factory sessions.
+- **"MCP tools can now request authentication interactively without an experimental opt-in"
+  (#28772).** → 👀 **touchpoint: MCP (`cs`).** Auth elicitation is on by default for MCP tools that need
+  it. Our `cs` server is local stdio with no OAuth, so expected impact is none — but **smoke
+  `mcp__cs__*` load** after the bump in case the elicitation path changes MCP client startup ordering
+  or hangs when a *second* MCP server in the same config needs auth.
+- **"Reduced plugin skill-loading time on remote executors by resolving namespaces once per root"
+  (#31348) + skill catalog/compaction parity tests.** → 👀 **touchpoint: `.codex/skills/`.** Perf/correctness
+  on plugin skill discovery. Local `.codex/skills/` mirror (from `cas integrate`) should be unaffected;
+  verify synced skills still list after upgrade.
+- **"Selecting Ultra reasoning now warns when high multi-agent concurrency could increase usage
+  quickly" (#31621).** → ✅ minor / TUI-adjacent. CAS sets effort via `-c model_reasoning_effort=<e>`
+  (vocabulary still `…|xhigh`, not "Ultra"); this is a TUI warning, not a config-key change. No CAS
+  action unless we start mapping a named "Ultra" product tier into the effort override.
+- **"Windows sandbox sessions can delete files in writable roots and access the managed primary
+  runtime" (#31138, #31574).** → 👀 minor **sandbox** (Windows host only). Factory `--yolo` path should
+  still bypass; note for Windows workers if any.
+- **MCP tool snapshot reuse within a sampling request (#31292); increase tool schema compaction
+  threshold (#31497); round MCP timeout durations in error messages (#31612).** → 👀 **MCP (`cs`)**
+  fidelity/perf. Schema compaction threshold up is usually helpful for large `cs` tool surfaces;
+  smoke a few multi-arg tools on upgrade.
+- **Usage-limit reset-credit picker, app-server hosted auth redirects, global pnpm install detection,
+  Bedrock display names, TUI paste sanitization, code-mode host defaults.** → ⏭ n/a (orthogonal to the
+  CAS launch surface).
+
+### 0.143.0 — `max` reasoning effort · MCP tool search default · rmcp 1.8 · AGENTS.md / skills
+
+Reviewed 2026-07-14 (w-codex-diary / cas-64d6). Triage pass vs touchpoints. Sources: `gh release view
+rust-v0.143.0 --repo openai/codex`. This is the first stable after the diary's previous 0.142.5 ceiling.
+
+- **"…first-class support for `max` reasoning effort" (#30467, #29899; Bedrock GPT-5.6 family
+  #30285).** → 👀 **touchpoint: `-c model_reasoning_effort`.** Codex now treats `max` as a first-class
+  effort level. CAS still maps `Effort::XHigh` → `xhigh` (`Effort::as_codex_config` in
+  `crates/cas-mux/src/spec.rs`) and documents vocabulary `none/minimal/low/medium/high/xhigh`. **Verify
+  on upgrade** that `xhigh` still accepts/works; if Codex deprecates `xhigh` in favor of `max` (or
+  models only advertise `max`), CAS needs a mapping update. No evidence of rename in this release —
+  additive `max` support is the safer reading.
+- **"MCP tools now use tool search by default" (#29486) + ChatGPT-hosted MCP session auth
+  (#29733).** → 👀 **touchpoint: MCP (`cs`).** Tool *search* as the default presentation path can change
+  how tools are discovered vs always-listed. **Highest-risk 0.143 item for CAS:** confirm factory
+  workers still see and invoke `mcp__cs__task` / `mcp__cs__coordination` (and the rest of the `cs`
+  surface) without an extra search step that hides tools. Session-auth is for ChatGPT-hosted MCP, not
+  local stdio `cs`.
+- **"Update rmcp to 1.8.0" (#29634).** → 👀 **touchpoint: MCP (`cs`).** MCP client dep bump (diary
+  already flags rmcp bumps). Smoke stdio MCP connect after upgrade; watch for protocol/schema
+  regressions on large tool lists.
+- **"core: make AGENTS.md react to environment changes" (#29810) + bounded AGENTS.md/Git root probes
+  (#29870) + "allow AGENTS.md and skills to authorize delegation" (#30274).** → 👀 **touchpoint:
+  AGENTS.md (+ skills).** Continuing AGENTS.md accuracy work (from 0.138/0.142). Env-reactive reload
+  likely *helps* worktree workers; delegation-authorization via AGENTS.md/skills is informational for
+  multi-agent v2 (CAS doesn't drive Codex-native delegation for factory workers today). Verify worker
+  role priming still lands from worktree `AGENTS.md`.
+- **Skills plumbing churn:** parallelize environment skill loading (#29990), project executor skills
+  through World State (#30088), load executor skills without host path conversion (#29626), user-level
+  `code-review-*` skills (#30143), model-metadata skill usage instructions (#29740). → 👀 **touchpoint:
+  `.codex/skills/`.** Same subsystem churn pattern as 0.137–0.142. **Verify the `cas integrate`
+  mirror still loads** post-bump.
+- **"cli: rename sandbox permission profile flag" (#30095) + expose permission profile to shell tools
+  (#29941); rm `AskForApproval::OnFailure` (#28418).** → 👀 **touchpoint: `--yolo`/approval.** Profile
+  flag rename is only a 👀 if anything in CAS or host docs still references the old flag — workers use
+  `--yolo`, not named profiles. Approval enum cleanup is internal; confirm `--yolo` still full-bypasses.
+- **Rollout budget continuity:** surface budget exhaustion (#29715), rename to session budget error
+  (#29744), raise token budget message limits (#29970). → 👀 carry-forward from **0.142 rollout token
+  budgets** — still verify factory turns don't inherit a low default budget.
+- **Remote plugins default-on, system proxy for auth/Responses, Bedrock models, `codex remote-control
+  pair`, app-server env/thread APIs, Windows ConPTY.** → ⏭ n/a (plugins/proxy/Bedrock/remote; not on
+  the CAS PTY launch surface). Cancelled-review MCP-busy fix (#31189) is a minor reliability win if a
+  human runs `/review` in a shared Codex, not a factory concern.
 
 ### 0.142.5 — trace-log payload redaction backport
 

--- a/docs/notes/grok-changelog-diary.md
+++ b/docs/notes/grok-changelog-diary.md
@@ -1,0 +1,211 @@
+# Grok Build Changelog Diary — CAS Response Ledger
+
+A living, **newest-first** ledger of xAI Grok Build CLI releases and how CAS
+responded to each. Sibling to `claude-code-changelog-diary.md` and
+`codex-changelog-diary.md` — CAS supports three harnesses (`cli=claude` /
+`cli=codex` / `cli=grok`, EPIC cas-8888), so we track Grok drift too.
+
+Grok ships a local changelog at `~/.grok/CHANGELOG.md` (and a flat item list at
+`~/.grok/CHANGELOG.json` for the current install). Unlike Claude Code (upstream
+GitHub CHANGELOG) or Codex (GitHub releases), the installable history on a host
+may only cover the versions present on that binary's changelog surface.
+
+## How to update
+
+When a new Grok Build version ships (or after `grok` upgrades on the host):
+
+1. Confirm the binary: `grok --version` (example: `grok 0.2.101 (… ) [stable]`).
+2. Read the local changelog: `~/.grok/CHANGELOG.md` (version sections) and, if
+   useful, `~/.grok/CHANGELOG.json` (flat feature/fix list for the current install).
+3. Verdict each user-facing item against the **CAS ↔ Grok touchpoints** below.
+   Most TUI polish is `⏭ n/a`. Prefer items that touch permissions, session IDs,
+   rules/system prompt, MCP discovery, env inheritance, transcripts, or hooks.
+4. Add a newest-first entry + index row. File a CAS task only when work is required.
+5. **Version gap matters:** keep **validated pin** (pty.rs comment) vs **locally
+   installed** vs **latest in changelog** honest. Do not invent older releases —
+   if the local changelog only has N versions, seed those N and mark the **seed floor**.
+
+**Verdict legend:** ✅ no action · 🟢 already covered · 👀 watch (touches a CAS
+dependency, verify on upgrade) · 🔧 fix shipped · 🏗 EPIC · ⏭ n/a
+
+## Version status
+
+- **CAS validated against:** Grok Build **0.2.93** (comment on
+  `crates/cas-pty/src/pty.rs` `PtyConfig::grok`, verified live 2026-07-09 via
+  `grok --help` / `grok inspect` / `grok mcp doctor`).
+- **Locally installed:** **0.2.101** (`grok 0.2.101`, checked 2026-07-14).
+- **Latest in local changelog:** **0.2.101** (2026-07-13). The installable
+  `~/.grok/CHANGELOG.md` currently documents only **0.2.100** and **0.2.101** —
+  that is the **seed floor** for this diary (do not invent pre-0.2.100 history).
+- **Gap:** ~8 patch versions between the validated pin (0.2.93) and installed/latest
+  (0.2.101). Entries below are a *triage pass* against touchpoints for the two
+  changelog-visible releases, not a re-run of the 0.2.93 live verification.
+  Upgrade-time re-verification of the full touchpoint checklist is the trigger for
+  promoting any 👀 to a task.
+
+## CAS ↔ Grok touchpoints (what a release can break)
+
+The load-bearing surface is `crates/cas-pty/src/pty.rs::PtyConfig::grok` (approx.
+lines 423–580; instructions constants near top of file). Ground truth is that
+code + its "Verified against … 0.2.93" block — re-read it on upgrade rather than
+trusting this diary alone.
+
+### CLI flags (spawn args)
+
+- **`--permission-mode bypassPermissions`** — factory workers skip interactive
+  approval (Grok's analogue of Claude's bypass / Codex's `--yolo`). Any rename,
+  removal, or semantic narrowing of `bypassPermissions` breaks unattended workers.
+- **`--session-id <uuid>`** — fresh UUID per *new* conversation (anti-overwrite
+  model, same family as Claude; not Codex's `codex-<name>-<uuid>` prefix). Phase 4
+  transcript resolution keys on this exact value. Doc comment also notes short form
+  `-s/--session-id` on the 0.2.93 binary.
+- **`-m` / `--model <MODEL>`** — optional model pin when the factory requests one.
+- **`--reasoning-effort <EFFORT>`** (alias `--effort` on the verified binary) —
+  vocabulary minimal/low/medium/high/xhigh via `Effort::as_claude_arg()` (no
+  separate `as_grok_arg`). Any "reasoning effort" changelog line is a 👀.
+- **`--cwd <path>`** — worktree/working directory for the worker process.
+- **`--rules <text>`** — **"Extra rules to append to the system prompt."** This is
+  the load-bearing context path for factory role priming. CAS injects
+  `GROK_WORKER_INSTRUCTIONS` or `GROK_SUPERVISOR_INSTRUCTIONS` (same file). Grok's
+  **SessionStart hook fires but its stdout is ignored** (delta #2) — do not assume
+  Claude-style SessionStart `additionalContext` delivery on Grok.
+
+### MCP discovery (no per-spawn `-c` override)
+
+- Grok has **no** ephemeral per-launch MCP config flag analogous to Codex
+  `-c mcp_servers.*`. Servers come from persistent discovery:
+  project `.mcp.json`, `~/.claude.json`, and/or `~/.grok/config.toml`
+  (`grok mcp add` writes the latter).
+- Tools are namespaced **`cas__*`** on Grok (e.g. `cas__task`, `cas__coordination`)
+  — **not** `mcp__cas__*` and **not** Codex's `mcp__cs__*` / `cs` prefix. Worker and
+  supervisor `--rules` text must keep that prefix honest.
+- Identity for `cas serve` rides ordinary **child-process env inheritance** from the
+  grok process (same pattern as Claude; no `mcp_servers.*.env` TOML block).
+
+### Process env (set on the grok child)
+
+At minimum, `PtyConfig::grok` sets:
+
+- `CAS_AGENT_NAME`, `CAS_AGENT_ROLE`
+- `CAS_FACTORY_MODE=1` (verification-jail / factory exemptions)
+- `CAS_SESSION_ID` — same UUID as `--session-id`; load-bearing identity when hooks
+  cannot deliver SessionStart context
+- `CAS_CLONE_PATH`, optional `CAS_ROOT`, optional `CAS_SUPERVISOR_NAME`
+- `CAS_FACTORY_WORKER_CLI=grok` — **unconditional** on a grok process (cas-921f);
+  required so harness-aware liveness looks under Grok paths, not Claude's
+- Plus shared factory metadata / cargo / zig env helpers used by other CLIs
+
+### Transcripts / liveness
+
+- Grok session transcripts live under **`~/.grok/sessions/*`**, not
+  `~/.claude/projects/*`. If `CAS_FACTORY_WORKER_CLI` is wrong, is-wedged/liveness
+  globs the Claude tree and always resolves `None` for a real grok worker.
+
+### Hooks posture (contrast Claude)
+
+- Claude path: SessionStart / PreToolUse are load-bearing.
+- Grok path: SessionStart stdout ignored → **`--rules` + env** carry factory
+  identity and role text. Changelog lines about "hooks disabled at session start"
+  or hook config are still 👀 (config surface), but do not restore Claude-style
+  stdout injection unless Grok documents a behavior change.
+
+## Index
+
+| Grok version | Headline | CAS verdict | Pointer |
+|--------------|----------|-------------|---------|
+| 0.2.101 | **grok inspect** multi-harness compatibility settings · TUI refresh cadence · queue/status/subagent polish · rate-limit copy | 👀 / ✅ / ⏭ | this doc |
+| 0.2.100 | **Session picker + welcome resume** across Claude/Codex/Cursor · web-fetch artifacts · queue/multiline Enter · pane-closed resume crash · hooks honor disabled-at-start · long-turn status markers | 👀 / ✅ / ⏭ | this doc |
+| *(seed floor)* | No older versions in host `~/.grok/CHANGELOG.md` as of 2026-07-14 | — | — |
+
+---
+
+## Entries
+
+### 0.2.101 — inspect multi-harness settings · queue/status polish · refresh rate
+
+Reviewed 2026-07-14 (w-grok-diary / cas-5828). Host install is **0.2.101**.
+Source: `~/.grok/CHANGELOG.md` (2026-07-13).
+
+- **"grok inspect now shows effective compatibility settings for Cursor, Claude, and
+  Codex sessions."** → 👀 **opportunity / ops win, no CAS code required.** Multi-harness
+  inspect is exactly the debugging surface factory hosts need when mixing CLIs. Does not
+  change spawn flags; useful when validating MCP discovery and compat layers after
+  upgrades. No task.
+- **"New setting: Match display refresh rate" (native high-refresh TUI cadence).** →
+  ⏭ n/a (host TUI preference; orthogonal to `PtyConfig::grok`).
+- **"Parked subagent status no longer duplicates or interleaves incorrectly in
+  scrollback."** → ✅ no action — render fix. Factory may spawn Grok-side subagents;
+  cleaner scrollback only. Not a spawn/MCP/rules break.
+- **"Status line during waits shows elapsed time before the queued-message hint."** →
+  ⏭ n/a (TUI chrome).
+- **"Queued messages sent with Enter now appear immediately instead of vanishing
+  briefly."** + related queue reliability in 0.2.100 → 👀 **watch (factory messaging
+  UX).** Supervisor→worker delivery often lands as injected/queued turns. Appearance
+  glitches can look like "message lost" during ops; this is a harness fix, not a CAS
+  change. Verify subjectively on upgrade if operators still report vanished queue items.
+- **"Resume hint after quitting minimal mode prints the correct `grok --minimal
+  --resume` command."** → ⏭ n/a (minimal-mode UX; factory workers are not launched in
+  that interactive path).
+- **"Rate-limit messages correctly direct API-key users to team plans."** → ⏭ n/a
+  (billing/copy).
+
+### 0.2.100 — cross-harness session picker · queue Enter · hooks disabled-at-start · pane-closed crash
+
+Reviewed 2026-07-14 (w-grok-diary / cas-5828). Source: `~/.grok/CHANGELOG.md`
+(2026-07-13). **Seed-floor version** — oldest section currently present in the local
+changelog; no pre-0.2.100 entries inventable from this host.
+
+- **"Session picker discovers and resumes recent Claude Code, Codex, and Cursor
+  sessions"** + **"Welcome screen one-click resume nudge for recent Claude, Codex, or
+  Cursor sessions."** → 👀 **strategic / host UX, not factory spawn.** Interesting for
+  multi-harness hosts running CAS, but factory panes use fresh `--session-id` UUIDs and
+  do not resume foreign harness sessions via this picker. No code action; note for
+  onboarding docs only.
+- **"Web fetch tool preserves full truncated page content as readable artifacts."** →
+  ✅ no action (agent tool quality; not a launch touchpoint).
+- **"Multiline mode correctly sends the top queued message on empty Enter when a turn
+  is running"** + **"Queued commands no longer disappear or delay when pressing Enter
+  twice quickly during a running turn."** → 👀 **watch — input/queue path.** Same class
+  as 0.2.101 queue-visibility fixes: factory coordination depends on messages actually
+  enqueueing during long turns. Harness-side reliability win; smoke "message during
+  running turn" after big Grok bumps.
+- **"Minimal mode text readable on dark terminals."** → ⏭ n/a.
+- **"Grok no longer crashes when printing resume hints after the terminal pane has
+  closed."** → 👀 **watch — factory mux / pane lifecycle.** Factory workers run inside
+  CAS-managed panes; a crash on post-close resume-hint printing could have looked like
+  a worker death. Fix is pure harness; confirm no residual panic on worker shutdown
+  after upgrade. No CAS change expected.
+- **"Long-running turns with multiple waits show updated status markers instead of
+  appearing stuck."** → ✅ no action — direct win for long factory tasks (stall
+  false-positives from "stuck" UI). Complements CAS is-wedged logic; does not replace
+  transcript-path correctness (`~/.grok/sessions/*` + `CAS_FACTORY_WORKER_CLI=grok`).
+- **"Claude and Cursor hooks are now correctly disabled at session start when disabled
+  in config."** → 👀 **touchpoint: hooks/config posture.** Grok already ignores
+  SessionStart *stdout* for CAS context injection (we use `--rules` + env). This line is
+  about honoring "disabled in config" for Claude/Cursor-compat hooks — verify that
+  disabling hooks in config does not also strip something CAS still relies on (unlikely
+  for factory spawn, since we do not depend on SessionStart stdout). On upgrade, re-check
+  that `CAS_SESSION_ID` registration and `--rules` role text still land with hooks
+  disabled.
+
+---
+
+## Backlog of opportunities (not required, tracked)
+
+- **0.2.93 → 0.2.101 upgrade validation:** re-run the live checklist that pinned 0.2.93
+  (`grok --help` flags, `grok inspect`, `grok mcp doctor`, factory spawn smoke):
+  `--permission-mode bypassPermissions`, `--session-id`, `-m` / `--reasoning-effort`,
+  `--cwd`, `--rules`, MCP discovery of `cas` without per-spawn `-c`, env inheritance
+  into `cas serve`, tools as `cas__*`, transcripts under `~/.grok/sessions/*`.
+- **Validated-pin comment bump:** after a successful factory smoke on 0.2.101, update
+  the `PtyConfig::grok` "Verified against … 0.2.93" comment (and this diary's Version
+  status) so the pin tracks reality.
+- **Changelog history depth:** when Grok exposes older releases beyond the two-section
+  local CHANGELOG, backfill entries without inventing notes; until then keep the seed
+  floor explicit.
+- **SessionStart stdout:** if a future Grok release starts delivering SessionStart
+  stdout like Claude, re-evaluate whether `--rules` remains the sole context path or
+  becomes defense-in-depth (would be a deliberate EPIC, not a silent drop of `--rules`).
+- **Queue/input reliability:** 0.2.100–0.2.101 cluster of queue/Enter fixes — if factory
+  operators still report lost mid-turn messages on Grok workers, capture repro before
+  assuming CAS delivery is at fault.


### PR DESCRIPTION
## Summary

- **Claude Code diary** backfilled through **2.1.209** (was 2.1.202) with CAS-angle verdicts (hooks, agent teams, DSP, MCP, worktrees).
- **Codex diary** backfilled **0.143.0–0.144.4**; Version status now matches host `codex-cli 0.144.4`.
- **New Grok Build diary** (`docs/notes/grok-changelog-diary.md`) with PtyConfig::grok touchpoints (validated pin 0.2.93), seed-floor entries for 0.2.100–0.2.101, and sibling links across all three ledgers.

## Test plan

- [x] Docs-only (no runtime code)
- [x] All child factory branches merged into epic
- [x] Epic verification approved (cas-fb6c / ver-f87214c65876)
- [ ] Spot-check the three files under `docs/notes/*-changelog-diary.md` on the PR diff

EPIC: cas-fb6c