### PR TITLE
fix: Jul 14 Ozer factory bugs — orphan lease, double-close, worktree list, coord, review envelope

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-code-review/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-code-review/SKILL.md
@@ -71,6 +71,14 @@ With the Workflow result in hand, branch on `mode`:
 
 In every mode, the output envelope includes `activation` (which personas ran and why) and `intent_summary` from the Workflow return value.
 
+When the caller must pass the result into `task.close` via `code_review_findings`, the wire envelope is:
+
+```
+{ "residual": Finding[], "pre_existing": Finding[], "mode": string }
+```
+
+Each **Finding** requires: `title`, `severity`, `file`, `line`, `why_it_matters`, `autofix_class`, `owner`, `confidence`, `evidence`, `pre_existing`. Optional: `suggested_fix`, `requires_verification`. Full field rules live in [references/findings-schema.md](references/findings-schema.md). A malformed envelope is rejected with **all** missing Finding fields listed in one response — do not invent a partial shape by hand.
+
 ## Review ownership model
 
 `[code_review] owner` in `.cas/config.toml`:

--- a/cas-cli/src/builtins/grok/skills/cas-code-review/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-code-review/SKILL.md
@@ -27,7 +27,7 @@ Return shape: `{"residual": [], "pre_existing": [], "mode": "<mode>", "skipped_r
    git diff --name-only <base_sha>..HEAD  # → file_list
    git log --format=%B <base_sha>..HEAD   # → commit_log
    ```
-   If `task_id` is known, also fetch task context: `cas__task action=show id=<task_id>` → `task_context` (title + description + acceptance criteria + notes).
+   If `task_id` is known, also fetch task context: `mcp__cas__task action=show id=<task_id>` → `task_context` (title + description + acceptance criteria + notes).
 
 3. **Call the Workflow:**
    ```
@@ -70,6 +70,14 @@ With the Workflow result in hand, branch on `mode`:
 - **`headless`** — return merged envelope as structured text to the caller. No side effects.
 
 In every mode, the output envelope includes `activation` (which personas ran and why) and `intent_summary` from the Workflow return value.
+
+When the caller must pass the result into `task.close` via `code_review_findings`, the wire envelope is:
+
+```
+{ "residual": Finding[], "pre_existing": Finding[], "mode": string }
+```
+
+Each **Finding** requires: `title`, `severity`, `file`, `line`, `why_it_matters`, `autofix_class`, `owner`, `confidence`, `evidence`, `pre_existing`. Optional: `suggested_fix`, `requires_verification`. Full field rules live in [references/findings-schema.md](references/findings-schema.md). A malformed envelope is rejected with **all** missing Finding fields listed in one response — do not invent a partial shape by hand.
 
 ## Review ownership model
 

--- a/cas-cli/src/builtins/skills/cas-code-review/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-code-review/SKILL.md
@@ -71,6 +71,14 @@ With the Workflow result in hand, branch on `mode`:
 
 In every mode, the output envelope includes `activation` (which personas ran and why) and `intent_summary` from the Workflow return value.
 
+When the caller must pass the result into `task.close` via `code_review_findings`, the wire envelope is:
+
+```
+{ "residual": Finding[], "pre_existing": Finding[], "mode": string }
+```
+
+Each **Finding** requires: `title`, `severity`, `file`, `line`, `why_it_matters`, `autofix_class`, `owner`, `confidence`, `evidence`, `pre_existing`. Optional: `suggested_fix`, `requires_verification`. Full field rules live in [references/findings-schema.md](references/findings-schema.md). A malformed envelope is rejected with **all** missing Finding fields listed in one response — do not invent a partial shape by hand.
+
 ## Review ownership model
 
 `[code_review] owner` in `.cas/config.toml`:

--- a/cas-cli/src/daemon/maintenance.rs
+++ b/cas-cli/src/daemon/maintenance.rs
@@ -10,10 +10,7 @@ use crate::error::CasError;
 
 /// Run a single maintenance cycle.
 pub fn run_maintenance(config: &DaemonConfig) -> Result<DaemonRunResult, CasError> {
-    use crate::store::{
-        open_agent_store, open_event_store, open_recording_store, open_store, open_task_store,
-    };
-    use crate::types::TaskStatus;
+    use crate::store::{open_agent_store, open_event_store, open_recording_store, open_store};
 
     let started_at = Utc::now();
     let mut errors = Vec::new();
@@ -98,36 +95,21 @@ pub fn run_maintenance(config: &DaemonConfig) -> Result<DaemonRunResult, CasErro
                     }
                 }
 
+                // Capture leases before mark_stale revokes them (cas-2e81).
+                let held_tasks = agent_store.list_agent_leases(&agent_id).unwrap_or_default();
+                let held_ids: Vec<String> = held_tasks.iter().map(|l| l.task_id.clone()).collect();
                 if agent_store.mark_stale(&agent_id).is_ok() {
                     agents_cleaned += 1;
-
-                    // Release any tasks that were assigned but never worked on
-                    let held_tasks = agent_store.list_agent_leases(&agent_id).unwrap_or_default();
-                    if !held_tasks.is_empty() {
-                        if let Ok(task_store) = open_task_store(&config.cas_root) {
-                            for lease in &held_tasks {
-                                if let Ok(mut task) = task_store.get(&lease.task_id) {
-                                    if task.status == TaskStatus::InProgress {
-                                        let timestamp = Utc::now().format("%Y-%m-%d %H:%M");
-                                        let note = format!(
-                                            "[{}] ⚠️ FAILED_STARTUP Agent {} registered but never confirmed startup — marking stale",
-                                            timestamp,
-                                            &agent_id[..12.min(agent_id.len())]
-                                        );
-                                        if task.notes.is_empty() {
-                                            task.notes = note;
-                                        } else {
-                                            task.notes = format!("{}\n\n{}", task.notes, note);
-                                        }
-                                        task.updated_at = Utc::now();
-                                        if task_store.update(&task).is_ok() {
-                                            tasks_interrupted += 1;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    // cas-2e81: park orphaned InProgress + emit worker_died.
+                    let summary =
+                        crate::mcp::tools::service::orphan_recovery::recover_worker_vanished(
+                            &config.cas_root,
+                            agent_store.as_ref(),
+                            agent,
+                            &held_ids,
+                            "daemon maintenance: failed startup",
+                        );
+                    tasks_interrupted += summary.recovered_task_ids.len();
                 }
             }
         }
@@ -135,41 +117,47 @@ pub fn run_maintenance(config: &DaemonConfig) -> Result<DaemonRunResult, CasErro
         if let Ok(stale_agents) = agent_store.list_stale(600) {
             for agent in &stale_agents {
                 let held_tasks = agent_store.list_agent_leases(&agent.id).unwrap_or_default();
+                let held_ids: Vec<String> = held_tasks.iter().map(|l| l.task_id.clone()).collect();
                 let agent_id = agent.id.clone();
 
                 if agent_store.mark_stale(&agent_id).is_ok() {
                     agents_cleaned += 1;
-
-                    if !held_tasks.is_empty() {
-                        if let Ok(task_store) = open_task_store(&config.cas_root) {
-                            for lease in &held_tasks {
-                                if let Ok(mut task) = task_store.get(&lease.task_id) {
-                                    if task.status == TaskStatus::InProgress {
-                                        let timestamp = Utc::now().format("%Y-%m-%d %H:%M");
-                                        let note = format!(
-                                            "[{}] ⚠️ INTERRUPTED Agent {} timed out while task was in progress",
-                                            timestamp,
-                                            &agent_id[..12.min(agent_id.len())]
-                                        );
-                                        if task.notes.is_empty() {
-                                            task.notes = note;
-                                        } else {
-                                            task.notes = format!("{}\n\n{}", task.notes, note);
-                                        }
-                                        task.updated_at = Utc::now();
-                                        if task_store.update(&task).is_ok() {
-                                            tasks_interrupted += 1;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    // cas-2e81: park orphaned InProgress + emit worker_died
+                    // (replaces note-only annotation that left status stuck).
+                    let summary =
+                        crate::mcp::tools::service::orphan_recovery::recover_worker_vanished(
+                            &config.cas_root,
+                            agent_store.as_ref(),
+                            agent,
+                            &held_ids,
+                            "daemon maintenance: heartbeat stale",
+                        );
+                    tasks_interrupted += summary.recovered_task_ids.len();
                 }
             }
         }
 
+        // Reclaim expired leases; park tasks when holder is already dead.
+        let expired: Vec<(String, String)> = agent_store
+            .list_active_leases()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|l| l.is_expired())
+            .map(|l| (l.task_id, l.agent_id))
+            .collect();
         let _ = agent_store.reclaim_expired_leases();
+        if !expired.is_empty() {
+            let summaries =
+                crate::mcp::tools::service::orphan_recovery::recover_expired_leases_for_dead_holders(
+                    &config.cas_root,
+                    agent_store.as_ref(),
+                    &expired,
+                    600,
+                );
+            for s in summaries {
+                tasks_interrupted += s.recovered_task_ids.len();
+            }
+        }
 
         if config.agent_purge_age_hours > 0 {
             let purge_cutoff =

--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -167,8 +167,9 @@ pub fn handle_pre_tool_use(
     //
     // New behaviour: parse the SendMessage call, enqueue the message on the
     // CAS prompt queue directly (same path `mcp__cas__coordination
-    // action=message` uses), notify the daemon, then return `deny` with an
-    // explicit "already delivered — do not retry" receipt so agents stop.
+    // action=message` uses), notify the daemon, then return `allow` with an
+    // `additionalContext` success receipt (cas-73c8) so agents see tool
+    // success — not a deny/`<error>` envelope — and stop retrying.
     //
     // On any failure (missing fields, queue open error, enqueue error) we
     // fall back to the original deny-with-guidance path — never silently drop.
@@ -1127,9 +1128,10 @@ fn is_own_verification_tool_call(tool_name: &str, tool_prefix: &str) -> bool {
 }
 
 /// Auto-route a factory-mode `SendMessage` tool call onto the CAS prompt
-/// queue so the message actually reaches its recipient, then return a
-/// `deny` receipt that tells the agent not to retry. See the `SendMessage`
-/// block in `handle_pre_tool_use` for the why.
+/// queue so the message actually reaches its recipient, then return an
+/// `allow` + `additionalContext` success receipt (cas-73c8). Returning
+/// `deny` wrapped the ✅ receipt in Claude Code's `<error>` envelope, which
+/// agents and tooling treated as failure even though delivery succeeded.
 ///
 /// On any parse / queue failure, falls back to the original deny-with-
 /// guidance path — we never silently drop the agent's message.
@@ -1252,14 +1254,19 @@ fn auto_route_send_message(
     );
 
     let prefix = crate::harness_policy::own_tool_prefix();
-    HookOutput::with_pre_tool_permission(
-        "deny",
-        &format!(
-            "✅ AUTO-ROUTED via CAS coordination (message id {message_id}).\n\n\
-             Message delivered to `{target}`. DO NOT retry this SendMessage call.\n\n\
-             For future messages, call `{prefix}coordination action=message target=<name> message=\"...\" summary=\"...\"` directly — skip SendMessage."
-        ),
-    )
+    // cas-73c8: success-shaped receipt. `permissionDecision=allow` so Claude
+    // Code does not wrap the receipt in `<error>`; the guidance lives in
+    // `additionalContext` (visible to the model next to the tool result).
+    // `permissionDecisionReason` is user-facing only on allow.
+    //
+    // Native SendMessage may also run after allow; inbox content-dedupe
+    // (teams write_to_inbox) suppresses an identical second write.
+    let receipt = format!(
+        "✅ AUTO-ROUTED via CAS coordination (message id {message_id}).\n\n\
+         Message delivered to `{target}`. DO NOT retry this SendMessage call.\n\n\
+         For future messages, call `{prefix}coordination action=message target=<name> message=\"...\" summary=\"...\"` directly — skip SendMessage."
+    );
+    HookOutput::with_pre_tool_permission_and_context("allow", "CAS auto-routed SendMessage", &receipt)
 }
 
 #[cfg(test)]

--- a/cas-cli/src/hooks/handlers/handlers_tests/send_message_autoroute.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/send_message_autoroute.rs
@@ -1,5 +1,5 @@
-//! Tests for cas-f32b: PreToolUse `SendMessage` auto-route onto the CAS
-//! prompt queue in factory mode.
+//! Tests for cas-f32b / cas-73c8: PreToolUse `SendMessage` auto-route onto
+//! the CAS prompt queue in factory mode.
 //!
 //! Before cas-f32b, the hook denied `SendMessage` with guidance telling the
 //! agent to call `mcp__cas__coordination action=message` instead. Claude
@@ -7,10 +7,12 @@
 //! so they often retried the denied call instead of switching tools —
 //! wedging workers on a deny loop (observed 2026-04-23, gabber-studio).
 //!
-//! New behaviour: parse the call, enqueue onto the CAS prompt queue, notify
-//! the daemon, and return `deny` with an "AUTO-ROUTED — do not retry"
-//! receipt. On any failure we fall back to the original deny-with-guidance
-//! path so the agent's message is never silently dropped.
+//! cas-f32b: parse the call, enqueue onto the CAS prompt queue, notify the
+//! daemon. cas-73c8: return `allow` + `additionalContext` with an
+//! "AUTO-ROUTED — do not retry" receipt so success is not wrapped in
+//! Claude Code's `<error>` envelope (deny always surfaces as tool error).
+//! On any failure we fall back to deny-with-guidance so the agent's
+//! message is never silently dropped.
 
 use crate::hooks::handlers::handle_pre_tool_use;
 use cas_core::hooks::types::HookInput;
@@ -58,6 +60,15 @@ fn send_message_input(tool_input: Option<serde_json::Value>) -> HookInput {
     }
 }
 
+fn permission_decision(out: &cas_core::hooks::types::HookOutput) -> Option<String> {
+    let specific = out.hook_specific_output.as_ref()?;
+    let value = serde_json::to_value(specific).ok()?;
+    value
+        .get("permissionDecision")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
 fn deny_reason(out: &cas_core::hooks::types::HookOutput) -> Option<String> {
     let specific = out.hook_specific_output.as_ref()?;
     let value = serde_json::to_value(specific).ok()?;
@@ -71,8 +82,18 @@ fn deny_reason(out: &cas_core::hooks::types::HookOutput) -> Option<String> {
         .map(str::to_string)
 }
 
+fn additional_context(out: &cas_core::hooks::types::HookOutput) -> Option<String> {
+    let specific = out.hook_specific_output.as_ref()?;
+    let value = serde_json::to_value(specific).ok()?;
+    value
+        .get("additionalContext")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
 // ============================================================================
-// Happy path — SendMessage with full args enqueues and returns AUTO-ROUTED.
+// Happy path — SendMessage with full args enqueues and returns AUTO-ROUTED
+// as tool success (allow + additionalContext), not deny/`<error>`.
 // ============================================================================
 
 #[test]
@@ -92,18 +113,28 @@ fn send_message_auto_routes_onto_prompt_queue() {
     })));
 
     let out = handle_pre_tool_use(&input, Some(tmp.path())).expect("handler ok");
-    let reason = deny_reason(&out).expect("expected deny receipt");
-    assert!(
-        reason.contains("AUTO-ROUTED"),
-        "deny reason should signal auto-route success, got: {reason}"
+    // cas-73c8: success must not use deny (deny → `<error>` envelope in CC).
+    assert_eq!(
+        permission_decision(&out).as_deref(),
+        Some("allow"),
+        "successful auto-route must be allow, not deny/error"
     );
     assert!(
-        reason.contains("supervisor"),
-        "receipt should name the target: {reason}"
+        deny_reason(&out).is_none(),
+        "successful auto-route must not emit a deny reason"
+    );
+    let ctx = additional_context(&out).expect("expected additionalContext receipt");
+    assert!(
+        ctx.contains("AUTO-ROUTED"),
+        "context should signal auto-route success, got: {ctx}"
     );
     assert!(
-        reason.contains("DO NOT"),
-        "receipt must tell the agent not to retry: {reason}"
+        ctx.contains("supervisor"),
+        "receipt should name the target: {ctx}"
+    );
+    assert!(
+        ctx.contains("DO NOT"),
+        "receipt must tell the agent not to retry: {ctx}"
     );
 
     // Verify a row actually landed on the prompt queue.
@@ -145,8 +176,15 @@ fn send_message_serializes_structured_payload() {
     })));
 
     let out = handle_pre_tool_use(&input, Some(tmp.path())).expect("handler ok");
+    assert_eq!(
+        permission_decision(&out).as_deref(),
+        Some("allow"),
+        "structured messages must auto-route as success"
+    );
     assert!(
-        deny_reason(&out).expect("deny").contains("AUTO-ROUTED"),
+        additional_context(&out)
+            .expect("context")
+            .contains("AUTO-ROUTED"),
         "structured messages must auto-route too"
     );
 

--- a/cas-cli/src/mcp/daemon.rs
+++ b/cas-cli/src/mcp/daemon.rs
@@ -610,24 +610,53 @@ impl EmbeddedDaemon {
             }
         }
 
-        // Agent cleanup: mark stale agents dead and reclaim expired leases
+        // Agent cleanup: mark stale agents dead, reclaim expired leases,
+        // and (cas-2e81) park orphaned InProgress tasks + emit worker_died.
         if let Ok(agent_store) = open_agent_store(&cas_root) {
             // Mark agents with no heartbeat in 600s (10 min) as stale
             // This is only for crash detection - normal cleanup via SessionEnd hook
             if let Ok(stale_agents) = agent_store.list_stale(600) {
                 for agent in stale_agents {
+                    let held: Vec<String> = agent_store
+                        .list_agent_leases(&agent.id)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|l| l.task_id)
+                        .collect();
                     if let Err(e) = agent_store.mark_stale(&agent.id) {
                         let msg = format!("Failed to mark stale agent {}: {}", agent.id, e);
                         eprintln!("[CAS] {msg}");
                         result.errors.push(msg);
+                    } else {
+                        let _ = crate::mcp::tools::service::orphan_recovery::recover_worker_vanished(
+                            &cas_root,
+                            agent_store.as_ref(),
+                            &agent,
+                            &held,
+                            "embedded daemon maintenance: heartbeat stale",
+                        );
                     }
                 }
             }
-            // Reclaim expired leases
+            // Reclaim expired leases (+ orphan recovery for dead holders)
+            let expired: Vec<(String, String)> = agent_store
+                .list_active_leases()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|l| l.is_expired())
+                .map(|l| (l.task_id, l.agent_id))
+                .collect();
             if let Err(e) = agent_store.reclaim_expired_leases() {
                 let msg = format!("Failed to reclaim expired leases: {e}");
                 eprintln!("[CAS] {msg}");
                 result.errors.push(msg);
+            } else if !expired.is_empty() {
+                let _ = crate::mcp::tools::service::orphan_recovery::recover_expired_leases_for_dead_holders(
+                    &cas_root,
+                    agent_store.as_ref(),
+                    &expired,
+                    600,
+                );
             }
         }
 

--- a/cas-cli/src/mcp/tools/core/agent_coordination/agent_management.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/agent_management.rs
@@ -230,11 +230,37 @@ impl CasCore {
         })?;
 
         let mut marked_stale = 0;
+        let mut tasks_recovered = 0usize;
+        // cas-2e81: before mark_stale revokes leases, capture held task IDs and
+        // park orphaned InProgress work + emit worker_died to supervisors.
         for agent in &stale_agents {
+            let held: Vec<String> = store
+                .list_agent_leases(&agent.id)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|l| l.task_id)
+                .collect();
             if store.mark_stale(&agent.id).is_ok() {
                 marked_stale += 1;
+                let summary = crate::mcp::tools::service::orphan_recovery::recover_worker_vanished(
+                    &self.cas_root,
+                    store.as_ref(),
+                    agent,
+                    &held,
+                    "agent_cleanup stale mark",
+                );
+                tasks_recovered += summary.recovered_task_ids.len();
             }
         }
+
+        // Capture expired leases before reclaim so we can recover dead holders.
+        let expired: Vec<(String, String)> = store
+            .list_active_leases()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|l| l.is_expired())
+            .map(|l| (l.task_id, l.agent_id))
+            .collect();
 
         // Reclaim expired leases
         let reclaimed = store.reclaim_expired_leases().map_err(|e| McpError {
@@ -243,10 +269,24 @@ impl CasCore {
             data: None,
         })?;
 
+        if !expired.is_empty() {
+            let summaries =
+                crate::mcp::tools::service::orphan_recovery::recover_expired_leases_for_dead_holders(
+                    &self.cas_root,
+                    store.as_ref(),
+                    &expired,
+                    threshold_secs,
+                );
+            for s in summaries {
+                tasks_recovered += s.recovered_task_ids.len();
+            }
+        }
+
         Ok(Self::success(format!(
             "Cleanup complete:\n\
              - Stale agents marked: {marked_stale}\n\
-             - Expired leases reclaimed: {reclaimed}"
+             - Expired leases reclaimed: {reclaimed}\n\
+             - Orphaned tasks parked Open: {tasks_recovered}"
         )))
     }
 

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -1593,7 +1593,12 @@ impl CasCore {
             // no-code (spike, chore, execution_note set, bypass).
             CodeReviewGateOutcome::Proceed
         } else {
-            run_code_review_gate(&task, &req, close_project_root)
+            run_code_review_gate(
+                &task,
+                &req,
+                close_project_root,
+                supervisor_review_mode,
+            )
         };
         match gate_outcome {
             CodeReviewGateOutcome::Proceed => {}
@@ -3673,10 +3678,50 @@ pub(crate) enum CodeReviewGateOutcome {
 ///   `pre_existing` flag; Check B rejects any P0 in `pre_existing[]`.
 ///   Then [`evaluate_gate`] is called as a safety net. Any rejection
 ///   returns a formatted block message; all checks pass → [`Proceed`].
+/// Build the `CODE_REVIEW_REQUIRED` rejection message with mode guidance
+/// that matches the configured `[code_review] owner` (cas-297e).
+///
+/// - `supervisor_owned = true` (default since v2.13.0): recommend
+///   `mode=interactive` / `mode=headless`.
+/// - `supervisor_owned = false` (`owner = "worker"`): recommend the
+///   legacy `mode=autofix` path.
+fn format_code_review_required(supervisor_owned: bool) -> String {
+    let step1 = if supervisor_owned {
+        "1. Invoke the cas-code-review skill via the Skill or Task tool with \
+         mode=interactive (or mode=headless for skill-to-skill) and the \
+         current diff.\n\
+         Note: mode=autofix is the legacy path for projects that pin \
+         [code_review] owner = \"worker\"."
+    } else {
+        "1. Invoke the cas-code-review skill via the Skill or Task tool with \
+         mode=autofix and the current diff."
+    };
+    format!(
+        "⚠️ CODE_REVIEW_REQUIRED\n\n\
+         task close rejected: this task has reviewable code changes \
+         and no code_review_findings envelope was provided.\n\n\
+         To resolve:\n\
+         {step1}\n\
+         2. Collect the returned ReviewOutcome envelope (residual, \
+            pre_existing, mode).\n\
+         3. Re-call task.close with the envelope JSON-stringified \
+            in code_review_findings.\n\n\
+         {}\n\n\
+         Supervisors may bypass this gate with \
+         bypass_code_review=true (logged as a decision note).",
+        cas_types::review_outcome_shape_hint(),
+    )
+}
+
+/// Run the cas-code-review P0 close gate.
+///
+/// `supervisor_owned` selects owner-aware mode guidance in
+/// `CODE_REVIEW_REQUIRED` (interactive/headless vs legacy autofix).
 pub(crate) fn run_code_review_gate(
     task: &Task,
     req: &TaskCloseRequest,
     project_root: &std::path::Path,
+    supervisor_owned: bool,
 ) -> CodeReviewGateOutcome {
     // Skip 1: additive-only tasks bypass the gate entirely.
     if task.execution_note.as_deref() == Some("additive-only") {
@@ -3734,45 +3779,31 @@ pub(crate) fn run_code_review_gate(
         _ => match persisted_envelope {
             Some(s) => s,
             None => {
-                return CodeReviewGateOutcome::Reject(
-                    "⚠️ CODE_REVIEW_REQUIRED\n\n\
-                     task close rejected: this task has reviewable code changes \
-                     and no code_review_findings envelope was provided.\n\n\
-                     To resolve:\n\
-                     1. Invoke the cas-code-review skill via the Skill or Task \
-                        tool with mode=autofix and the current diff.\n\
-                     2. Collect the returned ReviewOutcome envelope (residual, \
-                        pre_existing, mode).\n\
-                     3. Re-call task.close with the envelope JSON-stringified \
-                        in code_review_findings.\n\n\
-                     Supervisors may bypass this gate with \
-                     bypass_code_review=true (logged as a decision note)."
-                        .to_string(),
-                );
+                return CodeReviewGateOutcome::Reject(format_code_review_required(
+                    supervisor_owned,
+                ));
             }
         },
     };
 
-    let envelope: cas_types::ReviewOutcome = match serde_json::from_str(envelope_json) {
-        Ok(e) => e,
-        Err(e) => {
-            return CodeReviewGateOutcome::Reject(format!(
-                "⚠️ MALFORMED REVIEW ENVELOPE\n\n\
-                 task close rejected: code_review_findings failed to parse \
-                 as ReviewOutcome JSON: {e}\n\n\
-                 Expected shape: {{residual: Finding[], pre_existing: Finding[], mode: string}}."
-            ));
-        }
-    };
-
-    if let Err(e) = envelope.validate() {
-        return CodeReviewGateOutcome::Reject(format!(
-            "⚠️ MALFORMED REVIEW ENVELOPE\n\n\
-             task close rejected: code_review_findings failed validation: {e}\n\n\
-             The worker-side cas-code-review skill returned a structurally \
-             invalid envelope. Re-run the review and retry close."
-        ));
-    }
+    // cas-297e: multi-field parse via parse_review_outcome so a single
+    // bad envelope lists every missing Finding field (and documents the
+    // full Finding schema in the reject text).
+    let envelope: cas_types::ReviewOutcome =
+        match cas_types::parse_review_outcome(envelope_json) {
+            Ok(e) => e,
+            Err(e) => {
+                return CodeReviewGateOutcome::Reject(format!(
+                    "⚠️ MALFORMED REVIEW ENVELOPE\n\n\
+                     task close rejected: code_review_findings failed to parse \
+                     as ReviewOutcome JSON:\n{}\n\n\
+                     {}\n\n\
+                     Fix every listed field (or re-run cas-code-review) and retry close.",
+                    e.message,
+                    cas_types::review_outcome_shape_hint(),
+                ));
+            }
+        };
 
     use cas_store::code_review::close_gate::{GateDecision, evaluate_gate, format_block_message};
     use cas_types::FindingSeverity;
@@ -4968,7 +4999,7 @@ mod code_review_gate_tests {
         t.execution_note = Some("additive-only".to_string());
         let mut req = base_req(&t.id);
         req.code_review_findings = Some(autofix_envelope(vec![p0_finding()]));
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         assert!(matches!(out, CodeReviewGateOutcome::Proceed));
     }
 
@@ -4978,7 +5009,7 @@ mod code_review_gate_tests {
         let dir = repo_with_staged(&[("README.md", "new content\n"), ("docs/x.md", "x\n")]);
         let t = base_task();
         let req = base_req(&t.id); // no findings
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         assert!(
             matches!(out, CodeReviewGateOutcome::Proceed),
             "pure-docs diff must skip the review gate"
@@ -4991,14 +5022,106 @@ mod code_review_gate_tests {
         let dir = repo_with_staged(&[("src/foo.rs", "fn new() {}\n")]);
         let t = base_task();
         let req = base_req(&t.id);
-        let out = run_code_review_gate(&t, &req, dir.path());
+        // supervisor_owned=true is the config default (cas-865b).
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         match out {
             CodeReviewGateOutcome::Reject(msg) => {
                 assert!(msg.contains("CODE_REVIEW_REQUIRED"));
                 assert!(msg.contains("cas-code-review"));
                 assert!(msg.contains("code_review_findings"));
+                // cas-297e: supervisor-owned mode recommends interactive/headless.
+                assert!(
+                    msg.contains("mode=interactive"),
+                    "supervisor-owned guidance must recommend interactive: {msg}"
+                );
+                assert!(
+                    msg.contains("mode=headless"),
+                    "supervisor-owned guidance must mention headless: {msg}"
+                );
+                assert!(
+                    !msg.contains("mode=autofix and the current diff"),
+                    "supervisor-owned guidance must not primary-recommend autofix: {msg}"
+                );
+                // Finding schema documented at the point of failure.
+                assert!(
+                    msg.contains("why_it_matters"),
+                    "CODE_REVIEW_REQUIRED must document Finding fields: {msg}"
+                );
             }
             other => panic!("expected CODE_REVIEW_REQUIRED reject, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn code_review_required_worker_owned_recommends_autofix() {
+        // cas-297e AC3: owner=worker keeps the legacy autofix guidance.
+        let _g = env_lock();
+        let dir = repo_with_staged(&[("src/foo.rs", "fn new() {}\n")]);
+        let t = base_task();
+        let req = base_req(&t.id);
+        let out = run_code_review_gate(&t, &req, dir.path(), false);
+        match out {
+            CodeReviewGateOutcome::Reject(msg) => {
+                assert!(msg.contains("CODE_REVIEW_REQUIRED"));
+                assert!(
+                    msg.contains("mode=autofix"),
+                    "worker-owned guidance must recommend autofix: {msg}"
+                );
+                assert!(
+                    !msg.contains("mode=interactive"),
+                    "worker-owned guidance must not recommend interactive: {msg}"
+                );
+            }
+            other => panic!("expected CODE_REVIEW_REQUIRED reject, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn partial_finding_envelope_lists_all_missing_fields_once() {
+        // cas-297e AC1+AC2: one response lists every missing Finding field
+        // and documents the Finding schema.
+        let _g = env_lock();
+        let dir = repo_with_staged(&[("src/foo.rs", "fn new() {}\n")]);
+        let t = base_task();
+        let mut req = base_req(&t.id);
+        req.code_review_findings = Some(
+            r#"{
+                "mode": "interactive",
+                "residual": [{
+                    "title": "partial finding",
+                    "severity": "P2",
+                    "file": "src/foo.rs",
+                    "line": 1
+                }],
+                "pre_existing": []
+            }"#
+            .to_string(),
+        );
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
+        match out {
+            CodeReviewGateOutcome::Reject(msg) => {
+                assert!(msg.contains("MALFORMED REVIEW ENVELOPE"), "{msg}");
+                for field in [
+                    "why_it_matters",
+                    "autofix_class",
+                    "owner",
+                    "confidence",
+                    "evidence",
+                    "pre_existing",
+                ] {
+                    assert!(
+                        msg.contains(&format!("missing field `{field}`")),
+                        "expected all-fields list to include `{field}`:\n{msg}"
+                    );
+                }
+                // Schema hint documents required Finding keys.
+                assert!(
+                    msg.contains("Each Finding requires:"),
+                    "error must document Finding required fields:\n{msg}"
+                );
+                assert!(msg.contains("residual[0]"), "{msg}");
+            }
+            other => panic!("expected MALFORMED reject, got {other:?}"),
         }
     }
 
@@ -5009,7 +5132,7 @@ mod code_review_gate_tests {
         let t = base_task();
         let mut req = base_req(&t.id);
         req.code_review_findings = Some(autofix_envelope(vec![p0_finding()]));
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         match out {
             CodeReviewGateOutcome::Reject(msg) => {
                 assert!(msg.contains("P0 BLOCK"));
@@ -5027,7 +5150,7 @@ mod code_review_gate_tests {
         let t = base_task();
         let mut req = base_req(&t.id);
         req.code_review_findings = Some(autofix_envelope(vec![p2_finding()]));
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         assert!(
             matches!(out, CodeReviewGateOutcome::Proceed),
             "P2 residual must route to Unit 8, not block close"
@@ -5041,7 +5164,7 @@ mod code_review_gate_tests {
         let t = base_task();
         let mut req = base_req(&t.id);
         req.code_review_findings = Some(autofix_envelope(Vec::new()));
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         assert!(matches!(out, CodeReviewGateOutcome::Proceed));
     }
 
@@ -5054,7 +5177,7 @@ mod code_review_gate_tests {
         // Whitespace-only mode passes serde but fails validate().
         req.code_review_findings =
             Some(r#"{"residual":[],"pre_existing":[],"mode":"   "}"#.to_string());
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         match out {
             CodeReviewGateOutcome::Reject(msg) => {
                 assert!(msg.contains("MALFORMED REVIEW ENVELOPE"));
@@ -5070,11 +5193,16 @@ mod code_review_gate_tests {
         let t = base_task();
         let mut req = base_req(&t.id);
         req.code_review_findings = Some("not json at all".to_string());
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         match out {
             CodeReviewGateOutcome::Reject(msg) => {
                 assert!(msg.contains("MALFORMED REVIEW ENVELOPE"));
                 assert!(msg.contains("failed to parse"));
+                // cas-297e AC2: even parse failures document the Finding schema.
+                assert!(
+                    msg.contains("Each Finding requires:"),
+                    "parse error must document Finding schema:\n{msg}"
+                );
             }
             other => panic!("expected parse reject, got {other:?}"),
         }
@@ -5094,7 +5222,7 @@ mod code_review_gate_tests {
         req.bypass_code_review = Some(true);
         req.reason = Some("P0 is a false positive, tracked in cas-xyz".to_string());
 
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
 
         unsafe {
             match prev {
@@ -5126,7 +5254,7 @@ mod code_review_gate_tests {
         let mut req = base_req(&t.id);
         req.bypass_code_review = Some(true);
 
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
 
         unsafe {
             match prev {
@@ -5151,7 +5279,7 @@ mod code_review_gate_tests {
         t.execution_note = Some("additive-only".to_string());
         let req = base_req(&t.id); // no findings, no override
         // additive-only short-circuits before the findings check.
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         assert!(matches!(out, CodeReviewGateOutcome::Proceed));
     }
 
@@ -5162,7 +5290,7 @@ mod code_review_gate_tests {
         let t = base_task();
         let req = base_req(&t.id);
         // Non-git dir → has_reviewable_changes returns false → skip.
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         assert!(matches!(out, CodeReviewGateOutcome::Proceed));
     }
 
@@ -5179,7 +5307,7 @@ mod code_review_gate_tests {
         let mut t = base_task();
         t.deliverables.review_envelope = Some(autofix_envelope(Vec::new()));
         let req = base_req(&t.id); // no findings in request
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         assert!(
             matches!(out, CodeReviewGateOutcome::Proceed),
             "persisted clean envelope must let supervisor-close proceed without bypass"
@@ -5194,7 +5322,7 @@ mod code_review_gate_tests {
         let mut t = base_task();
         t.deliverables.review_envelope = Some(autofix_envelope(vec![p0_finding()]));
         let req = base_req(&t.id);
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         match out {
             CodeReviewGateOutcome::Reject(msg) => {
                 assert!(msg.contains("P0 BLOCK"), "P0 must still block: {msg}");
@@ -5215,7 +5343,7 @@ mod code_review_gate_tests {
         let mut req = base_req(&t.id);
         // Request envelope is clean — should let the close proceed.
         req.code_review_findings = Some(autofix_envelope(Vec::new()));
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         assert!(
             matches!(out, CodeReviewGateOutcome::Proceed),
             "explicit request envelope must win over persisted fallback"
@@ -5229,7 +5357,7 @@ mod code_review_gate_tests {
         let mut t = base_task();
         t.deliverables.review_envelope = Some("not-json".to_string());
         let req = base_req(&t.id);
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         assert!(
             matches!(out, CodeReviewGateOutcome::Reject(_)),
             "malformed persisted envelope must be rejected, not silently bypassed"
@@ -5394,7 +5522,7 @@ mod code_review_gate_tests {
         let forged = envelope_with_pre_existing(vec![p0_finding_pre_existing_true()], Vec::new());
         t.deliverables.review_envelope = Some(forged);
         let req = base_req(&t.id); // no findings in request — reads persisted
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         match out {
             CodeReviewGateOutcome::Reject(msg) => {
                 assert!(
@@ -5421,7 +5549,7 @@ mod code_review_gate_tests {
         let forged = envelope_with_pre_existing(Vec::new(), vec![p0_finding()]);
         t.deliverables.review_envelope = Some(forged);
         let req = base_req(&t.id);
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         match out {
             CodeReviewGateOutcome::Reject(msg) => {
                 assert!(
@@ -5466,7 +5594,7 @@ mod code_review_gate_tests {
         t.deliverables.review_envelope = Some(forged);
         // Step 3: worker retries without providing code_review_findings.
         let req = base_req(&t.id);
-        let out = run_code_review_gate(&t, &req, dir.path());
+        let out = run_code_review_gate(&t, &req, dir.path(), true);
         match out {
             CodeReviewGateOutcome::Reject(msg) => {
                 // Must block with P0 — not CODE_REVIEW_REQUIRED (which would

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -256,6 +256,25 @@ impl CasCore {
             data: None,
         })?;
 
+        // cas-6d0b: short-circuit already-Closed before merge/review/verification
+        // gates. A second close must not:
+        //   - return "Closed task:" (implying this call performed the close),
+        //   - overwrite `closed_at` / `close_reason` / append another Closed note,
+        //   - demand CODE_REVIEW_REQUIRED (or any other gate) for a terminal state.
+        // Racing supervisors both got success and corrupted the audit trail;
+        // return a distinct non-destructive already-closed result instead.
+        if task.status == TaskStatus::Closed {
+            let closed_at_msg = task
+                .closed_at
+                .map(|t| t.format("%Y-%m-%d %H:%M UTC").to_string())
+                .unwrap_or_else(|| "unknown time".to_string());
+            return Ok(Self::success(format!(
+                "Already closed: {} - {} (closed at {}). This call did not re-close \
+                 the task; closed_at and notes were left unchanged.",
+                req.id, task.title, closed_at_msg
+            )));
+        }
+
         // cas-6538 (EPIC cas-1255 — per-task depth speed mode): a `depth=light`
         // task is the feel-driven, fast-iteration path. The close gate skips
         // the two *rigor* gates — the verification jail (no `task-verifier`

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -298,12 +298,21 @@ impl CasCore {
             data: None,
         })?;
 
-        // cas-b269: already-Closed → idempotent success. Do not re-enter
-        // verification / merge / re-close work from stale guidance.
-        if super::stale_close_guard::is_terminal_closed(task.status) {
-            return Ok(Self::success(
-                super::stale_close_guard::already_closed_close_message(&req.id),
-            ));
+        // cas-6d0b / cas-b269: short-circuit already-Closed before
+        // merge/review/verification gates. Do not re-success, overwrite
+        // closed_at, or demand CODE_REVIEW_REQUIRED.
+        if super::stale_close_guard::is_terminal_closed(task.status)
+            || task.status == TaskStatus::Closed
+        {
+            let closed_at_msg = task
+                .closed_at
+                .map(|t| t.format("%Y-%m-%d %H:%M UTC").to_string())
+                .unwrap_or_else(|| "unknown time".to_string());
+            return Ok(Self::success(format!(
+                "Already closed: {} - {} (closed at {}). This call did not re-close \
+                 the task; closed_at and notes were left unchanged.",
+                req.id, task.title, closed_at_msg
+            )));
         }
 
         // cas-b269: urgent stop sets halt_task_work; block close until new start.

--- a/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
+++ b/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
@@ -1,5 +1,8 @@
 use crate::mcp::tools::core::imports::*;
 
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
 /// Check whether `path` looks like a live git worktree (has a `.git` entry
 /// — a file for linked worktrees, pointing back at the main repo's
 /// worktree admin dir).
@@ -9,8 +12,157 @@ use crate::mcp::tools::core::imports::*;
 /// it (cas-1d11). Returns `false` for a path that doesn't exist or isn't a
 /// git worktree — an unknowable worktree is not treated as a false
 /// positive.
-fn is_git_worktree(path: &std::path::Path) -> bool {
+fn is_git_worktree(path: &Path) -> bool {
     path.join(".git").exists()
+}
+
+/// Path prefix match with canonicalize fallback (symlinks / relative forms).
+fn path_is_under(path: &Path, base: &Path) -> bool {
+    if path.starts_with(base) {
+        return true;
+    }
+    match (std::fs::canonicalize(path), std::fs::canonicalize(base)) {
+        (Ok(p), Ok(b)) => p.starts_with(b),
+        _ => false,
+    }
+}
+
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    if a == b {
+        return true;
+    }
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => false,
+    }
+}
+
+/// Resolve the configured factory worktree base for this project.
+///
+/// Matches `spawn_workers isolate=true` / `WorktreeManager` resolution so
+/// `worktree_list` does not hardcode `<cas_root>/worktrees` (cas-d1a0).
+fn resolve_factory_worktree_base(cas_root: &Path) -> PathBuf {
+    use crate::config::Config;
+
+    let Some(project_dir) = cas_root.parent() else {
+        return cas_root.join("worktrees");
+    };
+    let config = Config::load(cas_root).unwrap_or_default();
+    config.worktrees().resolve_base_path(project_dir)
+}
+
+/// Whether a live git worktree looks CAS-managed (factory, epic, cas/*, or
+/// under known CAS worktree roots) and should appear in worktree_list even
+/// without a WorktreeStore row (sibling/predecessor sessions).
+fn is_cas_pattern_worktree(
+    path: &Path,
+    branch: Option<&str>,
+    cas_root: &Path,
+    factory_base: &Path,
+    repo_root: &Path,
+) -> bool {
+    // Main checkout is never listed as a managed worktree entry.
+    if paths_equal(path, repo_root) {
+        return false;
+    }
+
+    if path_is_under(path, factory_base) {
+        return true;
+    }
+    // Default System B layout — still scanned when base_path is customized.
+    if path_is_under(path, &cas_root.join("worktrees")) {
+        return true;
+    }
+    // Claude Code agent isolation dirs (also swept by factory cleanup).
+    if path_is_under(path, &repo_root.join(".claude").join("worktrees")) {
+        return true;
+    }
+
+    if let Some(b) = branch {
+        if b.starts_with("factory/") || b.starts_with("epic/") || b.starts_with("cas/") {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn is_factory_style_worktree(
+    path: &Path,
+    branch: &str,
+    cas_root: &Path,
+    factory_base: &Path,
+) -> bool {
+    branch.starts_with("factory/")
+        || path_is_under(path, factory_base)
+        || path_is_under(path, &cas_root.join("worktrees"))
+}
+
+/// Reconcile live git worktrees that match CAS patterns but are missing from
+/// the SQLite WorktreeStore (System B never registers; System A rows are
+/// project-scoped but may be absent for sibling-session worktrees).
+///
+/// Returns transient `Worktree` rows with `git:` id prefix for display.
+fn collect_untracked_git_worktrees(
+    cas_root: &Path,
+    factory_base: &Path,
+    tracked_branches: &HashSet<String>,
+    tracked_paths: &HashSet<PathBuf>,
+) -> Vec<crate::types::Worktree> {
+    use crate::types::Worktree;
+    use crate::worktree::GitOperations;
+
+    let mut out = Vec::new();
+    let Some(project_dir) = cas_root.parent() else {
+        return out;
+    };
+    let Ok(repo_root) = GitOperations::detect_repo_root(project_dir) else {
+        return out;
+    };
+    let git_ops = GitOperations::new(repo_root.clone());
+    let Ok(git_worktrees) = git_ops.list_worktrees() else {
+        return out;
+    };
+
+    for git_wt in git_worktrees {
+        if !is_cas_pattern_worktree(
+            &git_wt.path,
+            git_wt.branch.as_deref(),
+            cas_root,
+            factory_base,
+            &repo_root,
+        ) {
+            continue;
+        }
+
+        let branch = git_wt.branch.clone().unwrap_or_default();
+        if !branch.is_empty() && tracked_branches.contains(&branch) {
+            continue;
+        }
+        if tracked_paths.iter().any(|p| paths_equal(p, &git_wt.path)) {
+            continue;
+        }
+
+        let id_key = if !branch.is_empty() {
+            branch.clone()
+        } else {
+            git_wt.path.display().to_string()
+        };
+        let display_branch = if branch.is_empty() {
+            "(detached)".to_string()
+        } else {
+            branch
+        };
+
+        out.push(Worktree::new(
+            format!("git:{id_key}"),
+            display_branch,
+            "unknown".to_string(),
+            git_wt.path,
+        ));
+    }
+
+    out
 }
 
 /// Resolve the parent branch a System B worker's branch should merge into
@@ -166,6 +318,13 @@ impl CasCore {
     }
 
     /// List worktrees
+    ///
+    /// Combines the project-scoped WorktreeStore (System A) with a live
+    /// `git worktree list` reconcile for CAS-pattern paths/branches that were
+    /// never registered (System B factory workers, sibling-session epic
+    /// worktrees). Registry rows live in `.cas/cas.db` — shared by every
+    /// session in the project; git is the second source of truth when a
+    /// session never wrote a row (cas-d1a0).
     pub async fn worktree_list(
         &self,
         all: bool,
@@ -173,9 +332,7 @@ impl CasCore {
         orphans_only: bool,
     ) -> Result<CallToolResult, McpError> {
         use crate::store::{open_agent_store, open_task_store, open_worktree_store};
-        use crate::types::{AgentStatus, TaskStatus, Worktree, WorktreeStatus};
-        use crate::worktree::GitOperations;
-        use std::collections::HashSet;
+        use crate::types::{AgentStatus, TaskStatus, WorktreeStatus};
 
         let cas_root = self.cas_root.clone();
         let worktree_store = open_worktree_store(&cas_root).map_err(|e| McpError {
@@ -194,12 +351,17 @@ impl CasCore {
             data: None,
         })?;
 
-        let mut worktrees = if let Some(status_str) = status_filter {
-            let status: WorktreeStatus = status_str.parse().map_err(|_| McpError {
+        let parsed_status: Option<WorktreeStatus> = if let Some(status_str) = status_filter {
+            Some(status_str.parse().map_err(|_| McpError {
                 code: ErrorCode::INVALID_PARAMS,
                 message: Cow::from(format!("Invalid status: {status_str}")),
                 data: None,
-            })?;
+            })?)
+        } else {
+            None
+        };
+
+        let mut worktrees = if let Some(status) = parsed_status {
             worktree_store
                 .list_by_status(status)
                 .map_err(|e| McpError {
@@ -221,43 +383,27 @@ impl CasCore {
             })?
         };
 
-        // Get branches already in SQLite for deduplication
-        let tracked_branches: HashSet<String> =
-            worktrees.iter().map(|wt| wt.branch.clone()).collect();
+        // Live git reconcile only for views that include active worktrees.
+        // Non-active status filters (merged/abandoned/…) must not gain
+        // transient Active git rows.
+        let should_reconcile_git = match parsed_status {
+            None => true,
+            Some(WorktreeStatus::Active) => true,
+            Some(_) => false,
+        };
 
-        // Also include factory (System B) worktrees from git that are not yet
-        // tracked in the SQLite store.
-        //
-        // We scope the scan to paths under `<cas_root>/worktrees/` so that
-        // the main checkout (and any unrelated user worktrees) are excluded.
-        // Factory workers are always placed at `.cas/worktrees/<name>` by
-        // `spawn_workers isolate=true`, so this filter is both safe and precise.
-        let factory_worktrees_base = cas_root.join("worktrees");
-        if let Some(repo_root) = cas_root.parent() {
-            if let Ok(git_ops) = GitOperations::detect_repo_root(repo_root).map(GitOperations::new)
-            {
-                if let Ok(git_worktrees) = git_ops.list_worktrees() {
-                    for git_wt in git_worktrees {
-                        // Only include worktrees that live under .cas/worktrees/
-                        // (factory / System B) and are not already in the store.
-                        if !git_wt.path.starts_with(&factory_worktrees_base) {
-                            continue;
-                        }
-                        let branch = git_wt.branch.clone().unwrap_or_default();
-                        if !branch.is_empty() && !tracked_branches.contains(&branch) {
-                            // Create a transient Worktree entry for display.
-                            // The `git:` id prefix is used downstream to identify
-                            // factory worktrees and render the `[factory]` label.
-                            worktrees.push(Worktree::new(
-                                format!("git:{branch}"),
-                                branch,
-                                "unknown".to_string(),
-                                git_wt.path.clone(),
-                            ));
-                        }
-                    }
-                }
-            }
+        let factory_base = resolve_factory_worktree_base(&cas_root);
+        if should_reconcile_git {
+            let tracked_branches: HashSet<String> =
+                worktrees.iter().map(|wt| wt.branch.clone()).collect();
+            let tracked_paths: HashSet<PathBuf> =
+                worktrees.iter().map(|wt| wt.path.clone()).collect();
+            worktrees.extend(collect_untracked_git_worktrees(
+                &cas_root,
+                &factory_base,
+                &tracked_branches,
+                &tracked_paths,
+            ));
         }
 
         // Filter orphans if requested
@@ -306,21 +452,28 @@ impl CasCore {
                 WorktreeStatus::Removed => "🗑️",
             };
             let path_status = if wt.path.exists() { "" } else { " (missing)" };
-            // Factory worktrees have IDs starting with "git:"
+            // git: prefix = reconciled from live git (not in WorktreeStore).
+            // Factory-style vs other CAS patterns get distinct labels so
+            // supervisors can tell spawn workers from untracked epic trees.
             let type_indicator = if wt.id.starts_with("git:") {
-                " [factory]"
+                if is_factory_style_worktree(&wt.path, &wt.branch, &cas_root, &factory_base) {
+                    " [factory]"
+                } else {
+                    " [untracked]"
+                }
             } else {
                 ""
             };
             output.push_str(&format!(
-                "{} {} - {} {}{}{}\n   Epic: {}\n\n",
+                "{} {} - {} {}{}{}\n   Epic: {}\n   Path: {}\n\n",
                 status_icon,
                 wt.id,
                 wt.branch,
                 wt.status,
                 path_status,
                 type_indicator,
-                wt.epic_id.as_deref().unwrap_or("-")
+                wt.epic_id.as_deref().unwrap_or("-"),
+                wt.path.display()
             ));
         }
 
@@ -667,7 +820,6 @@ impl CasCore {
         use crate::config::Config;
         use crate::store::open_worktree_store;
         use crate::worktree::GitOperations;
-        use std::collections::HashSet;
 
         let cas_root = self.cas_root.clone();
         let config = Config::load(&cas_root).map_err(|e| McpError {
@@ -702,6 +854,7 @@ impl CasCore {
 
         // Query worktree store for active worktrees
         let mut stored_branches: HashSet<String> = HashSet::new();
+        let mut stored_paths: HashSet<PathBuf> = HashSet::new();
         let mut active_count = 0usize;
         let mut branch_names: Vec<String> = Vec::new();
 
@@ -710,29 +863,27 @@ impl CasCore {
                 active_count = active_worktrees.len();
                 for wt in &active_worktrees {
                     stored_branches.insert(wt.branch.clone());
+                    stored_paths.insert(wt.path.clone());
                     branch_names.push(wt.branch.clone());
                 }
             }
         }
 
-        // System B — factory (isolate=true) worktrees.
-        // Scoped to `<cas_root>/worktrees/` so the main checkout is excluded.
-        let factory_worktrees_base = cas_root.join("worktrees");
-        let mut factory_entries: Vec<(String, std::path::PathBuf)> = Vec::new();
-        if let Some(repo_root) = cas_root.parent() {
-            if let Ok(git_ops) = GitOperations::detect_repo_root(repo_root).map(GitOperations::new)
-            {
-                if let Ok(git_worktrees) = git_ops.list_worktrees() {
-                    for git_wt in git_worktrees {
-                        if !git_wt.path.starts_with(&factory_worktrees_base) {
-                            continue;
-                        }
-                        let branch = git_wt.branch.clone().unwrap_or_default();
-                        if !branch.is_empty() && !stored_branches.contains(&branch) {
-                            factory_entries.push((branch, git_wt.path.clone()));
-                        }
-                    }
-                }
+        // Live git reconcile — same CAS-pattern rules as worktree_list (cas-d1a0).
+        let factory_base = resolve_factory_worktree_base(&cas_root);
+        let untracked = collect_untracked_git_worktrees(
+            &cas_root,
+            &factory_base,
+            &stored_branches,
+            &stored_paths,
+        );
+        let mut factory_entries: Vec<(String, PathBuf)> = Vec::new();
+        let mut other_untracked: Vec<(String, PathBuf)> = Vec::new();
+        for wt in untracked {
+            if is_factory_style_worktree(&wt.path, &wt.branch, &cas_root, &factory_base) {
+                factory_entries.push((wt.branch, wt.path));
+            } else {
+                other_untracked.push((wt.branch, wt.path));
             }
         }
 
@@ -745,6 +896,15 @@ impl CasCore {
         } else {
             output.push_str(&format!("  Active: {b_active}\n"));
             for (branch, path) in &factory_entries {
+                output.push_str(&format!("    {} ({})\n", branch, path.display()));
+            }
+        }
+
+        // Untracked CAS-pattern worktrees (e.g. epic/* outside factory base)
+        // from sibling sessions — visible for management without a store row.
+        if !other_untracked.is_empty() {
+            output.push_str("\nUntracked CAS-pattern worktrees:\n");
+            for (branch, path) in &other_untracked {
                 output.push_str(&format!("    {} ({})\n", branch, path.display()));
             }
         }
@@ -764,7 +924,10 @@ impl CasCore {
 
 #[cfg(test)]
 mod tests {
-    use super::is_git_worktree;
+    use super::{
+        is_cas_pattern_worktree, is_factory_style_worktree, is_git_worktree, path_is_under,
+    };
+    use std::path::Path;
     use tempfile::TempDir;
 
     #[test]
@@ -791,5 +954,72 @@ mod tests {
         std::fs::create_dir_all(&path).unwrap();
 
         assert!(!is_git_worktree(&path));
+    }
+
+    #[test]
+    fn cas_pattern_matches_factory_branch_outside_cas_dir() {
+        let repo = Path::new("/repo");
+        let cas = Path::new("/repo/.cas");
+        let factory_base = Path::new("/repo/.cas/worktrees");
+        let path = Path::new("/tmp/elsewhere/worker");
+        assert!(is_cas_pattern_worktree(
+            path,
+            Some("factory/hv-food-qa"),
+            cas,
+            factory_base,
+            repo,
+        ));
+    }
+
+    #[test]
+    fn cas_pattern_matches_epic_branch_outside_cas_dir() {
+        let repo = Path::new("/repo");
+        let cas = Path::new("/repo/.cas");
+        let factory_base = Path::new("/repo/.cas/worktrees");
+        let path = Path::new("/tmp/ozer-epic-ea3e-hv");
+        assert!(is_cas_pattern_worktree(
+            path,
+            Some("epic/integrate-cas-ea3e"),
+            cas,
+            factory_base,
+            repo,
+        ));
+        assert!(!is_factory_style_worktree(
+            path,
+            "epic/integrate-cas-ea3e",
+            cas,
+            factory_base,
+        ));
+    }
+
+    #[test]
+    fn cas_pattern_rejects_main_checkout_and_unrelated_branches() {
+        let repo = Path::new("/repo");
+        let cas = Path::new("/repo/.cas");
+        let factory_base = Path::new("/repo/.cas/worktrees");
+        assert!(!is_cas_pattern_worktree(
+            repo,
+            Some("staging"),
+            cas,
+            factory_base,
+            repo,
+        ));
+        assert!(!is_cas_pattern_worktree(
+            Path::new("/tmp/hand-made"),
+            Some("feature/hand-made"),
+            cas,
+            factory_base,
+            repo,
+        ));
+    }
+
+    #[test]
+    fn path_is_under_matches_prefix() {
+        let base = Path::new("/proj/.cas/worktrees");
+        assert!(path_is_under(
+            Path::new("/proj/.cas/worktrees/alice"),
+            base
+        ));
+        assert!(!path_is_under(Path::new("/proj/other"), base));
     }
 }

--- a/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
+++ b/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
@@ -179,6 +179,7 @@ fn authorize_explicit_task_for_system_b_worker(
             data: None,
         }),
     }
+}
 
 /// Path prefix match with canonicalize fallback (symlinks / relative forms).
 fn path_is_under(path: &Path, base: &Path) -> bool {

--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -258,8 +258,15 @@ impl CasService {
         // signal this happened. Check registration state up front so the
         // response can say so honestly. `all_workers` is a broadcast, not a
         // single-target claim, so it's always reported as delivered framing.
+        //
+        // cas-73c8: `director` is a permanent team member (TeamsManager
+        // init_team_config) and the source of inbound teammate messages, but
+        // is not an agent_store registration. Treat it as always registered
+        // so outbound replies after an inbound director message are not
+        // reported as "not yet registered".
         let target_is_registered = resolved_target == "all_workers"
             || resolved_target == "supervisor"
+            || resolved_target.eq_ignore_ascii_case("director")
             || {
                 use crate::store::open_agent_store;
                 open_agent_store(&self.inner.cas_root)

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -575,9 +575,44 @@ impl CasService {
                     let _ = store.revive(&agent.id);
                     continue;
                 }
+                // cas-2e81: capture held leases BEFORE mark_stale revokes them,
+                // then park orphaned InProgress tasks + emit worker_died.
+                let held: Vec<String> = store
+                    .list_agent_leases(&agent.id)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|l| l.task_id)
+                    .collect();
                 if store.mark_stale(&agent.id).is_ok() {
                     stale_pruned += 1;
+                    let _ = super::orphan_recovery::recover_worker_vanished(
+                        &self.inner.cas_root,
+                        store.as_ref(),
+                        &agent,
+                        &held,
+                        "worker_status stale prune (heartbeat gone, process not alive)",
+                    );
                 }
+            }
+        }
+
+        // cas-2e81: reclaim expired leases and park tasks when the holder is
+        // already dead/stale (lease expiry alone must not silence orphans).
+        if let Ok(active_leases) = store.list_active_leases() {
+            let now = chrono::Utc::now();
+            let expired: Vec<(String, String)> = active_leases
+                .into_iter()
+                .filter(|l| l.expires_at < now)
+                .map(|l| (l.task_id, l.agent_id))
+                .collect();
+            if !expired.is_empty() {
+                let _ = store.reclaim_expired_leases();
+                let _ = super::orphan_recovery::recover_expired_leases_for_dead_holders(
+                    &self.inner.cas_root,
+                    store.as_ref(),
+                    &expired,
+                    worker_stale_threshold_secs,
+                );
             }
         }
 
@@ -593,10 +628,26 @@ impl CasService {
             .filter(|a| a.visible_to_factory_session(factory_session.as_deref()))
             .collect();
 
+        // cas-2e81: always surface recently-died-while-leased even when the
+        // Active roster is empty — "None active" must not hide a mid-P0 crash.
+        let died_section = super::orphan_recovery::format_recently_died_while_leased(
+            &self.inner.cas_root,
+            store.as_ref(),
+            factory_session.as_deref(),
+            3600, // 1h window
+        );
+
         if agents.is_empty() {
-            return Ok(Self::success(
+            let mut msg = String::from(
                 "No active agents registered.\n\nNote: Factory TUI must be running for agents to be registered.",
-            ));
+            );
+            msg.push_str(&died_section);
+            if stale_pruned > 0 {
+                msg.push_str(&format!(
+                    "\nFiltered stale agent record(s): {stale_pruned} (>{worker_stale_threshold_secs}s heartbeat age)\n"
+                ));
+            }
+            return Ok(Self::success(msg));
         }
 
         let owned = supervisor_owned_workers();
@@ -777,6 +828,9 @@ impl CasService {
                 ));
             }
         }
+
+        // cas-2e81: died-while-leased section (empty-fleet vs crash distinction).
+        output.push_str(&died_section);
 
         if stale_pruned > 0 {
             output.push_str(&format!(

--- a/cas-cli/src/mcp/tools/service/mod.rs
+++ b/cas-cli/src/mcp/tools/service/mod.rs
@@ -1106,6 +1106,7 @@ pub(crate) mod agent_liveness;
 mod core;
 pub(crate) mod factory_ops;
 mod factory_remind;
+pub(crate) mod orphan_recovery;
 mod panic_catch;
 #[cfg(test)]
 mod panic_regression_test;

--- a/cas-cli/src/mcp/tools/service/orphan_recovery.rs
+++ b/cas-cli/src/mcp/tools/service/orphan_recovery.rs
@@ -1,0 +1,388 @@
+//! Orphan recovery when a worker vanishes mid-task (cas-2e81).
+//!
+//! `mark_stale` / lease reclaim revoke leases but historically left the task
+//! row as `InProgress` with no supervisor signal. This module parks eligible
+//! tasks Open with an audit note, records a `WorkerDied` event, and queues a
+//! critical `worker_died` notification for active supervisors.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use cas_types::{
+    Agent, AgentRole, AgentStatus, Event, EventEntityType, EventType, TaskStatus,
+};
+use chrono::Utc;
+
+use crate::store::{
+    AgentStore, NotificationPriority, TaskStore, open_event_store, open_supervisor_queue_store,
+    open_task_store,
+};
+
+/// Summary of a single recovery pass.
+#[derive(Debug, Default, Clone)]
+pub struct OrphanRecoverySummary {
+    pub recovered_task_ids: Vec<String>,
+    pub held_task_ids: Vec<String>,
+}
+
+/// Statuses that must NOT be auto-parked (cas-6e4c PSR + merge-gate work).
+fn is_protected_status(status: TaskStatus) -> bool {
+    matches!(
+        status,
+        TaskStatus::Closed
+            | TaskStatus::Open
+            | TaskStatus::PendingSupervisorReview
+            | TaskStatus::AwaitingMerge
+    )
+}
+
+/// Park orphaned working tasks for a dead agent and emit supervisor signals.
+///
+/// `held_task_ids` should be the leases observed *before* `mark_stale` /
+/// reclaim (those calls clear active leases). Also recovers InProgress/
+/// Blocked tasks still assigned to the agent by name or id.
+pub fn recover_worker_vanished(
+    cas_root: &Path,
+    agent_store: &dyn AgentStore,
+    agent: &Agent,
+    held_task_ids: &[String],
+    reason: &str,
+) -> OrphanRecoverySummary {
+    let mut summary = OrphanRecoverySummary {
+        held_task_ids: held_task_ids.to_vec(),
+        ..Default::default()
+    };
+
+    let task_store = match open_task_store(cas_root) {
+        Ok(s) => s,
+        Err(_) => {
+            emit_worker_died_signals(cas_root, agent_store, agent, &summary, reason);
+            return summary;
+        }
+    };
+
+    let mut candidate_ids: Vec<String> = held_task_ids.to_vec();
+
+    // Also pick up tasks still assigned to this worker whose lease may already
+    // have been reclaimed earlier without recovery.
+    if let Ok(in_progress) = task_store.list(Some(TaskStatus::InProgress)) {
+        for t in in_progress {
+            if task_assigned_to_agent(&t.assignee, agent) {
+                candidate_ids.push(t.id);
+            }
+        }
+    }
+    if let Ok(blocked) = task_store.list(Some(TaskStatus::Blocked)) {
+        for t in blocked {
+            if task_assigned_to_agent(&t.assignee, agent) {
+                candidate_ids.push(t.id);
+            }
+        }
+    }
+    candidate_ids.sort();
+    candidate_ids.dedup();
+    summary.held_task_ids = candidate_ids.clone();
+
+    for task_id in &candidate_ids {
+        if park_orphaned_task(&task_store, task_id, agent, reason) {
+            summary.recovered_task_ids.push(task_id.clone());
+        }
+    }
+
+    emit_worker_died_signals(cas_root, agent_store, agent, &summary, reason);
+    summary
+}
+
+/// Recover tasks whose leases just expired, but only when the holder is dead
+/// or heartbeat-stale (worker vanished) — not when a live agent simply failed
+/// to renew mid-turn.
+pub fn recover_expired_leases_for_dead_holders(
+    cas_root: &Path,
+    agent_store: &dyn AgentStore,
+    expired: &[(String, String)], // (task_id, agent_id)
+    stale_threshold_secs: i64,
+) -> Vec<OrphanRecoverySummary> {
+    use std::collections::HashMap;
+
+    let mut by_agent: HashMap<String, Vec<String>> = HashMap::new();
+    for (task_id, agent_id) in expired {
+        by_agent
+            .entry(agent_id.clone())
+            .or_default()
+            .push(task_id.clone());
+    }
+
+    let mut out = Vec::new();
+    for (agent_id, task_ids) in by_agent {
+        let agent = match agent_store.get(&agent_id) {
+            Ok(a) => a,
+            Err(_) => continue,
+        };
+        if holder_is_alive(&agent, stale_threshold_secs) {
+            continue;
+        }
+        let summary = recover_worker_vanished(
+            cas_root,
+            agent_store,
+            &agent,
+            &task_ids,
+            "lease expired while holder gone",
+        );
+        out.push(summary);
+    }
+    out
+}
+
+fn holder_is_alive(agent: &Agent, stale_threshold_secs: i64) -> bool {
+    if !matches!(agent.status, AgentStatus::Active | AgentStatus::Idle) {
+        return false;
+    }
+    let elapsed = (Utc::now() - agent.last_heartbeat).num_seconds();
+    elapsed <= stale_threshold_secs
+}
+
+fn task_assigned_to_agent(assignee: &Option<String>, agent: &Agent) -> bool {
+    match assignee {
+        Some(a) => a == &agent.name || a == &agent.id,
+        None => false,
+    }
+}
+
+/// Returns true if the task was parked to Open.
+fn park_orphaned_task(
+    task_store: &Arc<dyn TaskStore>,
+    task_id: &str,
+    agent: &Agent,
+    reason: &str,
+) -> bool {
+    let mut task = match task_store.get(task_id) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    if is_protected_status(task.status) {
+        return false;
+    }
+
+    let prior_status = task.status;
+    let prior_assignee = task.assignee.clone();
+    task.status = TaskStatus::Open;
+    task.assignee = None;
+    let ts = Utc::now().format("%Y-%m-%d %H:%M");
+    let audit = format!(
+        "[{ts}] ⚠ orphan recovery: worker vanished mid-task — parked {prior_status:?}→Open \
+         (prior assignee: {}, worker: {} / {}, reason: {reason}). \
+         Use `task action=reset` only if still stuck; task is now claimable.",
+        prior_assignee.as_deref().unwrap_or("<none>"),
+        agent.name,
+        &agent.id[..8.min(agent.id.len())],
+    );
+    task.notes = if task.notes.is_empty() {
+        audit
+    } else {
+        format!("{}\n\n{}", task.notes, audit)
+    };
+    task.updated_at = Utc::now();
+    task_store.update(&task).is_ok()
+}
+
+fn emit_worker_died_signals(
+    cas_root: &Path,
+    agent_store: &dyn AgentStore,
+    agent: &Agent,
+    summary: &OrphanRecoverySummary,
+    reason: &str,
+) {
+    let held = summary.held_task_ids.join(",");
+    let recovered = summary.recovered_task_ids.join(",");
+    let payload = serde_json::json!({
+        "worker_id": agent.id,
+        "worker_name": agent.name,
+        "held_tasks": summary.held_task_ids,
+        "recovered_tasks": summary.recovered_task_ids,
+        "reason": reason,
+        "last_heartbeat": agent.last_heartbeat.to_rfc3339(),
+        "factory_session": agent.factory_session,
+    });
+
+    // Activity feed event.
+    if let Ok(event_store) = open_event_store(cas_root) {
+        let summary_text = if summary.held_task_ids.is_empty() {
+            format!(
+                "Worker {} died ({reason}); no held tasks",
+                agent.name
+            )
+        } else {
+            format!(
+                "Worker {} died mid-task ({reason}); held=[{held}]; recovered=[{recovered}]",
+                agent.name
+            )
+        };
+        let event = Event::new(
+            EventType::WorkerDied,
+            EventEntityType::Agent,
+            agent.id.clone(),
+            summary_text,
+        )
+        .with_metadata(payload.clone())
+        .with_session(agent.id.clone());
+        let _ = event_store.record(&event);
+    }
+
+    // Supervisor queue — critical priority.
+    let supervisors = match agent_store.list(None) {
+        Ok(agents) => agents
+            .into_iter()
+            .filter(|a| {
+                matches!(a.role, AgentRole::Supervisor | AgentRole::Director)
+                    && matches!(a.status, AgentStatus::Active | AgentStatus::Idle)
+                    && a.visible_to_factory_session(agent.factory_session.as_deref())
+            })
+            .collect::<Vec<_>>(),
+        Err(_) => Vec::new(),
+    };
+
+    if let Ok(queue) = open_supervisor_queue_store(cas_root) {
+        let payload_str = payload.to_string();
+        for sup in &supervisors {
+            let _ = queue.notify(
+                &sup.id,
+                "worker_died",
+                &payload_str,
+                NotificationPriority::Critical,
+            );
+        }
+        // If no live supervisor rows, still notify parent_id when set.
+        if supervisors.is_empty() {
+            if let Some(ref parent) = agent.parent_id {
+                let _ = queue.notify(
+                    parent,
+                    "worker_died",
+                    &payload_str,
+                    NotificationPriority::Critical,
+                );
+            }
+        }
+    }
+}
+
+/// Format the "Recently died while leased" section for worker_status.
+///
+/// Pulls recent WorkerDied events (last `window_secs`) and any still-stale
+/// workers that held leases at death. Returns empty string when nothing to show.
+pub fn format_recently_died_while_leased(
+    cas_root: &Path,
+    agent_store: &dyn AgentStore,
+    factory_session: Option<&str>,
+    window_secs: i64,
+) -> String {
+    let cutoff = Utc::now() - chrono::Duration::seconds(window_secs);
+    let mut lines: Vec<String> = Vec::new();
+
+    // Prefer structured WorkerDied events.
+    if let Ok(event_store) = open_event_store(cas_root) {
+        if let Ok(events) = event_store.list_since(cutoff, 100) {
+            for ev in events {
+                if ev.event_type != EventType::WorkerDied {
+                    continue;
+                }
+                let meta = ev.metadata.as_ref();
+                let name = meta
+                    .and_then(|m| m.get("worker_name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(ev.entity_id.as_str());
+                let held = meta
+                    .and_then(|m| m.get("held_tasks"))
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|x| x.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    })
+                    .unwrap_or_default();
+                if held.is_empty() {
+                    // AC: died-while-leased — skip pure idle deaths.
+                    continue;
+                }
+                let recovered = meta
+                    .and_then(|m| m.get("recovered_tasks"))
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|x| x.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    })
+                    .unwrap_or_default();
+                let hb = meta
+                    .and_then(|m| m.get("last_heartbeat"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                let elapsed = chrono::DateTime::parse_from_rfc3339(hb)
+                    .map(|dt| (Utc::now() - dt.with_timezone(&Utc)).num_seconds())
+                    .unwrap_or(-1);
+                let since = if elapsed >= 0 {
+                    format!("{elapsed}s ago")
+                } else {
+                    hb.to_string()
+                };
+                let rec_note = if recovered.is_empty() {
+                    String::new()
+                } else {
+                    format!(" → Open (orphaned: {recovered})")
+                };
+                lines.push(format!(
+                    "  • {name} (last heartbeat: {since}) [stale]\n    held: {held}{rec_note}"
+                ));
+            }
+        }
+    }
+
+    // Also surface currently-stale workers that still hold InProgress assignee
+    // (recovery not yet run) — defensive second signal.
+    if let Ok(stale) = agent_store.list(Some(AgentStatus::Stale)) {
+        if let Ok(task_store) = open_task_store(cas_root) {
+            for agent in stale {
+                if !agent.visible_to_factory_session(factory_session) {
+                    continue;
+                }
+                if agent.role != AgentRole::Worker {
+                    continue;
+                }
+                // Skip if already listed via WorkerDied event for this agent.
+                if lines.iter().any(|l| l.contains(&agent.name)) {
+                    continue;
+                }
+                let mut held = Vec::new();
+                if let Ok(tasks) = task_store.list(Some(TaskStatus::InProgress)) {
+                    for t in tasks {
+                        if task_assigned_to_agent(&t.assignee, &agent) {
+                            held.push(t.id);
+                        }
+                    }
+                }
+                if held.is_empty() {
+                    continue;
+                }
+                let elapsed = (Utc::now() - agent.last_heartbeat).num_seconds();
+                lines.push(format!(
+                    "  • {} (last heartbeat: {elapsed}s ago) [stale]\n    held: {} (still InProgress — run agent_cleanup)",
+                    agent.name,
+                    held.join(", ")
+                ));
+            }
+        }
+    }
+
+    if lines.is_empty() {
+        return String::new();
+    }
+    // Dedupe by worker name line prefix.
+    lines.sort();
+    lines.dedup();
+    format!(
+        "\nRecently died while leased ({}):\n{}\n",
+        lines.len(),
+        lines.join("\n")
+    )
+}

--- a/cas-cli/src/mcp/tools/types/task.rs
+++ b/cas-cli/src/mcp/tools/types/task.rs
@@ -181,7 +181,11 @@ pub struct TaskCloseRequest {
                        Required whenever the task has reviewable code \
                        changes unless bypass_code_review=true or the \
                        task is additive-only. Shape: \
-                       {residual: Finding[], pre_existing: Finding[], mode: string}."
+                       {residual: Finding[], pre_existing: Finding[], mode: string}. \
+                       Each Finding requires: title, severity, file, line, \
+                       why_it_matters, autofix_class, owner, confidence, \
+                       evidence, pre_existing (optional: suggested_fix, \
+                       requires_verification)."
     )]
     #[serde(default)]
     pub code_review_findings: Option<String>,

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -197,9 +197,15 @@ impl FactoryDaemon {
         // session running in the same project directory.
         let supervisor_name = self.app.supervisor_name().to_string();
         let worker_names = self.app.worker_names().to_vec();
-        let mut targets: Vec<&str> = Vec::with_capacity(worker_names.len() + 2);
+        // cas-73c8: include `director` so outbound replies to the permanent
+        // team director member are delivered (write_to_inbox / PTY), matching
+        // inbound director → agent delivery. Without this, messages queued
+        // to target=director sat forever while registration reported them
+        // as "not yet registered".
+        let mut targets: Vec<&str> = Vec::with_capacity(worker_names.len() + 3);
         targets.push(&supervisor_name);
         targets.push("all_workers");
+        targets.push(super::teams::DIRECTOR_AGENT_NAME);
         for w in &worker_names {
             targets.push(w.as_str());
         }

--- a/cas-cli/src/ui/factory/daemon/runtime/teams.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/teams.rs
@@ -29,20 +29,19 @@ pub const DIRECTOR_AGENT_NAME: &str = "director";
 /// record (cas-405f D-4).
 pub const DIRECTOR_AGENT_COLOR: &str = "white";
 
-/// Dedup window for identical (from, text) inbox writes (task cas-7f57).
+/// Content-dedupe for identical (from, text) inbox writes (cas-7f57, cas-73c8).
 ///
 /// The daemon can re-fire the same auto-prompt (e.g. "You have been assigned
-/// cas-X") in a number of documented-but-unintended paths — event-detector
-/// last_state resets across refresh ticks, prompt_queue retry loops on pane
-/// busy, teams-inbox outbox replays on client reconnect. Workers live-reported
-/// receiving dozens of identical assignment messages minutes apart for tasks
-/// that were already Closed, each costing ~100–500 tokens of context per
-/// repeat. This is the coordination-layer guard: if the target's inbox
-/// already contains a message with identical `from` + `text` within the last
-/// `INBOX_DEDUP_WINDOW`, we skip the append and no-op the write. The deeper
-/// causes are left as follow-ups; this stops the bleeding at the delivery
-/// boundary.
-const INBOX_DEDUP_WINDOW: chrono::Duration = chrono::Duration::minutes(10);
+/// cas-X") via event-detector resets, prompt_queue retries, outbox replays,
+/// or SendMessage auto-route + native dual-write. A time-bounded window
+/// (previously 10 minutes) still re-delivered handled messages after the
+/// window expired with no redelivery marker (cas-73c8).
+///
+/// Guard: if the target's inbox already contains an identical `from` + `text`
+/// entry (any age, still present in the file), skip the append. Intentional
+/// redelivery must change the payload or include an explicit redelivery
+/// marker so the text is no longer identical. Retention pruning eventually
+/// drops old entries and allows a fresh identical send after cleanup.
 
 /// Retention window for messages in the inbox file (task cas-7f57).
 ///
@@ -664,31 +663,23 @@ impl TeamsManager {
         });
         let retention_pruned = messages.len() != messages_before_retain;
 
-        // Dedup guard: if an identical (from, text) message exists within
-        // the dedup window, skip the append. This is the coordination
-        // message-dedupe layer called out in the cas-7f57 acceptance
-        // criteria — prevents the director/prompt_queue/outbox replay
-        // paths from writing the same "You have been assigned cas-X"
-        // message to the same worker repeatedly.
-        let dedup_cutoff = now_utc - INBOX_DEDUP_WINDOW;
-        let is_recent_duplicate = messages.iter().rev().any(|m| {
-            if m.from != from || m.text != message {
-                return false;
-            }
-            match chrono::DateTime::parse_from_rfc3339(&m.timestamp) {
-                Ok(ts) => ts.with_timezone(&chrono::Utc) >= dedup_cutoff,
-                Err(_) => false,
-            }
-        });
+        // Dedup guard (cas-7f57 / cas-73c8): if an identical (from, text)
+        // message is still present in the inbox, skip the append — no
+        // time window. Prevents director/prompt_queue/outbox replay and
+        // post-handle redelivery without an intentional redelivery marker.
+        let is_content_duplicate = messages
+            .iter()
+            .rev()
+            .any(|m| m.from == from && m.text == message);
 
-        if is_recent_duplicate {
+        if is_content_duplicate {
             tracing::debug!(
                 target: "cas::coordination",
                 stage = "dedup_skip",
                 channel = "teams_inbox",
                 from = from,
                 target_agent = target,
-                "inbox write skipped — identical message within dedup window"
+                "inbox write skipped — identical message already present"
             );
             // Only re-serialize+write if the retention sweep actually
             // removed anything; otherwise this is a pure no-op and we
@@ -1300,11 +1291,10 @@ mod tests {
         }
     }
 
-    /// Cross-refresh replay: identical (from, text) writes within
-    /// `INBOX_DEDUP_WINDOW` must no-op, dropping the duplicate before it
-    /// reaches the worker. This is the core regression guard for cas-7f57
-    /// — workers observed "You have been assigned cas-X" messages replayed
-    /// minutes apart for tasks that were already Closed.
+    /// Cross-refresh replay: identical (from, text) writes must no-op while
+    /// the original remains in the inbox. Core regression guard for
+    /// cas-7f57 / cas-73c8 — workers observed "You have been assigned cas-X"
+    /// messages replayed for tasks that were already Closed.
     #[test]
     fn write_to_inbox_dedups_identical_messages_within_window() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1327,7 +1317,7 @@ mod tests {
         assert_eq!(
             inbox.len(),
             1,
-            "identical within-window writes must dedupe down to one entry; inbox={inbox:?}"
+            "identical writes must dedupe down to one entry; inbox={inbox:?}"
         );
 
         // A genuinely different payload still gets through.
@@ -1344,6 +1334,25 @@ mod tests {
         )
         .unwrap();
         assert_eq!(inbox.len(), 2, "distinct payload must not be deduped");
+
+        // Intentional redelivery marker changes text → allowed through.
+        mgr.write_to_inbox(
+            "swift-fox",
+            DIRECTOR_AGENT_NAME,
+            "[redelivery] You have been assigned cas-7f57\nTask: dup guard",
+            None,
+            None,
+        )
+        .unwrap();
+        let inbox: Vec<InboxMessage> = serde_json::from_str(
+            &std::fs::read_to_string(mgr.inboxes_dir.join("swift-fox.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            inbox.len(),
+            3,
+            "redelivery-marked payload must not be content-deduped"
+        );
     }
 
     /// Writes from different senders with the same text are independent —
@@ -1372,16 +1381,17 @@ mod tests {
         );
     }
 
-    /// A duplicate write beyond `INBOX_DEDUP_WINDOW` must pass through
-    /// and append — dedup is time-bounded, not permanent. Guards against
-    /// off-by-one sign flips on the cutoff comparison.
+    /// cas-73c8: identical (from, text) still present in the inbox is
+    /// suppressed regardless of age. A time-bounded window re-delivered
+    /// handled messages after 10+ minutes with no redelivery marker.
     #[test]
-    fn write_to_inbox_does_not_dedup_past_window() {
+    fn write_to_inbox_dedups_identical_messages_regardless_of_age() {
         let tmp = tempfile::tempdir().unwrap();
         let mgr = manager_in(tmp.path(), "t_expire");
         std::fs::create_dir_all(&mgr.inboxes_dir).unwrap();
 
-        // Seed inbox with a 15-minute-old duplicate (beyond 10-min window).
+        // Seed inbox with a 15-minute-old identical message (formerly
+        // beyond the 10-min window — must still suppress).
         let old_ts = (chrono::Utc::now() - chrono::Duration::minutes(15))
             .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
         let seeded = vec![InboxMessage {
@@ -1390,15 +1400,14 @@ mod tests {
             summary: Some("ping".to_string()),
             timestamp: old_ts,
             color: "green".to_string(),
-            // Must be marked read or retention will keep it for
-            // unrelated reasons; we want dedup to be the only variable.
+            // Marked read so retention is not the reason it stays —
+            // dedup alone must suppress the re-write.
             read: true,
         }];
         let inbox_path = mgr.inboxes_dir.join("swift-fox.json");
         std::fs::write(&inbox_path, serde_json::to_string_pretty(&seeded).unwrap())
             .unwrap();
 
-        // Fresh write with identical (from, text). Must pass through.
         mgr.write_to_inbox("swift-fox", DIRECTOR_AGENT_NAME, "ping", None, None)
             .unwrap();
 
@@ -1408,8 +1417,8 @@ mod tests {
         .unwrap();
         assert_eq!(
             inbox.len(),
-            2,
-            "15-minute-old duplicate is beyond dedup window and must not suppress a fresh write"
+            1,
+            "identical content still in inbox must be suppressed even when older than 10 minutes"
         );
     }
 

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -1192,18 +1192,22 @@ async fn test_worker_status_prunes_stale_worker_and_keeps_live_one() {
         .expect("worker_status call should succeed");
     let text = get_text(&result);
 
-    // Live worker must appear; stale must not.
+    // Live worker must appear; stale must not appear as an Active bullet.
+    // cas-2e81: stale workers that held no lease may be absent entirely;
+    // those that held a lease can appear under "Recently died while leased".
     assert!(
         text.contains("live-fox"),
         "live worker must appear in Active listing. Got:\n{text}"
     );
+    let active_section = text
+        .split("Recently died while leased")
+        .next()
+        .unwrap_or(&text);
     assert!(
-        !text.contains("dead-wolf"),
+        !active_section
+            .lines()
+            .any(|l| l.contains("• dead-wolf") || l.contains(&format!("• {stale_id}"))),
         "stale worker must be pruned out of the Active listing. Got:\n{text}"
-    );
-    assert!(
-        !text.contains(&stale_id),
-        "stale worker's id must not appear in render. Got:\n{text}"
     );
 
     // The footer must account for the prune so operators can see the
@@ -1332,6 +1336,216 @@ async fn test_9829_worker_status_marks_stalled_worker_with_in_progress_task() {
     assert!(
         !ibis_block.contains("⚠ STALLED"),
         "a worker with no claimed task must never be marked STALLED. Got:\n{ibis_block}"
+    );
+}
+
+// =============================================================================
+// cas-2e81: orphan InProgress + death/lease-expiry signal
+// =============================================================================
+
+/// Simulated kill of a lease holder after start: worker_status prune must
+/// park the InProgress task Open with an audit note (non-silent recovery).
+#[tokio::test]
+async fn test_2e81_worker_status_parks_orphaned_inprogress_on_stale_prune() {
+    let _guard = EnvGuard::set(&[]);
+    let env = FactoryTestEnv::new();
+    let sup_id = env.register_supervisor("sup-orphan");
+
+    let worker_id =
+        env.register_stale_worker_with_clone_path("gone-worker", "/tmp/cas-worktrees/gone", 40);
+    let task_store = env.task_store();
+    let mut task = Task::new("cas-orphan1".to_string(), "Orphan mid-task".to_string());
+    task.status = TaskStatus::InProgress;
+    task.assignee = Some("gone-worker".to_string());
+    task_store.add(&task).expect("add task");
+    env.agent_store()
+        .try_claim("cas-orphan1", &worker_id, 600, Some("started"))
+        .expect("claim")
+        .is_success();
+
+    let req = factory_req("worker_status");
+    let result = env
+        .service
+        .factory(Parameters(req))
+        .await
+        .expect("worker_status");
+    let text = get_text(&result);
+
+    let recovered = task_store.get("cas-orphan1").expect("task still exists");
+    assert_eq!(
+        recovered.status,
+        TaskStatus::Open,
+        "orphaned InProgress must park to Open. Got notes: {}",
+        recovered.notes
+    );
+    assert!(
+        recovered.assignee.is_none(),
+        "assignee must clear on orphan recovery"
+    );
+    assert!(
+        recovered.notes.contains("orphaned")
+            || recovered.notes.contains("worker vanished")
+            || recovered.notes.contains("lease"),
+        "audit note required. notes={}",
+        recovered.notes
+    );
+
+    // Recovery signal also visible on worker_status (died-while-leased section).
+    assert!(
+        text.contains("Recently died while leased") || text.contains("gone-worker"),
+        "worker_status must surface death/orphan signal. Got:\n{text}"
+    );
+    assert!(
+        text.contains("cas-orphan1"),
+        "held task id must appear in death signal. Got:\n{text}"
+    );
+
+    // worker_died queue notification for the supervising session.
+    let queue = cas::store::open_supervisor_queue_store(&env.cas_root).expect("queue");
+    let pending = queue.peek(&sup_id, 20).expect("peek");
+    assert!(
+        pending.iter().any(|n| n.event_type == "worker_died"),
+        "worker_died must be queued for supervisor. pending={pending:?}"
+    );
+    let _ = sup_id;
+}
+
+/// Empty fleet with no deaths vs died-while-leased must read differently.
+#[tokio::test]
+async fn test_2e81_worker_status_distinguishes_empty_fleet_vs_died_while_leased() {
+    let _guard = EnvGuard::set(&[]);
+    let env = FactoryTestEnv::new();
+    env.register_supervisor("sup-empty");
+
+    // Empty fleet (only supervisor) — no died-while-leased section.
+    let empty_text = get_text(
+        &env.service
+            .factory(Parameters(factory_req("worker_status")))
+            .await
+            .expect("worker_status empty"),
+    );
+    assert!(
+        empty_text.contains("None active") || empty_text.contains("No active"),
+        "empty fleet must say no active workers. Got:\n{empty_text}"
+    );
+    assert!(
+        !empty_text.contains("Recently died while leased"),
+        "empty fleet must NOT claim died-while-leased. Got:\n{empty_text}"
+    );
+
+    // Kill a lease holder mid-task.
+    let worker_id =
+        env.register_stale_worker_with_clone_path("crash-worker", "/tmp/cas-worktrees/crash", 45);
+    let task_store = env.task_store();
+    let mut task = Task::new("cas-crash1".to_string(), "Crash mid-task".to_string());
+    task.status = TaskStatus::InProgress;
+    task.assignee = Some("crash-worker".to_string());
+    task_store.add(&task).expect("add");
+    env.agent_store()
+        .try_claim("cas-crash1", &worker_id, 600, None)
+        .expect("claim")
+        .is_success();
+
+    let died_text = get_text(
+        &env.service
+            .factory(Parameters(factory_req("worker_status")))
+            .await
+            .expect("worker_status after death"),
+    );
+    assert!(
+        died_text.contains("Recently died while leased"),
+        "died-while-leased must be explicit. Got:\n{died_text}"
+    );
+    assert!(
+        died_text.contains("crash-worker") && died_text.contains("cas-crash1"),
+        "must name dead worker + held task. Got:\n{died_text}"
+    );
+}
+
+/// agent_cleanup path: lease reclaim + stale mark also parks orphaned tasks
+/// and emits worker_died (not only worker_status).
+#[tokio::test]
+async fn test_2e81_agent_cleanup_parks_orphan_and_emits_worker_died() {
+    let _guard = EnvGuard::set(&[]);
+    let env = FactoryTestEnv::new();
+    let sup_id = env.register_supervisor("sup-cleanup");
+
+    let worker_id =
+        env.register_stale_worker_with_clone_path("cleanup-dead", "/tmp/cas-worktrees/cd", 200);
+    let task_store = env.task_store();
+    let mut task = Task::new("cas-clean1".to_string(), "Cleanup orphan".to_string());
+    task.status = TaskStatus::InProgress;
+    task.assignee = Some("cleanup-dead".to_string());
+    task_store.add(&task).expect("add");
+    env.agent_store()
+        .try_claim("cas-clean1", &worker_id, 600, None)
+        .expect("claim")
+        .is_success();
+
+    let mut req = coord_req("agent_cleanup");
+    req.stale_threshold_secs = Some(30);
+    let result = env
+        .service
+        .coordination(Parameters(req))
+        .await
+        .expect("agent_cleanup");
+    let text = get_text(&result);
+    assert!(
+        text.contains("Cleanup complete") || text.contains("Stale"),
+        "cleanup should succeed: {text}"
+    );
+
+    let recovered = task_store.get("cas-clean1").expect("task");
+    assert_eq!(
+        recovered.status,
+        TaskStatus::Open,
+        "agent_cleanup must park orphaned InProgress. notes={}",
+        recovered.notes
+    );
+
+    let queue = cas::store::open_supervisor_queue_store(&env.cas_root).expect("queue");
+    let pending = queue.peek(&sup_id, 20).expect("peek");
+    assert!(
+        pending.iter().any(|n| n.event_type == "worker_died"),
+        "agent_cleanup must queue worker_died. pending={pending:?}"
+    );
+}
+
+/// PSR tasks must not be reset to Open by orphan recovery (cas-6e4c invariant).
+#[tokio::test]
+async fn test_2e81_orphan_recovery_skips_psr_tasks() {
+    let _guard = EnvGuard::set(&[]);
+    let env = FactoryTestEnv::new();
+    env.register_supervisor("sup-psr");
+
+    let worker_id =
+        env.register_stale_worker_with_clone_path("psr-worker", "/tmp/cas-worktrees/psr", 40);
+    let task_store = env.task_store();
+    let mut task = Task::new("cas-psr1".to_string(), "PSR task".to_string());
+    task.status = TaskStatus::PendingSupervisorReview;
+    task.assignee = Some("psr-worker".to_string());
+    task_store.add(&task).expect("add");
+    // Still hold a lease so mark_stale revokes something — recovery must skip status flip.
+    env.agent_store()
+        .try_claim("cas-psr1", &worker_id, 600, None)
+        .expect("claim")
+        .is_success();
+    // Force PSR again in case claim path rewrote status.
+    let mut t = task_store.get("cas-psr1").unwrap();
+    t.status = TaskStatus::PendingSupervisorReview;
+    task_store.update(&t).unwrap();
+
+    let _ = env
+        .service
+        .factory(Parameters(factory_req("worker_status")))
+        .await
+        .expect("worker_status");
+
+    let after = task_store.get("cas-psr1").unwrap();
+    assert_eq!(
+        after.status,
+        TaskStatus::PendingSupervisorReview,
+        "PSR must not be auto-reset to Open by orphan recovery"
     );
 }
 

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -1829,6 +1829,32 @@ async fn test_coordination_message_to_registered_target_reports_delivery_status(
     );
 }
 
+/// cas-73c8 AC3: `director` is a permanent team member and the source of
+/// inbound teammate messages, but is not an agent_store registration.
+/// Outbound `target=director` must report registered (symmetric with inbound).
+#[tokio::test]
+async fn test_coordination_message_to_director_reports_registered() {
+    let _guard = EnvGuard::set(&[
+        ("CAS_AGENT_ROLE", "supervisor"),
+        ("CAS_AGENT_NAME", "supervisor"),
+    ]);
+    let env = FactoryTestEnv::new();
+    // Deliberately do NOT register "director" in agent_store.
+
+    let req = coord_msg("message", "director", "ack director nudge", None);
+    let result = env.service.coordination(Parameters(req)).await;
+    assert!(result.is_ok(), "message to director should succeed: {result:?}");
+    let text = get_text(&result.unwrap());
+    assert!(
+        text.contains("target is registered"),
+        "director must resolve as registered: {text}"
+    );
+    assert!(
+        !text.contains("not yet registered"),
+        "director must not read as unregistered after inbound teammate traffic: {text}"
+    );
+}
+
 /// cas-6913 AC2: the defect this task exists to fix — "Message queued" reads
 /// as delivery confirmation even when the target name isn't in the agent
 /// store yet (the common spawn-then-immediately-assign race). The ack must

--- a/cas-cli/tests/mcp_tools_test/task_tools/double_close.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/double_close.rs
@@ -1,0 +1,276 @@
+//! cas-6d0b: `task action=close` on an already-Closed task must short-circuit.
+//!
+//! Bug report: docs/requests/BUG-task-close-double-close-not-detected-2026-07-14.md
+//!
+//! Pre-fix, a second close returned success ("Closed task: …"), overwrote
+//! `closed_at`, appended a second `Closed:` note, and could demand
+//! `CODE_REVIEW_REQUIRED` before mutating. Expected: distinct already-closed
+//! result, no mutation, no review-gate demand.
+
+use crate::support::*;
+use cas::mcp::tools::*;
+use cas::mcp::CasService;
+use cas::store::open_task_store;
+use cas::types::TaskStatus;
+use rmcp::handler::server::wrapper::Parameters;
+use std::process::Command;
+
+fn create_req(title: &str, depth: Option<&str>) -> TaskCreateRequest {
+    TaskCreateRequest {
+        depth: depth.map(str::to_string),
+        title: title.to_string(),
+        description: None,
+        priority: 2,
+        task_type: "task".to_string(),
+        labels: None,
+        notes: None,
+        blocked_by: None,
+        design: None,
+        acceptance_criteria: None,
+        external_ref: None,
+        assignee: None,
+        demo_statement: None,
+        execution_note: None,
+        epic: None,
+    }
+}
+
+fn task_req(value: serde_json::Value) -> cas_mcp::TaskRequest {
+    serde_json::from_value(value).expect("TaskRequest should deserialize from test JSON")
+}
+
+/// RAII guard that installs factory-worker env vars and clears them on drop.
+struct FactoryWorkerGuard;
+
+impl FactoryWorkerGuard {
+    fn enter() -> Self {
+        unsafe {
+            std::env::set_var("CAS_AGENT_ROLE", "worker");
+            std::env::set_var("CAS_FACTORY_MODE", "1");
+        }
+        Self
+    }
+}
+
+impl Drop for FactoryWorkerGuard {
+    fn drop(&mut self) {
+        unsafe {
+            std::env::remove_var("CAS_AGENT_ROLE");
+            std::env::remove_var("CAS_FACTORY_MODE");
+        }
+    }
+}
+
+fn write_worker_review_config(cas_dir: &std::path::Path) {
+    let toml = r#"
+[verification]
+enabled = false
+
+[code_review]
+owner = "worker"
+"#;
+    std::fs::write(cas_dir.join("config.toml"), toml).expect("config.toml should be writable");
+}
+
+fn init_git_repo_with_staged_changes(project_root: &std::path::Path) {
+    let git = |args: &[&str]| {
+        Command::new("git")
+            .args(args)
+            .current_dir(project_root)
+            .output()
+            .expect("git command should run")
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "test@example.com"]);
+    git(&["config", "user.name", "Test"]);
+    std::fs::write(project_root.join("base.rs"), "fn main() {}\n").expect("write should succeed");
+    git(&["add", "base.rs"]);
+    git(&["commit", "-m", "init"]);
+    std::fs::write(
+        project_root.join("feature.rs"),
+        "pub fn feature() -> u32 { 42 }\n",
+    )
+    .expect("write should succeed");
+    git(&["add", "feature.rs"]);
+}
+
+/// AC1/AC2: second close returns already-closed style result and does not
+/// overwrite `closed_at` or append another Closed note.
+#[tokio::test]
+async fn test_close_on_already_closed_is_non_destructive() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    let task_store = open_task_store(&cas_dir).unwrap();
+
+    let created = core
+        .cas_task_create(Parameters(create_req(
+            "double-close non-destructive",
+            Some("light"),
+        )))
+        .await
+        .expect("task_create should succeed");
+    let id = extract_task_id(&extract_text(created))
+        .expect("should have task ID")
+        .to_string();
+
+    core.cas_task_start(Parameters(IdRequest { id: id.clone() }))
+        .await
+        .expect("task_start should succeed");
+
+    let first_close = extract_text(
+        core.cas_task_close(Parameters(TaskCloseRequest {
+            id: id.clone(),
+            reason: Some("First closer wins.".to_string()),
+            bypass_code_review: None,
+            code_review_findings: None,
+        }))
+        .await
+        .expect("first close should return a result"),
+    );
+    assert!(
+        first_close.contains("Closed task:"),
+        "first close must succeed as a real close: {first_close}"
+    );
+
+    let after_first = task_store.get(&id).expect("task should exist");
+    assert_eq!(after_first.status, TaskStatus::Closed);
+    let closed_at_first = after_first
+        .closed_at
+        .expect("closed_at must be set after first close");
+    let notes_first = after_first.notes.clone();
+    let close_reason_first = after_first.close_reason.clone();
+    let closed_note_count_first = notes_first.matches("Closed:").count();
+    assert!(
+        closed_note_count_first >= 1,
+        "first close should leave a Closed note: {notes_first}"
+    );
+
+    // Second close with a different reason — must not claim credit or mutate.
+    let second_close = extract_text(
+        core.cas_task_close(Parameters(TaskCloseRequest {
+            id: id.clone(),
+            reason: Some("Second closer races.".to_string()),
+            bypass_code_review: None,
+            code_review_findings: None,
+        }))
+        .await
+        .expect("second close should return a result"),
+    );
+
+    let lower = second_close.to_lowercase();
+    assert!(
+        lower.contains("already closed") || lower.contains("already-closed"),
+        "second close must report already-closed style result, got: {second_close}"
+    );
+    assert!(
+        !second_close.contains("Closed task:"),
+        "second close must NOT imply this call performed the close: {second_close}"
+    );
+
+    let after_second = task_store.get(&id).expect("task should exist");
+    assert_eq!(after_second.status, TaskStatus::Closed);
+    assert_eq!(
+        after_second.closed_at,
+        Some(closed_at_first),
+        "closed_at must not be overwritten by a second close"
+    );
+    assert_eq!(
+        after_second.notes, notes_first,
+        "notes must not gain a second Closed note on re-close"
+    );
+    assert_eq!(
+        after_second.close_reason, close_reason_first,
+        "close_reason must remain the first closer's reason"
+    );
+    assert_eq!(
+        after_second.notes.matches("Closed:").count(),
+        closed_note_count_first,
+        "Closed note count must stay stable"
+    );
+}
+
+/// AC3: already-Closed must skip CODE_REVIEW_REQUIRED even under worker-owned
+/// review with reviewable diffs (the path that raced in the bug report).
+#[tokio::test]
+async fn test_close_on_already_closed_skips_code_review_gate() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    let task_store = open_task_store(&cas_dir).unwrap();
+
+    // Close once outside factory mode (light skips jail).
+    let created = core
+        .cas_task_create(Parameters(create_req(
+            "double-close skips review gate",
+            Some("light"),
+        )))
+        .await
+        .expect("task_create should succeed");
+    let id = extract_task_id(&extract_text(created))
+        .expect("should have task ID")
+        .to_string();
+
+    core.cas_task_start(Parameters(IdRequest { id: id.clone() }))
+        .await
+        .expect("task_start should succeed");
+
+    let first = extract_text(
+        core.cas_task_close(Parameters(TaskCloseRequest {
+            id: id.clone(),
+            reason: Some("Initial close.".to_string()),
+            bypass_code_review: None,
+            code_review_findings: None,
+        }))
+        .await
+        .expect("first close should return a result"),
+    );
+    assert!(
+        first.contains("Closed task:"),
+        "first close should succeed: {first}"
+    );
+    let closed_at = task_store
+        .get(&id)
+        .expect("task")
+        .closed_at
+        .expect("closed_at set");
+    let notes_before = task_store.get(&id).expect("task").notes;
+
+    // Now arm the worker-owned review path that would demand CODE_REVIEW_REQUIRED
+    // on an open task with reviewable changes.
+    write_worker_review_config(&cas_dir);
+    init_git_repo_with_staged_changes(temp.path());
+    let core2 = core_with_test_agent(&cas_dir);
+    let service = CasService::new(core2, None);
+    let _worker_guard = FactoryWorkerGuard::enter();
+
+    let second = extract_text(
+        service
+            .task(Parameters(task_req(serde_json::json!({
+                "action": "close",
+                "id": id,
+                "reason": "Racing closer with reviewable diff.",
+            }))))
+            .await
+            .expect("second close should return a result"),
+    );
+
+    assert!(
+        !second.contains("CODE_REVIEW_REQUIRED"),
+        "already-Closed must not demand CODE_REVIEW_REQUIRED: {second}"
+    );
+    let lower = second.to_lowercase();
+    assert!(
+        lower.contains("already closed") || lower.contains("already-closed"),
+        "second close must report already-closed: {second}"
+    );
+    assert!(
+        !second.contains("Closed task:"),
+        "must not claim this call closed the task: {second}"
+    );
+
+    let after = task_store.get(&id).expect("task");
+    assert_eq!(after.status, TaskStatus::Closed);
+    assert_eq!(after.closed_at, Some(closed_at));
+    assert_eq!(after.notes, notes_before);
+}

--- a/cas-cli/tests/mcp_tools_test/task_tools/mod.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/mod.rs
@@ -2,6 +2,7 @@ mod create_and_epic;
 mod dependencies;
 mod depth_e2e;
 mod depth_light_close;
+mod double_close;
 mod operations;
 mod supervisor_review_flow;
 mod verification_flow;

--- a/cas-cli/tests/worktree_surface_test.rs
+++ b/cas-cli/tests/worktree_surface_test.rs
@@ -238,6 +238,159 @@ async fn test_worktree_list_no_disabled_message_when_no_factory_worktrees() {
 }
 
 // =============================================================================
+// cas-d1a0: project-scoped git reconcile — sibling-session worktrees must
+// appear in worktree_list even with no WorktreeStore row (System B never
+// registers; epic worktrees often live outside .cas/worktrees).
+// =============================================================================
+
+/// Factory worktree under a *customized* `worktrees.base_path` (not the
+/// hardcoded `<cas_root>/worktrees` layout) must still appear in
+/// `worktree_list` — same path resolution spawn / worktree_merge use.
+#[tokio::test]
+async fn test_worktree_list_honors_configured_base_path() {
+    let repo = GitRepo::new();
+    let cas_root = init_cas_dir(&repo.root).expect("init_cas_dir");
+    // Unique name: relative base_path resolves under the project parent
+    // (often /tmp), so a fixed name collides across tests/processes.
+    let base_name = format!(
+        "cas-d1a0-list-base-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    std::fs::write(
+        cas_root.join("config.toml"),
+        format!("[worktrees]\nenabled = false\nbase_path = \"{base_name}\"\n"),
+    )
+    .unwrap();
+
+    // Mirrors WorktreeManager::worktree_root for relative non-{project} base_path:
+    // repo_root.parent().join(base_path)/<worker>
+    let base_root = repo.root.parent().unwrap().join(&base_name);
+    let wt_path = base_root.join("erin");
+    repo.add_worktree(&wt_path, "factory/erin");
+    assert_ne!(wt_path, cas_root.join("worktrees").join("erin"));
+
+    let svc = make_service(cas_root);
+    let result = svc
+        .coordination(Parameters(coord_req("worktree_list")))
+        .await
+        .expect("coordination call should succeed");
+    let text = get_text(&result);
+
+    // Reclaim external worktree before asserts so a failure still cleans up.
+    let _ = Command::new("git")
+        .args(["worktree", "remove", "--force", wt_path.to_str().unwrap()])
+        .current_dir(&repo.root)
+        .output();
+    let _ = std::fs::remove_dir_all(&base_root);
+
+    assert!(
+        text.contains("factory/erin"),
+        "worktree_list must surface factory worktrees under configured base_path.\nGot:\n{text}"
+    );
+    assert!(
+        text.contains("[factory]"),
+        "custom-base factory worktree must be labeled [factory].\nGot:\n{text}"
+    );
+}
+/// Epic worktree outside `.cas/worktrees` (e.g. director `/tmp/…-epic-…`)
+/// with an `epic/*` branch must appear as untracked so a sibling session
+/// can see it for merge/cleanup (BUG report cas-d1a0).
+#[tokio::test]
+async fn test_worktree_list_surfaces_unregistered_epic_worktree_outside_cas_dir() {
+    let repo = GitRepo::new();
+    let cas_root = init_cas_dir(&repo.root).expect("init_cas_dir");
+    disable_system_a(&cas_root);
+
+    // No SQLite WorktreeStore row — simulates a worktree created by a
+    // sibling/predecessor session that never registered System A.
+    let tmp = TempDir::new().expect("TempDir for epic worktree");
+    let epic_path = tmp.path().join("ozer-epic-ea3e-hv");
+    repo.add_worktree(&epic_path, "epic/integrate-cas-ea3e");
+
+    let svc = make_service(cas_root);
+    let result = svc
+        .coordination(Parameters(coord_req("worktree_list")))
+        .await
+        .expect("coordination call should succeed");
+    let text = get_text(&result);
+
+    assert!(
+        text.contains("epic/integrate-cas-ea3e"),
+        "unregistered epic/* worktree outside .cas/worktrees must appear in list.\nGot:\n{text}"
+    );
+    assert!(
+        text.contains("[untracked]"),
+        "CAS-pattern worktree with no store row must be labeled [untracked].\nGot:\n{text}"
+    );
+    // Keep the temp dir alive until after the list call (git worktree still present).
+    drop(tmp);
+}
+
+/// Non-CAS user worktrees (arbitrary branch outside CAS layouts) must NOT
+/// pollute worktree_list — only CAS-pattern paths/branches are reconciled.
+#[tokio::test]
+async fn test_worktree_list_ignores_unrelated_git_worktrees() {
+    let repo = GitRepo::new();
+    let cas_root = init_cas_dir(&repo.root).expect("init_cas_dir");
+    disable_system_a(&cas_root);
+
+    let tmp = TempDir::new().expect("TempDir for unrelated worktree");
+    let other_path = tmp.path().join("hand-made-wt");
+    repo.add_worktree(&other_path, "feature/hand-made");
+
+    let svc = make_service(cas_root);
+    let result = svc
+        .coordination(Parameters(coord_req("worktree_list")))
+        .await
+        .expect("coordination call should succeed");
+    let text = get_text(&result);
+
+    assert!(
+        !text.contains("feature/hand-made"),
+        "unrelated user worktrees must not appear in worktree_list.\nGot:\n{text}"
+    );
+    assert!(
+        text.contains("No worktrees"),
+        "only non-CAS worktrees present → empty list message.\nGot:\n{text}"
+    );
+    drop(tmp);
+}
+
+/// Sibling-session factory worker under the default `.cas/worktrees/<name>`
+/// path with no store row must still list (git reconcile is the project-
+/// scoped source of truth for System B).
+#[tokio::test]
+async fn test_worktree_list_shows_sibling_session_factory_worktree_without_store_row() {
+    let repo = GitRepo::new();
+    let cas_root = init_cas_dir(&repo.root).expect("init_cas_dir");
+    disable_system_a(&cas_root);
+
+    // Session A created this; session B only has the git worktree + shared .cas.
+    let wt_path = cas_root.join("worktrees").join("hv-food-qa");
+    repo.add_worktree(&wt_path, "factory/hv-food-qa");
+
+    let svc = make_service(cas_root);
+    let result = svc
+        .coordination(Parameters(coord_req("worktree_list")))
+        .await
+        .expect("coordination call should succeed");
+    let text = get_text(&result);
+
+    assert!(
+        text.contains("factory/hv-food-qa"),
+        "director-spawned factory worktree must be visible to another session's worktree_list.\nGot:\n{text}"
+    );
+    assert!(
+        text.contains("[factory]"),
+        "expected [factory] label for System B reconcile entry.\nGot:\n{text}"
+    );
+}
+
+// =============================================================================
 // cas-1d11: worktree_merge must agree with spawn isolate=true on
 // worktrees.enabled — a factory (System B) worktree must be mergeable
 // even when System A is off, since spawn never checked that flag either.

--- a/crates/cas-core/src/hooks/types.rs
+++ b/crates/cas-core/src/hooks/types.rs
@@ -169,6 +169,12 @@ pub enum HookSpecificOutput {
         permission_decision_reason: Option<String>,
         #[serde(rename = "updatedInput", skip_serializing_if = "Option::is_none")]
         updated_input: Option<serde_json::Value>,
+        /// Optional context injected alongside the tool result (Claude Code
+        /// PreToolUse supports this). Used by factory SendMessage auto-route
+        /// to surface a success receipt without a deny/`<error>` envelope
+        /// (cas-73c8).
+        #[serde(rename = "additionalContext", skip_serializing_if = "Option::is_none")]
+        additional_context: Option<String>,
     },
     UserPromptSubmit {
         /// Required by Claude Code's schema — a UserPromptSubmit
@@ -341,6 +347,29 @@ impl HookOutput {
                 permission_decision: Some(decision.to_string()),
                 permission_decision_reason: Some(reason.to_string()),
                 updated_input: None,
+                additional_context: None,
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// PreToolUse permission decision with `additionalContext` for Claude.
+    ///
+    /// Use when the hook both decides permission and needs to inject a
+    /// success-shaped receipt into the model's context (e.g. factory
+    /// SendMessage auto-route: `allow` + "AUTO-ROUTED" context so the tool
+    /// is not reported as an `<error>`).
+    pub fn with_pre_tool_permission_and_context(
+        decision: &str,
+        reason: &str,
+        additional_context: &str,
+    ) -> Self {
+        Self {
+            hook_specific_output: Some(HookSpecificOutput::PreToolUse {
+                permission_decision: Some(decision.to_string()),
+                permission_decision_reason: Some(reason.to_string()),
+                updated_input: None,
+                additional_context: Some(additional_context.to_string()),
             }),
             ..Default::default()
         }
@@ -354,6 +383,7 @@ impl HookOutput {
                 permission_decision: None,
                 permission_decision_reason: None,
                 updated_input: Some(updated_input),
+                additional_context: None,
             }),
             ..Default::default()
         }

--- a/crates/cas-core/tests/hook_schema.rs
+++ b/crates/cas-core/tests/hook_schema.rs
@@ -137,10 +137,10 @@ fn pretooluse_permission_decision_output_schema() {
         hso.get("permissionDecisionReason").and_then(Value::as_str),
         Some("auto-approved")
     );
-    // additionalContext has no place on PreToolUse permission-decision output.
+    // Default permission builder omits additionalContext (optional field).
     assert!(
         hso.get("additionalContext").is_none(),
-        "PreToolUse permission output must not carry additionalContext"
+        "default with_pre_tool_permission must not emit additionalContext"
     );
     assert_hook_specific_keys_subset(
         hso,
@@ -149,8 +149,30 @@ fn pretooluse_permission_decision_output_schema() {
             "permissionDecision",
             "permissionDecisionReason",
             "updatedInput",
+            "additionalContext",
         ],
         "PreToolUse.permission",
+    );
+}
+
+#[test]
+fn pretooluse_permission_with_context_emits_additional_context() {
+    // cas-73c8: successful SendMessage auto-route uses allow + additionalContext
+    // so Claude sees a success receipt instead of a deny/`<error>` envelope.
+    let output = HookOutput::with_pre_tool_permission_and_context(
+        "allow",
+        "auto-routed",
+        "✅ AUTO-ROUTED via CAS coordination",
+    );
+    let value = to_value(&output);
+    let hso = hook_specific(&value, "PreToolUse.permission+context");
+    assert_eq!(
+        hso.get("permissionDecision").and_then(Value::as_str),
+        Some("allow")
+    );
+    assert_eq!(
+        hso.get("additionalContext").and_then(Value::as_str),
+        Some("✅ AUTO-ROUTED via CAS coordination")
     );
 }
 

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -212,7 +212,11 @@ pub struct TaskRequest {
                        Required for tasks with reviewable code changes \
                        unless bypass_code_review is set or the task is \
                        additive-only. Shape: \
-                       {residual: Finding[], pre_existing: Finding[], mode: string}."
+                       {residual: Finding[], pre_existing: Finding[], mode: string}. \
+                       Each Finding requires: title, severity, file, line, \
+                       why_it_matters, autofix_class, owner, confidence, \
+                       evidence, pre_existing (optional: suggested_fix, \
+                       requires_verification)."
     )]
     #[serde(default)]
     pub code_review_findings: Option<String>,

--- a/crates/cas-types/src/code_review.rs
+++ b/crates/cas-types/src/code_review.rs
@@ -393,6 +393,157 @@ impl ReviewOutcome {
     }
 }
 
+/// Required `Finding` JSON keys (semantic rules still enforced by
+/// [`Finding::validate`] after successful deserialization).
+pub const FINDING_REQUIRED_FIELDS: &[&str] = &[
+    "title",
+    "severity",
+    "file",
+    "line",
+    "why_it_matters",
+    "autofix_class",
+    "owner",
+    "confidence",
+    "evidence",
+    "pre_existing",
+];
+
+/// Optional `Finding` JSON keys.
+pub const FINDING_OPTIONAL_FIELDS: &[&str] = &["suggested_fix", "requires_verification"];
+
+/// Compact shape + Finding field list for close-gate / tool error text.
+///
+/// Used when `code_review_findings` fails to parse so callers see the full
+/// `Finding` contract in one response instead of discovering it field-by-field
+/// across serial close attempts (cas-297e).
+pub fn review_outcome_shape_hint() -> String {
+    format!(
+        "Expected shape: {{residual: Finding[], pre_existing: Finding[], mode: string}}.\n\
+         Each Finding requires: {}.\n\
+         Optional Finding fields: {}.",
+        FINDING_REQUIRED_FIELDS.join(", "),
+        FINDING_OPTIONAL_FIELDS.join(", "),
+    )
+}
+
+/// Multi-error parse failure for a `ReviewOutcome` JSON envelope.
+///
+/// Unlike bare `serde_json::from_str`, this collects **all** missing
+/// required Finding fields (and other structural issues) into a single
+/// message so callers can fix the envelope in one round trip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReviewOutcomeParseError {
+    /// Human-readable multi-line diagnostic.
+    pub message: String,
+}
+
+impl fmt::Display for ReviewOutcomeParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ReviewOutcomeParseError {}
+
+/// Parse + structurally multi-validate + semantically validate a
+/// [`ReviewOutcome`] JSON string.
+///
+/// Structural missing-field checks run over every Finding in `residual[]`
+/// and `pre_existing[]` **before** serde type conversion, so a single bad
+/// envelope reports every missing key at once.
+pub fn parse_review_outcome(json: &str) -> Result<ReviewOutcome, ReviewOutcomeParseError> {
+    let value: serde_json::Value = serde_json::from_str(json).map_err(|e| {
+        ReviewOutcomeParseError {
+            message: format!("invalid JSON: {e}"),
+        }
+    })?;
+
+    let obj = value.as_object().ok_or_else(|| ReviewOutcomeParseError {
+        message: "ReviewOutcome must be a JSON object".to_string(),
+    })?;
+
+    let mut errors: Vec<String> = Vec::new();
+
+    match obj.get("mode") {
+        None => errors.push("missing field `mode`".to_string()),
+        Some(v) if !v.is_string() => {
+            errors.push("`mode` must be a string".to_string());
+        }
+        Some(v) if v.as_str().map(|s| s.trim().is_empty()).unwrap_or(true) => {
+            errors.push("`mode` must be a non-empty string".to_string());
+        }
+        Some(_) => {}
+    }
+
+    for key in ["residual", "pre_existing"] {
+        match obj.get(key) {
+            None | Some(serde_json::Value::Null) => {}
+            Some(v) => {
+                if let Some(arr) = v.as_array() {
+                    for (i, item) in arr.iter().enumerate() {
+                        errors.extend(collect_finding_field_errors(
+                            item,
+                            &format!("{key}[{i}]"),
+                        ));
+                    }
+                } else {
+                    errors.push(format!("`{key}` must be an array of Finding objects"));
+                }
+            }
+        }
+    }
+
+    for k in obj.keys() {
+        if !matches!(k.as_str(), "residual" | "pre_existing" | "mode") {
+            errors.push(format!("unknown field `{k}`"));
+        }
+    }
+
+    if !errors.is_empty() {
+        return Err(ReviewOutcomeParseError {
+            message: errors.join("\n"),
+        });
+    }
+
+    let outcome: ReviewOutcome = serde_json::from_value(value).map_err(|e| {
+        ReviewOutcomeParseError {
+            message: format!("type/shape error: {e}"),
+        }
+    })?;
+
+    outcome.validate().map_err(|e| ReviewOutcomeParseError {
+        message: e.to_string(),
+    })?;
+
+    Ok(outcome)
+}
+
+fn collect_finding_field_errors(value: &serde_json::Value, path: &str) -> Vec<String> {
+    let mut errs = Vec::new();
+    let Some(obj) = value.as_object() else {
+        errs.push(format!("{path}: expected a Finding object"));
+        return errs;
+    };
+
+    for field in FINDING_REQUIRED_FIELDS {
+        if !obj.contains_key(*field) {
+            errs.push(format!("{path}: missing field `{field}`"));
+        }
+    }
+
+    let known: std::collections::HashSet<&str> = FINDING_REQUIRED_FIELDS
+        .iter()
+        .chain(FINDING_OPTIONAL_FIELDS.iter())
+        .copied()
+        .collect();
+    for k in obj.keys() {
+        if !known.contains(k.as_str()) {
+            errs.push(format!("{path}: unknown field `{k}`"));
+        }
+    }
+    errs
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -755,5 +906,110 @@ mod tests {
         let s = out.to_string();
         assert!(s.contains("== reviewer: gpt-5.5:independent (0 findings) =="));
         assert!(s.contains("skipped_reason: codex CLI not installed"));
+    }
+
+    // --- parse_review_outcome multi-field diagnostics (cas-297e) -----------
+
+    #[test]
+    fn parse_review_outcome_happy_path() {
+        let env = ReviewOutcome {
+            residual: vec![valid_finding()],
+            pre_existing: vec![],
+            mode: "autofix".to_string(),
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        let parsed = parse_review_outcome(&json).unwrap();
+        assert_eq!(parsed, env);
+    }
+
+    #[test]
+    fn parse_review_outcome_reports_all_missing_finding_fields_at_once() {
+        // Minimal Finding-shaped object missing several required keys
+        // (the piecemeal failure mode reported in the Ozer bug).
+        let json = r#"{
+            "mode": "interactive",
+            "residual": [{
+                "title": "partial finding",
+                "severity": "P2",
+                "file": "src/a.rs",
+                "line": 1
+            }],
+            "pre_existing": []
+        }"#;
+        let err = parse_review_outcome(json).unwrap_err();
+        let msg = err.message;
+        // All missing required fields must appear in ONE response.
+        for field in [
+            "why_it_matters",
+            "autofix_class",
+            "owner",
+            "confidence",
+            "evidence",
+            "pre_existing",
+        ] {
+            assert!(
+                msg.contains(&format!("missing field `{field}`")),
+                "expected missing field `{field}` in multi-error message, got:\n{msg}"
+            );
+        }
+        // Present fields must not be reported as missing.
+        assert!(!msg.contains("missing field `title`"), "{msg}");
+        assert!(!msg.contains("missing field `severity`"), "{msg}");
+        assert!(!msg.contains("missing field `file`"), "{msg}");
+        assert!(!msg.contains("missing field `line`"), "{msg}");
+        // Path prefix points at the residual entry.
+        assert!(msg.contains("residual[0]"), "{msg}");
+    }
+
+    #[test]
+    fn parse_review_outcome_aggregates_errors_across_findings() {
+        let json = r#"{
+            "mode": "autofix",
+            "residual": [
+                { "title": "a", "severity": "P1", "file": "a.rs", "line": 1 },
+                { "title": "b", "severity": "P2", "file": "b.rs", "line": 2 }
+            ],
+            "pre_existing": [
+                { "title": "c", "severity": "P3", "file": "c.rs", "line": 3 }
+            ]
+        }"#;
+        let err = parse_review_outcome(json).unwrap_err();
+        let msg = err.message;
+        assert!(msg.contains("residual[0]"), "{msg}");
+        assert!(msg.contains("residual[1]"), "{msg}");
+        assert!(msg.contains("pre_existing[0]"), "{msg}");
+        // Each finding should report why_it_matters among the missing set.
+        assert_eq!(
+            msg.matches("missing field `why_it_matters`").count(),
+            3,
+            "expected 3 findings missing why_it_matters, got:\n{msg}"
+        );
+    }
+
+    #[test]
+    fn review_outcome_shape_hint_documents_finding_fields() {
+        let hint = review_outcome_shape_hint();
+        assert!(hint.contains("residual: Finding[]"));
+        assert!(hint.contains("pre_existing: Finding[]"));
+        assert!(hint.contains("mode: string"));
+        for field in FINDING_REQUIRED_FIELDS {
+            assert!(
+                hint.contains(field),
+                "shape hint must document required field `{field}`: {hint}"
+            );
+        }
+        assert!(hint.contains("suggested_fix"));
+        assert!(hint.contains("requires_verification"));
+    }
+
+    #[test]
+    fn parse_review_outcome_rejects_empty_mode() {
+        let json = r#"{"residual":[],"pre_existing":[],"mode":"   "}"#;
+        let err = parse_review_outcome(json).unwrap_err();
+        assert!(
+            err.message.contains("mode"),
+            "expected mode error, got: {}",
+            err.message
+        );
     }
 }

--- a/crates/cas-types/src/lib.rs
+++ b/crates/cas-types/src/lib.rs
@@ -60,8 +60,10 @@ pub use agent::{
     DEFAULT_HEARTBEAT_TIMEOUT_SECS, DEFAULT_LEASE_DURATION_SECS, DEFAULT_MAX_CONCURRENT_TASKS,
 };
 pub use code_review::{
-    AutofixClass, Finding, FindingValidationError, MAX_TITLE_LEN, Owner, ReviewOutcome,
-    ReviewerOutput, Severity as FindingSeverity, parse_reviewer_output,
+    AutofixClass, FINDING_OPTIONAL_FIELDS, FINDING_REQUIRED_FIELDS, Finding,
+    FindingValidationError, MAX_TITLE_LEN, Owner, ReviewOutcome, ReviewOutcomeParseError,
+    ReviewerOutput, Severity as FindingSeverity, parse_review_outcome, parse_reviewer_output,
+    review_outcome_shape_hint,
 };
 pub use commit_link::CommitLink;
 pub use dependency::{Dependency, DependencyType};

--- a/docs/requests/BUG-coordination-message-duplicate-delivery-and-error-styled-success-2026-07-14.md
+++ b/docs/requests/BUG-coordination-message-duplicate-delivery-and-error-styled-success-2026-07-14.md
@@ -1,0 +1,33 @@
+---
+from: Ozer supervisor (pippenz @ /home/pippenz/Petrastella/ozer)
+date: 2026-07-14
+priority: P3
+---
+
+# BUG: Teammate message re-delivered verbatim after being handled; SendMessage auto-route reports success inside an error envelope; asymmetric registration
+
+Three related coordination-bridge issues from one director↔supervisor exchange:
+
+## 1. Duplicate delivery of an already-handled message
+
+The director's "epic cas-ea3e subtasks closed — verify/close/shutdown" message was delivered to my session **twice**, the second time well after I had completed all requested work AND replied (my reply: message id 3083, auto-routed via CAS). The duplicate was byte-identical, with no redelivery marker. If the bridge re-queues on missing ack, the ack either wasn't recorded or the dedup window is broken; either way the receiver has no way to distinguish "re-sent intentionally" from "queue replay", so every duplicate forces a re-verification pass (tool calls, task reads) to prove it's stale.
+
+## 2. Successful auto-route surfaced as a tool **error**
+
+Calling the builtin `SendMessage(to: "director", …)` returned:
+
+```
+<error>✅ AUTO-ROUTED via CAS coordination (message id 3083). Message delivered to `director`.
+DO NOT retry this SendMessage call.</error>
+```
+
+A delivered message reported through the error channel (with a ✅ inside) is confusing for agents and any tooling keying on error status — several harness behaviors treat tool errors as failures to retry or surface. If the hook intercepts and routes successfully, it should return a normal success result carrying the "use `coordination action=message` next time" guidance.
+
+## 3. Asymmetric registration
+
+Immediately after receiving a message FROM the director, my `coordination action=message target=director` reply queued with *"target not yet registered, will deliver on registration"*. The director can evidently reach me while being unregistered as a target in the same registry — inbound and outbound identity resolution disagree. (Delivery-on-registration is a fine fallback; the inconsistency is the bug.)
+
+## Environment
+
+- `cas 2.27.0 (dd8bcbd-dirty 2026-07-11)`, factory mode, supervisor `fast-kestrel-14`, team `ozer-keen-hawk-76`, session `07275a32-c0d5-4695-abbb-5c04663df721`
+- Director = separate Claude session on the same project, messages arriving as `teammate-message` blocks

--- a/docs/requests/BUG-orphaned-inprogress-task-no-death-signal-2026-07-14.md
+++ b/docs/requests/BUG-orphaned-inprogress-task-no-death-signal-2026-07-14.md
@@ -1,0 +1,40 @@
+---
+from: Ozer supervisor (pippenz @ /home/pippenz/Petrastella/ozer)
+date: 2026-07-14
+priority: P1
+---
+
+# BUG: Worker died mid-task; task stayed `InProgress` indefinitely with no orphan/death signal to the supervisor
+
+## Summary
+
+Worker on `cas-5127` (P0 hotfix child of epic `cas-ea3e`) committed its finished fix to its worktree branch (`factory/hv-food-qa` @ `a90f98a6`, clean tree) and then its session died before `task close`. Afterwards:
+
+- `task show cas-5127` → `Status: InProgress`, no staleness indicator, last note 13:59.
+- `coordination worker_status` → "Workers: None active" — the dead worker simply vanished from the list; nothing marked it as died-while-holding-a-lease.
+- No `worker_died` / `task_blocked` notification reached the supervisor (nothing surfaced in-session).
+- The default 600s lease had long expired, but lease expiry did not flip the task to open/orphaned or annotate it.
+
+I only discovered the orphan because a (stale, incorrect) director message claimed "all subtasks closed" and I went to verify. The completed work sat invisible in a worktree; the P0 epic would have stalled indefinitely.
+
+## Environment
+
+- `cas 2.27.0 (dd8bcbd-dirty 2026-07-11)`, factory mode, supervisor `fast-kestrel-14`, session `07275a32-c0d5-4695-abbb-5c04663df721`, project `/home/pippenz/Petrastella/ozer`
+- Worker had been spawned by a different (director) session; worktree `.cas/worktrees/hv-food-qa`
+
+## Expected
+
+Some combination of:
+1. Lease expiry on an `InProgress` task whose holder has no heartbeat → automatic transition to an explicit orphaned/open state (or at minimum a visible `⚠ lease expired, holder gone` marker in `task show` / `task list` / `epic_status`).
+2. A `worker_died` queue notification to the supervising session(s) when a registered worker's heartbeat disappears while holding a lease.
+3. `worker_status` listing recently-died workers (with last heartbeat + held task) instead of only live ones — "None active" hides the difference between "all done and shut down" and "one crashed mid-P0".
+
+## Repro
+
+1. Spawn a worker, assign a task, let it `task start`.
+2. Kill the worker session (or let it crash) after it commits but before close.
+3. Wait > lease duration. Observe: task remains `InProgress`, `worker_status` shows no workers, no notification is queued for the supervisor.
+
+## Impact
+
+Factory reliability: a P0 epic silently stalls on completed-but-unclosed work. The recovery path (`task action=reset` exists and is well-designed) is useless if nothing tells the supervisor a reset is needed.

--- a/docs/requests/BUG-review-envelope-validation-piecemeal-2026-07-14.md
+++ b/docs/requests/BUG-review-envelope-validation-piecemeal-2026-07-14.md
@@ -1,0 +1,41 @@
+---
+from: Ozer supervisor (pippenz @ /home/pippenz/Petrastella/ozer)
+date: 2026-07-14
+priority: P3
+---
+
+# BUG: Review-envelope validation reports one missing field per attempt; Finding schema undocumented; gate error text recommends the wrong mode
+
+Three small quality-of-life defects in the `task close` code-review gate, hit in sequence today:
+
+## 1. Piecemeal validation errors
+
+Submitting `code_review_findings` with findings missing optional-looking fields produced serial rejections — first:
+
+```
+missing field `why_it_matters` at line 1 column 252
+```
+
+then, after adding that field everywhere:
+
+```
+missing field `evidence` at line 1 column 424
+```
+
+Each attempt costs a full close-call round trip with a large JSON payload. Validation should report **all** missing/invalid fields for all findings in one response.
+
+## 2. Required Finding shape is undocumented at the point of failure
+
+Both errors say only `Expected shape: {residual: Finding[], pre_existing: Finding[], mode: string}` — the `Finding` fields (`title`, `severity`, `file`, `line`, `why_it_matters`, `evidence`, `autofix_class`, `owner`, `confidence`, `pre_existing`, …?) are nowhere in the error, the `task` tool description, or the skill doc's Step 5. Callers have to discover the schema by trial or by fishing a prior workflow result out of a journal.
+
+## 3. `CODE_REVIEW_REQUIRED` guidance contradicts the ownership model
+
+The rejection text says:
+
+> 1. Invoke the cas-code-review skill … with **mode=autofix** and the current diff.
+
+but the skill doc states autofix is the **legacy `owner=worker`** path and the default `[code_review] owner = "supervisor"` config routes through `interactive` (or `headless` for skill-to-skill). A supervisor obeying the error verbatim would run the wrong mode. The error text should branch on (or at least mention) the configured owner, and for supervisors suggest `mode=interactive`/`headless`.
+
+## Environment
+
+- `cas 2.27.0 (dd8bcbd-dirty 2026-07-11)`, supervisor closing tasks `cas-5372` / `cas-ea3e`, session `07275a32-c0d5-4695-abbb-5c04663df721`, project `/home/pippenz/Petrastella/ozer`

--- a/docs/requests/BUG-task-close-double-close-not-detected-2026-07-14.md
+++ b/docs/requests/BUG-task-close-double-close-not-detected-2026-07-14.md
@@ -1,0 +1,34 @@
+---
+from: Ozer supervisor (pippenz @ /home/pippenz/Petrastella/ozer)
+date: 2026-07-14
+priority: P2
+---
+
+# BUG: `task action=close` on an already-Closed task succeeds silently — no already-closed detection
+
+## Summary
+
+Two supervising sessions (director + supervisor) raced to close epic `cas-ea3e`. The director closed it at 14:04. My close at 14:05 **also returned success** ("Closed task: cas-ea3e - … (verification skipped — orphaned task, no assignee)") with no indication the task was already Closed. The task now carries two consecutive `Closed:` notes with different reason texts, and both sessions believe *they* performed the close.
+
+Additionally, my close attempt was first rejected with `CODE_REVIEW_REQUIRED` — meaning the review gate ran its full check against a task that was (very likely, given timestamps) already Closed, instead of short-circuiting with "already closed".
+
+## Environment
+
+- `cas 2.27.0 (dd8bcbd-dirty 2026-07-11)`, factory mode, role supervisor (`fast-kestrel-14`), session `07275a32-c0d5-4695-abbb-5c04663df721`, project `/home/pippenz/Petrastella/ozer`
+- Concurrent director session operating on the same epic
+
+## Repro / evidence
+
+1. Session A closes epic `cas-ea3e` (14:04 note: "Closed: All subtasks complete and merged. …").
+2. Session B calls `task action=close id=cas-ea3e` at 14:05 → first gets `CODE_REVIEW_REQUIRED`, then with an envelope gets **success**: `Closed task: cas-ea3e - HOTFIX: … (verification skipped — orphaned task, no assignee)`.
+3. `task action=show id=cas-ea3e` now shows both 14:04 and 14:05 `Closed:` notes; `Closed: 2026-07-14 14:05` (the second close overwrote the close timestamp).
+
+## Expected
+
+- Close on a task whose status is already `Closed` should return a distinct non-destructive result ("already closed at <ts> by <agent>; note appended" or an outright rejection), never a plain success that implies this call performed the close.
+- The close timestamp/audit fields should not be silently overwritten by a second close.
+- The `CODE_REVIEW_REQUIRED` gate should check status first — demanding a review envelope for an already-closed task wastes a full multi-persona review cycle if the caller obeys.
+
+## Impact
+
+Racing supervisors both get positive confirmation, which corrupts the audit trail (who closed it, when) and hides coordination races that the humans/leads would want to know about. In this instance it was harmless, but the same pattern on a task with side-effectful close hooks (verification spawns, notifications) would double-fire them.

--- a/docs/requests/BUG-worktree-registry-cross-session-invisible-2026-07-14.md
+++ b/docs/requests/BUG-worktree-registry-cross-session-invisible-2026-07-14.md
@@ -1,0 +1,32 @@
+---
+from: Ozer supervisor (pippenz @ /home/pippenz/Petrastella/ozer)
+date: 2026-07-14
+priority: P2
+---
+
+# BUG: `coordination worktree_list` returns "No worktrees found" while CAS-created worktrees from sibling sessions exist
+
+## Summary
+
+While integrating epic `cas-ea3e`, `git worktree list` showed three worktrees:
+
+```
+/home/pippenz/Petrastella/ozer                           b3022aa6 [staging]
+/home/pippenz/Petrastella/ozer/.cas/worktrees/hv-food-qa a90f98a6 [factory/hv-food-qa]
+/tmp/ozer-epic-ea3e-hv                                   ec0087ce [epic/…-cas-ea3e]
+```
+
+Two were created by CAS factory tooling in *other* sessions (a director session and its worker). Yet `mcp__cas__coordination action=worktree_list` in my session returned **"No worktrees found."** — so `worktree_show` / `worktree_merge` / `worktree_cleanup` were unusable for exactly the cleanup the factory pattern says the supervisor should run. I had to fall back to raw `git worktree remove` / `branch -D` / `push --delete`.
+
+## Environment
+
+- `cas 2.27.0 (dd8bcbd-dirty 2026-07-11)`, factory mode, supervisor `fast-kestrel-14`, session `07275a32-c0d5-4695-abbb-5c04663df721`, project `/home/pippenz/Petrastella/ozer`
+- Worktrees created by a concurrent director session (same project, same `.cas` root)
+
+## Expected
+
+The worktree registry should be project-scoped (keyed under `.cas/` for the repo), not session-scoped — any supervisor in the project should see and be able to manage worktrees created by sibling/predecessor sessions. Alternatively, `worktree_list` could reconcile against `git worktree list` and report unregistered CAS-pattern worktrees (`.cas/worktrees/*`, epic worktrees) as "untracked".
+
+## Impact
+
+Cross-session handoffs (director spawns workers, supervisor integrates — exactly the flow the director requested of me) lose all worktree bookkeeping: no merge-state tracking, no policy checks before cleanup, and orphaned worktrees accumulate invisibly unless someone happens to run raw git commands.

--- a/docs/requests/completed/BUG-coordination-message-duplicate-delivery-and-error-styled-success-2026-07-14.md
+++ b/docs/requests/completed/BUG-coordination-message-duplicate-delivery-and-error-styled-success-2026-07-14.md
@@ -1,0 +1,33 @@
+---
+from: Ozer supervisor (pippenz @ /home/pippenz/Petrastella/ozer)
+date: 2026-07-14
+priority: P3
+---
+
+# BUG: Teammate message re-delivered verbatim after being handled; SendMessage auto-route reports success inside an error envelope; asymmetric registration
+
+Three related coordination-bridge issues from one director↔supervisor exchange:
+
+## 1. Duplicate delivery of an already-handled message
+
+The director's "epic cas-ea3e subtasks closed — verify/close/shutdown" message was delivered to my session **twice**, the second time well after I had completed all requested work AND replied (my reply: message id 3083, auto-routed via CAS). The duplicate was byte-identical, with no redelivery marker. If the bridge re-queues on missing ack, the ack either wasn't recorded or the dedup window is broken; either way the receiver has no way to distinguish "re-sent intentionally" from "queue replay", so every duplicate forces a re-verification pass (tool calls, task reads) to prove it's stale.
+
+## 2. Successful auto-route surfaced as a tool **error**
+
+Calling the builtin `SendMessage(to: "director", …)` returned:
+
+```
+<error>✅ AUTO-ROUTED via CAS coordination (message id 3083). Message delivered to `director`.
+DO NOT retry this SendMessage call.</error>
+```
+
+A delivered message reported through the error channel (with a ✅ inside) is confusing for agents and any tooling keying on error status — several harness behaviors treat tool errors as failures to retry or surface. If the hook intercepts and routes successfully, it should return a normal success result carrying the "use `coordination action=message` next time" guidance.
+
+## 3. Asymmetric registration
+
+Immediately after receiving a message FROM the director, my `coordination action=message target=director` reply queued with *"target not yet registered, will deliver on registration"*. The director can evidently reach me while being unregistered as a target in the same registry — inbound and outbound identity resolution disagree. (Delivery-on-registration is a fine fallback; the inconsistency is the bug.)
+
+## Environment
+
+- `cas 2.27.0 (dd8bcbd-dirty 2026-07-11)`, factory mode, supervisor `fast-kestrel-14`, team `ozer-keen-hawk-76`, session `07275a32-c0d5-4695-abbb-5c04663df721`
+- Director = separate Claude session on the same project, messages arriving as `teammate-message` blocks

--- a/docs/requests/completed/BUG-orphaned-inprogress-task-no-death-signal-2026-07-14.md
+++ b/docs/requests/completed/BUG-orphaned-inprogress-task-no-death-signal-2026-07-14.md
@@ -1,0 +1,70 @@
+---
+from: Ozer supervisor (pippenz @ /home/pippenz/Petrastella/ozer)
+date: 2026-07-14
+priority: P1
+---
+
+# BUG: Worker died mid-task; task stayed `InProgress` indefinitely with no orphan/death signal to the supervisor
+
+## Summary
+
+Worker on `cas-5127` (P0 hotfix child of epic `cas-ea3e`) committed its finished fix to its worktree branch (`factory/hv-food-qa` @ `a90f98a6`, clean tree) and then its session died before `task close`. Afterwards:
+
+- `task show cas-5127` → `Status: InProgress`, no staleness indicator, last note 13:59.
+- `coordination worker_status` → "Workers: None active" — the dead worker simply vanished from the list; nothing marked it as died-while-holding-a-lease.
+- No `worker_died` / `task_blocked` notification reached the supervisor (nothing surfaced in-session).
+- The default 600s lease had long expired, but lease expiry did not flip the task to open/orphaned or annotate it.
+
+I only discovered the orphan because a (stale, incorrect) director message claimed "all subtasks closed" and I went to verify. The completed work sat invisible in a worktree; the P0 epic would have stalled indefinitely.
+
+## Environment
+
+- `cas 2.27.0 (dd8bcbd-dirty 2026-07-11)`, factory mode, supervisor `fast-kestrel-14`, session `07275a32-c0d5-4695-abbb-5c04663df721`, project `/home/pippenz/Petrastella/ozer`
+- Worker had been spawned by a different (director) session; worktree `.cas/worktrees/hv-food-qa`
+
+## Expected
+
+Some combination of:
+1. Lease expiry on an `InProgress` task whose holder has no heartbeat → automatic transition to an explicit orphaned/open state (or at minimum a visible `⚠ lease expired, holder gone` marker in `task show` / `task list` / `epic_status`).
+2. A `worker_died` queue notification to the supervising session(s) when a registered worker's heartbeat disappears while holding a lease.
+3. `worker_status` listing recently-died workers (with last heartbeat + held task) instead of only live ones — "None active" hides the difference between "all done and shut down" and "one crashed mid-P0".
+
+## Repro
+
+1. Spawn a worker, assign a task, let it `task start`.
+2. Kill the worker session (or let it crash) after it commits but before close.
+3. Wait > lease duration. Observe: task remains `InProgress`, `worker_status` shows no workers, no notification is queued for the supervisor.
+
+## Impact
+
+Factory reliability: a P0 epic silently stalls on completed-but-unclosed work. The recovery path (`task action=reset` exists and is well-designed) is useless if nothing tells the supervisor a reset is needed.
+
+## Resolution (cas-2e81, 2026-07-14)
+
+Fixed in factory worker branch `factory/hv-orphan`.
+
+### Root cause
+- `mark_stale` revoked leases but left task rows as `InProgress` with assignee intact.
+- `worker_status` prune used that path and then showed only the Active roster ("None active"), hiding died-while-leased.
+- Daemon maintenance only annotated notes on InProgress tasks — no status flip, no `worker_died` queue event.
+- Lease reclaim (`reclaim_expired_leases`) similarly cleared leases without parking tasks.
+
+### Fix
+- New module `cas-cli/src/mcp/tools/service/orphan_recovery.rs`:
+  - Parks eligible InProgress/Blocked tasks → Open + clears assignee + audit note
+  - Skips PSR / AwaitingMerge / Closed / Open (cas-6e4c invariant)
+  - Records `EventType::WorkerDied` and queues critical `worker_died` supervisor notifications
+- Wired into: `factory_worker_status` prune, `cas_agent_cleanup`, daemon maintenance, embedded daemon maintenance
+- `worker_status` now appends **Recently died while leased (N)** with last heartbeat + held task ids
+
+### Evidence (focused tests)
+```
+cargo test --test factory_mcp_ops_test test_2e81 -- --test-threads=1
+# test_2e81_worker_status_parks_orphaned_inprogress_on_stale_prune ... ok
+# test_2e81_worker_status_distinguishes_empty_fleet_vs_died_while_leased ... ok
+# test_2e81_agent_cleanup_parks_orphan_and_emits_worker_died ... ok
+# test_2e81_orphan_recovery_skips_psr_tasks ... ok
+# 4 passed
+```
+
+Also: `cargo test --test factory_mcp_ops_test test_worker_status -- --test-threads=1` → 7 passed (existing liveness suite still green).

--- a/docs/requests/completed/BUG-review-envelope-validation-piecemeal-2026-07-14.md
+++ b/docs/requests/completed/BUG-review-envelope-validation-piecemeal-2026-07-14.md
@@ -1,0 +1,41 @@
+---
+from: Ozer supervisor (pippenz @ /home/pippenz/Petrastella/ozer)
+date: 2026-07-14
+priority: P3
+---
+
+# BUG: Review-envelope validation reports one missing field per attempt; Finding schema undocumented; gate error text recommends the wrong mode
+
+Three small quality-of-life defects in the `task close` code-review gate, hit in sequence today:
+
+## 1. Piecemeal validation errors
+
+Submitting `code_review_findings` with findings missing optional-looking fields produced serial rejections — first:
+
+```
+missing field `why_it_matters` at line 1 column 252
+```
+
+then, after adding that field everywhere:
+
+```
+missing field `evidence` at line 1 column 424
+```
+
+Each attempt costs a full close-call round trip with a large JSON payload. Validation should report **all** missing/invalid fields for all findings in one response.
+
+## 2. Required Finding shape is undocumented at the point of failure
+
+Both errors say only `Expected shape: {residual: Finding[], pre_existing: Finding[], mode: string}` — the `Finding` fields (`title`, `severity`, `file`, `line`, `why_it_matters`, `evidence`, `autofix_class`, `owner`, `confidence`, `pre_existing`, …?) are nowhere in the error, the `task` tool description, or the skill doc's Step 5. Callers have to discover the schema by trial or by fishing a prior workflow result out of a journal.
+
+## 3. `CODE_REVIEW_REQUIRED` guidance contradicts the ownership model
+
+The rejection text says:
+
+> 1. Invoke the cas-code-review skill … with **mode=autofix** and the current diff.
+
+but the skill doc states autofix is the **legacy `owner=worker`** path and the default `[code_review] owner = "supervisor"` config routes through `interactive` (or `headless` for skill-to-skill). A supervisor obeying the error verbatim would run the wrong mode. The error text should branch on (or at least mention) the configured owner, and for supervisors suggest `mode=interactive`/`headless`.
+
+## Environment
+
+- `cas 2.27.0 (dd8bcbd-dirty 2026-07-11)`, supervisor closing tasks `cas-5372` / `cas-ea3e`, session `07275a32-c0d5-4695-abbb-5c04663df721`, project `/home/pippenz/Petrastella/ozer`

--- a/docs/requests/completed/BUG-task-close-double-close-not-detected-2026-07-14.md
+++ b/docs/requests/completed/BUG-task-close-double-close-not-detected-2026-07-14.md
@@ -1,0 +1,34 @@
+---
+from: Ozer supervisor (pippenz @ /home/pippenz/Petrastella/ozer)
+date: 2026-07-14
+priority: P2
+---
+
+# BUG: `task action=close` on an already-Closed task succeeds silently — no already-closed detection
+
+## Summary
+
+Two supervising sessions (director + supervisor) raced to close epic `cas-ea3e`. The director closed it at 14:04. My close at 14:05 **also returned success** ("Closed task: cas-ea3e - … (verification skipped — orphaned task, no assignee)") with no indication the task was already Closed. The task now carries two consecutive `Closed:` notes with different reason texts, and both sessions believe *they* performed the close.
+
+Additionally, my close attempt was first rejected with `CODE_REVIEW_REQUIRED` — meaning the review gate ran its full check against a task that was (very likely, given timestamps) already Closed, instead of short-circuiting with "already closed".
+
+## Environment
+
+- `cas 2.27.0 (dd8bcbd-dirty 2026-07-11)`, factory mode, role supervisor (`fast-kestrel-14`), session `07275a32-c0d5-4695-abbb-5c04663df721`, project `/home/pippenz/Petrastella/ozer`
+- Concurrent director session operating on the same epic
+
+## Repro / evidence
+
+1. Session A closes epic `cas-ea3e` (14:04 note: "Closed: All subtasks complete and merged. …").
+2. Session B calls `task action=close id=cas-ea3e` at 14:05 → first gets `CODE_REVIEW_REQUIRED`, then with an envelope gets **success**: `Closed task: cas-ea3e - HOTFIX: … (verification skipped — orphaned task, no assignee)`.
+3. `task action=show id=cas-ea3e` now shows both 14:04 and 14:05 `Closed:` notes; `Closed: 2026-07-14 14:05` (the second close overwrote the close timestamp).
+
+## Expected
+
+- Close on a task whose status is already `Closed` should return a distinct non-destructive result ("already closed at <ts> by <agent>; note appended" or an outright rejection), never a plain success that implies this call performed the close.
+- The close timestamp/audit fields should not be silently overwritten by a second close.
+- The `CODE_REVIEW_REQUIRED` gate should check status first — demanding a review envelope for an already-closed task wastes a full multi-persona review cycle if the caller obeys.
+
+## Impact
+
+Racing supervisors both get positive confirmation, which corrupts the audit trail (who closed it, when) and hides coordination races that the humans/leads would want to know about. In this instance it was harmless, but the same pattern on a task with side-effectful close hooks (verification spawns, notifications) would double-fire them.

--- a/docs/requests/completed/BUG-worktree-registry-cross-session-invisible-2026-07-14.md
+++ b/docs/requests/completed/BUG-worktree-registry-cross-session-invisible-2026-07-14.md
@@ -1,0 +1,50 @@
+---
+from: Ozer supervisor (pippenz @ /home/pippenz/Petrastella/ozer)
+date: 2026-07-14
+priority: P2
+cas_task: cas-d1a0
+status: fixed
+---
+
+# BUG: `coordination worktree_list` returns "No worktrees found" while CAS-created worktrees from sibling sessions exist
+
+## Summary
+
+While integrating epic `cas-ea3e`, `git worktree list` showed three worktrees:
+
+```
+/home/pippenz/Petrastella/ozer                           b3022aa6 [staging]
+/home/pippenz/Petrastella/ozer/.cas/worktrees/hv-food-qa a90f98a6 [factory/hv-food-qa]
+/tmp/ozer-epic-ea3e-hv                                   ec0087ce [epic/…-cas-ea3e]
+```
+
+Two were created by CAS factory tooling in *other* sessions (a director session and its worker). Yet `mcp__cas__coordination action=worktree_list` in my session returned **"No worktrees found."** — so `worktree_show` / `worktree_merge` / `worktree_cleanup` were unusable for exactly the cleanup the factory pattern says the supervisor should run. I had to fall back to raw `git worktree remove` / `branch -D` / `push --delete`.
+
+## Environment
+
+- `cas 2.27.0 (dd8bcbd-dirty 2026-07-11)`, factory mode, supervisor `fast-kestrel-14`, session `07275a32-c0d5-4695-abbb-5c04663df721`, project `/home/pippenz/Petrastella/ozer`
+- Worktrees created by a concurrent director session (same project, same `.cas` root)
+
+## Expected
+
+The worktree registry should be project-scoped (keyed under `.cas/` for the repo), not session-scoped — any supervisor in the project should see and be able to manage worktrees created by sibling/predecessor sessions. Alternatively, `worktree_list` could reconcile against `git worktree list` and report unregistered CAS-pattern worktrees (`.cas/worktrees/*`, epic worktrees) as "untracked".
+
+## Impact
+
+Cross-session handoffs (director spawns workers, supervisor integrates — exactly the flow the director requested of me) lose all worktree bookkeeping: no merge-state tracking, no policy checks before cleanup, and orphaned worktrees accumulate invisibly unless someone happens to run raw git commands.
+
+## Resolution (cas-d1a0)
+
+**Root cause:** System B (`spawn_workers isolate=true`) never writes `WorktreeStore` rows. `worktree_list` already reconciled live git worktrees, but only under the hardcoded path `<cas_root>/worktrees`. That missed:
+
+1. Customized `worktrees.base_path` (same path spawn/merge use)
+2. CAS-pattern worktrees outside that tree (e.g. director epic worktrees under `/tmp/…` with `epic/*` branches)
+
+**Fix:** Project-scoped list is store rows (`.cas/cas.db`) **plus** a git reconcile of CAS-pattern worktrees:
+
+- Paths under configured factory base, `<cas_root>/worktrees`, or `<repo>/.claude/worktrees`
+- Branches matching `factory/*`, `epic/*`, or `cas/*`
+- Unregistered entries labeled `[factory]` or `[untracked]` with path shown
+- Unrelated user worktrees are not listed
+
+**Proof:** `cargo test --test worktree_surface_test` — 13 passed (including cas-d1a0 cases for custom base_path, unregistered epic outside `.cas/`, sibling factory without store row, and ignore non-CAS worktrees).


### PR DESCRIPTION
## Summary

Fixes five factory bugs reported from Ozer (2026-07-14):

1. **Orphan InProgress** — park + `worker_died` when lease holder vanishes
2. **Double close** — already-Closed short-circuit (no audit overwrite / no review gate)
3. **worktree_list** — reconcile CAS-pattern worktrees from sibling sessions
4. **Coordination** — dedupe teammate delivery; SendMessage auto-route as success; director registration
5. **Review envelope** — all-fields validation; Finding schema in errors; owner-aware mode guidance

Reports moved to `docs/requests/completed/`.

## Test plan

- [x] `cargo check -p cas` on epic tip
- [ ] CI full suite
- Worker proofs per child task notes