### PR TITLE
fix(factory): open docs/requests reliability bugs (cas-887b)

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/preflight.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/preflight.md
@@ -6,10 +6,13 @@ The canonical instance of this was 2026-04-22 (~8 min × 2 closes wasted) when `
 
 **30-second check before `mcp__cs__coordination action=spawn_workers`:**
 
+`cas --version` prints `cas <semver> (<hash>[-dirty] <date>)`, e.g. `cas 2.27.0 (9b52e17-dirty 2026-07-16)`. Extract the short hash after `(`; strip optional `-dirty` (means the binary was built with a dirty worktree — not part of the git object id). **Do not** use `awk '{print $NF}'` — that yields the date token (`2026-07-16)`), not the hash.
+
 ```
-cas --version                                      # running binary's git hash
+# extract short hash (sample → 9b52e17)
+cas_hash=$(cas --version | sed -E 's/.*\(([0-9a-f]+)(-dirty)? .*/\1/')
 git rev-parse HEAD                                 # repo HEAD
-git log --oneline HEAD --not $(cas --version | awk '{print $NF}') -- \
+git log --oneline HEAD --not "$cas_hash" -- \
     cas-cli/src/mcp cas-cli/src/hooks cas-cli/src/cli/factory 2>/dev/null | head -20
 ```
 
@@ -22,4 +25,4 @@ cargo build --release
 
 If you don't rebuild and close-time jails every task, that's on you. The running-cas-vs-HEAD drift is the single highest-cost preventable session friction (epic cas-9508).
 
-Shortcut: `cas --version | awk '{print $NF}'` vs `git rev-parse --short HEAD`. If they match, skip the log check and proceed.
+Shortcut: `cas --version | sed -E 's/.*\(([0-9a-f]+)(-dirty)? .*/\1/'` vs `git rev-parse --short HEAD`. If they match, skip the log check and proceed.

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor-checklist.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor-checklist.md
@@ -11,8 +11,11 @@ managed_by: cas
 0. **Binary freshness check (cas-d0f9).** Before anything else — confirm the running `cas serve` binary matches HEAD of this repo. If it doesn't and you spawn workers anyway, every close hits `VERIFICATION_JAIL_BLOCKED` and you burn ~8 min per task on manual verifier runs. See the Pre-flight section in the cas-supervisor SKILL for the full command; the 10-second version:
 
    ```
-   cas --version | awk '{print $NF}'        # hash the running binary was built from
-   git rev-parse --short HEAD               # hash of the repo right now
+   # cas --version format: cas 2.27.0 (9b52e17-dirty 2026-07-16)
+   # Fields after '(': short hash, optional -dirty (build tree had local mods), then build date.
+   # Do NOT use awk '{print $NF}' — that grabs the date token, not the hash.
+   cas --version | sed -E 's/.*\(([0-9a-f]+)(-dirty)? .*/\1/'   # → 9b52e17
+   git rev-parse --short HEAD                                   # hash of the repo right now
    ```
 
    If they don't match AND `git log --oneline HEAD --not <running-hash> -- cas-cli/src/mcp cas-cli/src/hooks cas-cli/src/cli/factory` returns anything, run `cargo build --release` and restart any live `cas serve` processes before continuing.

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor/references/preflight.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor/references/preflight.md
@@ -6,10 +6,13 @@ The canonical instance of this was 2026-04-22 (~8 min × 2 closes wasted) when `
 
 **30-second check before `cas__coordination action=spawn_workers`:**
 
+`cas --version` prints `cas <semver> (<hash>[-dirty] <date>)`, e.g. `cas 2.27.0 (9b52e17-dirty 2026-07-16)`. Extract the short hash after `(`; strip optional `-dirty` (means the binary was built with a dirty worktree — not part of the git object id). **Do not** use `awk '{print $NF}'` — that yields the date token (`2026-07-16)`), not the hash.
+
 ```
-cas --version                                      # running binary's git hash
+# extract short hash (sample → 9b52e17)
+cas_hash=$(cas --version | sed -E 's/.*\(([0-9a-f]+)(-dirty)? .*/\1/')
 git rev-parse HEAD                                 # repo HEAD
-git log --oneline HEAD --not $(cas --version | awk '{print $NF}') -- \
+git log --oneline HEAD --not "$cas_hash" -- \
     cas-cli/src/mcp cas-cli/src/hooks cas-cli/src/cli/factory 2>/dev/null | head -20
 ```
 
@@ -22,4 +25,4 @@ cargo build --release
 
 If you don't rebuild and close-time jails every task, that's on you. The running-cas-vs-HEAD drift is the single highest-cost preventable session friction (epic cas-9508).
 
-Shortcut: `cas --version | awk '{print $NF}'` vs `git rev-parse --short HEAD`. If they match, skip the log check and proceed.
+Shortcut: `cas --version | sed -E 's/.*\(([0-9a-f]+)(-dirty)? .*/\1/'` vs `git rev-parse --short HEAD`. If they match, skip the log check and proceed.

--- a/cas-cli/src/builtins/skills/cas-supervisor-checklist.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor-checklist.md
@@ -11,8 +11,11 @@ managed_by: cas
 0. **Binary freshness check (cas-d0f9).** Before anything else — confirm the running `cas serve` binary matches HEAD of this repo. If it doesn't and you spawn workers anyway, every close hits `VERIFICATION_JAIL_BLOCKED` and you burn ~8 min per task on manual verifier runs. See the Pre-flight section in the cas-supervisor SKILL for the full command; the 10-second version:
 
    ```
-   cas --version | awk '{print $NF}'        # hash the running binary was built from
-   git rev-parse --short HEAD               # hash of the repo right now
+   # cas --version format: cas 2.27.0 (9b52e17-dirty 2026-07-16)
+   # Fields after '(': short hash, optional -dirty (build tree had local mods), then build date.
+   # Do NOT use awk '{print $NF}' — that grabs the date token, not the hash.
+   cas --version | sed -E 's/.*\(([0-9a-f]+)(-dirty)? .*/\1/'   # → 9b52e17
+   git rev-parse --short HEAD                                   # hash of the repo right now
    ```
 
    If they don't match AND `git log --oneline HEAD --not <running-hash> -- cas-cli/src/mcp cas-cli/src/hooks cas-cli/src/cli/factory` returns anything, run `cargo build --release` and restart any live `cas serve` processes before continuing.

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/preflight.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/preflight.md
@@ -6,10 +6,13 @@ The canonical instance of this was 2026-04-22 (~8 min × 2 closes wasted) when `
 
 **30-second check before `mcp__cas__coordination action=spawn_workers`:**
 
+`cas --version` prints `cas <semver> (<hash>[-dirty] <date>)`, e.g. `cas 2.27.0 (9b52e17-dirty 2026-07-16)`. Extract the short hash after `(`; strip optional `-dirty` (means the binary was built with a dirty worktree — not part of the git object id). **Do not** use `awk '{print $NF}'` — that yields the date token (`2026-07-16)`), not the hash.
+
 ```
-cas --version                                      # running binary's git hash
+# extract short hash (sample → 9b52e17)
+cas_hash=$(cas --version | sed -E 's/.*\(([0-9a-f]+)(-dirty)? .*/\1/')
 git rev-parse HEAD                                 # repo HEAD
-git log --oneline HEAD --not $(cas --version | awk '{print $NF}') -- \
+git log --oneline HEAD --not "$cas_hash" -- \
     cas-cli/src/mcp cas-cli/src/hooks cas-cli/src/cli/factory 2>/dev/null | head -20
 ```
 
@@ -22,4 +25,4 @@ cargo build --release
 
 If you don't rebuild and close-time jails every task, that's on you. The running-cas-vs-HEAD drift is the single highest-cost preventable session friction (epic cas-9508).
 
-Shortcut: `cas --version | awk '{print $NF}'` vs `git rev-parse --short HEAD`. If they match, skip the log check and proceed.
+Shortcut: `cas --version | sed -E 's/.*\(([0-9a-f]+)(-dirty)? .*/\1/'` vs `git rev-parse --short HEAD`. If they match, skip the log check and proceed.

--- a/cas-cli/src/cli/factory/wedged.rs
+++ b/cas-cli/src/cli/factory/wedged.rs
@@ -34,8 +34,11 @@
 //! with a `signals.json` turn/token counter file, no known crash-screen
 //! signature) and are resolved/classified differently; see
 //! [`resolve_worker`]'s harness branch and [`effective_transcript_age`] /
-//! [`effective_crash_signature`]. Codex still has no dedicated transcript
-//! reader and resolves to `None` regardless of harness.
+//! [`effective_crash_signature`]. Codex rollouts live under
+//! `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` and are matched by
+//! `session_meta.cwd` (cas-c655); classification also refuses to declare
+//! Starved solely on a missing transcript when the process is busy or the
+//! worktree was recently written.
 
 use anyhow::{Context, Result, anyhow, bail};
 use std::io::{BufRead, BufReader, Read};
@@ -43,8 +46,8 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use crate::mcp::tools::service::factory_ops::{
-    TranscriptResolution, default_claude_projects_dir, default_grok_sessions_dir,
-    resolve_transcript, worker_cli_from_agent,
+    TranscriptResolution, default_claude_projects_dir, default_codex_sessions_dir,
+    default_grok_sessions_dir, resolve_transcript, worker_cli_from_agent,
 };
 
 /// Window in which a transcript mtime counts as "recent" — used to distinguish
@@ -60,6 +63,13 @@ use crate::mcp::tools::service::factory_ops::{
 /// A transcript that hasn't been touched in a minute is almost certainly not
 /// actively executing; that's the signal the supervisor needs.
 pub(crate) const TRANSCRIPT_FRESH_WINDOW: Duration = Duration::from_secs(60);
+
+/// Codex workers routinely sit mid-inference for several minutes without a
+/// CAS tool call (and sometimes without a rollout append). A 60 s transcript
+/// window false-flags them Starved; prefer a longer harness-specific window
+/// (cas-c655 / 2026-07-21 bug report). Worktree + CPU activity still override
+/// Starved even inside this window when the transcript is missing entirely.
+pub(crate) const CODEX_TRANSCRIPT_FRESH_WINDOW: Duration = Duration::from_secs(5 * 60);
 
 /// Number of trailing JSONL lines inspected for the crash-screen signature.
 ///
@@ -175,14 +185,24 @@ const CRASH_SIGNATURE_NEEDLES: &[&str] = &[
 /// [`classify_worker`] wrapper does the measurement; keeping the decision
 /// logic separate means the 4-way branch is exhaustively unit-testable
 /// without ptrace or tempdir dependencies.
+///
+/// `fresh_window` is harness-specific (see [`activity_fresh_window`]).
+/// `process_busy` is true when the resolved worker PID is consuming CPU
+/// (cas-c655: codex mid-inference must not be Starved solely because the
+/// rollout path was unresolved or cold).
 pub(crate) fn classify_from_evidence(
     pid_alive: bool,
     transcript_mtime_age: Option<Duration>,
     crash_signature: bool,
     worktree_recent_edit_age: Option<Duration>,
+    process_busy: bool,
+    fresh_window: Duration,
 ) -> WorkerLivenessState {
     let fresh = transcript_mtime_age
-        .map(|age| age < TRANSCRIPT_FRESH_WINDOW)
+        .map(|age| age < fresh_window)
+        .unwrap_or(false);
+    let worktree_recent = worktree_recent_edit_age
+        .map(|age| age < fresh_window)
         .unwrap_or(false);
     if !pid_alive {
         // cas-f781 AC c: a pid-only "not alive" reading must never emit
@@ -194,9 +214,6 @@ pub(crate) fn classify_from_evidence(
         // writing to its transcript and worktree. Report Unverified so a
         // caller (e.g. a supervisor auto-reset) doesn't treat one
         // contradicted signal as ground truth for a destructive action.
-        let worktree_recent = worktree_recent_edit_age
-            .map(|age| age < TRANSCRIPT_FRESH_WINDOW)
-            .unwrap_or(false);
         return if fresh || worktree_recent {
             WorkerLivenessState::Unverified
         } else {
@@ -206,7 +223,21 @@ pub(crate) fn classify_from_evidence(
     match (fresh, crash_signature) {
         (true, true) => WorkerLivenessState::Wedged,
         (true, false) => WorkerLivenessState::Alive,
+        // cas-c655: missing/stale transcript alone must not force Starved
+        // when the process is demonstrably busy (CPU) or the worktree was
+        // recently written (including a fresh HEAD commit). Healthy codex
+        // workers mid-inference hit this path constantly.
+        (false, _) if worktree_recent || process_busy => WorkerLivenessState::Alive,
         (false, _) => WorkerLivenessState::Starved,
+    }
+}
+
+/// Harness-specific transcript freshness window. Codex gets a longer
+/// grace period (cas-c655); Claude/Grok keep the original 60 s.
+pub(crate) fn activity_fresh_window(cli: cas_mux::SupervisorCli) -> Duration {
+    match cli {
+        cas_mux::SupervisorCli::Codex => CODEX_TRANSCRIPT_FRESH_WINDOW,
+        cas_mux::SupervisorCli::Claude | cas_mux::SupervisorCli::Grok => TRANSCRIPT_FRESH_WINDOW,
     }
 }
 
@@ -224,11 +255,27 @@ pub(crate) fn transcript_mtime_age(path: &Path) -> Option<Duration> {
 /// alongside pid liveness and transcript mtime). Only files git considers
 /// dirty are checked, not the whole tree — `.git/objects` and `target/`
 /// churn constantly regardless of real edits and would swamp the signal.
-/// `None` when `clone_path` isn't a git worktree, git isn't on `PATH`, or
-/// nothing is dirty — callers must treat `None` as "no signal", never as
-/// "confirmed clean" (a worker between edits with a clean tree still
-/// exists and may be alive).
+///
+/// cas-c655: also considers the current branch tip (`git log -1 --format=%ct`)
+/// so a worker that just committed/pushed (clean tree, fresh HEAD) still
+/// counts as active. Takes the freshest (minimum age) of dirty-file mtime
+/// and HEAD commit age.
+///
+/// `None` when `clone_path` isn't a git worktree, git isn't on `PATH`, and
+/// neither dirty files nor HEAD resolve — callers must treat `None` as
+/// "no signal", never as "confirmed clean".
 pub(crate) fn worktree_recent_edit_age(clone_path: &Path) -> Option<Duration> {
+    let dirty = worktree_dirty_file_age(clone_path);
+    let tip = worktree_branch_tip_age(clone_path);
+    match (dirty, tip) {
+        (Some(d), Some(t)) => Some(d.min(t)),
+        (Some(d), None) => Some(d),
+        (None, Some(t)) => Some(t),
+        (None, None) => None,
+    }
+}
+
+fn worktree_dirty_file_age(clone_path: &Path) -> Option<Duration> {
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(clone_path)
@@ -251,6 +298,25 @@ pub(crate) fn worktree_recent_edit_age(clone_path: &Path) -> Option<Duration> {
         }
     }
     newest
+}
+
+/// Age of `HEAD` on the worktree's current branch (`git log -1 --format=%ct`).
+/// Used so a just-committed clean tree still counts as active (cas-c655).
+pub(crate) fn worktree_branch_tip_age(clone_path: &Path) -> Option<Duration> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(clone_path)
+        .arg("log")
+        .arg("-1")
+        .arg("--format=%ct")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let ts: u64 = String::from_utf8_lossy(&output.stdout).trim().parse().ok()?;
+    let commit_time = SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(ts))?;
+    SystemTime::now().duration_since(commit_time).ok()
 }
 
 /// Collect the last `n` lines from `reader` via a bounded ring buffer.
@@ -324,9 +390,9 @@ fn grok_activity_age(updates_jsonl_path: &Path) -> Option<Duration> {
 }
 
 /// Harness-aware transcript freshness: Grok prefers `signals.json` (see
-/// [`grok_activity_age`]); Claude and Codex use the transcript's own mtime
-/// (Codex has no dedicated transcript reader today and resolves to `None`
-/// upstream anyway — see `factory_ops::resolve_transcript` docs).
+/// [`grok_activity_age`]); Claude and Codex use the transcript/rollout's
+/// own mtime (Codex rollouts resolved via `factory_ops::resolve_codex_transcript`,
+/// cas-c655).
 fn effective_transcript_age(path: &Path, cli: cas_mux::SupervisorCli) -> Option<Duration> {
     match cli {
         cas_mux::SupervisorCli::Grok => grok_activity_age(path),
@@ -339,16 +405,15 @@ fn effective_transcript_age(path: &Path, cli: cas_mux::SupervisorCli) -> Option<
 /// Harness-aware crash-signature detection. [`CRASH_SIGNATURE_NEEDLES`] are
 /// Claude/Bun/React-Ink-specific — cas-058f audited whether they apply to
 /// Grok's UI stack and found no evidence they would (Grok isn't a Bun/Ink
-/// CLI), and no Grok-specific crash signature is known yet. Rather than
-/// silently no-op-matching Claude's needles against Grok transcripts (which
-/// would never fire but implies a false sense of coverage), skip the check
-/// explicitly for Grok — `Wedged` simply isn't a classification this
-/// harness supports today; a stalled/crashed Grok worker still correctly
-/// falls into `Starved`/`Dead`/`Unverified` via the other signals.
+/// CLI), and no Grok-specific crash signature is known yet. Codex is also
+/// not a Bun/Ink CLI (cas-c655) — skip the check for both. `Wedged` simply
+/// isn't a classification those harnesses support today; a stalled/crashed
+/// worker still correctly falls into `Starved`/`Dead`/`Unverified` via the
+/// other signals.
 fn effective_crash_signature(path: &Path, cli: cas_mux::SupervisorCli) -> bool {
     match cli {
-        cas_mux::SupervisorCli::Grok => false,
-        cas_mux::SupervisorCli::Claude | cas_mux::SupervisorCli::Codex => {
+        cas_mux::SupervisorCli::Grok | cas_mux::SupervisorCli::Codex => false,
+        cas_mux::SupervisorCli::Claude => {
             transcript_has_crash_signature(path, CRASH_SIGNATURE_TAIL_LINES)
         }
     }
@@ -360,9 +425,11 @@ fn effective_crash_signature(path: &Path, cli: cas_mux::SupervisorCli) -> bool {
 ///
 /// `pid_alive_probe` is injectable so tests don't need to exercise the real
 /// `kill(pid, 0)` path (cas-2749's `pid_alive` helper covers production).
-/// `cli` (cas-058f) selects the harness-appropriate freshness/crash-signature
-/// logic — see [`effective_transcript_age`] / [`effective_crash_signature`].
-pub(crate) fn classify_worker<F, G>(
+/// `process_busy_probe` is injectable for the same reason (cas-c655 CPU
+/// activity signal). `cli` (cas-058f) selects the harness-appropriate
+/// freshness/crash-signature logic — see [`effective_transcript_age`] /
+/// [`effective_crash_signature`] / [`activity_fresh_window`].
+pub(crate) fn classify_worker<F, G, H>(
     pid: Option<u32>,
     transcript_path: Option<&Path>,
     clone_path: Option<&Path>,
@@ -370,12 +437,18 @@ pub(crate) fn classify_worker<F, G>(
     cli: cas_mux::SupervisorCli,
     pid_alive_probe: F,
     worktree_age_probe: G,
+    process_busy_probe: H,
 ) -> (WorkerLivenessState, WorkerEvidence)
 where
     F: FnOnce(u32) -> bool,
     G: FnOnce(&Path) -> Option<Duration>,
+    H: FnOnce(u32) -> bool,
 {
     let pid_alive = pid.map(pid_alive_probe).unwrap_or(false);
+    let process_busy = pid
+        .filter(|_| pid_alive)
+        .map(process_busy_probe)
+        .unwrap_or(false);
     let (age_opt, sig) = match transcript_path {
         Some(p) => (
             effective_transcript_age(p, cli),
@@ -384,7 +457,14 @@ where
         None => (None, false),
     };
     let worktree_age = clone_path.and_then(worktree_age_probe);
-    let state = classify_from_evidence(pid_alive, age_opt, sig, worktree_age);
+    let state = classify_from_evidence(
+        pid_alive,
+        age_opt,
+        sig,
+        worktree_age,
+        process_busy,
+        activity_fresh_window(cli),
+    );
     let evidence = WorkerEvidence {
         pid,
         pid_alive,
@@ -433,15 +513,14 @@ pub(crate) fn resolve_worker(
         .cc_session_id
         .clone()
         .unwrap_or_else(|| agent.id.clone());
-    // cas-058f: which harness this worker runs determines both the
-    // transcript layout (Claude's single JSONL vs. Grok's session
-    // directory) and the base dir to glob under.
+    // cas-058f / cas-c655: which harness this worker runs determines both
+    // the transcript layout (Claude JSONL / Grok session dir / Codex
+    // rollout tree) and the base dir to glob under.
     let cli = worker_cli_from_agent(&agent);
     let base_dir = match cli {
         cas_mux::SupervisorCli::Grok => default_grok_sessions_dir(),
-        cas_mux::SupervisorCli::Claude | cas_mux::SupervisorCli::Codex => {
-            default_claude_projects_dir()
-        }
+        cas_mux::SupervisorCli::Codex => default_codex_sessions_dir(),
+        cas_mux::SupervisorCli::Claude => default_claude_projects_dir(),
     };
     let transcript_path = match resolve_transcript(base_dir.as_deref(), clone_path.as_deref(), &session_id, cli) {
         TranscriptResolution::Resolved(p) => Some(p),
@@ -521,14 +600,21 @@ pub(crate) fn execute_is_wedged(
     // function skips Rust destructors entirely. cas-4513 adversarial P2.
     let exit_code = {
         let w = resolve_worker(cas_root, worker)?;
+        // cas-c655 / cas-f781: the agent-store PID is frequently the MCP
+        // `cas serve` child (self-registration), not the real worker. Prefer
+        // a live process-table match (argv --agent-name / CAS_AGENT_NAME,
+        // with codex binary preferred over cas-serve descendants).
+        let resolved_pid = find_worker_pid(&RealProcessTable, &w.name);
+        let pid = pick_kill_pid(w.pid, resolved_pid);
         let (state, evidence) = classify_worker(
-            w.pid,
+            pid,
             w.transcript_path.as_deref(),
             w.clone_path.as_deref().map(Path::new),
             &w.session_id,
             w.cli,
             crate::mcp::daemon::pid_alive,
             worktree_recent_edit_age,
+            process_cpu_busy,
         );
         if json {
             println!("{}", format_state_json(&state, &evidence));
@@ -654,11 +740,11 @@ pub(crate) fn agent_name_from_environ(environ: &[u8]) -> Option<String> {
 
 /// Scan the live process table for the pid whose cmdline or environ
 /// identifies it as `worker_name`. This is the authoritative resolution
-/// [`execute_kill`] trusts over the agent store's `pid` column — that
-/// column can be overwritten by an unrelated process's self-registration
-/// (cas-f781 discovery: an MCP-server child process re-registers over the
-/// real `claude --agent-name <worker>` pid using its own
-/// `std::process::id()`). Matching against a live process's own
+/// [`execute_kill`] / [`execute_is_wedged`] trust over the agent store's
+/// `pid` column — that column can be overwritten by an unrelated process's
+/// self-registration (cas-f781 discovery: an MCP-server child process
+/// re-registers over the real `claude --agent-name <worker>` pid using its
+/// own `std::process::id()`). Matching against a live process's own
 /// argv/environ is a direct identity proof, unlike a stored pid that might
 /// describe the wrong process entirely.
 pub(crate) fn find_worker_pid<T: ProcessTable + ?Sized>(
@@ -685,13 +771,124 @@ pub(crate) fn find_worker_pid<T: ProcessTable + ?Sized>(
     }) {
         return Some(pid);
     }
-    pids.into_iter().find(|&pid| {
-        table
-            .environ(pid)
-            .and_then(|e| agent_name_from_environ(&e))
-            .as_deref()
-            == Some(worker_name)
-    })
+    // cas-c655: among environ matches, prefer the real harness binary
+    // (codex/claude/grok) over inherited descendants like `cas serve`.
+    // Score all candidates and pick the highest; ties break on lowest pid
+    // for determinism under unspecified `pids()` order.
+    let mut best: Option<(u32, i32)> = None;
+    for pid in pids {
+        let Some(environ) = table.environ(pid) else {
+            continue;
+        };
+        if agent_name_from_environ(&environ).as_deref() != Some(worker_name) {
+            continue;
+        }
+        let score = environ_candidate_score(table.cmdline(pid).as_deref());
+        match best {
+            Some((_, best_score)) if score < best_score => {}
+            Some((best_pid, best_score)) if score == best_score && pid >= best_pid => {}
+            _ => best = Some((pid, score)),
+        }
+    }
+    best.map(|(pid, _)| pid)
+}
+
+/// Rank an environ-matched process by how likely it is to be the actual
+/// worker harness rather than a descendant that inherited `CAS_AGENT_NAME`.
+/// Higher is better. Pure function of cmdline bytes so tests drive it
+/// without `/proc`.
+pub(crate) fn environ_candidate_score(cmdline: Option<&[u8]>) -> i32 {
+    let Some(raw) = cmdline else {
+        return 40;
+    };
+    let tokens: Vec<&str> = raw
+        .split(|b| *b == 0)
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| std::str::from_utf8(s).ok())
+        .collect();
+    if tokens.is_empty() {
+        return 40;
+    }
+    let joined = tokens.join(" ").to_ascii_lowercase();
+    // MCP self-registration child — the cas-f781 / cas-c655 false-pid
+    // source. Hard deprioritize so is-wedged doesn't report cas-serve as
+    // the worker.
+    if tokens.iter().any(|t| {
+        let base = std::path::Path::new(t)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(t)
+            .to_ascii_lowercase();
+        base == "cas" || base.starts_with("cas-")
+    }) && joined.contains("serve")
+    {
+        return 0;
+    }
+    // Prefer harness binaries (argv0 basename or path component).
+    for t in &tokens {
+        let base = std::path::Path::new(t)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(t)
+            .to_ascii_lowercase();
+        if base == "codex" || base.starts_with("codex-") {
+            return 100;
+        }
+        if base == "claude" || base.starts_with("claude") {
+            return 100;
+        }
+        if base == "grok" || base.starts_with("grok") {
+            return 100;
+        }
+    }
+    // Common tool descendants of a worker — keep above cas-serve but well
+    // below the harness so a busy cargo child doesn't win when codex is
+    // also visible.
+    if joined.contains("cargo")
+        || joined.contains("rustc")
+        || joined.contains("git")
+        || joined.contains("node")
+        || joined.contains("python")
+    {
+        return 10;
+    }
+    50
+}
+
+/// Sum of user+system jiffies from `/proc/<pid>/stat` (fields 14 and 15
+/// after the parenthesized `comm`). `None` when unreadable or non-Linux.
+pub(crate) fn process_cpu_ticks(pid: u32) -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        let raw = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        let last_paren = raw.rfind(')')?;
+        let tail = raw.get(last_paren + 1..)?;
+        // fields after comm: state(3) ppid(4) ... utime(14) stime(15)
+        // index 0 of tail split is state → utime is index 11, stime index 12
+        let mut parts = tail.split_whitespace();
+        let utime: u64 = parts.nth(11)?.parse().ok()?;
+        let stime: u64 = parts.next()?.parse().ok()?;
+        Some(utime.saturating_add(stime))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
+/// True when `pid` consumed CPU between two short samples — the mid-
+/// inference signal for codex workers whose rollout path is unresolved
+/// (cas-c655). 50 ms ceiling keeps `is-wedged` snappy.
+pub(crate) fn process_cpu_busy(pid: u32) -> bool {
+    let Some(t1) = process_cpu_ticks(pid) else {
+        return false;
+    };
+    std::thread::sleep(Duration::from_millis(50));
+    let Some(t2) = process_cpu_ticks(pid) else {
+        return false;
+    };
+    t2 > t1
 }
 
 /// Convert `pid` to its process GROUP LEADER's pid via `getpgid()` (cas-a91b).
@@ -1133,7 +1330,7 @@ mod tests {
         // cas-f781 AC c: Dead requires TWO independent signals to agree —
         // pid gone AND (transcript stale AND worktree not recently edited).
         for sig in [true, false] {
-            let got = classify_from_evidence(false, Some(Duration::from_secs(5 * 60)), sig, None);
+            let got = classify_from_evidence(false, Some(Duration::from_secs(5 * 60)), sig, None, false, TRANSCRIPT_FRESH_WINDOW);
             assert_eq!(got, WorkerLivenessState::Dead, "sig={sig}");
         }
     }
@@ -1147,7 +1344,7 @@ mod tests {
         // Report Unverified so an operator investigates before a caller
         // (e.g. a supervisor auto-reset) treats it as ground truth.
         for sig in [true, false] {
-            let got = classify_from_evidence(false, Some(Duration::from_secs(5)), sig, None);
+            let got = classify_from_evidence(false, Some(Duration::from_secs(5)), sig, None, false, TRANSCRIPT_FRESH_WINDOW);
             assert_eq!(got, WorkerLivenessState::Unverified, "sig={sig}");
         }
     }
@@ -1162,6 +1359,8 @@ mod tests {
             Some(Duration::from_secs(5 * 60)),
             false,
             Some(Duration::from_secs(20)),
+            false,
+            TRANSCRIPT_FRESH_WINDOW,
         );
         assert_eq!(got, WorkerLivenessState::Unverified);
     }
@@ -1171,19 +1370,19 @@ mod tests {
         // No transcript resolved, no worktree resolved, pid gone: nothing
         // contradicts "dead", so Dead still fires — matches the
         // no-pid-registered case (classify_worker_no_pid_short_circuits_to_dead).
-        let got = classify_from_evidence(false, None, true, None);
+        let got = classify_from_evidence(false, None, true, None, false, TRANSCRIPT_FRESH_WINDOW);
         assert_eq!(got, WorkerLivenessState::Dead);
     }
 
     #[test]
     fn classify_wedged_when_alive_fresh_and_signature_matches() {
-        let got = classify_from_evidence(true, Some(Duration::from_secs(5)), true, None);
+        let got = classify_from_evidence(true, Some(Duration::from_secs(5)), true, None, false, TRANSCRIPT_FRESH_WINDOW);
         assert_eq!(got, WorkerLivenessState::Wedged);
     }
 
     #[test]
     fn classify_alive_when_fresh_and_no_signature() {
-        let got = classify_from_evidence(true, Some(Duration::from_secs(5)), false, None);
+        let got = classify_from_evidence(true, Some(Duration::from_secs(5)), false, None, false, TRANSCRIPT_FRESH_WINDOW);
         assert_eq!(got, WorkerLivenessState::Alive);
     }
 
@@ -1194,7 +1393,7 @@ mod tests {
         // is the same (SIGKILL + respawn) but the label matters for
         // operator triage.
         for sig in [true, false] {
-            let got = classify_from_evidence(true, Some(Duration::from_secs(120)), sig, None);
+            let got = classify_from_evidence(true, Some(Duration::from_secs(120)), sig, None, false, TRANSCRIPT_FRESH_WINDOW);
             assert_eq!(got, WorkerLivenessState::Starved, "sig={sig}");
         }
     }
@@ -1202,8 +1401,110 @@ mod tests {
     #[test]
     fn classify_starved_when_no_mtime_available() {
         // File missing / mtime unreadable → treated as not-fresh.
-        let got = classify_from_evidence(true, None, true, None);
+        let got = classify_from_evidence(true, None, true, None, false, TRANSCRIPT_FRESH_WINDOW);
         assert_eq!(got, WorkerLivenessState::Starved);
+    }
+
+    /// cas-c655 AC: missing transcript alone must not force Starved when the
+    /// resolved process is busy (codex mid-inference).
+    #[test]
+    fn classify_alive_when_no_transcript_but_process_busy() {
+        let got = classify_from_evidence(
+            true,
+            None,
+            false,
+            None,
+            true,
+            CODEX_TRANSCRIPT_FRESH_WINDOW,
+        );
+        assert_eq!(got, WorkerLivenessState::Alive);
+    }
+
+    /// cas-c655 AC: fixture codex worker with recent worktree writes → not
+    /// starved even with unresolved transcript.
+    #[test]
+    fn classify_alive_when_no_transcript_but_worktree_recent() {
+        let got = classify_from_evidence(
+            true,
+            None,
+            false,
+            Some(Duration::from_secs(15)),
+            false,
+            CODEX_TRANSCRIPT_FRESH_WINDOW,
+        );
+        assert_eq!(got, WorkerLivenessState::Alive);
+    }
+
+    /// cas-c655 edge: truly dead process with no corroborating activity
+    /// still reports Dead.
+    #[test]
+    fn classify_dead_when_pid_gone_and_no_activity_codex_window() {
+        let got = classify_from_evidence(
+            false,
+            None,
+            false,
+            None,
+            false,
+            CODEX_TRANSCRIPT_FRESH_WINDOW,
+        );
+        assert_eq!(got, WorkerLivenessState::Dead);
+    }
+
+    /// cas-c655: a stale-but-within-codex-window transcript is still Alive.
+    #[test]
+    fn classify_codex_window_keeps_3min_transcript_fresh() {
+        let age = Duration::from_secs(3 * 60);
+        assert!(
+            age < CODEX_TRANSCRIPT_FRESH_WINDOW && age >= TRANSCRIPT_FRESH_WINDOW,
+            "fixture must sit between the claude and codex windows"
+        );
+        let got = classify_from_evidence(
+            true,
+            Some(age),
+            false,
+            None,
+            false,
+            CODEX_TRANSCRIPT_FRESH_WINDOW,
+        );
+        assert_eq!(got, WorkerLivenessState::Alive);
+        let claude = classify_from_evidence(
+            true,
+            Some(age),
+            false,
+            None,
+            false,
+            TRANSCRIPT_FRESH_WINDOW,
+        );
+        assert_eq!(claude, WorkerLivenessState::Starved);
+    }
+
+    #[test]
+    fn activity_fresh_window_is_longer_for_codex() {
+        assert_eq!(
+            activity_fresh_window(cas_mux::SupervisorCli::Codex),
+            CODEX_TRANSCRIPT_FRESH_WINDOW
+        );
+        assert_eq!(
+            activity_fresh_window(cas_mux::SupervisorCli::Claude),
+            TRANSCRIPT_FRESH_WINDOW
+        );
+        assert_eq!(
+            activity_fresh_window(cas_mux::SupervisorCli::Grok),
+            TRANSCRIPT_FRESH_WINDOW
+        );
+    }
+
+    #[test]
+    fn environ_candidate_score_prefers_codex_over_cas_serve() {
+        assert!(
+            environ_candidate_score(Some(b"codex\0--yolo\0"))
+                > environ_candidate_score(Some(b"cas\0serve\0--foreground\0"))
+        );
+        assert_eq!(
+            environ_candidate_score(Some(b"cas\0serve\0--foreground\0")),
+            0
+        );
+        assert_eq!(environ_candidate_score(Some(b"codex\0--yolo\0")), 100);
     }
 
     #[test]
@@ -1367,6 +1668,7 @@ mod tests {
             cas_mux::SupervisorCli::Grok,
             pid_probe,
             worktree_probe,
+            |_: u32| false,
         );
         assert_eq!(
             state,
@@ -1452,6 +1754,7 @@ mod tests {
             cas_mux::SupervisorCli::Claude,
             probe,
             worktree_probe,
+            |_: u32| false,
         );
         assert!(called.get(), "probe must be called when pid is Some");
         // no transcript → not fresh, crash=false, alive=true → Starved.
@@ -1474,6 +1777,7 @@ mod tests {
             cas_mux::SupervisorCli::Claude,
             probe,
             worktree_probe,
+            |_: u32| false,
         );
         assert_eq!(state, WorkerLivenessState::Dead);
         assert!(!ev.pid_alive);
@@ -1494,6 +1798,7 @@ mod tests {
             cas_mux::SupervisorCli::Claude,
             pid_probe,
             worktree_probe,
+            |_: u32| false,
         );
         assert_eq!(state, WorkerLivenessState::Dead);
         assert_eq!(ev.worktree_edit_age_secs, None);
@@ -1511,6 +1816,7 @@ mod tests {
             cas_mux::SupervisorCli::Claude,
             pid_probe,
             worktree_probe,
+            |_: u32| false,
         );
         // pid gone, transcript unresolved (not fresh), but worktree edited
         // 20s ago (fresh) — contradiction → Unverified, not Dead.
@@ -1821,6 +2127,81 @@ mod tests {
         );
         let table = FakeProcessTable { entries };
         assert_eq!(find_worker_pid(&table, "hv-live"), Some(5555));
+    }
+
+    /// cas-c655: when both `cas serve` (MCP child) and the real `codex`
+    /// binary inherit `CAS_AGENT_NAME`, prefer the codex PID — is-wedged
+    /// was previously reporting the cas-serve PID as the worker.
+    #[test]
+    fn find_worker_pid_prefers_codex_binary_over_cas_serve_environ_twin() {
+        let mut entries = std::collections::HashMap::new();
+        entries.insert(
+            111084, // cas serve — the false PID from the bug report
+            (
+                Some(b"cas\0serve\0--foreground\0".to_vec()),
+                Some(b"PATH=/usr/bin\0CAS_AGENT_NAME=worker-android\0".to_vec()),
+            ),
+        );
+        entries.insert(
+            222000,
+            (
+                Some(b"/home/x/.local/bin/codex\0--yolo\0--no-alt-screen\0".to_vec()),
+                Some(b"PATH=/usr/bin\0CAS_AGENT_NAME=worker-android\0".to_vec()),
+            ),
+        );
+        let table = OrderedFakeProcessTable {
+            // Enumerate cas-serve FIRST so a naive .find() would pick it.
+            order: vec![111084, 222000],
+            entries,
+        };
+        assert_eq!(
+            find_worker_pid(&table, "worker-android"),
+            Some(222000),
+            "codex harness binary must win over cas-serve descendant"
+        );
+    }
+
+    /// End-to-end cas-c655 happy path through classify_worker: codex cli,
+    /// unresolved transcript, process busy → Alive (not Starved).
+    #[test]
+    fn classify_worker_codex_busy_without_transcript_is_alive() {
+        let pid_probe = |_: u32| true;
+        let worktree_probe = |_: &Path| None::<Duration>;
+        let (state, ev) = classify_worker(
+            Some(222000),
+            None,
+            None,
+            "codex-worker-android-2f828ac6-deadbeef",
+            cas_mux::SupervisorCli::Codex,
+            pid_probe,
+            worktree_probe,
+            |_: u32| true, // process busy
+        );
+        assert_eq!(
+            state,
+            WorkerLivenessState::Alive,
+            "busy codex with unresolved transcript must not be Starved: {ev:?}"
+        );
+        assert_eq!(ev.pid, Some(222000));
+        assert!(ev.transcript_path.is_none());
+    }
+
+    /// End-to-end cas-c655: recent worktree activity rescues missing transcript.
+    #[test]
+    fn classify_worker_codex_recent_worktree_without_transcript_is_alive() {
+        let pid_probe = |_: u32| true;
+        let worktree_probe = |_: &Path| Some(Duration::from_secs(10));
+        let (state, _) = classify_worker(
+            Some(222000),
+            None,
+            Some(Path::new("/tmp/clone")),
+            "codex-worker-android-2f828ac6-deadbeef",
+            cas_mux::SupervisorCli::Codex,
+            pid_probe,
+            worktree_probe,
+            |_: u32| false,
+        );
+        assert_eq!(state, WorkerLivenessState::Alive);
     }
 
     #[test]

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -1330,7 +1330,12 @@ impl CasCore {
                                 .map(|wt| wt.parent_branch.clone())
                         })
                         .unwrap_or_else(|| "main".to_string());
-                    match check_commit_claim_integrity(worker_wt, &parent_branch, true) {
+                    match check_commit_claim_integrity(
+                        worker_wt,
+                        &parent_branch,
+                        true,
+                        task.deliverables.factory_branch_anchor.as_deref(),
+                    ) {
                         CommitClaimGateOutcome::Reject(msg) => {
                             return Ok(Self::tool_error(msg));
                         }
@@ -1700,6 +1705,9 @@ impl CasCore {
                         &task.task_type,
                         task.execution_note.as_deref(),
                         has_review_findings,
+                        // cas-127f: parked tip from MERGE REQUIRED — proves
+                        // real work even when merge-base..HEAD is now empty.
+                        task.deliverables.factory_branch_anchor.as_deref(),
                     ) {
                         ZeroCommitCloseOutcome::AmbiguousCodeTask(msg) => {
                             return Ok(Self::tool_error(msg));
@@ -3568,12 +3576,21 @@ pub(crate) fn check_commit_claim_integrity(
     worker_worktree_path: &std::path::Path,
     parent_branch: &str,
     has_review_findings: bool,
+    factory_branch_anchor: Option<&str>,
 ) -> CommitClaimGateOutcome {
     if !has_review_findings {
         return CommitClaimGateOutcome::Proceed;
     }
     let commit_count = count_worker_branch_commits(worker_worktree_path, parent_branch);
     if commit_count == 0 {
+        // cas-127f: after MERGE REQUIRED + supervisor merge, merge-base..HEAD
+        // is empty even though real work (the parked anchor) landed on parent.
+        // That is not fabrication — it is merge-satisfied.
+        if let Some(anchor) = factory_branch_anchor {
+            if commit_is_merged_into_parent(worker_worktree_path, anchor, parent_branch) {
+                return CommitClaimGateOutcome::Proceed;
+            }
+        }
         CommitClaimGateOutcome::Reject(format!(
             "⚠️ FABRICATION DETECTED\n\n\
             task close rejected: code_review_findings was provided (indicating \
@@ -3620,6 +3637,46 @@ pub(crate) enum ZeroCommitCloseOutcome {
     AmbiguousCodeTask(String),
 }
 
+/// cas-127f: true when `commit_ish` is an ancestor of `parent_branch`
+/// (or `origin/<parent_branch>` when that ref exists) inside `repo_path`.
+///
+/// Used to distinguish "never committed" from "committed, MERGE REQUIRED
+/// parked an anchor, supervisor already integrated those commits" — after
+/// a successful merge, `count_worker_branch_commits` is 0 even though real
+/// work landed on the parent. Fail closed on any git error.
+pub(crate) fn commit_is_merged_into_parent(
+    repo_path: &std::path::Path,
+    commit_ish: &str,
+    parent_branch: &str,
+) -> bool {
+    use std::process::Command;
+    if commit_ish.is_empty() || !is_safe_git_refname(parent_branch) {
+        return false;
+    }
+    // Reject option-injection on the commit-ish too (full SHAs are fine;
+    // leading `-` is not a valid commit ref for our purposes).
+    if commit_ish.starts_with('-') {
+        return false;
+    }
+    let check = |parent: &str| -> bool {
+        Command::new("git")
+            .args(["merge-base", "--is-ancestor", commit_ish, parent])
+            .current_dir(repo_path)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+    if check(parent_branch) {
+        return true;
+    }
+    // Mirror cas-38e2: local parent ref can lag origin after a remote merge.
+    let origin_parent = format!("origin/{parent_branch}");
+    if git_ref_exists(repo_path, &origin_parent) {
+        return check(&origin_parent);
+    }
+    false
+}
+
 /// cas-ee2b: check whether a zero-commit close is ambiguous and should be
 /// rejected.
 ///
@@ -3628,7 +3685,7 @@ pub(crate) enum ZeroCommitCloseOutcome {
 /// i.e. after the main `has_worker_committed_reviewable_changes` check
 /// returned false.
 ///
-/// Three-case decision tree:
+/// Decision tree:
 ///
 /// 1. **Docs-only commits** (`count > 0` but no reviewable files): worker
 ///    committed work; the reviewable-files check correctly returned false.
@@ -3639,8 +3696,16 @@ pub(crate) enum ZeroCommitCloseOutcome {
 ///    gate handles that case):
 ///    → `Proceed`. No ambiguity.
 ///
-/// 3. **Ambiguous zero-commit** (`count == 0`, no `execution_note`, task
-///    type is Bug/Feature/Task, no review findings):
+/// 3. **Merge-satisfied** (cas-127f): `count == 0` but
+///    `factory_branch_anchor` is set and that SHA is an ancestor of
+///    `parent_branch` (work was committed, MERGE REQUIRED parked the tip,
+///    supervisor merged into the epic). → `Proceed`. Without this path,
+///    post-merge close false-rejects ZERO-COMMIT because the worker tip
+///    is no longer *ahead of* parent even though the work landed.
+///
+/// 4. **Ambiguous zero-commit** (`count == 0`, no anchor / anchor not
+///    integrated, no `execution_note`, task type is Bug/Feature/Task, no
+///    review findings):
 ///    → `AmbiguousCodeTask(msg)`. Ask worker to commit, set `execution_note`,
 ///    or have the supervisor bypass.
 ///
@@ -3648,8 +3713,14 @@ pub(crate) enum ZeroCommitCloseOutcome {
 /// When true, the cas-490f gate fires upstream; this function returns `Proceed`
 /// so the two gates don't double-reject.
 ///
-/// Returns `Proceed` on any git failure (graceful degradation — not
-/// ambiguous when history is unknowable).
+/// `factory_branch_anchor`: optional tip SHA recorded by
+/// `park_task_awaiting_merge` the first time the merge gate rejected this
+/// task. Only set when the factory branch had unmerged commits — genuine
+/// zero-commit tasks never park, so they never get an anchor.
+///
+/// Returns `Proceed` on any git failure for the count path (graceful
+/// degradation — not ambiguous when history is unknowable). Ancestor
+/// checks fail closed (unknown integration ≠ merge-satisfied).
 pub(crate) fn check_zero_commit_close(
     worker_worktree_path: &std::path::Path,
     parent_branch: &str,
@@ -3657,6 +3728,7 @@ pub(crate) fn check_zero_commit_close(
     task_type: &TaskType,
     execution_note: Option<&str>,
     has_review_findings: bool,
+    factory_branch_anchor: Option<&str>,
 ) -> ZeroCommitCloseOutcome {
     // Not a code-expecting task type → no ambiguity.
     if !matches!(
@@ -3712,6 +3784,12 @@ pub(crate) fn check_zero_commit_close(
             3. Supervisors may bypass this gate with bypass_code_review=true \
                (logged as a decision note)."
         ));
+    }
+    // cas-127f: merge-satisfied — parked tip is now on the parent.
+    if let Some(anchor) = factory_branch_anchor {
+        if commit_is_merged_into_parent(worker_worktree_path, anchor, parent_branch) {
+            return ZeroCommitCloseOutcome::Proceed;
+        }
     }
     // Case 3: ambiguous zero-commit close.
     let task_type_str = format!("{task_type:?}").to_lowercase();
@@ -8710,7 +8788,7 @@ mod commit_claim_integrity_tests {
     fn fabrication_detected_when_zero_commits_with_review_findings() {
         let dir = init_worker_repo();
         // No commits beyond base — fabrication scenario.
-        let outcome = check_commit_claim_integrity(dir.path(), "main", true);
+        let outcome = check_commit_claim_integrity(dir.path(), "main", true, None);
         match outcome {
             CommitClaimGateOutcome::Reject(msg) => {
                 assert!(
@@ -8737,7 +8815,7 @@ mod commit_claim_integrity_tests {
         // Worker did documentation-only work and did not supply
         // code_review_findings. Empty branch is fine in that case.
         let dir = init_worker_repo();
-        let outcome = check_commit_claim_integrity(dir.path(), "main", false);
+        let outcome = check_commit_claim_integrity(dir.path(), "main", false, None);
         assert!(
             matches!(outcome, CommitClaimGateOutcome::Proceed),
             "no-findings close on empty branch must proceed (no fabrication claim)"
@@ -8752,10 +8830,52 @@ mod commit_claim_integrity_tests {
         git(dir.path(), &["add", "real.rs"]);
         git(dir.path(), &["commit", "-q", "-m", "real work"]);
 
-        let outcome = check_commit_claim_integrity(dir.path(), "main", true);
+        let outcome = check_commit_claim_integrity(dir.path(), "main", true, None);
         assert!(
             matches!(outcome, CommitClaimGateOutcome::Proceed),
             "commits + findings must proceed (worker did real work)"
+        );
+    }
+
+    /// cas-127f: findings + empty merge-base..HEAD after supervisor merge is
+    /// not fabrication when the parked factory tip is an ancestor of parent.
+    #[test]
+    fn findings_after_merge_satisfied_anchor_proceeds() {
+        let dir = init_worker_repo();
+        std::fs::write(dir.path().join("real.rs"), "fn real() {}\n").unwrap();
+        git(dir.path(), &["add", "real.rs"]);
+        git(dir.path(), &["commit", "-q", "-m", "real work"]);
+        let anchor = String::from_utf8(
+            std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(dir.path())
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        // Supervisor merges factory tip into main (no-ff).
+        git(dir.path(), &["checkout", "-q", "main"]);
+        git(
+            dir.path(),
+            &["merge", "--no-ff", "-m", "merge worker", "factory/test-worker"],
+        );
+        // Worker tip is now even with parent (or still at anchor which is
+        // ancestor) — count beyond parent is 0 either way after checkout.
+        git(dir.path(), &["checkout", "-q", "factory/test-worker"]);
+        git(dir.path(), &["reset", "--hard", "main"]);
+
+        assert_eq!(
+            count_worker_branch_commits(dir.path(), "main"),
+            0,
+            "post-merge worker tip must not be ahead of parent"
+        );
+        let outcome = check_commit_claim_integrity(dir.path(), "main", true, Some(&anchor));
+        assert!(
+            matches!(outcome, CommitClaimGateOutcome::Proceed),
+            "merge-satisfied anchor must not look like fabrication"
         );
     }
 }
@@ -8894,6 +9014,7 @@ mod zero_change_close_tests {
             &TaskType::Bug,
             None,  // no execution_note
             false, // no review findings
+            None,  // factory_branch_anchor
         );
         assert!(
             matches!(outcome, ZeroCommitCloseOutcome::Proceed),
@@ -8914,6 +9035,7 @@ mod zero_change_close_tests {
             &TaskType::Bug,
             None,  // no execution_note
             false, // no review findings
+            None,  // factory_branch_anchor
         );
         match outcome {
             ZeroCommitCloseOutcome::AmbiguousCodeTask(msg) => {
@@ -8944,6 +9066,7 @@ mod zero_change_close_tests {
             &TaskType::Bug,
             Some("additive-only"), // explicit no-code signal
             false,
+            None, // factory_branch_anchor
         );
         assert!(
             matches!(outcome, ZeroCommitCloseOutcome::Proceed),
@@ -8957,7 +9080,7 @@ mod zero_change_close_tests {
         let dir = init_worker_repo();
         for task_type in [TaskType::Chore, TaskType::Epic] {
             let outcome =
-                check_zero_commit_close(dir.path(), "main", "cas-test1", &task_type, None, false);
+                check_zero_commit_close(dir.path(), "main", "cas-test1", &task_type, None, false, None);
             assert!(
                 matches!(outcome, ZeroCommitCloseOutcome::Proceed),
                 "{task_type:?} task type must not be flagged as ambiguous"
@@ -8977,6 +9100,7 @@ mod zero_change_close_tests {
             &TaskType::Bug,
             None,
             true, // has_review_findings = true (cas-490f rejects, not this gate)
+            None, // factory_branch_anchor
         );
         assert!(
             matches!(outcome, ZeroCommitCloseOutcome::Proceed),
@@ -9030,6 +9154,7 @@ mod zero_change_close_tests {
             &TaskType::Bug,
             None,  // no execution_note
             false, // no review findings
+            None,  // factory_branch_anchor
         );
         match outcome {
             ZeroCommitCloseOutcome::AmbiguousCodeTask(msg) => {
@@ -9046,6 +9171,147 @@ mod zero_change_close_tests {
                 );
             }
         }
+    }
+
+    // ── cas-127f: post-MERGE-REQUIRED zero-commit false-positive ───────────
+
+    /// Happy path: worker commits C, MERGE REQUIRED records C as anchor,
+    /// supervisor merges C into parent, worker tip is no longer ahead →
+    /// count==0 but anchor is ancestor → Proceed (not ZERO-COMMIT).
+    #[test]
+    fn cas127f_post_merge_ancestor_anchor_proceeds() {
+        let dir = init_worker_repo();
+        std::fs::write(dir.path().join("fix.rs"), "pub fn work() {}\n").unwrap();
+        git(dir.path(), &["add", "fix.rs"]);
+        git(dir.path(), &["commit", "-q", "-m", "feat: task work"]);
+        let anchor = String::from_utf8(
+            std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(dir.path())
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+
+        // Sanity: before merge, zero-commit gate would Proceed via count>0.
+        assert!(count_worker_branch_commits(dir.path(), "main") > 0);
+
+        // Supervisor merges factory tip into main.
+        git(dir.path(), &["checkout", "-q", "main"]);
+        git(
+            dir.path(),
+            &["merge", "--no-ff", "-m", "merge factory/test-worker", "factory/test-worker"],
+        );
+        // Worker factory branch reset to epic tip (post-merge sync).
+        git(dir.path(), &["checkout", "-q", "factory/test-worker"]);
+        git(dir.path(), &["reset", "--hard", "main"]);
+
+        assert_eq!(
+            count_worker_branch_commits(dir.path(), "main"),
+            0,
+            "post-merge: merge-base..HEAD must be empty (the false-positive fixture)"
+        );
+        assert!(
+            commit_is_merged_into_parent(dir.path(), &anchor, "main"),
+            "parked anchor must be ancestor of parent after merge"
+        );
+
+        let outcome = check_zero_commit_close(
+            dir.path(),
+            "main",
+            "cas-127f",
+            &TaskType::Bug,
+            None,
+            false,
+            Some(&anchor),
+        );
+        assert!(
+            matches!(outcome, ZeroCommitCloseOutcome::Proceed),
+            "merge-satisfied anchor must Proceed, not ZERO-COMMIT; got {outcome:?}"
+        );
+    }
+
+    /// Edge: genuine never-had-commits code task still rejects (no anchor).
+    #[test]
+    fn cas127f_genuine_zero_commit_without_anchor_still_rejects() {
+        let dir = init_worker_repo();
+        let outcome = check_zero_commit_close(
+            dir.path(),
+            "main",
+            "cas-127f",
+            &TaskType::Bug,
+            None,
+            false,
+            None,
+        );
+        match outcome {
+            ZeroCommitCloseOutcome::AmbiguousCodeTask(msg) => {
+                assert!(
+                    msg.contains("ZERO-COMMIT CLOSE ON CODE TASK"),
+                    "genuine zero-commit must still name the gate: {msg}"
+                );
+            }
+            ZeroCommitCloseOutcome::Proceed => {
+                panic!("genuine zero-commit without anchor must not Proceed");
+            }
+        }
+    }
+
+    /// Edge: anchor set but not integrated (still unmerged) + count 0 —
+    /// e.g. factory tip was force-reset without merging. Fail closed.
+    #[test]
+    fn cas127f_unmerged_anchor_with_empty_ahead_still_rejects() {
+        let dir = init_worker_repo();
+        // Commit work, record anchor, then hard-reset factory away so the
+        // commit is orphaned from parent *and* HEAD is back at base.
+        std::fs::write(dir.path().join("orphan.rs"), "fn orphan() {}\n").unwrap();
+        git(dir.path(), &["add", "orphan.rs"]);
+        git(dir.path(), &["commit", "-q", "-m", "orphaned work"]);
+        let anchor = String::from_utf8(
+            std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(dir.path())
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        git(dir.path(), &["reset", "--hard", "main"]);
+
+        assert_eq!(count_worker_branch_commits(dir.path(), "main"), 0);
+        assert!(
+            !commit_is_merged_into_parent(dir.path(), &anchor, "main"),
+            "orphan anchor must not be considered merged"
+        );
+
+        let outcome = check_zero_commit_close(
+            dir.path(),
+            "main",
+            "cas-127f",
+            &TaskType::Feature,
+            None,
+            false,
+            Some(&anchor),
+        );
+        assert!(
+            matches!(outcome, ZeroCommitCloseOutcome::AmbiguousCodeTask(_)),
+            "unmerged anchor must not unlock zero-commit; got {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn commit_is_merged_into_parent_false_for_unknown_sha() {
+        let dir = init_worker_repo();
+        assert!(!commit_is_merged_into_parent(
+            dir.path(),
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "main"
+        ));
     }
 }
 

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -165,6 +165,67 @@ pub(crate) fn epic_owner_transfer_audit_note(
     )
 }
 
+/// Non-empty branch string from a task, if present.
+fn task_branch_if_set(task: &Task) -> Option<String> {
+    task.branch
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Session focus epic id: `pinned_epic_id` first, then session default `epic_id`.
+/// Used only as a secondary fallback when the assigned task has no parent epic branch
+/// (cas-44e9). Does not invent a branch from concurrent `epic/*` listings.
+fn session_focus_epic_id() -> Option<String> {
+    let session = std::env::var("CAS_FACTORY_SESSION").ok()?;
+    if session.trim().is_empty() {
+        return None;
+    }
+    let data = std::fs::read_to_string(crate::ui::factory::metadata_path(&session)).ok()?;
+    let meta: crate::ui::factory::SessionMetadata = serde_json::from_str(&data).ok()?;
+    meta.pinned_epic_id
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| meta.epic_id.filter(|s| !s.trim().is_empty()))
+}
+
+/// Resolve the branch the assignment freshness gate should compare against (cas-44e9).
+///
+/// Order:
+/// 1. If the task itself is an epic with `branch` set → that branch
+/// 2. Parent epic (ParentChild) → `epic.branch`
+/// 3. Session `focus_epic` pin / session default epic → its `branch`
+/// 4. `None` → caller falls through to base/main inside `check_worktree_staleness`
+///
+/// Never returns a branch derived from "most recent / last listed `epic/*`".
+pub(crate) fn resolve_assignment_freshness_branch(
+    task_store: &dyn cas_store::TaskStore,
+    task: &Task,
+) -> Option<String> {
+    if task.task_type == TaskType::Epic {
+        if let Some(branch) = task_branch_if_set(task) {
+            return Some(branch);
+        }
+    }
+
+    match task_store.get_parent_epic(&task.id) {
+        Ok(Some(epic)) => {
+            if let Some(branch) = task_branch_if_set(&epic) {
+                return Some(branch);
+            }
+        }
+        Ok(None) => {}
+        Err(_) => {}
+    }
+
+    let focus_id = session_focus_epic_id()?;
+    let epic = task_store.get(&focus_id).ok()?;
+    if epic.task_type != TaskType::Epic {
+        return None;
+    }
+    task_branch_if_set(&epic)
+}
+
 impl CasCore {
     pub async fn cas_task_update(
         &self,
@@ -284,6 +345,10 @@ impl CasCore {
             if std::env::var("CAS_FACTORY_MODE").is_ok() {
                 let config = self.load_config();
                 let factory_config = config.factory();
+                // cas-44e9: scope freshness to this task's parent epic (or focus pin),
+                // never an unrelated concurrent epic branch.
+                let preferred_sync =
+                    resolve_assignment_freshness_branch(task_store.as_ref(), &task);
 
                 if let Ok(agent_store) = self.open_agent_store() {
                     if let Ok(agents) = agent_store.list(None) {
@@ -306,9 +371,10 @@ impl CasCore {
                                 || factory_config.block_stale_assignment
                             {
                                 if let Some(clone_path) = worker.metadata.get("clone_path") {
-                                    if let Some((behind_count, branch)) =
-                                        check_worktree_staleness(clone_path)
-                                    {
+                                    if let Some((behind_count, branch)) = check_worktree_staleness(
+                                        clone_path,
+                                        preferred_sync.as_deref(),
+                                    ) {
                                         if behind_count > 0 {
                                             let warning_msg = format!(
                                                 "⚠️ Worker '{assignee}' is {behind_count} commit(s) \
@@ -356,9 +422,10 @@ impl CasCore {
                                 || factory_config.block_stale_assignment
                             {
                                 if let Some(clone_path) = worker.metadata.get("clone_path") {
-                                    if let Some((behind_count, branch)) =
-                                        check_worktree_staleness(clone_path)
-                                    {
+                                    if let Some((behind_count, branch)) = check_worktree_staleness(
+                                        clone_path,
+                                        preferred_sync.as_deref(),
+                                    ) {
                                         if behind_count > 0 {
                                             let staleness_msg = format!(
                                                 "⚠️ Worker '{worker_name}' is {behind_count} \
@@ -841,6 +908,139 @@ mod epic_owner_transfer_auth_tests {
         assert!(
             note_unset.contains("<unset>") && note_unset.contains("new-owner"),
             "unset previous must be explicit: {note_unset}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod assignment_freshness_branch_tests {
+    use super::*;
+    use cas_types::{Dependency, DependencyType, Task, TaskType};
+    use tempfile::TempDir;
+
+    fn open_store() -> (TempDir, std::sync::Arc<dyn cas_store::TaskStore>) {
+        let temp = TempDir::new().unwrap();
+        let cas_dir = temp.path().join(".cas");
+        std::fs::create_dir_all(&cas_dir).unwrap();
+        let store = crate::store::open_task_store(&cas_dir).expect("open task store");
+        store.init().expect("init task store");
+        (temp, store)
+    }
+
+    #[test]
+    fn prefers_parent_epic_branch_over_unrelated_epic() {
+        let (_tmp, store) = open_store();
+
+        let mut epic_a = Task::new("cas-epica".into(), "Epic A".into());
+        epic_a.task_type = TaskType::Epic;
+        epic_a.branch = Some("epic/a".into());
+        store.add(&epic_a).unwrap();
+
+        let mut epic_b = Task::new("cas-epicb".into(), "Epic B".into());
+        epic_b.task_type = TaskType::Epic;
+        epic_b.branch = Some("epic/z-last".into());
+        store.add(&epic_b).unwrap();
+
+        let child = Task::new("cas-childa".into(), "Child of A".into());
+        store.add(&child).unwrap();
+        store
+            .add_dependency(&Dependency::new(
+                child.id.clone(),
+                epic_a.id.clone(),
+                DependencyType::ParentChild,
+            ))
+            .unwrap();
+
+        let branch = resolve_assignment_freshness_branch(store.as_ref(), &child);
+        assert_eq!(
+            branch.as_deref(),
+            Some("epic/a"),
+            "must use parent epic A branch, not concurrent epic B"
+        );
+        assert_ne!(branch.as_deref(), Some("epic/z-last"));
+    }
+
+    #[test]
+    fn epic_task_uses_own_branch() {
+        let (_tmp, store) = open_store();
+        let mut epic = Task::new("cas-epic1".into(), "Epic".into());
+        epic.task_type = TaskType::Epic;
+        epic.branch = Some("epic/self".into());
+        store.add(&epic).unwrap();
+
+        let branch = resolve_assignment_freshness_branch(store.as_ref(), &epic);
+        assert_eq!(branch.as_deref(), Some("epic/self"));
+    }
+
+    #[test]
+    fn standalone_task_without_focus_returns_none() {
+        let (_tmp, store) = open_store();
+        // Ensure no session focus leaks from the factory environment.
+        // SAFETY: unit test; no concurrent env readers for this process section.
+        unsafe {
+            std::env::remove_var("CAS_FACTORY_SESSION");
+        }
+        let task = Task::new("cas-solo".into(), "Standalone".into());
+        store.add(&task).unwrap();
+
+        let branch = resolve_assignment_freshness_branch(store.as_ref(), &task);
+        assert_eq!(
+            branch, None,
+            "no parent epic and no focus pin → None (caller uses base/main)"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_session_focus_pin_branch() {
+        let (_tmp, store) = open_store();
+
+        let mut epic_a = Task::new("cas-epinf".into(), "Focused Epic".into());
+        epic_a.task_type = TaskType::Epic;
+        epic_a.branch = Some("epic/focused".into());
+        store.add(&epic_a).unwrap();
+
+        let mut epic_b = Task::new("cas-epother".into(), "Other Epic".into());
+        epic_b.task_type = TaskType::Epic;
+        epic_b.branch = Some("epic/other".into());
+        store.add(&epic_b).unwrap();
+
+        let solo = Task::new("cas-solof".into(), "No parent".into());
+        store.add(&solo).unwrap();
+
+        // Write session metadata with pinned focus on epic A.
+        let session = format!("test-focus-{}", std::process::id());
+        let meta_path = crate::ui::factory::metadata_path(&session);
+        if let Some(parent) = meta_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let meta = serde_json::json!({
+            "name": session,
+            "created_at": "2026-07-21T00:00:00Z",
+            "daemon_pid": 1,
+            "socket_path": "/tmp/test.sock",
+            "supervisor": { "name": "sup", "pid": null },
+            "workers": [],
+            "epic_id": null,
+            "pinned_epic_id": "cas-epinf",
+            "project_dir": null
+        });
+        std::fs::write(&meta_path, meta.to_string()).unwrap();
+        // SAFETY: unit test scoped env for focus pin path.
+        unsafe {
+            std::env::set_var("CAS_FACTORY_SESSION", &session);
+        }
+
+        let branch = resolve_assignment_freshness_branch(store.as_ref(), &solo);
+        // Cleanup env + file before assert so panics still clean in drop path
+        unsafe {
+            std::env::remove_var("CAS_FACTORY_SESSION");
+        }
+        let _ = std::fs::remove_file(&meta_path);
+
+        assert_eq!(
+            branch.as_deref(),
+            Some("epic/focused"),
+            "standalone task should fall back to focus_epic pin branch"
         );
     }
 }

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -15,6 +15,23 @@ pub(crate) fn normalize_epic_verification_owner(raw: &str) -> Option<String> {
     }
 }
 
+/// Normalize `assignee` on task update (cas-bf98).
+///
+/// - Empty / whitespace-only → `None` (explicit **clear / unassign**).
+/// - Non-empty → trimmed string for storage and factory session-id normalization.
+///
+/// Must run **before** session-id → display-name remapping: `Some("")` is still
+/// `Some`, so without this guard factory mode can treat empty as a session id
+/// and rewrite it to a live worker name (observed: remapped to `hv-scope`).
+pub(crate) fn normalize_assignee_update_value(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 /// True when any caller identity facet matches the stored owner (after trim).
 pub(crate) fn caller_matches_epic_owner(
     owner: &str,
@@ -326,148 +343,181 @@ impl CasCore {
         // Track warnings to include in response
         let mut warnings: Vec<String> = Vec::new();
 
-        if let Some(ref assignee) = req.assignee {
-            // In factory mode: normalize and validate the assignee value.
-            //
-            // cas-dbbb: `task mine` matches assignees against agent_name (the
-            // display name) and CAS_AGENT_NAME env var. Assigning by session UUID /
-            // agent ID is silently accepted but the task never appears in the target
-            // worker's `task mine` list — observed in the 2026-06-30 smoke test
-            // where director-provided session IDs left tasks in Ready/Open with no
-            // visible assignee, while worker names dispatched correctly.
-            //
-            // Resolution order:
-            //   1. Assignee matches agent.name → canonical, store as-is.
-            //   2. Assignee matches agent.id  → normalize to agent.name, warn.
-            //   3. No match                   → warn; store as-is (agent may not yet
-            //                                   be registered, e.g. pre-spawn).
-            let mut canonical_assignee = assignee.clone();
-            if std::env::var("CAS_FACTORY_MODE").is_ok() {
-                let config = self.load_config();
-                let factory_config = config.factory();
-                // cas-44e9: scope freshness to this task's parent epic (or focus pin),
-                // never an unrelated concurrent epic branch.
-                let preferred_sync =
-                    resolve_assignment_freshness_branch(task_store.as_ref(), &task);
+        if let Some(ref assignee_raw) = req.assignee {
+            // cas-bf98: empty/whitespace = explicit clear (unassign). Must run
+            // before factory session-id normalization — `Some("")` is still Some
+            // and was previously stored as empty or remapped to a live worker.
+            match normalize_assignee_update_value(assignee_raw) {
+                None => {
+                    task.assignee = None;
+                    changes.push("assignee");
+                }
+                Some(assignee) => {
+                    // In factory mode: normalize and validate the assignee value.
+                    //
+                    // cas-dbbb: `task mine` matches assignees against agent_name (the
+                    // display name) and CAS_AGENT_NAME env var. Assigning by session UUID /
+                    // agent ID is silently accepted but the task never appears in the target
+                    // worker's `task mine` list — observed in the 2026-06-30 smoke test
+                    // where director-provided session IDs left tasks in Ready/Open with no
+                    // visible assignee, while worker names dispatched correctly.
+                    //
+                    // Resolution order:
+                    //   1. Assignee matches agent.name → canonical, store as-is.
+                    //   2. Assignee matches agent.id  → normalize to agent.name, warn.
+                    //   3. No match                   → warn; store as-is (agent may not yet
+                    //                                   be registered, e.g. pre-spawn).
+                    let mut canonical_assignee = assignee.clone();
+                    if std::env::var("CAS_FACTORY_MODE").is_ok() {
+                        let config = self.load_config();
+                        let factory_config = config.factory();
+                        // cas-44e9: scope freshness to this task's parent epic (or focus pin),
+                        // never an unrelated concurrent epic branch.
+                        let preferred_sync =
+                            resolve_assignment_freshness_branch(task_store.as_ref(), &task);
 
-                if let Ok(agent_store) = self.open_agent_store() {
-                    if let Ok(agents) = agent_store.list(None) {
-                        // Find by name first (canonical path).
-                        // cas-dbbb P2: use case-insensitive compare to match
-                        // `task mine`'s own identity matching logic.
-                        let by_name =
-                            agents.iter().find(|a| a.name.eq_ignore_ascii_case(assignee));
-                        // Fall back to ID lookup (supervisor may have copy-pasted session UUID).
-                        let by_id = if by_name.is_none() {
-                            agents.iter().find(|a| a.id.eq_ignore_ascii_case(assignee))
-                        } else {
-                            None
-                        };
+                        if let Ok(agent_store) = self.open_agent_store() {
+                            if let Ok(agents) = agent_store.list(None) {
+                                // Find by name first (canonical path).
+                                // cas-dbbb P2: use case-insensitive compare to match
+                                // `task mine`'s own identity matching logic.
+                                let by_name = agents
+                                    .iter()
+                                    .find(|a| a.name.eq_ignore_ascii_case(&assignee));
+                                // Fall back to ID lookup (supervisor may have copy-pasted
+                                // session UUID).
+                                let by_id = if by_name.is_none() {
+                                    agents
+                                        .iter()
+                                        .find(|a| a.id.eq_ignore_ascii_case(&assignee))
+                                } else {
+                                    None
+                                };
 
-                        if let Some(worker) = by_name {
-                            // Canonical — no normalization needed.
-                            // Worktree staleness check.
-                            if factory_config.warn_stale_assignment
-                                || factory_config.block_stale_assignment
-                            {
-                                if let Some(clone_path) = worker.metadata.get("clone_path") {
-                                    if let Some((behind_count, branch)) = check_worktree_staleness(
-                                        clone_path,
-                                        preferred_sync.as_deref(),
-                                    ) {
-                                        if behind_count > 0 {
-                                            let warning_msg = format!(
-                                                "⚠️ Worker '{assignee}' is {behind_count} commit(s) \
-                                                 behind {branch}. Consider syncing first."
-                                            );
-                                            if factory_config.block_stale_assignment
-                                                && behind_count
-                                                    >= factory_config.stale_threshold_commits
+                                if let Some(worker) = by_name {
+                                    // Canonical — no normalization needed.
+                                    // Worktree staleness check.
+                                    if factory_config.warn_stale_assignment
+                                        || factory_config.block_stale_assignment
+                                    {
+                                        if let Some(clone_path) =
+                                            worker.metadata.get("clone_path")
+                                        {
+                                            if let Some((behind_count, branch)) =
+                                                check_worktree_staleness(
+                                                    clone_path,
+                                                    preferred_sync.as_deref(),
+                                                )
                                             {
-                                                return Err(McpError {
-                                                    code: ErrorCode::INVALID_PARAMS,
-                                                    message: Cow::from(format!(
-                                                        "Cannot assign to worker '{}': {} commits \
-                                                         behind {} (threshold: {}). Ask the worker \
-                                                         to rebase: `git rebase {}`",
-                                                        assignee,
-                                                        behind_count,
-                                                        branch,
-                                                        factory_config.stale_threshold_commits,
-                                                        branch
-                                                    )),
-                                                    data: None,
-                                                });
+                                                if behind_count > 0 {
+                                                    let warning_msg = format!(
+                                                        "⚠️ Worker '{assignee}' is {behind_count} \
+                                                         commit(s) behind {branch}. Consider \
+                                                         syncing first."
+                                                    );
+                                                    if factory_config.block_stale_assignment
+                                                        && behind_count
+                                                            >= factory_config
+                                                                .stale_threshold_commits
+                                                    {
+                                                        return Err(McpError {
+                                                            code: ErrorCode::INVALID_PARAMS,
+                                                            message: Cow::from(format!(
+                                                                "Cannot assign to worker '{}': {} \
+                                                                 commits behind {} (threshold: \
+                                                                 {}). Ask the worker to rebase: \
+                                                                 `git rebase {}`",
+                                                                assignee,
+                                                                behind_count,
+                                                                branch,
+                                                                factory_config
+                                                                    .stale_threshold_commits,
+                                                                branch
+                                                            )),
+                                                            data: None,
+                                                        });
+                                                    }
+                                                    warnings.push(warning_msg);
+                                                }
                                             }
-                                            warnings.push(warning_msg);
                                         }
                                     }
-                                }
-                            }
-                        } else if let Some(worker) = by_id {
-                            // Assignee is a session UUID — normalize to display name
-                            // so `task mine` can find it.
-                            let worker_name = worker.name.clone();
-                            warnings.push(format!(
-                                "⚠️ Assignee '{assignee}' is a session ID. \
-                                 Normalized to display name '{worker_name}' so \
-                                 `task mine` can find this task. \
-                                 Use '{worker_name}' directly to avoid this warning."
-                            ));
-                            canonical_assignee = worker_name.clone();
-                            // cas-dbbb P1: run the same staleness check as the by_name
-                            // branch. The original code skipped this after normalization,
-                            // leaving stale-worktree blocking disabled for UUID assignees.
-                            if factory_config.warn_stale_assignment
-                                || factory_config.block_stale_assignment
-                            {
-                                if let Some(clone_path) = worker.metadata.get("clone_path") {
-                                    if let Some((behind_count, branch)) = check_worktree_staleness(
-                                        clone_path,
-                                        preferred_sync.as_deref(),
-                                    ) {
-                                        if behind_count > 0 {
-                                            let staleness_msg = format!(
-                                                "⚠️ Worker '{worker_name}' is {behind_count} \
-                                                 commit(s) behind {branch}. Consider syncing first."
-                                            );
-                                            if factory_config.block_stale_assignment
-                                                && behind_count
-                                                    >= factory_config.stale_threshold_commits
+                                } else if let Some(worker) = by_id {
+                                    // Assignee is a session UUID — normalize to display name
+                                    // so `task mine` can find it.
+                                    let worker_name = worker.name.clone();
+                                    warnings.push(format!(
+                                        "⚠️ Assignee '{assignee}' is a session ID. \
+                                         Normalized to display name '{worker_name}' so \
+                                         `task mine` can find this task. \
+                                         Use '{worker_name}' directly to avoid this warning."
+                                    ));
+                                    canonical_assignee = worker_name.clone();
+                                    // cas-dbbb P1: run the same staleness check as the by_name
+                                    // branch. The original code skipped this after
+                                    // normalization, leaving stale-worktree blocking disabled
+                                    // for UUID assignees.
+                                    if factory_config.warn_stale_assignment
+                                        || factory_config.block_stale_assignment
+                                    {
+                                        if let Some(clone_path) =
+                                            worker.metadata.get("clone_path")
+                                        {
+                                            if let Some((behind_count, branch)) =
+                                                check_worktree_staleness(
+                                                    clone_path,
+                                                    preferred_sync.as_deref(),
+                                                )
                                             {
-                                                return Err(McpError {
-                                                    code: ErrorCode::INVALID_PARAMS,
-                                                    message: Cow::from(format!(
-                                                        "Cannot assign to worker '{worker_name}': \
-                                                         {behind_count} commits behind {branch} \
-                                                         (threshold: {}). Ask the worker to rebase: \
-                                                         `git rebase {branch}`",
-                                                        factory_config.stale_threshold_commits,
-                                                    )),
-                                                    data: None,
-                                                });
+                                                if behind_count > 0 {
+                                                    let staleness_msg = format!(
+                                                        "⚠️ Worker '{worker_name}' is \
+                                                         {behind_count} commit(s) behind \
+                                                         {branch}. Consider syncing first."
+                                                    );
+                                                    if factory_config.block_stale_assignment
+                                                        && behind_count
+                                                            >= factory_config
+                                                                .stale_threshold_commits
+                                                    {
+                                                        return Err(McpError {
+                                                            code: ErrorCode::INVALID_PARAMS,
+                                                            message: Cow::from(format!(
+                                                                "Cannot assign to worker \
+                                                                 '{worker_name}': {behind_count} \
+                                                                 commits behind {branch} \
+                                                                 (threshold: {}). Ask the worker \
+                                                                 to rebase: `git rebase {branch}`",
+                                                                factory_config
+                                                                    .stale_threshold_commits,
+                                                            )),
+                                                            data: None,
+                                                        });
+                                                    }
+                                                    warnings.push(staleness_msg);
+                                                }
                                             }
-                                            warnings.push(staleness_msg);
                                         }
                                     }
+                                } else {
+                                    // No agent found by name or ID — warn but allow (agent
+                                    // may not yet be registered, e.g. spawning in progress).
+                                    warnings.push(format!(
+                                        "⚠️ No registered factory agent found for assignee \
+                                         '{assignee}'. Verify the worker name with \
+                                         `mcp__cas__system action=worker_status`. Use the \
+                                         worker's display name (e.g. 'codex-jester'), not \
+                                         their session UUID, for reliable `task mine` dispatch."
+                                    ));
                                 }
                             }
-                        } else {
-                            // No agent found by name or ID — warn but allow (agent
-                            // may not yet be registered, e.g. spawning in progress).
-                            warnings.push(format!(
-                                "⚠️ No registered factory agent found for assignee '{assignee}'. \
-                                 Verify the worker name with `mcp__cas__system action=worker_status`. \
-                                 Use the worker's display name (e.g. 'codex-jester'), not their \
-                                 session UUID, for reliable `task mine` dispatch."
-                            ));
                         }
                     }
+
+                    task.assignee = Some(canonical_assignee);
+                    changes.push("assignee");
                 }
             }
-
-            task.assignee = Some(canonical_assignee);
-            changes.push("assignee");
         }
 
         // cas-cc74: epic_verification_owner is an authorized transfer, not a
@@ -697,6 +747,18 @@ mod epic_owner_transfer_auth_tests {
         a.status = status;
         a.last_heartbeat = chrono::Utc::now();
         a
+    }
+
+    #[test]
+    fn test_bf98_normalize_assignee_empty_clears() {
+        assert_eq!(normalize_assignee_update_value(""), None);
+        assert_eq!(normalize_assignee_update_value("   \t  "), None);
+        assert_eq!(
+            normalize_assignee_update_value("  hv-scope  ").as_deref(),
+            Some("hv-scope")
+        );
+        // Must never treat empty as a value that could session-id match.
+        assert!(normalize_assignee_update_value("").is_none());
     }
 
     #[test]

--- a/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
+++ b/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
@@ -41,6 +41,30 @@ fn merge_target_remediation(assignee: &str) -> String {
     )
 }
 
+/// cas-369f: decide whether `worktree_merge` should remove the worktree after
+/// merging. Pure — unit-tested.
+///
+/// Rules:
+/// - Explicit `cleanup` request always wins (end-of-lane consume vs preserve).
+/// - `force` is **not** consulted here (dirty-tree only; cas-0b32 / cas-369f).
+/// - System B (`spawn_workers isolate=true` factory workers): default **preserve**
+///   so mid-epic merges do not ENOENT the live worker cwd.
+/// - System A: fall back to config `cleanup_on_close`.
+pub(crate) fn resolve_worktree_merge_cleanup(
+    requested_cleanup: Option<bool>,
+    is_system_b: bool,
+    config_cleanup_on_close: bool,
+) -> bool {
+    if let Some(c) = requested_cleanup {
+        return c;
+    }
+    if is_system_b {
+        false
+    } else {
+        config_cleanup_on_close
+    }
+}
+
 /// True when `token` is the System-B worker name (bare or `factory/<name>`).
 fn worker_name_token_matches(token: &str, worker: &str) -> bool {
     token == worker || token.strip_prefix("factory/") == Some(worker)
@@ -1117,12 +1141,19 @@ impl CasCore {
     /// defaults a factory worker merge to trunk — trunk requires explicit
     /// `allow_trunk=true` (independent of `force`, which only bypasses dirty
     /// worktree protection). The resolved target is always surfaced.
+    ///
+    /// `cleanup` (cas-369f) is independent of `force`:
+    /// - `force` only allows merging a dirty worktree
+    /// - `cleanup=true` removes the worktree + deletes the branch after merge
+    /// - System-B default is **preserve** (mid-session merges leave the
+    ///   worker cwd intact); System-A uses `worktrees.cleanup_on_close`
     pub async fn worktree_merge(
         &self,
         id: &str,
         force: bool,
         task_id: Option<&str>,
         allow_trunk: bool,
+        cleanup: Option<bool>,
     ) -> Result<CallToolResult, McpError> {
         use crate::config::Config;
         use crate::store::open_worktree_store;
@@ -1227,8 +1258,16 @@ impl CasCore {
             }
         };
 
+        // cas-369f: force (dirty) ≠ cleanup (remove). System-B factory
+        // workers default to preserving the worktree mid-session.
+        let do_cleanup = resolve_worktree_merge_cleanup(
+            cleanup,
+            is_system_b,
+            wt_config.cleanup_on_close,
+        );
+
         let merge_commit = manager
-            .merge_and_cleanup(&mut worktree, force)
+            .merge_and_cleanup(&mut worktree, force, do_cleanup)
             .map_err(|e| McpError {
                 code: ErrorCode::INTERNAL_ERROR,
                 message: Cow::from(format!("Failed to merge worktree: {e}")),
@@ -1237,7 +1276,7 @@ impl CasCore {
 
         // Update store — System B worktrees were never registered there, so
         // there's no row to update (and nothing worth persisting: the
-        // git-level merge + cleanup above already happened).
+        // git-level merge + optional cleanup above already happened).
         if !is_system_b {
             worktree_store.update(&worktree).map_err(|e| McpError {
                 code: ErrorCode::INTERNAL_ERROR,
@@ -1255,16 +1294,23 @@ impl CasCore {
             String::new()
         };
 
+        let cleanup_note = if do_cleanup {
+            " Worktree removed (cleanup=true)."
+        } else {
+            " Worktree preserved (mid-session merge; pass cleanup=true to remove)."
+        };
+
         // Promote entries if configured
         if wt_config.promote_entries_on_merge {
             if let Ok(count) = self.promote_branch_entries(&worktree.branch) {
                 if count > 0 {
                     return Ok(Self::success(format!(
-                        "Merged worktree {} to {}.{} Commit: {}\nPromoted {} entries from branch scope.",
+                        "Merged worktree {} to {}.{} Commit: {}{}\nPromoted {} entries from branch scope.",
                         worktree.id,
                         worktree.parent_branch,
                         target_suffix,
                         merge_commit.as_deref().unwrap_or("none"),
+                        cleanup_note,
                         count
                     )));
                 }
@@ -1272,11 +1318,12 @@ impl CasCore {
         }
 
         Ok(Self::success(format!(
-            "Merged worktree {} to {}.{} Commit: {}",
+            "Merged worktree {} to {}.{} Commit: {}{}",
             worktree.id,
             worktree.parent_branch,
             target_suffix,
-            merge_commit.as_deref().unwrap_or("none")
+            merge_commit.as_deref().unwrap_or("none"),
+            cleanup_note
         )))
     }
 
@@ -1391,6 +1438,7 @@ impl CasCore {
 mod tests {
     use super::{
         is_cas_pattern_worktree, is_factory_style_worktree, is_git_worktree, path_is_under,
+        resolve_worktree_merge_cleanup,
     };
     use std::path::Path;
     use tempfile::TempDir;
@@ -1486,5 +1534,34 @@ mod tests {
             base
         ));
         assert!(!path_is_under(Path::new("/proj/other"), base));
+    }
+
+    // --- cas-369f: force ≠ cleanup; System-B default preserve -------------
+
+    #[test]
+    fn resolve_merge_cleanup_system_b_defaults_to_preserve() {
+        assert!(
+            !resolve_worktree_merge_cleanup(None, true, true),
+            "System-B mid-session default must preserve even if config cleanup_on_close=true"
+        );
+        assert!(!resolve_worktree_merge_cleanup(None, true, false));
+    }
+
+    #[test]
+    fn resolve_merge_cleanup_explicit_true_wins() {
+        assert!(resolve_worktree_merge_cleanup(Some(true), true, false));
+        assert!(resolve_worktree_merge_cleanup(Some(true), false, false));
+    }
+
+    #[test]
+    fn resolve_merge_cleanup_explicit_false_wins() {
+        assert!(!resolve_worktree_merge_cleanup(Some(false), true, true));
+        assert!(!resolve_worktree_merge_cleanup(Some(false), false, true));
+    }
+
+    #[test]
+    fn resolve_merge_cleanup_system_a_uses_config() {
+        assert!(resolve_worktree_merge_cleanup(None, false, true));
+        assert!(!resolve_worktree_merge_cleanup(None, false, false));
     }
 }

--- a/cas-cli/src/mcp/tools/mod.rs
+++ b/cas-cli/src/mcp/tools/mod.rs
@@ -140,10 +140,50 @@ fn check_unmerged_epic_branches(epic_id: &str, target_branch: &str) -> Vec<Strin
         .collect()
 }
 
-/// Check how many commits behind its sync target a worktree is
+/// Resolve which git ref a worktree should be compared against for assignment
+/// freshness (cas-44e9).
 ///
-/// Returns (commits_behind, sync_ref) or None if check fails
-fn check_worktree_staleness(clone_path: &str) -> Option<(u32, String)> {
+/// Order:
+/// 1. `preferred` — task's parent epic branch, or session focus_epic pin (caller-resolved)
+/// 2. upstream tracking ref of HEAD (when set)
+/// 3. current branch when it is already `epic/*`
+/// 4. repository default / base branch
+///
+/// **Never** picks an arbitrary `epic/*` from `git branch --list` — that is the
+/// multi-epic bug where concurrent epic B contaminated assignments for epic A.
+pub(crate) fn resolve_staleness_sync_ref(
+    preferred: Option<&str>,
+    current_branch: &str,
+    upstream: Option<&str>,
+    default_branch: &str,
+) -> String {
+    if let Some(p) = preferred.map(str::trim).filter(|s| !s.is_empty()) {
+        return p.to_string();
+    }
+    if let Some(u) = upstream.map(str::trim).filter(|s| !s.is_empty()) {
+        return u.to_string();
+    }
+    if current_branch.starts_with("epic/") {
+        return current_branch.to_string();
+    }
+    // factory/* and all other local branches: base/main — not "last epic/*".
+    if default_branch.trim().is_empty() {
+        "main".to_string()
+    } else {
+        default_branch.to_string()
+    }
+}
+
+/// Check how many commits behind its sync target a worktree is.
+///
+/// `preferred_sync_ref` is the task-scoped target (parent epic branch / focus pin).
+/// When set, it always wins so multi-epic factories compare against the correct epic.
+///
+/// Returns (commits_behind, sync_ref) or None if check fails (missing path / git error).
+fn check_worktree_staleness(
+    clone_path: &str,
+    preferred_sync_ref: Option<&str>,
+) -> Option<(u32, String)> {
     use crate::worktree::GitOperations;
     use std::path::Path;
     use std::process::Command;
@@ -168,29 +208,18 @@ fn check_worktree_staleness(clone_path: &str) -> Option<(u32, String)> {
         return None;
     };
 
-    // Prefer upstream tracking ref, fall back to local parent/default branch.
-    let sync_ref = if let Some(upstream) = current_upstream(path) {
-        upstream
-    } else if current_branch.starts_with("epic/") {
-        current_branch.clone()
-    } else if current_branch.starts_with("factory/") {
-        list_git_branches(Some(path), &["branch", "--list", "epic/*"])
-            .last()
-            .cloned()
-            .or_else(|| {
-                GitOperations::detect_repo_root(path)
-                    .ok()
-                    .map(GitOperations::new)
-                    .map(|git| git.detect_default_branch())
-            })
-            .unwrap_or_else(|| "main".to_string())
-    } else {
-        GitOperations::detect_repo_root(path)
-            .ok()
-            .map(GitOperations::new)
-            .map(|git| git.detect_default_branch())
-            .unwrap_or_else(|| "main".to_string())
-    };
+    let default_branch = GitOperations::detect_repo_root(path)
+        .ok()
+        .map(GitOperations::new)
+        .map(|git| git.detect_default_branch())
+        .unwrap_or_else(|| "main".to_string());
+
+    let sync_ref = resolve_staleness_sync_ref(
+        preferred_sync_ref,
+        &current_branch,
+        current_upstream(path).as_deref(),
+        &default_branch,
+    );
 
     // Fetch latest refs when sync target is a remote-tracking ref.
     if let Some(remote) = remote_for_ref(path, &sync_ref) {

--- a/cas-cli/src/mcp/tools/mod_tests.rs
+++ b/cas-cli/src/mcp/tools/mod_tests.rs
@@ -1,8 +1,10 @@
-use crate::mcp::tools::*;
-
 #[cfg(test)]
 mod tests {
-    use crate::mcp::tools::mod_tests::*;
+    use super::super::{
+        check_worktree_staleness, resolve_staleness_sync_ref, slugify_for_branch, truncate_str,
+    };
+    use std::process::Command;
+    use tempfile::TempDir;
 
     // ========================================================================
     // Epic Branch Slugification Tests
@@ -64,5 +66,123 @@ mod tests {
     #[test]
     fn truncate_str_keeps_short_values() {
         assert_eq!(truncate_str("short", 10), "short");
+    }
+
+    // ========================================================================
+    // Assignment freshness sync-ref resolution (cas-44e9)
+    // ========================================================================
+
+    #[test]
+    fn resolve_staleness_preferred_wins_over_upstream_and_default() {
+        let got = resolve_staleness_sync_ref(
+            Some("epic/alpha"),
+            "factory/worker",
+            Some("origin/factory/worker"),
+            "main",
+        );
+        assert_eq!(got, "epic/alpha");
+    }
+
+    #[test]
+    fn resolve_staleness_preferred_wins_even_when_two_epics_would_exist() {
+        // Regression: old code listed epic/* and took .last() — wrong under multi-epic.
+        // Preferred (task parent epic A) must always win; never invent from listing.
+        let got = resolve_staleness_sync_ref(
+            Some("epic/a-first"),
+            "factory/hv-scope",
+            None,
+            "main",
+        );
+        assert_eq!(got, "epic/a-first");
+        assert_ne!(got, "epic/z-last");
+    }
+
+    #[test]
+    fn resolve_staleness_factory_without_preferred_uses_default_not_epic_list() {
+        // No parent epic / focus pin → base/main. Must not return an epic/* name.
+        let got = resolve_staleness_sync_ref(None, "factory/worker", None, "main");
+        assert_eq!(got, "main");
+        assert!(!got.starts_with("epic/"));
+    }
+
+    #[test]
+    fn resolve_staleness_empty_preferred_falls_through_to_upstream() {
+        let got = resolve_staleness_sync_ref(
+            Some("   "),
+            "factory/worker",
+            Some("origin/main"),
+            "main",
+        );
+        assert_eq!(got, "origin/main");
+    }
+
+    #[test]
+    fn resolve_staleness_epic_branch_without_preferred_uses_self() {
+        let got = resolve_staleness_sync_ref(None, "epic/own", None, "main");
+        assert_eq!(got, "epic/own");
+    }
+
+    fn git(path: &std::path::Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .status()
+            .expect("git spawn");
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    /// Multi-epic repo: epic/a and epic/z both exist; worker on factory/* is behind
+    /// only epic/a. Preferred=epic/a must report that branch — never epic/z.
+    #[test]
+    fn check_worktree_staleness_uses_preferred_when_two_epic_branches_exist() {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path();
+        git(p, &["init", "-q", "-b", "main"]);
+        std::fs::write(p.join("seed.txt"), "seed\n").unwrap();
+        git(p, &["add", "seed.txt"]);
+        git(p, &["commit", "-q", "-m", "seed"]);
+
+        // epic/a: one extra commit (worker will be behind this)
+        git(p, &["checkout", "-q", "-b", "epic/a"]);
+        std::fs::write(p.join("a.txt"), "a\n").unwrap();
+        git(p, &["add", "a.txt"]);
+        git(p, &["commit", "-q", "-m", "epic a"]);
+
+        // epic/z: two extra commits off main (would be wrong multi-epic pick if .last())
+        git(p, &["checkout", "-q", "main"]);
+        git(p, &["checkout", "-q", "-b", "epic/z"]);
+        std::fs::write(p.join("z1.txt"), "z1\n").unwrap();
+        git(p, &["add", "z1.txt"]);
+        git(p, &["commit", "-q", "-m", "epic z1"]);
+        std::fs::write(p.join("z2.txt"), "z2\n").unwrap();
+        git(p, &["add", "z2.txt"]);
+        git(p, &["commit", "-q", "-m", "epic z2"]);
+
+        // factory worker branched from main (behind both epics)
+        git(p, &["checkout", "-q", "main"]);
+        git(p, &["checkout", "-q", "-b", "factory/worker"]);
+
+        let path = p.to_str().unwrap();
+        let (behind, branch) = check_worktree_staleness(path, Some("epic/a"))
+            .expect("staleness check should succeed");
+        assert_eq!(branch, "epic/a", "must name preferred epic A, not concurrent epic Z");
+        assert!(!branch.contains("epic/z"), "wrong epic must not appear: {branch}");
+        assert_eq!(behind, 1, "worker is 1 commit behind epic/a");
+
+        // Without preferred: base/main — still must not invent epic/z via list.last()
+        let (behind_main, branch_main) =
+            check_worktree_staleness(path, None).expect("staleness without preferred");
+        assert_eq!(branch_main, "main");
+        assert_eq!(behind_main, 0);
+        assert!(!branch_main.starts_with("epic/"));
+    }
+
+    #[test]
+    fn check_worktree_staleness_missing_path_returns_none() {
+        assert!(check_worktree_staleness("/nonexistent/worktree/path", Some("epic/a")).is_none());
     }
 }

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -1996,7 +1996,8 @@ pub(crate) fn resolve_transcript(
 ) -> TranscriptResolution {
     match cli {
         cas_mux::SupervisorCli::Grok => resolve_grok_transcript(base_dir, clone_path, session_id),
-        cas_mux::SupervisorCli::Claude | cas_mux::SupervisorCli::Codex => {
+        cas_mux::SupervisorCli::Codex => resolve_codex_transcript(base_dir, clone_path, session_id),
+        cas_mux::SupervisorCli::Claude => {
             resolve_claude_transcript(base_dir, clone_path, session_id)
         }
     }
@@ -2138,6 +2139,134 @@ fn resolve_grok_transcript(
     }
 }
 
+// ---------------------------------------------------------------------------
+// cas-c655: Codex rollout resolution.
+//
+// Codex does NOT use Claude's `~/.claude/projects/<escaped-cwd>/<session>.jsonl`
+// layout. Factory workers get a CAS session id of the form
+// `codex-<name>-<uuid>` (see `PtyConfig::codex`), but on-disk rollouts live at:
+//   ~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>-<rollout-uuid>.jsonl
+// with `session_meta.payload.cwd` equal to the worker's clone_path and a
+// different rollout UUID than the CAS session id. Matching is therefore by
+// cwd (primary) and by rollout UUID substring in the filename (secondary —
+// useful only when the caller already knows the rollout id).
+// ---------------------------------------------------------------------------
+
+/// `~/.codex/sessions` — Codex CLI's per-user rollout root.
+/// `CODEX_HOME` overrides the base directory when set (mirrors Codex's own
+/// env-var convention). Returns `None` if neither resolves.
+pub(crate) fn default_codex_sessions_dir() -> Option<std::path::PathBuf> {
+    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
+        return Some(std::path::PathBuf::from(codex_home).join("sessions"));
+    }
+    dirs::home_dir().map(|h| h.join(".codex").join("sessions"))
+}
+
+fn synthesized_codex_transcript_path(clone_path: &str, session_id: &str) -> String {
+    format!(
+        "~/.codex/sessions/<YYYY/MM/DD>/rollout-*-*.jsonl (cwd={clone_path}; cas_session={session_id})"
+    )
+}
+
+fn synthesized_unknown_codex_clone_path(session_id: &str) -> String {
+    format!(
+        "~/.codex/sessions/<YYYY/MM/DD>/rollout-*-*.jsonl (clone path unknown; cas_session={session_id})"
+    )
+}
+
+/// Read `payload.cwd` from the first JSONL line when it is a `session_meta`
+/// event. Returns `None` on any parse/IO failure — callers treat that as
+/// "this rollout does not match by cwd".
+pub(crate) fn codex_rollout_cwd(path: &std::path::Path) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut line = String::new();
+    std::io::BufRead::read_line(&mut reader, &mut line).ok()?;
+    let value: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
+    // Be tolerant of missing/mismatched type — still try payload.cwd.
+    value
+        .get("payload")
+        .and_then(|p| p.get("cwd"))
+        .and_then(|c| c.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Scan budget for `**/rollout-*.jsonl` under the sessions root. Codex hosts
+/// accumulate hundreds of historical rollouts; matching by cwd only needs
+/// recent ones, so we mtime-sort and cap the walk (cas-c655 / cas-900b cap
+/// spirit).
+const MAX_CODEX_ROLLOUT_SCAN: usize = 200;
+
+/// Collect recent rollout paths under `sessions_dir`, newest mtime first.
+fn collect_codex_rollouts(sessions_dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let pattern = format!("{}/**/rollout-*.jsonl", sessions_dir.to_string_lossy());
+    let iter = match glob::glob(&pattern) {
+        Ok(it) => it,
+        Err(_) => return Vec::new(),
+    };
+    let mut all: Vec<std::path::PathBuf> = iter.flatten().collect();
+    all.sort_by_key(|p| {
+        std::fs::metadata(p)
+            .and_then(|m| m.modified())
+            .ok()
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+    all.reverse(); // newest first
+    if all.len() > MAX_CODEX_ROLLOUT_SCAN {
+        all.truncate(MAX_CODEX_ROLLOUT_SCAN);
+    }
+    all
+}
+
+/// Whether `path`'s filename contains `session_id` (rollout UUID match).
+fn codex_rollout_filename_matches_session(path: &std::path::Path, session_id: &str) -> bool {
+    if session_id.is_empty() {
+        return false;
+    }
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .is_some_and(|name| name.contains(session_id))
+}
+
+fn resolve_codex_transcript(
+    sessions_dir: Option<&std::path::Path>,
+    clone_path: Option<&str>,
+    session_id: &str,
+) -> TranscriptResolution {
+    let synthesized = clone_path
+        .map(|p| synthesized_codex_transcript_path(p, session_id))
+        .unwrap_or_else(|| synthesized_unknown_codex_clone_path(session_id));
+    let Some(dir) = sessions_dir else {
+        return TranscriptResolution::Synthesized(synthesized);
+    };
+    let candidates = collect_codex_rollouts(dir);
+    let mut matches = Vec::new();
+    let mut truncated = false;
+    for path in candidates {
+        let cwd_hit = clone_path
+            .map(|cwd| codex_rollout_cwd(&path).as_deref() == Some(cwd))
+            .unwrap_or(false);
+        let id_hit = codex_rollout_filename_matches_session(&path, session_id);
+        if !cwd_hit && !id_hit {
+            continue;
+        }
+        if matches.len() >= MAX_TRANSCRIPT_CANDIDATES {
+            truncated = true;
+            break;
+        }
+        matches.push(path);
+    }
+    match matches.len() {
+        0 => TranscriptResolution::Synthesized(synthesized),
+        1 => TranscriptResolution::Resolved(matches.remove(0)),
+        _ => TranscriptResolution::Ambiguous {
+            matches,
+            synthesized,
+            truncated,
+        },
+    }
+}
+
 /// Render the transcript block for `worker_status` output. Always surfaces
 /// the raw `session_id` so a supervisor who doesn't trust our resolution
 /// can grep the projects tree themselves (cas-900b AC).
@@ -2152,9 +2281,8 @@ fn format_transcript_block(
 ) -> String {
     let base_dir = match cli {
         cas_mux::SupervisorCli::Grok => default_grok_sessions_dir(),
-        cas_mux::SupervisorCli::Claude | cas_mux::SupervisorCli::Codex => {
-            default_claude_projects_dir()
-        }
+        cas_mux::SupervisorCli::Codex => default_codex_sessions_dir(),
+        cas_mux::SupervisorCli::Claude => default_claude_projects_dir(),
     };
     let resolution = resolve_transcript(base_dir.as_deref(), clone_path, session_id, cli);
     render_transcript_block(&resolution, session_id, base_dir.is_some())
@@ -3104,6 +3232,146 @@ effort = "high"
             got,
             Some(std::path::PathBuf::from("/custom/grok/home/sessions"))
         );
+    }
+
+    // --- cas-c655: Codex rollout resolution ---------------------------------
+
+    /// Build `sessions/YYYY/MM/DD/rollout-...jsonl` with a `session_meta`
+    /// first line carrying `cwd` — matches Codex CLI's on-disk layout.
+    fn fake_codex_sessions_dir(
+        rollouts: &[(&str /* relative path under sessions */, &str /* cwd */)],
+    ) -> (tempfile::TempDir, std::path::PathBuf) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sessions = tmp.path().join("sessions");
+        for (rel, cwd) in rollouts {
+            let path = sessions.join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            let meta = serde_json::json!({
+                "timestamp": "2026-07-21T12:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "session_id": "019f84af-3121-7950-ba14-b01db2dad6c7",
+                    "cwd": cwd,
+                    "originator": "codex-tui"
+                }
+            });
+            std::fs::write(&path, format!("{meta}\n")).unwrap();
+        }
+        (tmp, sessions)
+    }
+
+    #[test]
+    fn default_codex_sessions_dir_honors_codex_home_override() {
+        let _lock = crate::hooks::test_env_lock();
+        let old = std::env::var("CODEX_HOME").ok();
+        unsafe {
+            std::env::set_var("CODEX_HOME", "/custom/codex/home");
+        }
+        let got = default_codex_sessions_dir();
+        unsafe {
+            match &old {
+                Some(v) => std::env::set_var("CODEX_HOME", v),
+                None => std::env::remove_var("CODEX_HOME"),
+            }
+        }
+        assert_eq!(
+            got,
+            Some(std::path::PathBuf::from("/custom/codex/home/sessions"))
+        );
+    }
+
+    #[test]
+    fn resolve_codex_transcript_matches_by_cwd() {
+        let clone = "/home/pippenz/Petrastella/ozer/.cas/worktrees/worker-android";
+        let rel = "2026/07/21/rollout-2026-07-21T08-38-21-019f84af-3121-7950-ba14-b01db2dad6c7.jsonl";
+        let (_tmp, sessions) = fake_codex_sessions_dir(&[(rel, clone)]);
+        // CAS session id is NOT the rollout UUID — resolution must use cwd.
+        let cas_session = "codex-worker-android-2f828ac6-deadbeefcafe";
+        let got = resolve_transcript(
+            Some(&sessions),
+            Some(clone),
+            cas_session,
+            cas_mux::SupervisorCli::Codex,
+        );
+        let expected = sessions.join(rel);
+        assert_eq!(got, TranscriptResolution::Resolved(expected));
+    }
+
+    #[test]
+    fn resolve_codex_transcript_matches_by_rollout_uuid_in_filename() {
+        let clone = "/tmp/other-worktree";
+        let uuid = "019f84af-3121-7950-ba14-b01db2dad6c7";
+        let rel = format!("2026/07/21/rollout-2026-07-21T08-38-21-{uuid}.jsonl");
+        let (_tmp, sessions) = fake_codex_sessions_dir(&[(&rel, clone)]);
+        // Even with a mismatched/missing clone_path match path, filename
+        // UUID lookup works when the caller has the rollout id.
+        let got = resolve_transcript(
+            Some(&sessions),
+            Some("/tmp/unrelated"),
+            uuid,
+            cas_mux::SupervisorCli::Codex,
+        );
+        let expected = sessions.join(rel);
+        assert_eq!(got, TranscriptResolution::Resolved(expected));
+    }
+
+    #[test]
+    fn resolve_codex_transcript_synthesized_on_no_match() {
+        let (_tmp, sessions) = fake_codex_sessions_dir(&[(
+            "2026/07/21/rollout-other.jsonl",
+            "/tmp/other",
+        )]);
+        let clone = "/tmp/missing-worker";
+        let cas_session = "codex-worker-x-aaaa";
+        let got = resolve_transcript(
+            Some(&sessions),
+            Some(clone),
+            cas_session,
+            cas_mux::SupervisorCli::Codex,
+        );
+        assert_eq!(
+            got,
+            TranscriptResolution::Synthesized(synthesized_codex_transcript_path(
+                clone,
+                cas_session
+            ))
+        );
+    }
+
+    #[test]
+    fn resolve_codex_transcript_no_sessions_dir_is_synthesized() {
+        let clone = "/tmp/w";
+        let session = "codex-worker-x-aaaa";
+        let got = resolve_transcript(None, Some(clone), session, cas_mux::SupervisorCli::Codex);
+        assert_eq!(
+            got,
+            TranscriptResolution::Synthesized(synthesized_codex_transcript_path(clone, session))
+        );
+    }
+
+    #[test]
+    fn resolve_codex_transcript_no_clone_path_falls_back_to_placeholder() {
+        let (_tmp, sessions) = fake_codex_sessions_dir(&[]);
+        let session = "codex-worker-x-aaaa";
+        let got = resolve_transcript(Some(&sessions), None, session, cas_mux::SupervisorCli::Codex);
+        assert_eq!(
+            got,
+            TranscriptResolution::Synthesized(synthesized_unknown_codex_clone_path(session))
+        );
+    }
+
+    #[test]
+    fn codex_rollout_cwd_reads_session_meta() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("rollout.jsonl");
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "payload": { "cwd": "/work/tree", "session_id": "abc" }
+        });
+        std::fs::write(&path, format!("{meta}\n")).unwrap();
+        assert_eq!(codex_rollout_cwd(&path).as_deref(), Some("/work/tree"));
     }
 
     #[test]

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -1114,7 +1114,6 @@ impl CasService {
     ) -> Result<CallToolResult, McpError> {
         use crate::store::{open_agent_store, open_task_store};
         use cas_types::{AgentRole, AgentStatus, TaskStatus, TaskType};
-        use std::path::Path;
 
         let store = open_agent_store(&self.inner.cas_root).map_err(|e| {
             Self::error(
@@ -1203,23 +1202,20 @@ impl CasService {
         let mut failed = Vec::new();
 
         for worker in workers {
-            let clone_path = match worker.metadata.get("clone_path") {
-                Some(p) => p.clone(),
-                None => {
-                    skipped.push(format!("{} (missing clone_path metadata)", worker.name));
-                    continue;
-                }
-            };
-            let path = Path::new(&clone_path);
-            if !path.exists() {
-                skipped.push(format!(
-                    "{} (clone path not found: {})",
-                    worker.name, clone_path
-                ));
+            // cas-f53c: same path resolution as worker_status — do not require
+            // clone_path metadata when the convention worktree already exists
+            // (common race right after isolate spawn).
+            let resolve = resolve_worker_clone_path(&self.inner.cas_root, &worker);
+            if let Some(reason) = sync_skip_reason_for_clone_resolve(&worker.name, &resolve) {
+                skipped.push(reason);
                 continue;
             }
+            let WorkerClonePathResolve::Ready(path) = resolve else {
+                // Exhaustive: skip helper already covered NotOnDisk.
+                continue;
+            };
 
-            match sync_worker_clone(path, &sync_ref) {
+            match sync_worker_clone(&path, &sync_ref) {
                 Ok(details) => synced.push(format!("{} ({})", worker.name, details)),
                 Err(err) => failed.push(format!("{} ({})", worker.name, err)),
             }
@@ -1639,36 +1635,101 @@ struct WorkerWorktreeStatus {
     git_info: String,
 }
 
+/// cas-f53c: shared resolution for worker clone/worktree path used by both
+/// `worker_status` and `sync_all_workers`.
+///
+/// Priority when a path exists on disk:
+/// 1. `agent.metadata["clone_path"]` if present and exists
+/// 2. Convention path `{cas_root}/worktrees/{worker_name}` if it exists
+///
+/// When nothing is on disk, returns `NotOnDisk` with the best candidate path
+/// for messaging (metadata if set, else convention). Sync treats that as a
+/// **retryable** skip (registration/provisioning lag), not a success.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WorkerClonePathResolve {
+    /// Worktree path exists and is ready for git ops / status.
+    Ready(std::path::PathBuf),
+    /// No worktree on disk at metadata or convention path.
+    NotOnDisk {
+        candidate: std::path::PathBuf,
+        /// True when `clone_path` metadata was set (even if the path is missing).
+        had_metadata: bool,
+    },
+}
+
+fn resolve_worker_clone_path(
+    cas_root: &std::path::Path,
+    agent: &cas_types::Agent,
+) -> WorkerClonePathResolve {
+    let metadata_path = agent
+        .metadata
+        .get("clone_path")
+        .map(|s| std::path::PathBuf::from(s));
+    let convention_path = cas_root.join("worktrees").join(&agent.name);
+
+    if let Some(ref meta) = metadata_path {
+        if meta.exists() {
+            return WorkerClonePathResolve::Ready(meta.clone());
+        }
+    }
+    if convention_path.exists() {
+        return WorkerClonePathResolve::Ready(convention_path);
+    }
+
+    WorkerClonePathResolve::NotOnDisk {
+        candidate: metadata_path.unwrap_or(convention_path),
+        had_metadata: agent.metadata.contains_key("clone_path"),
+    }
+}
+
+/// Human-readable skip reason for `sync_all_workers` when no worktree is ready.
+/// Pure for unit testing (cas-f53c).
+fn sync_skip_reason_for_clone_resolve(
+    worker_name: &str,
+    resolve: &WorkerClonePathResolve,
+) -> Option<String> {
+    match resolve {
+        WorkerClonePathResolve::Ready(_) => None,
+        WorkerClonePathResolve::NotOnDisk {
+            candidate,
+            had_metadata: false,
+        } => Some(format!(
+            "{worker_name} (registration in progress or no worktree — retry sync after \
+             isolate spawn completes; expected path: {})",
+            candidate.display()
+        )),
+        WorkerClonePathResolve::NotOnDisk {
+            candidate,
+            had_metadata: true,
+        } => Some(format!(
+            "{worker_name} (clone path not found: {} — retry if spawn still provisioning)",
+            candidate.display()
+        )),
+    }
+}
+
 fn collect_worker_worktree_status(
     cas_root: &std::path::Path,
     agent: &cas_types::Agent,
 ) -> WorkerWorktreeStatus {
-    let metadata_clone_path = agent.metadata.get("clone_path").cloned();
-    let inferred_path = cas_root.join("worktrees").join(&agent.name);
-
-    let resolved_path = metadata_clone_path
-        .clone()
-        .filter(|path| std::path::Path::new(path).exists())
-        .or_else(|| {
-            inferred_path
-                .exists()
-                .then(|| inferred_path.display().to_string())
-        });
-
-    if let Some(clone_path) = resolved_path {
-        let gs = collect_worker_git_status(std::path::Path::new(&clone_path));
-        return WorkerWorktreeStatus {
-            clone_info: format!("\n    Clone: {clone_path}"),
-            git_info: format_worker_git_status(&gs),
-            clone_path: Some(clone_path),
-        };
-    }
-
-    let missing_path = metadata_clone_path.unwrap_or_else(|| inferred_path.display().to_string());
-    WorkerWorktreeStatus {
-        clone_info: format!("\n    Clone: {missing_path} [missing-worktree]"),
-        git_info: "\n    git: missing-worktree".to_string(),
-        clone_path: Some(missing_path),
+    match resolve_worker_clone_path(cas_root, agent) {
+        WorkerClonePathResolve::Ready(path) => {
+            let clone_path = path.display().to_string();
+            let gs = collect_worker_git_status(&path);
+            WorkerWorktreeStatus {
+                clone_info: format!("\n    Clone: {clone_path}"),
+                git_info: format_worker_git_status(&gs),
+                clone_path: Some(clone_path),
+            }
+        }
+        WorkerClonePathResolve::NotOnDisk { candidate, .. } => {
+            let missing_path = candidate.display().to_string();
+            WorkerWorktreeStatus {
+                clone_info: format!("\n    Clone: {missing_path} [missing-worktree]"),
+                git_info: "\n    git: missing-worktree".to_string(),
+                clone_path: Some(missing_path),
+            }
+        }
     }
 }
 
@@ -4005,6 +4066,96 @@ effort = "high"
             out.contains("not pushed") || out.contains("none"),
             "unpushed state must be visible in output: {out}"
         );
+    }
+
+    // --- cas-f53c: sync_all_workers clone_path resolution -----------------
+
+    #[test]
+    fn resolve_worker_clone_path_uses_convention_when_metadata_absent_and_worktree_exists() {
+        let (_tmp, project) = setup_factory_project_with_worker_worktrees(&["recipes-fixer"]);
+        let cas_root = project.join(".cas");
+        let expected = cas_root.join("worktrees/recipes-fixer");
+        let agent = cas_types::Agent::new_with_role(
+            "session-1".to_string(),
+            "recipes-fixer".to_string(),
+            AgentRole::Worker,
+        );
+        // No clone_path metadata — the post-spawn race in the bug report.
+        assert!(!agent.metadata.contains_key("clone_path"));
+
+        match resolve_worker_clone_path(&cas_root, &agent) {
+            WorkerClonePathResolve::Ready(path) => {
+                assert_eq!(path, expected);
+            }
+            other => panic!("expected Ready(convention path), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_worker_clone_path_prefers_existing_metadata_over_convention() {
+        let (_tmp, project) =
+            setup_factory_project_with_worker_worktrees(&["named-a", "named-b"]);
+        let cas_root = project.join(".cas");
+        let meta_path = cas_root.join("worktrees/named-b");
+        let mut agent = cas_types::Agent::new_with_role(
+            "session-1".to_string(),
+            "named-a".to_string(),
+            AgentRole::Worker,
+        );
+        agent.metadata.insert(
+            "clone_path".to_string(),
+            meta_path.to_string_lossy().to_string(),
+        );
+
+        match resolve_worker_clone_path(&cas_root, &agent) {
+            WorkerClonePathResolve::Ready(path) => assert_eq!(path, meta_path),
+            other => panic!("expected Ready(metadata path), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_worker_clone_path_not_on_disk_when_neither_exists() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let cas_root = tmp.path().join(".cas");
+        std::fs::create_dir_all(&cas_root).unwrap();
+        let agent = cas_types::Agent::new_with_role(
+            "session-1".to_string(),
+            "ghost-worker".to_string(),
+            AgentRole::Worker,
+        );
+
+        match resolve_worker_clone_path(&cas_root, &agent) {
+            WorkerClonePathResolve::NotOnDisk {
+                candidate,
+                had_metadata,
+            } => {
+                assert!(!had_metadata);
+                assert_eq!(candidate, cas_root.join("worktrees/ghost-worker"));
+            }
+            other => panic!("expected NotOnDisk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sync_skip_reason_is_retryable_when_metadata_missing_and_no_worktree() {
+        let resolve = WorkerClonePathResolve::NotOnDisk {
+            candidate: std::path::PathBuf::from("/proj/.cas/worktrees/w1"),
+            had_metadata: false,
+        };
+        let msg = sync_skip_reason_for_clone_resolve("w1", &resolve).expect("skip reason");
+        assert!(
+            msg.contains("registration in progress") || msg.contains("retry"),
+            "must be retryable, not silent missing-metadata: {msg}"
+        );
+        assert!(
+            !msg.contains("missing clone_path metadata"),
+            "old skip text must not return: {msg}"
+        );
+        assert!(sync_skip_reason_for_clone_resolve(
+            "w1",
+            &WorkerClonePathResolve::Ready(std::path::PathBuf::from("/x"))
+        )
+        .is_none());
     }
 
     #[test]

--- a/cas-cli/src/mcp/tools/service/factory_remind.rs
+++ b/cas-cli/src/mcp/tools/service/factory_remind.rs
@@ -96,6 +96,13 @@ impl CasService {
 
         let ttl_secs = req.remind_ttl_secs.unwrap_or(3600);
 
+        // cas-fcd4: bind event-based (and all) reminds to the registering factory
+        // session so concurrent factories sharing cas.db do not cross-fire.
+        let session_id = std::env::var("CAS_FACTORY_SESSION")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         if has_delay {
             let delay_secs = req.remind_delay_secs.unwrap();
             if delay_secs <= 0 {
@@ -117,6 +124,7 @@ impl CasService {
                     None,
                     None,
                     ttl_secs,
+                    session_id.as_deref(),
                 )
                 .map_err(|e| {
                     Self::error(
@@ -195,6 +203,7 @@ impl CasService {
                     Some(&event_type),
                     filter.as_ref(),
                     ttl_secs,
+                    session_id.as_deref(),
                 )
                 .map_err(|e| {
                     Self::error(
@@ -214,8 +223,13 @@ impl CasService {
                 None => String::new(),
             };
 
+            let session_desc = match &session_id {
+                Some(s) => format!(", session: {s}"),
+                None => String::new(),
+            };
+
             Ok(Self::success(format!(
-                "Reminder #{id} set (event-based, fires on {event_type}{filter_desc}{target_desc})\nMessage: {message}"
+                "Reminder #{id} set (event-based, fires on {event_type}{filter_desc}{target_desc}{session_desc})\nMessage: {message}"
             )))
         }
     }

--- a/cas-cli/src/mcp/tools/service/mod.rs
+++ b/cas-cli/src/mcp/tools/service/mod.rs
@@ -106,6 +106,8 @@ pub struct WorktreeRequest {
     pub force: Option<bool>,
     /// Explicit trunk merge intent (cas-0b32) — independent of force.
     pub allow_trunk: Option<bool>,
+    /// cas-369f: remove worktree after merge (independent of force=dirty).
+    pub cleanup: Option<bool>,
 }
 
 // ============================================================================
@@ -594,6 +596,7 @@ impl CasService {
                         dry_run: req.dry_run,
                         force: req.force,
                         allow_trunk: req.allow_trunk,
+                        cleanup: req.cleanup,
                     };
                     match wt_action {
                         "create" => this.worktree_create(wt_req).await,

--- a/cas-cli/src/mcp/tools/service/worktree_verification_team_ops.rs
+++ b/cas-cli/src/mcp/tools/service/worktree_verification_team_ops.rs
@@ -59,6 +59,7 @@ impl CasService {
                 req.force.unwrap_or(false),
                 req.task_id.as_deref(),
                 req.allow_trunk.unwrap_or(false),
+                req.cleanup,
             )
             .await
     }

--- a/cas-cli/src/mcp/tools/types/task.rs
+++ b/cas-cli/src/mcp/tools/types/task.rs
@@ -251,8 +251,10 @@ pub struct TaskUpdateRequest {
     #[serde(default)]
     pub external_ref: Option<String>,
 
-    /// Update assignee
-    #[schemars(description = "New assignee")]
+    /// Update assignee. Empty string clears (unassigns). Omit to leave unchanged.
+    #[schemars(
+        description = "New assignee (worker display name). Pass empty string to clear/unassign; omit to leave unchanged."
+    )]
     #[serde(default)]
     pub assignee: Option<String>,
 

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -30,7 +30,7 @@ mod branch_visibility;
 mod imports;
 mod init;
 mod panels_and_modes;
-mod render_and_ops;
+pub(crate) mod render_and_ops;
 mod sidecar_and_selection;
 
 pub(crate) use branch_visibility::BranchAheadBehind;

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -1,4 +1,4 @@
-use crate::store::open_task_store;
+use crate::store::{open_agent_store, open_task_store};
 use crate::ui::factory::app::imports::*;
 use crate::worktree::RemoveOutcome;
 
@@ -95,19 +95,26 @@ fn worker_has_open_tasks(cas_dir: &std::path::Path, agent_id: &str) -> bool {
     }
 }
 
-/// cas-6913: pre-assign `task_id` to the just-spawned `worker_name`, so the
-/// worker's very first `task action=mine` shows it without the supervisor
-/// needing to send a follow-up assignment message. Assignees are display
-/// names, not session IDs (cas-dbbb, same convention as `task action=start`'s
-/// auto-assign in cas-6945's task/lifecycle.rs).
+/// cas-6913 / cas-7a94: pre-assign `task_id` to `worker_name` so the worker's
+/// first `task action=mine` shows it without a follow-up assignment message.
+/// Assignees are display names, not session IDs (cas-dbbb).
 ///
-/// Best-effort and silent on failure by design: `finish_worker_spawn` calls
-/// this after the worker's PTY is already running, so raising an error here
-/// has nowhere useful to go — it would only orphan a live process. Every
-/// failure path is logged instead so it's diagnosable without being fatal.
-/// Never overwrites an existing assignee (e.g. a concurrent supervisor
-/// action beat the spawn to it).
-fn assign_task_to_new_worker(cas_dir: &std::path::Path, task_id: &str, worker_name: &str) {
+/// Called once the worker name is known (after `prepare_worker_spawn`, before
+/// the isolate worktree finishes) and again at `finish_worker_spawn` as a
+/// confirm path — so codex+isolate async gaps cannot skip the binding.
+///
+/// Best-effort and silent on failure by design: callers may already have a
+/// live PTY, so raising here has nowhere useful to go. Every failure path is
+/// logged instead. Never overwrites a *different* assignee; re-assigning to
+/// the same worker is a no-op success (finish-path confirm after early assign).
+///
+/// Returns `true` when the task is assigned to `worker_name` after this call
+/// (including already-ours), `false` on any miss/skip/error.
+pub(crate) fn assign_task_to_new_worker(
+    cas_dir: &std::path::Path,
+    task_id: &str,
+    worker_name: &str,
+) -> bool {
     let store = match open_task_store(cas_dir) {
         Ok(store) => store,
         Err(e) => {
@@ -115,7 +122,7 @@ fn assign_task_to_new_worker(cas_dir: &std::path::Path, task_id: &str, worker_na
                 task_id, worker_name, error = %e,
                 "cas-6913: failed to open task store for spawn-time task pre-assignment"
             );
-            return;
+            return false;
         }
     };
 
@@ -126,30 +133,188 @@ fn assign_task_to_new_worker(cas_dir: &std::path::Path, task_id: &str, worker_na
                 task_id, worker_name, error = %e,
                 "cas-6913: task not found for spawn-time pre-assignment"
             );
-            return;
+            return false;
         }
     };
 
     if let Some(ref existing) = task.assignee {
+        if existing == worker_name {
+            // Early-assign already pinned this worker (cas-7a94 isolate path).
+            return true;
+        }
         tracing::warn!(
             task_id, worker_name, existing_assignee = %existing,
             "cas-6913: task already has an assignee — not overwriting at spawn-time pre-assignment"
         );
-        return;
+        return false;
     }
 
     let mut updated = task;
     updated.assignee = Some(worker_name.to_string());
+    updated.updated_at = chrono::Utc::now();
     match store.update(&updated) {
         Ok(()) => {
-            tracing::info!(task_id, worker_name, "cas-6913: pre-assigned task to newly spawned worker");
+            tracing::info!(
+                task_id,
+                worker_name,
+                "cas-6913: pre-assigned task to newly spawned worker"
+            );
+            true
         }
         Err(e) => {
             tracing::error!(
                 task_id, worker_name, error = %e,
                 "cas-6913: failed to persist spawn-time task pre-assignment"
             );
+            false
         }
+    }
+}
+
+/// cas-7a94: release tasks bound to a dead/shutting-down worker so they are
+/// claimable again without a manual `task action=reset`.
+///
+/// Covers pure spawn-time pre-assigns (`Open` + assignee, no lease) and the
+/// ghost `InProgress`/`Blocked` state left when a worker dies before a real
+/// lease is held. For each matching non-Closed task assigned to
+/// `worker_name`: force-release any lease, force status to `Open`, clear
+/// assignee. Closed and AwaitingMerge tasks are left alone (supervisor-owned
+/// merge parking must not be clobbered by worker teardown).
+///
+/// Best-effort: store failures are logged; returns the number of tasks cleared.
+pub(crate) fn release_worker_task_bindings(
+    cas_dir: &std::path::Path,
+    worker_name: &str,
+) -> usize {
+    let task_store = match open_task_store(cas_dir) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(
+                worker_name, error = %e,
+                "cas-7a94: failed to open task store for shutdown task release"
+            );
+            return 0;
+        }
+    };
+    let agent_store = match open_agent_store(cas_dir) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                worker_name, error = %e,
+                "cas-7a94: failed to open agent store for lease release — continuing with assignee clear"
+            );
+            // Continue without lease release — clearing assignee is still useful.
+            // agent_store calls below are skipped when this is None-equivalent by
+            // using a local flag.
+            return release_worker_task_bindings_tasks_only(&*task_store, worker_name, None);
+        }
+    };
+
+    release_worker_task_bindings_tasks_only(&*task_store, worker_name, Some(&*agent_store))
+}
+
+fn release_worker_task_bindings_tasks_only(
+    task_store: &dyn cas_store::TaskStore,
+    worker_name: &str,
+    agent_store: Option<&dyn cas_store::AgentStore>,
+) -> usize {
+    let assigned: Vec<_> = match task_store.list(None) {
+        Ok(tasks) => tasks
+            .into_iter()
+            .filter(|t| {
+                t.assignee.as_deref() == Some(worker_name)
+                    && matches!(
+                        t.status,
+                        cas_types::TaskStatus::Open
+                            | cas_types::TaskStatus::InProgress
+                            | cas_types::TaskStatus::Blocked
+                    )
+            })
+            .collect(),
+        Err(e) => {
+            tracing::error!(
+                worker_name, error = %e,
+                "cas-7a94: failed to list tasks for shutdown release"
+            );
+            return 0;
+        }
+    };
+
+    let mut released = 0usize;
+    for mut t in assigned {
+        if let Some(agents) = agent_store {
+            let _ = agents.release_lease_for_task(&t.id);
+        }
+        t.status = cas_types::TaskStatus::Open;
+        t.assignee = None;
+        t.updated_at = chrono::Utc::now();
+        match task_store.update(&t) {
+            Ok(()) => {
+                released += 1;
+                tracing::info!(
+                    task_id = %t.id,
+                    worker_name,
+                    "cas-7a94: released task binding on worker shutdown/cancel"
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    task_id = %t.id, worker_name, error = %e,
+                    "cas-7a94: failed to clear assignee on worker shutdown"
+                );
+            }
+        }
+    }
+    released
+}
+
+/// cas-7a94: release a single task by id if it is still bound to `worker_name`
+/// (or bound to anyone when `worker_name` is empty — used for failed pre-boots
+/// where we know the task_id but want a surgical clear only when assignee
+/// matches the aborted worker).
+pub(crate) fn release_preassign_if_bound(
+    cas_dir: &std::path::Path,
+    task_id: &str,
+    worker_name: &str,
+) {
+    let store = match open_task_store(cas_dir) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(
+                task_id, worker_name, error = %e,
+                "cas-7a94: failed to open task store for pre-assign release"
+            );
+            return;
+        }
+    };
+    let mut task = match store.get(task_id) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    if task.assignee.as_deref() != Some(worker_name) {
+        return;
+    }
+    if matches!(task.status, cas_types::TaskStatus::Closed | cas_types::TaskStatus::AwaitingMerge)
+    {
+        return;
+    }
+    if let Ok(agents) = open_agent_store(cas_dir) {
+        let _ = agents.release_lease_for_task(task_id);
+    }
+    task.status = cas_types::TaskStatus::Open;
+    task.assignee = None;
+    task.updated_at = chrono::Utc::now();
+    if let Err(e) = store.update(&task) {
+        tracing::error!(
+            task_id, worker_name, error = %e,
+            "cas-7a94: failed to release pre-assign after aborted spawn"
+        );
+    } else {
+        tracing::info!(
+            task_id,
+            worker_name,
+            "cas-7a94: released pre-assign after aborted/cancelled spawn"
+        );
     }
 }
 
@@ -477,11 +642,19 @@ impl FactoryApp {
         // Track the worker name
         self.worker_names.push(worker_name.clone());
 
-        // cas-6913: pre-assign the requested task now that the worker name
-        // is final. Best-effort — a failure here must not unwind the spawn,
-        // the worker's PTY is already running.
+        // cas-6913 / cas-7a94: pre-assign (or confirm early-assign) now that
+        // the worker name is final and the PTY is up. Best-effort — a failure
+        // here must not unwind the spawn.
         if let Some(ref task_id) = task_id {
-            assign_task_to_new_worker(self.cas_dir(), task_id, &worker_name);
+            let ok = assign_task_to_new_worker(self.cas_dir(), task_id, &worker_name);
+            if !ok {
+                tracing::warn!(
+                    task_id = %task_id,
+                    worker = %worker_name,
+                    "cas-7a94: finish_worker_spawn pre-assign did not stick — \
+                     worker boots without the requested task"
+                );
+            }
         }
 
         crate::ui::factory::app::queue_codex_worker_intro_prompt(
@@ -524,6 +697,20 @@ impl FactoryApp {
             anyhow::bail!("Worker '{name}' not found");
         }
 
+        // cas-7a94: release pre-assigns / leases bound to this worker *before*
+        // tearing down the agent record. Assignees are display names (cas-dbbb),
+        // so match on `name` not agent_id. Without this, spawn-time pre-assigns
+        // and InProgress ghosts survive shutdown and block transfer/start.
+        let cas_dir = self.cas_dir().to_path_buf();
+        let released = release_worker_task_bindings(&cas_dir, name);
+        if released > 0 {
+            tracing::info!(
+                worker = %name,
+                released,
+                "cas-7a94: released task bindings on shutdown_worker"
+            );
+        }
+
         // Mark agent as shutdown in CAS first; this must succeed so supervisor sees errors
         // instead of silently leaving stale idle agents in director panels.
         let agent_store = open_agent_store(self.cas_dir())?;
@@ -545,11 +732,12 @@ impl FactoryApp {
             )
         })?;
 
-        // Snapshot task state BEFORE graceful_shutdown() — that call zeroes the
-        // agent's active_tasks counter, which would otherwise mask open work.
+        // Snapshot task state AFTER release — should be free of this worker's
+        // Open/InProgress/Blocked bindings. Remaining non-Closed work (e.g.
+        // AwaitingMerge) still blocks worktree reclaim.
         let agent_id = agent.id.clone();
-        let cas_dir = self.cas_dir().to_path_buf();
-        let has_open_tasks = worker_has_open_tasks(&cas_dir, &agent_id);
+        let has_open_tasks = worker_has_open_tasks(&cas_dir, name)
+            || worker_has_open_tasks(&cas_dir, &agent_id);
 
         if let Err(e) = agent_store.graceful_shutdown(&agent.id) {
             // Best effort fallback to stale state for consistency, but still surface original failure.
@@ -1022,7 +1210,7 @@ mod tests {
         assert!(!worker_has_open_tasks(&cas_dir, "agent-d"));
     }
 
-    // --- cas-6913: spawn-time task pre-assignment -----------------------
+    // --- cas-6913 / cas-7a94: spawn-time task pre-assignment ------------
 
     /// AC3: `spawn_workers task_id=<id>` must result in the task's assignee
     /// being the newly spawned worker's display name — the same field
@@ -1036,7 +1224,10 @@ mod tests {
             .add(&task_with("cas-abc1", None, TaskStatus::Open))
             .unwrap();
 
-        assign_task_to_new_worker(&cas_dir, "cas-abc1", "swift-fox");
+        assert!(
+            assign_task_to_new_worker(&cas_dir, "cas-abc1", "swift-fox"),
+            "pre-assign should report success"
+        );
 
         let updated = store.get("cas-abc1").unwrap();
         assert_eq!(
@@ -1057,7 +1248,10 @@ mod tests {
             .add(&task_with("cas-abc1", Some("other-worker"), TaskStatus::Open))
             .unwrap();
 
-        assign_task_to_new_worker(&cas_dir, "cas-abc1", "swift-fox");
+        assert!(
+            !assign_task_to_new_worker(&cas_dir, "cas-abc1", "swift-fox"),
+            "must not steal another worker's assignment"
+        );
 
         let updated = store.get("cas-abc1").unwrap();
         assert_eq!(
@@ -1072,8 +1266,130 @@ mod tests {
     fn assign_task_to_new_worker_missing_task_does_not_panic() {
         let (_temp, cas_dir) = seeded_cas_dir();
         // No task seeded — "cas-missing" does not exist.
-        assign_task_to_new_worker(&cas_dir, "cas-missing", "swift-fox");
-        // Reaching this line without panicking is the assertion.
+        assert!(!assign_task_to_new_worker(
+            &cas_dir,
+            "cas-missing",
+            "swift-fox"
+        ));
+    }
+
+    /// cas-7a94: finish-path confirm after early-assign must treat
+    /// already-ours as success (no warn-and-skip that would look like failure).
+    #[test]
+    fn assign_task_to_new_worker_idempotent_for_same_worker() {
+        let (_temp, cas_dir) = seeded_cas_dir();
+        let store = crate::store::open_task_store(&cas_dir).unwrap();
+        store
+            .add(&task_with("cas-abc1", None, TaskStatus::Open))
+            .unwrap();
+
+        assert!(assign_task_to_new_worker(
+            &cas_dir,
+            "cas-abc1",
+            "recipes-fixer"
+        ));
+        assert!(
+            assign_task_to_new_worker(&cas_dir, "cas-abc1", "recipes-fixer"),
+            "confirm-path after early-assign must succeed for the same worker"
+        );
+        assert_eq!(
+            store.get("cas-abc1").unwrap().assignee.as_deref(),
+            Some("recipes-fixer")
+        );
+    }
+
+    // --- cas-7a94: shutdown / cancel must release pre-assigns -----------
+
+    /// Inverse bug: Open pre-assign to a dead worker must clear on release so
+    /// the next worker can transfer/start without a manual reset.
+    #[test]
+    fn release_worker_task_bindings_clears_open_preassign() {
+        let (_temp, cas_dir) = seeded_cas_dir();
+        let store = crate::store::open_task_store(&cas_dir).unwrap();
+        store
+            .add(&task_with(
+                "cas-7f61",
+                Some("recipes-fixer"),
+                TaskStatus::Open,
+            ))
+            .unwrap();
+
+        let n = release_worker_task_bindings(&cas_dir, "recipes-fixer");
+        assert_eq!(n, 1, "should clear the Open pre-assign");
+
+        let updated = store.get("cas-7f61").unwrap();
+        assert_eq!(updated.assignee, None, "assignee cleared");
+        assert_eq!(
+            updated.status,
+            TaskStatus::Open,
+            "Open stays Open"
+        );
+    }
+
+    /// Inverse bug (observed): InProgress ghost with no live agent / no lease
+    /// blocks transfer. Release must force Open + clear assignee.
+    #[test]
+    fn release_worker_task_bindings_resets_in_progress_ghost() {
+        let (_temp, cas_dir) = seeded_cas_dir();
+        let store = crate::store::open_task_store(&cas_dir).unwrap();
+        store
+            .add(&task_with(
+                "cas-3d23",
+                Some("sow-auditor"),
+                TaskStatus::InProgress,
+            ))
+            .unwrap();
+
+        let n = release_worker_task_bindings(&cas_dir, "sow-auditor");
+        assert_eq!(n, 1);
+
+        let updated = store.get("cas-3d23").unwrap();
+        assert_eq!(updated.assignee, None);
+        assert_eq!(updated.status, TaskStatus::Open);
+    }
+
+    /// Surgical release used when isolate prep fails after early assign.
+    #[test]
+    fn release_preassign_if_bound_only_clears_matching_worker() {
+        let (_temp, cas_dir) = seeded_cas_dir();
+        let store = crate::store::open_task_store(&cas_dir).unwrap();
+        store
+            .add(&task_with(
+                "cas-abc1",
+                Some("recipes-fixer"),
+                TaskStatus::Open,
+            ))
+            .unwrap();
+
+        // Wrong worker name → no-op
+        release_preassign_if_bound(&cas_dir, "cas-abc1", "other-worker");
+        assert_eq!(
+            store.get("cas-abc1").unwrap().assignee.as_deref(),
+            Some("recipes-fixer")
+        );
+
+        // Matching worker → cleared
+        release_preassign_if_bound(&cas_dir, "cas-abc1", "recipes-fixer");
+        assert_eq!(store.get("cas-abc1").unwrap().assignee, None);
+    }
+
+    /// Closed tasks must never be reopened by shutdown release.
+    #[test]
+    fn release_worker_task_bindings_skips_closed() {
+        let (_temp, cas_dir) = seeded_cas_dir();
+        let store = crate::store::open_task_store(&cas_dir).unwrap();
+        store
+            .add(&task_with(
+                "cas-done",
+                Some("dead-worker"),
+                TaskStatus::Closed,
+            ))
+            .unwrap();
+
+        assert_eq!(release_worker_task_bindings(&cas_dir, "dead-worker"), 0);
+        let t = store.get("cas-done").unwrap();
+        assert_eq!(t.assignee.as_deref(), Some("dead-worker"));
+        assert_eq!(t.status, TaskStatus::Closed);
     }
 
     // --- cas-9bc6: resolve_live_worker_harness reads from disk, not cache ----

--- a/cas-cli/src/ui/factory/app/render_and_ops/mod.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/mod.rs
@@ -1,4 +1,4 @@
-mod epic_workers;
+pub(crate) mod epic_workers;
 mod recording;
 mod rendering;
 mod worktree;

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -1208,6 +1208,14 @@ impl FactoryDaemon {
             };
 
             for reminder in &candidates {
+                // cas-fcd4: only fire reminds registered in this factory session
+                // (shared cas.db otherwise cross-fires concurrent sessions).
+                if !reminder_matches_factory_session(
+                    reminder.session_id.as_deref(),
+                    &self.session_name,
+                ) {
+                    continue;
+                }
                 if matches_event_filter(reminder, event) {
                     fire_reminder(
                         reminder,
@@ -1424,11 +1432,28 @@ fn fire_reminder(
     }
 }
 
+/// Whether this factory daemon session may fire the reminder (cas-fcd4).
+///
+/// Reminders registered with a non-empty `session_id` only fire when the
+/// processing daemon's session name matches. Legacy / non-factory reminds
+/// (`session_id` unset) still fire in any session so single-session behavior
+/// is unchanged.
+pub(crate) fn reminder_matches_factory_session(
+    reminder_session_id: Option<&str>,
+    current_session: &str,
+) -> bool {
+    match reminder_session_id.map(str::trim).filter(|s| !s.is_empty()) {
+        None => true,
+        Some(sid) => sid == current_session,
+    }
+}
+
 /// Check if a reminder's event filter matches a detected DirectorEvent.
 ///
 /// Uses JSON subset matching: every key-value in the filter must appear
 /// in the event's JSON representation. An empty or missing filter matches
-/// any event of the correct type.
+/// any event of the correct type (after session scoping — see
+/// [`reminder_matches_factory_session`]).
 fn matches_event_filter(
     reminder: &cas_store::Reminder,
     event: &crate::ui::factory::director::DirectorEvent,
@@ -1460,10 +1485,79 @@ fn is_exact_agent_name_match(agent: &AgentSummary, worker_name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_exact_agent_name_match;
+    use super::{
+        is_exact_agent_name_match, matches_event_filter, reminder_matches_factory_session,
+    };
     use crate::ui::factory::daemon::FactoryDaemon;
-    use crate::ui::factory::director::AgentSummary;
+    use crate::ui::factory::director::{AgentSummary, DirectorEvent};
     use cas_types::AgentStatus;
+
+    // -----------------------------------------------------------------------
+    // cas-fcd4: event remind session scoping
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn reminder_session_scope_blocks_foreign_factory_session() {
+        assert!(
+            !reminder_matches_factory_session(Some("session-a"), "session-b"),
+            "session A remind must not fire in session B"
+        );
+        assert!(
+            reminder_matches_factory_session(Some("session-a"), "session-a"),
+            "same-session must match"
+        );
+    }
+
+    #[test]
+    fn reminder_session_scope_legacy_none_matches_any_session() {
+        // Single-session / pre-cas-fcd4 rows keep working.
+        assert!(reminder_matches_factory_session(None, "session-a"));
+        assert!(reminder_matches_factory_session(None, "session-b"));
+        assert!(reminder_matches_factory_session(Some(""), "session-a"));
+        assert!(reminder_matches_factory_session(Some("  "), "session-b"));
+    }
+
+    #[test]
+    fn matches_event_filter_task_id_still_works() {
+        let reminder = cas_store::Reminder {
+            id: 1,
+            owner_id: "owner".into(),
+            target_id: "owner".into(),
+            message: "review".into(),
+            trigger_type: cas_store::ReminderTriggerType::Event,
+            trigger_at: None,
+            trigger_event: Some("task_completed".into()),
+            trigger_filter: Some(serde_json::json!({"task_id": "cas-keep"})),
+            status: cas_store::ReminderStatus::Pending,
+            ttl_secs: 3600,
+            created_at: chrono::Utc::now(),
+            fired_at: None,
+            cancelled_at: None,
+            fired_event: None,
+            session_id: Some("session-a".into()),
+        };
+        let match_event = DirectorEvent::TaskCompleted {
+            task_id: "cas-keep".into(),
+            task_title: "Keep".into(),
+            worker: "worker-1".into(),
+        };
+        let other_event = DirectorEvent::TaskCompleted {
+            task_id: "cas-other".into(),
+            task_title: "Other".into(),
+            worker: "worker-2".into(),
+        };
+        assert!(matches_event_filter(&reminder, &match_event));
+        assert!(!matches_event_filter(&reminder, &other_event));
+        // Session gate is separate: filter alone still matches; session blocks foreign.
+        assert!(reminder_matches_factory_session(
+            reminder.session_id.as_deref(),
+            "session-a"
+        ));
+        assert!(!reminder_matches_factory_session(
+            reminder.session_id.as_deref(),
+            "session-b"
+        ));
+    }
 
     #[test]
     fn test_agent_match_is_exact_not_substring() {

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -726,7 +726,31 @@ impl FactoryDaemon {
                 self.spawn_task.take().unwrap();
             // Remove from pending workers (boot pane transitions to real pane or disappears)
             self.app.remove_pending_worker(&pending_name);
+            // cas-7a94: if this worker was cancelled via shutdown while the
+            // isolate worktree was still building, drop the result and release
+            // any early pre-assign so the task is not stuck on a never-started
+            // worker.
+            let cancelled = self.dead_workers.contains(&pending_name);
             match handle.await {
+                Ok(Ok(_result)) if cancelled => {
+                    tracing::info!(
+                        worker = %pending_name,
+                        "cas-7a94: spawn finished after shutdown cancel — discarding pane, releasing pre-assign"
+                    );
+                    if let Some(ref task_id) = pending_task_id {
+                        crate::ui::factory::app::render_and_ops::epic_workers::release_preassign_if_bound(
+                            self.app.cas_dir(),
+                            task_id,
+                            &pending_name,
+                        );
+                    }
+                    crate::ui::factory::app::render_and_ops::epic_workers::release_worker_task_bindings(
+                        self.app.cas_dir(),
+                        &pending_name,
+                    );
+                    // Do not call finish_worker_spawn — the worktree (if any) is
+                    // left for the reaper; no PTY pane is registered.
+                }
                 Ok(Ok(result)) => {
                     // Build per-worker Teams config before finish_worker_spawn adds to worker list
                     let worker_name_for_teams = result.worker_name.clone();
@@ -744,10 +768,13 @@ impl FactoryDaemon {
                     if let Some(ref tc) = teams_config {
                         crate::ui::theme::register_agent_color(&tc.agent_name, &tc.agent_color);
                     }
-                    match self
-                        .app
-                        .finish_worker_spawn(result, teams_config, pending_spec, pending_task_id)
-                    {
+                    let task_id_for_finish = pending_task_id.clone();
+                    match self.app.finish_worker_spawn(
+                        result,
+                        teams_config,
+                        pending_spec,
+                        task_id_for_finish,
+                    ) {
                         Ok(name) => {
                             tracing::info!("Spawned worker (async): {}", name);
                             // A worker may reuse a retired name (e.g. a Codex worker
@@ -796,6 +823,15 @@ impl FactoryDaemon {
                                     ("reason", "finish_worker_spawn_failed"),
                                 ],
                             );
+                            // cas-7a94: early pre-assign may have bound the task —
+                            // release so a failed finish cannot leave a ghost assignee.
+                            if let Some(ref task_id) = pending_task_id {
+                                crate::ui::factory::app::render_and_ops::epic_workers::release_preassign_if_bound(
+                                    self.app.cas_dir(),
+                                    task_id,
+                                    &pending_name,
+                                );
+                            }
                             self.app.set_error(format!("Failed to finish spawn: {e}"));
                         }
                     }
@@ -805,6 +841,14 @@ impl FactoryDaemon {
                         "factory_worker_spawn_result",
                         vec![("success", "false"), ("reason", "background_spawn_failed")],
                     );
+                    // cas-7a94: isolate worktree failed after early pre-assign.
+                    if let Some(ref task_id) = pending_task_id {
+                        crate::ui::factory::app::render_and_ops::epic_workers::release_preassign_if_bound(
+                            self.app.cas_dir(),
+                            task_id,
+                            &pending_name,
+                        );
+                    }
                     self.app.set_error(format!("Failed to spawn worker: {e}"));
                 }
                 Err(e) => {
@@ -812,6 +856,13 @@ impl FactoryDaemon {
                         "factory_worker_spawn_result",
                         vec![("success", "false"), ("reason", "spawn_task_panicked")],
                     );
+                    if let Some(ref task_id) = pending_task_id {
+                        crate::ui::factory::app::render_and_ops::epic_workers::release_preassign_if_bound(
+                            self.app.cas_dir(),
+                            task_id,
+                            &pending_name,
+                        );
+                    }
                     self.app.set_error(format!("Spawn task panicked: {e}"));
                 }
             }
@@ -834,6 +885,18 @@ impl FactoryDaemon {
                 match self.app.prepare_worker_spawn(None, isolate) {
                     Ok(prep) => {
                         let worker_name = prep.worker_name.clone();
+                        // cas-7a94: bind task_id as soon as the worker name is
+                        // known — before the isolate worktree finishes — so
+                        // codex+isolate async gaps cannot skip pre-assign.
+                        // finish_worker_spawn confirms; failure/cancel paths
+                        // release via release_preassign_if_bound.
+                        if let Some(ref tid) = task_id {
+                            let _ = crate::ui::factory::app::render_and_ops::epic_workers::assign_task_to_new_worker(
+                                self.app.cas_dir(),
+                                tid,
+                                &worker_name,
+                            );
+                        }
                         self.app.add_pending_worker(worker_name.clone(), isolate);
                         self.spawn_task = Some((
                             worker_name,
@@ -864,6 +927,14 @@ impl FactoryDaemon {
                 match self.app.prepare_worker_spawn(Some(&name), isolate) {
                     Ok(prep) => {
                         let worker_name = prep.worker_name.clone();
+                        // cas-7a94: early pre-assign once name is final (see Anonymous).
+                        if let Some(ref tid) = task_id {
+                            let _ = crate::ui::factory::app::render_and_ops::epic_workers::assign_task_to_new_worker(
+                                self.app.cas_dir(),
+                                tid,
+                                &worker_name,
+                            );
+                        }
                         self.app.add_pending_worker(worker_name.clone(), isolate);
                         self.spawn_task = Some((
                             worker_name,
@@ -903,14 +974,75 @@ impl FactoryDaemon {
                         self.app.worker_names().iter().take(c).cloned().collect()
                     }
                 };
+
+                // cas-7a94: drop still-queued spawns for these names and release
+                // any early pre-assigns so "shutdown before boot finishes" cannot
+                // leave Open/InProgress ghosts on never-started workers.
+                {
+                    let stop_set: std::collections::HashSet<&str> =
+                        workers_to_stop.iter().map(String::as_str).collect();
+                    let cancel_all = names.is_empty() && count.unwrap_or(0) == 0;
+                    let mut kept = std::collections::VecDeque::new();
+                    while let Some(pending) = self.pending_spawns.pop_front() {
+                        match pending {
+                            PendingSpawn::Named {
+                                name,
+                                isolate,
+                                spec,
+                                task_id,
+                            } if cancel_all || stop_set.contains(name.as_str()) => {
+                                if let Some(ref tid) = task_id {
+                                    crate::ui::factory::app::render_and_ops::epic_workers::release_preassign_if_bound(
+                                        self.app.cas_dir(),
+                                        tid,
+                                        &name,
+                                    );
+                                }
+                                crate::ui::factory::app::render_and_ops::epic_workers::release_worker_task_bindings(
+                                    self.app.cas_dir(),
+                                    &name,
+                                );
+                                self.app.spawning_count =
+                                    self.app.spawning_count.saturating_sub(1);
+                                tracing::info!(
+                                    worker = %name,
+                                    "cas-7a94: cancelled pending spawn on shutdown — released pre-assign"
+                                );
+                                let _ = (isolate, spec); // consumed
+                            }
+                            PendingSpawn::Anonymous {
+                                isolate,
+                                spec,
+                                task_id,
+                            } if cancel_all => {
+                                // Anonymous names are only known once prepare runs;
+                                // if still in the queue, no early assign has fired yet.
+                                let _ = (isolate, spec, task_id);
+                                self.app.spawning_count =
+                                    self.app.spawning_count.saturating_sub(1);
+                            }
+                            other => kept.push_back(other),
+                        }
+                    }
+                    self.pending_spawns = kept;
+                }
+
                 if self.app.record_enabled() {
                     for name in &workers_to_stop {
                         let _ = self.app.stop_recording_for_pane(name).await;
                     }
                 }
                 // Track shut-down workers so their queued messages are dropped
+                // and any in-flight isolate spawn is discarded on completion.
                 for name in &workers_to_stop {
                     self.dead_workers.insert(name.clone());
+                    // Also release bindings for workers that never made it into
+                    // worker_names (early pre-assign only) — shutdown_worker
+                    // only runs for live workers.
+                    crate::ui::factory::app::render_and_ops::epic_workers::release_worker_task_bindings(
+                        self.app.cas_dir(),
+                        name,
+                    );
                 }
                 if let Err(e) = self.app.shutdown_workers(count, &names, force) {
                     let target = if !names.is_empty() {

--- a/cas-cli/src/worktree/manager/mod.rs
+++ b/cas-cli/src/worktree/manager/mod.rs
@@ -246,11 +246,16 @@ impl WorktreeManager {
         path.exists()
     }
 
-    /// Merge and cleanup a worktree
+    /// Merge a worktree into its parent branch, optionally removing it.
     ///
     /// # Arguments
     /// * `worktree` - The worktree to merge
-    /// * `force` - Force removal even if there are uncommitted changes
+    /// * `force` - Bypass dirty-tree protection only (cas-369f / cas-0b32).
+    ///   Does **not** imply worktree removal.
+    /// * `cleanup` - When true, remove the worktree directory and delete the
+    ///   branch after a successful merge. When false, leave both intact so a
+    ///   live factory worker can keep working mid-epic (cas-369f). Independent
+    ///   of `force` and of `config.cleanup_on_close` — callers decide.
     ///
     /// # Returns
     /// The merge commit hash if successful, or None if merge was skipped
@@ -258,6 +263,7 @@ impl WorktreeManager {
         &self,
         worktree: &mut Worktree,
         force: bool,
+        cleanup: bool,
     ) -> WorktreeResult<Option<String>> {
         // Check for uncommitted changes
         if !force && self.git.has_uncommitted_changes(&worktree.path)? {
@@ -285,8 +291,9 @@ impl WorktreeManager {
             None
         };
 
-        // Remove the worktree
-        if self.config.cleanup_on_close {
+        // cas-369f: force ≠ cleanup. Only remove when the caller explicitly
+        // requested cleanup (or System-A path that passed config-driven true).
+        if cleanup {
             self.git.remove_worktree(&worktree.path, force)?;
 
             // Delete the branch

--- a/cas-cli/src/worktree/manager/tests.rs
+++ b/cas-cli/src/worktree/manager/tests.rs
@@ -388,6 +388,131 @@ fn test_merge_workers_to_epic() {
     assert!(repo_path.join("worker-file.txt").exists());
 }
 
+/// cas-369f: mid-session merge with cleanup=false leaves worktree + branch.
+#[test]
+fn merge_and_cleanup_preserve_leaves_worktree_and_branch() {
+    let (_temp, repo_path) = create_test_repo();
+    let mut config = WorktreeConfig::default();
+    config.auto_merge = true;
+    config.cleanup_on_close = true; // config would clean — caller opts out
+    let mut manager = WorktreeManager::new(&repo_path, config).unwrap();
+
+    let epic_branch = manager.create_epic_branch("Preserve Merge").unwrap();
+    let mut worktree = manager.create_for_worker("preserve-worker").unwrap();
+    let wt_path = worktree.path.clone();
+    let worker_branch = worktree.branch.clone();
+
+    std::fs::write(wt_path.join("mid-epic.txt"), "still working").unwrap();
+    Command::new("git")
+        .args(["add", "mid-epic.txt"])
+        .current_dir(&wt_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "mid-epic work"])
+        .current_dir(&wt_path)
+        .output()
+        .unwrap();
+
+    worktree.parent_branch = epic_branch.clone();
+    let commit = manager
+        .merge_and_cleanup(&mut worktree, false, false)
+        .expect("merge preserve");
+    assert!(commit.is_some());
+
+    assert!(
+        wt_path.exists(),
+        "worktree path must remain when cleanup=false (mid-session)"
+    );
+    assert!(
+        manager.git.branch_exists(&worker_branch).unwrap(),
+        "factory branch must remain when cleanup=false"
+    );
+    manager.git.checkout(&epic_branch).unwrap();
+    assert!(
+        repo_path.join("mid-epic.txt").exists(),
+        "merge content must land on parent"
+    );
+}
+
+/// cas-369f: cleanup=true still consumes the worktree after merge.
+#[test]
+fn merge_and_cleanup_true_removes_worktree() {
+    let (_temp, repo_path) = create_test_repo();
+    let mut config = WorktreeConfig::default();
+    config.auto_merge = true;
+    let mut manager = WorktreeManager::new(&repo_path, config).unwrap();
+
+    let epic_branch = manager.create_epic_branch("Cleanup Merge").unwrap();
+    let mut worktree = manager.create_for_worker("cleanup-merge-worker").unwrap();
+    let wt_path = worktree.path.clone();
+    let worker_branch = worktree.branch.clone();
+
+    std::fs::write(wt_path.join("done.txt"), "lane done").unwrap();
+    Command::new("git")
+        .args(["add", "done.txt"])
+        .current_dir(&wt_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "done"])
+        .current_dir(&wt_path)
+        .output()
+        .unwrap();
+
+    worktree.parent_branch = epic_branch.clone();
+    manager
+        .merge_and_cleanup(&mut worktree, false, true)
+        .expect("merge cleanup");
+
+    assert!(
+        !wt_path.exists(),
+        "worktree must be removed when cleanup=true"
+    );
+    assert!(
+        !manager.git.branch_exists(&worker_branch).unwrap(),
+        "branch must be deleted when cleanup=true"
+    );
+}
+
+/// cas-369f: force=true on dirty tree merges without implying cleanup.
+#[test]
+fn merge_force_dirty_does_not_remove_when_cleanup_false() {
+    let (_temp, repo_path) = create_test_repo();
+    let mut config = WorktreeConfig::default();
+    config.auto_merge = true;
+    let mut manager = WorktreeManager::new(&repo_path, config).unwrap();
+
+    let epic_branch = manager.create_epic_branch("Force Dirty").unwrap();
+    let mut worktree = manager.create_for_worker("force-dirty-worker").unwrap();
+    let wt_path = worktree.path.clone();
+
+    std::fs::write(wt_path.join("committed.txt"), "c").unwrap();
+    Command::new("git")
+        .args(["add", "committed.txt"])
+        .current_dir(&wt_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "committed"])
+        .current_dir(&wt_path)
+        .output()
+        .unwrap();
+    // Dirty uncommitted change
+    std::fs::write(wt_path.join("dirty.txt"), "uncommitted").unwrap();
+
+    worktree.parent_branch = epic_branch;
+    // Without force, dirty fails
+    assert!(manager
+        .merge_and_cleanup(&mut worktree, false, false)
+        .is_err());
+    // force=true merges dirty; cleanup=false keeps path
+    manager
+        .merge_and_cleanup(&mut worktree, true, false)
+        .expect("force dirty merge preserve");
+    assert!(wt_path.exists(), "force must not imply cleanup");
+}
+
 #[test]
 fn test_cleanup_worker_branches_after_merge() {
     let (_temp, repo_path) = create_test_repo();

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -2987,3 +2987,176 @@ async fn test_factory_mode_normalizes_session_uuid_assignee_to_display_name() {
         "cas-dbbb: stored assignee must NOT retain session UUID '{WORKER_SESSION}' after normalization"
     );
 }
+
+// =============================================================================
+// cas-bf98: empty assignee clear must unassign — never remap to a live worker
+// =============================================================================
+
+/// Supervisor used `assignee=""` to clear so a worker would not hold two concurrent
+/// tasks. Factory-mode session-id normalization treated `""` as a session id and
+/// rewrote it to a live worker display name (e.g. hv-scope). Empty/whitespace must
+/// clear the assignee (None), not assign anyone.
+#[tokio::test]
+async fn test_factory_mode_empty_assignee_clears_without_remapping_to_live_worker() {
+    let (temp, service) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    let agent_store = open_agent_store(&cas_dir).expect("open agent store");
+    let task_store = cas::store::open_task_store(&cas_dir).expect("open task store");
+
+    // Live worker that must NOT receive a silent reassignment on clear.
+    const WORKER_SESSION: &str = "sess-uuid-bf98-hv-scope";
+    const WORKER_NAME: &str = "hv-scope";
+    const PRIOR_ASSIGNEE: &str = "std-life";
+
+    let worker =
+        cas::types::Agent::new(WORKER_SESSION.to_string(), WORKER_NAME.to_string());
+    agent_store.register(&worker).expect("register worker");
+
+    unsafe { std::env::set_var("CAS_FACTORY_MODE", "1") }
+
+    let created = service
+        .cas_task_create(Parameters(make_task_create_req(
+            "empty-assignee clear (cas-bf98)",
+        )))
+        .await
+        .expect("create task");
+    let task_id = extract_task_id(&extract_text(created))
+        .expect("task id")
+        .to_string();
+
+    // Seed a real assignee, then clear with empty string (supervisor intent).
+    service
+        .cas_task_update(Parameters(TaskUpdateRequest {
+            depth: None,
+            id: task_id.clone(),
+            title: None,
+            notes: None,
+            priority: None,
+            labels: None,
+            description: None,
+            design: None,
+            acceptance_criteria: None,
+            demo_statement: None,
+            execution_note: None,
+            external_ref: None,
+            assignee: Some(PRIOR_ASSIGNEE.to_string()),
+            status: None,
+            epic: None,
+            epic_verification_owner: None,
+        }))
+        .await
+        .expect("seed assignee");
+
+    let seeded = task_store.get(&task_id).expect("get after seed");
+    assert_eq!(
+        seeded.assignee.as_deref(),
+        Some(PRIOR_ASSIGNEE),
+        "precondition: assignee seeded to {PRIOR_ASSIGNEE}"
+    );
+
+    let clear_result = service
+        .cas_task_update(Parameters(TaskUpdateRequest {
+            depth: None,
+            id: task_id.clone(),
+            title: None,
+            notes: None,
+            priority: None,
+            labels: None,
+            description: None,
+            design: None,
+            acceptance_criteria: None,
+            demo_statement: None,
+            execution_note: None,
+            external_ref: None,
+            assignee: Some(String::new()),
+            status: None,
+            epic: None,
+            epic_verification_owner: None,
+        }))
+        .await
+        .expect("empty assignee update must succeed as clear");
+
+    unsafe { std::env::remove_var("CAS_FACTORY_MODE") }
+
+    let text = extract_text(clear_result);
+    assert!(
+        !text.contains("Normalized to display name"),
+        "cas-bf98: empty assignee must not session-id-normalize; got: {text}"
+    );
+    assert!(
+        !text.contains(WORKER_NAME),
+        "cas-bf98: clear must not mention live worker '{WORKER_NAME}'; got: {text}"
+    );
+
+    let task = task_store.get(&task_id).expect("get task after clear");
+    assert!(
+        task.assignee.is_none(),
+        "cas-bf98: empty assignee must unassign (None); got {:?}",
+        task.assignee
+    );
+    assert_ne!(
+        task.assignee.as_deref(),
+        Some(WORKER_NAME),
+        "cas-bf98: must never remap empty clear to live worker '{WORKER_NAME}'"
+    );
+    assert_ne!(
+        task.assignee.as_deref(),
+        Some(PRIOR_ASSIGNEE),
+        "cas-bf98: prior assignee must be cleared"
+    );
+
+    // Whitespace-only is also an explicit clear.
+    service
+        .cas_task_update(Parameters(TaskUpdateRequest {
+            depth: None,
+            id: task_id.clone(),
+            title: None,
+            notes: None,
+            priority: None,
+            labels: None,
+            description: None,
+            design: None,
+            acceptance_criteria: None,
+            demo_statement: None,
+            execution_note: None,
+            external_ref: None,
+            assignee: Some(PRIOR_ASSIGNEE.to_string()),
+            status: None,
+            epic: None,
+            epic_verification_owner: None,
+        }))
+        .await
+        .expect("re-seed");
+
+    unsafe { std::env::set_var("CAS_FACTORY_MODE", "1") }
+    service
+        .cas_task_update(Parameters(TaskUpdateRequest {
+            depth: None,
+            id: task_id.clone(),
+            title: None,
+            notes: None,
+            priority: None,
+            labels: None,
+            description: None,
+            design: None,
+            acceptance_criteria: None,
+            demo_statement: None,
+            execution_note: None,
+            external_ref: None,
+            assignee: Some("   \t  ".to_string()),
+            status: None,
+            epic: None,
+            epic_verification_owner: None,
+        }))
+        .await
+        .expect("whitespace assignee must clear");
+    unsafe { std::env::remove_var("CAS_FACTORY_MODE") }
+
+    let after_ws = task_store.get(&task_id).expect("get after whitespace clear");
+    assert!(
+        after_ws.assignee.is_none(),
+        "cas-bf98: whitespace-only assignee must unassign; got {:?}",
+        after_ws.assignee
+    );
+}

--- a/crates/cas-mcp/src/types/ops_secondary.rs
+++ b/crates/cas-mcp/src/types/ops_secondary.rs
@@ -565,6 +565,17 @@ pub struct CoordinationRequest {
     #[serde(default)]
     pub allow_trunk: Option<bool>,
 
+    /// worktree_merge only: remove the worktree directory and delete the
+    /// factory branch after a successful merge (cas-369f). Independent of
+    /// `force` (dirty-tree override). Default for System-B factory workers is
+    /// preserve (mid-session merges leave the worker cwd intact); pass
+    /// `cleanup=true` for end-of-lane consume.
+    #[schemars(
+        description = "worktree_merge only: remove worktree + delete branch after merge (end-of-lane). Separate from force= (dirty only). System-B default is preserve so mid-epic merges do not destroy a live worker cwd."
+    )]
+    #[serde(default)]
+    pub cleanup: Option<bool>,
+
     /// Clear the pinned epic focus for focus_epic
     #[schemars(description = "Clear the pinned epic focus (focus_epic only)")]
     #[serde(default)]

--- a/crates/cas-store/src/reminder_store.rs
+++ b/crates/cas-store/src/reminder_store.rs
@@ -117,6 +117,11 @@ pub struct Reminder {
     /// JSON snapshot of the DirectorEvent that triggered this reminder
     /// (only set for event-based reminders after firing)
     pub fired_event: Option<serde_json::Value>,
+    /// Factory session that registered this reminder (`CAS_FACTORY_SESSION`).
+    /// Event-based fires only match in this session (cas-fcd4 multi-factory).
+    /// `None` = legacy / non-factory registration (any session may fire).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 }
 
 /// Schema for reminders table
@@ -148,6 +153,9 @@ const MIGRATION_TARGET_ID: &str = "ALTER TABLE reminders ADD COLUMN target_id TE
 /// Migration to add fired_event column (stores triggering event JSON)
 const MIGRATION_FIRED_EVENT: &str = "ALTER TABLE reminders ADD COLUMN fired_event TEXT";
 
+/// Migration: factory session scope for event-based multi-session isolation (cas-fcd4)
+const MIGRATION_SESSION_ID: &str = "ALTER TABLE reminders ADD COLUMN session_id TEXT";
+
 /// Trait for reminder storage operations
 #[allow(clippy::too_many_arguments)]
 pub trait ReminderStore: Send + Sync {
@@ -157,6 +165,8 @@ pub trait ReminderStore: Send + Sync {
     /// Create a new reminder, returns its ID.
     /// `target_id` is the agent who should receive the reminder. If `None`,
     /// defaults to `owner_id` (self-reminder).
+    /// `session_id` is the registering factory session (`CAS_FACTORY_SESSION`);
+    /// event-based delivery is scoped to that session (cas-fcd4).
     fn create(
         &self,
         owner_id: &str,
@@ -167,6 +177,7 @@ pub trait ReminderStore: Send + Sync {
         trigger_event: Option<&str>,
         trigger_filter: Option<&serde_json::Value>,
         ttl_secs: i64,
+        session_id: Option<&str>,
     ) -> Result<i64>;
 
     /// List pending reminders owned by a specific agent
@@ -258,6 +269,17 @@ impl SqliteReminderStore {
         let fired_event_str: Option<String> = row.get(13)?;
         let fired_event = fired_event_str.and_then(|s| serde_json::from_str(&s).ok());
 
+        // Column 14 is session_id (may be NULL for pre-cas-fcd4 rows)
+        let session_id: Option<String> = row.get(14)?;
+        let session_id = session_id.and_then(|s| {
+            let t = s.trim();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t.to_string())
+            }
+        });
+
         Ok(Reminder {
             id: row.get(0)?,
             target_id: target_id.unwrap_or_else(|| owner_id.clone()),
@@ -273,6 +295,7 @@ impl SqliteReminderStore {
             fired_at,
             cancelled_at,
             fired_event,
+            session_id,
         })
     }
 
@@ -292,10 +315,17 @@ impl SqliteReminderStore {
             conn.execute_batch(MIGRATION_FIRED_EVENT)?;
         }
 
+        if conn
+            .prepare_cached("SELECT session_id FROM reminders LIMIT 0")
+            .is_err()
+        {
+            conn.execute_batch(MIGRATION_SESSION_ID)?;
+        }
+
         Ok(())
     }
 
-    const SELECT_COLUMNS: &str = "id, supervisor_id, message, trigger_type, trigger_at, trigger_event, trigger_filter, status, ttl_secs, created_at, fired_at, cancelled_at, target_id, fired_event";
+    const SELECT_COLUMNS: &str = "id, supervisor_id, message, trigger_type, trigger_at, trigger_event, trigger_filter, status, ttl_secs, created_at, fired_at, cancelled_at, target_id, fired_event, session_id";
 }
 
 impl ReminderStore for SqliteReminderStore {
@@ -316,16 +346,21 @@ impl ReminderStore for SqliteReminderStore {
         trigger_event: Option<&str>,
         trigger_filter: Option<&serde_json::Value>,
         ttl_secs: i64,
+        session_id: Option<&str>,
     ) -> Result<i64> {
         let conn = self.conn.lock().unwrap();
         let now = Utc::now().to_rfc3339();
         let trigger_at_str = trigger_at.map(|dt| dt.to_rfc3339());
         let trigger_filter_str = trigger_filter.map(|f| f.to_string());
         let resolved_target = target_id.unwrap_or(owner_id);
+        let session_id = session_id
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
 
         conn.execute(
-            "INSERT INTO reminders (supervisor_id, message, trigger_type, trigger_at, trigger_event, trigger_filter, ttl_secs, created_at, target_id)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO reminders (supervisor_id, message, trigger_type, trigger_at, trigger_event, trigger_filter, ttl_secs, created_at, target_id, session_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 owner_id,
                 message,
@@ -336,6 +371,7 @@ impl ReminderStore for SqliteReminderStore {
                 ttl_secs,
                 now,
                 resolved_target,
+                session_id,
             ],
         )?;
 
@@ -534,6 +570,7 @@ mod tests {
                 None,
                 None,
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -564,6 +601,7 @@ mod tests {
                 None,
                 None,
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -591,6 +629,7 @@ mod tests {
                 Some("task_completed"),
                 Some(&filter),
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -621,6 +660,7 @@ mod tests {
                 None,
                 None,
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -636,6 +676,7 @@ mod tests {
                 None,
                 None,
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -658,6 +699,7 @@ mod tests {
                 Some("task_completed"),
                 None,
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -671,6 +713,7 @@ mod tests {
                 Some("worker_idle"),
                 None,
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -701,6 +744,7 @@ mod tests {
                 None,
                 None,
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -745,6 +789,7 @@ mod tests {
                 Some("task_completed"),
                 None,
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -777,6 +822,7 @@ mod tests {
                 None,
                 None,
                 1, // 1 second TTL
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -791,6 +837,7 @@ mod tests {
                 None,
                 None,
                 99999,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -819,6 +866,7 @@ mod tests {
                 Some("task_completed"),
                 None,
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -832,6 +880,7 @@ mod tests {
                 Some("task_completed"),
                 None,
                 3600,
+                None, // session_id cas-fcd4
             )
             .unwrap();
 
@@ -846,5 +895,87 @@ mod tests {
         // get_event_reminders returns all owners (daemon processes all)
         let all = store.get_event_reminders("task_completed").unwrap();
         assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn test_session_id_persisted_on_create() {
+        let (_temp, store) = create_test_store();
+        let id = store
+            .create(
+                "sup-a",
+                None,
+                "session scoped",
+                ReminderTriggerType::Event,
+                None,
+                Some("task_completed"),
+                None,
+                3600,
+                Some("factory-session-a"),
+            )
+            .unwrap();
+        assert!(id > 0);
+        let pending = store.list_pending("sup-a").unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(
+            pending[0].session_id.as_deref(),
+            Some("factory-session-a")
+        );
+    }
+
+    #[test]
+    fn test_session_id_empty_stored_as_none() {
+        let (_temp, store) = create_test_store();
+        store
+            .create(
+                "sup-a",
+                None,
+                "blank session",
+                ReminderTriggerType::Event,
+                None,
+                Some("task_completed"),
+                None,
+                3600,
+                Some("   "),
+            )
+            .unwrap();
+        let pending = store.list_pending("sup-a").unwrap();
+        assert_eq!(pending[0].session_id, None);
+    }
+
+    #[test]
+    fn test_event_reminders_from_two_sessions_both_listed() {
+        // Store returns both; session filter is applied at fire time (daemon).
+        let (_temp, store) = create_test_store();
+        store
+            .create(
+                "sup-a",
+                None,
+                "from A",
+                ReminderTriggerType::Event,
+                None,
+                Some("task_completed"),
+                None,
+                3600,
+                Some("session-a"),
+            )
+            .unwrap();
+        store
+            .create(
+                "sup-b",
+                None,
+                "from B",
+                ReminderTriggerType::Event,
+                None,
+                Some("task_completed"),
+                None,
+                3600,
+                Some("session-b"),
+            )
+            .unwrap();
+        let all = store.get_event_reminders("task_completed").unwrap();
+        assert_eq!(all.len(), 2);
+        let sessions: Vec<_> = all.iter().filter_map(|r| r.session_id.as_deref()).collect();
+        assert!(sessions.contains(&"session-a"));
+        assert!(sessions.contains(&"session-b"));
     }
 }


### PR DESCRIPTION
## Summary

Ships EPIC **cas-887b** — fixes for the open factory bug reports under `docs/requests/` (2026-07-16 / 2026-07-21), plus two session-observed CAS bugs filed mid-flight.

### Fixes
- **cas-127f** — ZERO-COMMIT false-positive after MERGE REQUIRED + supervisor merge (merge-satisfied anchor)
- **cas-44e9** — Assignment freshness gate scopes to the task's parent epic branch (not an unrelated epic)
- **cas-fcd4** — Event reminds scoped to registering factory session
- **cas-c655** — Codex-aware `is-wedged` (real PID + rollout resolution; CPU/worktree liveness)
- **cas-7a94** — `spawn_workers task_id=` pre-assign for isolate path + release on shutdown
- **cas-f53c** — `sync_all_workers` resolves clone_path like worker_status (post-spawn race)
- **cas-369f** — `worktree_merge` preserves live worker worktree by default (`cleanup=true` to consume)
- **cas-5a01** — Supervisor-checklist version freshness recipe extracts git hash, not build date
- **cas-bf98** — Empty `assignee=""` clears assignment instead of remapping to a live worker

### Follow-on (not in this PR)
- **cas-126b** — Grok workers stay idle after MERGE DONE / interrupt re-close (supervisor escape-hatch closes)

### Test plan
- [x] `cargo test -p cas --lib` zero_change_close_tests (15 passed, incl. cas127f post-merge)
- [x] `cargo test -p cas --lib` factory_ops::tests (76 passed, incl. clone_path resolve)
- [x] `check_worktree_staleness` two-epic unit tests
- [ ] CI green
- [ ] Post-merge: rebuild `cas` release binary if factory surfaces changed