### PR TITLE
docs(cas-f5a7): archive cas-887b bug reports into completed/

### DIFF
--- a/docs/requests/completed/2026-07-16-worktree-merge-removes-live-worker-worktree.md
+++ b/docs/requests/completed/2026-07-16-worktree-merge-removes-live-worker-worktree.md
@@ -1,0 +1,53 @@
+# Bug: coordination worktree_merge removes a live worker's worktree mid-session
+
+**Date:** 2026-07-16
+**Reporter:** loyal-merlin-56 (Ozer factory supervisor, session 1e692247)
+**Severity:** P2 — breaks active workers, recoverable manually
+**CAS version:** 2.27.0 (9b52e17-dirty 2026-07-16)
+
+## What happened
+
+During epic cas-c446 (Ozer), supervisor drained the merge queue with:
+
+```
+mcp__cas__coordination action=worktree_merge id=hv-food branch=epic/... force=true
+```
+
+The merge succeeded (commit e550ef30), but the tool also **removed the worker's
+worktree and local branch** while worker `hv-food` was still alive with two more
+assigned open tasks (cas-57ba8, cas-de1e5):
+
+- `/home/pippenz/Petrastella/ozer/.cas/worktrees/hv-food` → ENOENT; worker's shell
+  failed on cwd mid-task and it had to manually `git worktree add` to recover.
+- Local branch `factory/hv-food` stopped resolving (`git rev-parse` fatal); only
+  `origin/factory/hv-food` survived because the worker had pushed.
+- Same for `hv-reco`/`st-layout` merges (95eccf89, 848bcf6f).
+
+## Expected
+
+`worktree_merge` should either (a) leave the worktree + branch intact when the
+assignee has other open/in_progress tasks or a fresh heartbeat, or (b) require an
+explicit `cleanup=true` flag for consume-on-merge semantics. Merging a worker's
+completed commits is a mid-epic operation; the worktree is the worker's home for
+the rest of the lane.
+
+## Repro
+
+1. Spawn isolated worker, assign 2+ tasks.
+2. Worker commits + pushes task 1; supervisor runs `worktree_merge id=<worker> branch=epic/... force=true`.
+3. Worker's next shell command in its worktree → ENOENT.
+
+## Notes
+
+- `force=true` was passed (worktree dirty with only untracked `.husky/_/`); if
+  force implies consume, that coupling is surprising — `force` is documented as
+  "dirty worktree override", not "remove worktree after merge".
+- Recovery that worked: `git worktree add .cas/worktrees/<name> <origin-branch>`.
+
+
+## Completion
+
+- **completed:** 2026-07-21
+- **epic:** cas-887b — Factory reliability: open docs/requests bugs → main
+- **completed_by:** cas-369f
+- **status:** Fixed on epic tip; report archived from `docs/requests/`.

--- a/docs/requests/completed/2026-07-21-assign-gate-compares-wrong-epic-branch.md
+++ b/docs/requests/completed/2026-07-21-assign-gate-compares-wrong-epic-branch.md
@@ -1,0 +1,55 @@
+# Worker-assignment freshness gate compares against an unrelated epic's branch
+
+**Date:** 2026-07-21
+**Reporter:** nimble-octopus-55 (supervisor, ozer project, factory session ozer-strong-jay-96)
+**Severity:** major (blocks supervisor task assignment entirely for affected worker)
+
+## Symptom
+`task action=update id=cas-3d23 assignee=telehealth-auditor` fails:
+
+    Cannot assign to worker 'telehealth-auditor': 10 commits behind
+    epic/widget-parity-saffron-light-mode-jill-request-cas-960d (threshold: 1).
+    Ask the worker to rebase: `git rebase epic/widget-parity-saffron-light-mode-jill-request-cas-960d`
+
+But cas-3d23 belongs to epic cas-60e3 (branch epic/jill-feedback-wave-2026-07-17-20-investigate-answe-cas-60e3). cas-960d is a different, older epic. The suggested remediation (rebase the worker onto the unrelated epic branch) would actively pollute the worker's branch.
+
+## What didn't fix it
+`coordination action=focus_epic id=cas-60e3` (pin accepted: "Pinned epic focus to cas-60e3 for factory session ozer-strong-jay-96") → identical error on retry immediately after.
+
+## Context
+- Multiple epics concurrently active in this repo (cas-60e3 jill-feedback, cas-96cb sleep-rhythm with its own supervisor warm-falcon-13 + 4 codex workers, and evidently cas-960d widget-parity with a live branch).
+- Worker telehealth-auditor's branch: factory/telehealth-auditor, based on staging @ 0cfa3864, its work already merged into the cas-60e3 epic branch.
+- Guess: the gate resolves "the epic branch" globally (most recently active? lexical? last-created?) instead of from the target task's parent epic. Possibly related to the c133b94 regression cluster.
+
+## Expected
+Freshness gate should compare the worker's branch against the epic branch of the TASK being assigned (cas-3d23 → cas-60e3), or honor the session's pinned focus epic.
+
+## Related same-day symptom: reminders also cross epic scopes
+A `remind` registered by the sleep-rhythm factory ("Reminder #27: Sleep-rhythm
+task completed — run the review gate (…no crossfade settings…)") was delivered
+to THIS supervisor, triggered by MY worker completing cas-3d23 (jill-feedback
+epic, zero overlap with sleep-rhythm). remind_event filters appear to match on
+bare `task_completed` across all factory sessions in the repo instead of the
+registering session/epic. Same root theme as the assignment gate: multi-epic
+concurrency in one repo isn't scoped.
+
+## Same-day symptom #3: normal-priority message delivery stalls while workers idle
+Workers heartbeat fresh (4-22s) but sit idle 10+ min with supervisor messages
+stuck at status=pending (IDs 3631, 3633 verified pending via message_status).
+Idle workers appear to never poll the inbox, and pending messages are only
+injected on a poll → deadlock: worker idles waiting for work, work waits in a
+queue the idle worker never reads. `interrupt`/urgent=true delivery works
+(breaks the turn and injects), which is the workaround, but it discards
+in-flight state and shouldn't be the only reliable channel. User-visible
+symptom: "no workers are working."
+
+## Workaround in use
+Worker self-claims via `task action=start id=<task>` (different code path; pending confirmation it bypasses the gate).
+
+
+## Completion
+
+- **completed:** 2026-07-21
+- **epic:** cas-887b — Factory reliability: open docs/requests bugs → main
+- **completed_by:** cas-44e9
+- **status:** Fixed on epic tip; report archived from `docs/requests/`.

--- a/docs/requests/completed/2026-07-21-is-wedged-codex-transcript-unresolved-false-starved.md
+++ b/docs/requests/completed/2026-07-21-is-wedged-codex-transcript-unresolved-false-starved.md
@@ -1,0 +1,48 @@
+# is-wedged can't resolve codex worker transcripts → false "starved" + director stall-alert spam
+
+**Date:** 2026-07-21
+**Reporter:** warm-falcon-13 (supervisor, ozer project, session ozer-nimble-panda-75)
+**Severity:** major (no data loss, but the monitoring loop cries wolf — 4 false stall alerts in one session, and a hasty supervisor following the kill guidance would destroy in-flight work)
+
+## Symptom
+With `cli=codex` workers (`gpt-5.6-sol`), the director emits "stalled ~5m, alive heartbeat, no activity, auto-nudge did not unstick" for workers that are demonstrably mid-inference. Triage tooling can't see codex activity:
+
+```
+$ cas factory is-wedged worker-android
+state: starved
+  pid: 111084 (alive: true)          <-- this is `cas serve`, NOT the worker
+  transcript: <unresolved>
+  transcript mtime age: <unknown>
+  worktree recent-edit age: <unknown>
+
+$ cas factory debug worker-android
+[ERROR] no transcript found for worker `worker-android`
+(session codex-worker-android-2f828ac6-...)
+```
+
+Ground truth at that exact moment: `ps aux | grep codex` showed four wrapper+vendor-binary pairs at 3.8–6.6% CPU (actively inferencing), and two of the four "stalled" workers had already pushed commits to their factory branches.
+
+## Two distinct defects
+1. **Registered PID is wrong for codex workers.** `is-wedged` inspects PIDs 111084/111599/130021 — all `cas serve` processes — so "alive: true" is vacuous and CPU/state signals come from the daemon, not the worker.
+2. **Transcript resolution doesn't know the codex session layout.** `codex-worker-<name>-<uuid>` sessions resolve to nothing (`~/.codex/sessions/` uses a different scheme), so mtime-age classification degrades to "starved" whenever the worker goes >N min without a CAS tool call — which codex workers routinely do during long read/plan/inference stretches.
+
+## Impact
+- Director fires stall alerts on a timer for healthy workers (observed for all 4 workers within the first ~15 min of an epic).
+- The alert text steers supervisors toward `cas factory kill`; the only guard is the supervisor independently knowing to check `ps`.
+- 5-minute "no activity" is far too aggressive a threshold for codex-CLI workers even once transcripts resolve.
+
+## Expected
+- `is-wedged` tracks the actual codex child process (wrapper or vendor binary) per worker.
+- Codex transcript/rollout files resolved (or an explicit "codex: transcript introspection unsupported — classifying by process CPU + worktree writes" downgrade path).
+- Classification should incorporate process CPU and git activity (branch tip movement) before declaring starved; stall threshold per-CLI.
+
+## Workaround (documented in ozer project memory 2026-07-21-4)
+`ps aux | grep codex` — vendor binary at 3–7% CPU = inferencing; check factory branch tips for commits; ignore "starved" verdicts lacking corroboration.
+
+
+## Completion
+
+- **completed:** 2026-07-21
+- **epic:** cas-887b — Factory reliability: open docs/requests bugs → main
+- **completed_by:** cas-c655
+- **status:** Fixed on epic tip; report archived from `docs/requests/`.

--- a/docs/requests/completed/2026-07-21-merge-required-vs-zero-commit-catch22.md
+++ b/docs/requests/completed/2026-07-21-merge-required-vs-zero-commit-catch22.md
@@ -1,0 +1,39 @@
+# Close gates contradict: MERGE REQUIRED forces the state ZERO-COMMIT then rejects
+
+**Date:** 2026-07-21
+**Reporter:** nimble-octopus-55 (supervisor, ozer, factory session ozer-strong-jay-96)
+**Severity:** major (every code-task close needs a supervisor bypass — 2/2 today)
+
+## Symptom
+Worker close on a code task is a guaranteed two-failure sequence:
+1. Worker finishes, attempts `task action=close` → rejected: **MERGE REQUIRED**
+   (worker branch has commits not on the epic branch).
+2. Supervisor merges worker branch into the epic branch (--no-ff), pushes.
+3. Worker retries close → rejected: **ZERO-COMMIT CLOSE ON CODE TASK — 0 commits
+   on the worker branch** — because the merge absorbed them, the branch now has
+   0 commits unique vs the epic branch.
+4. Only path left: supervisor close with `bypass_code_review=true`.
+
+Observed on cas-a889 (e7e354bc → merge 90734cff) and cas-8b07 (ae042b26 →
+merge b0c53e78), same session, 100% reproduction.
+
+## Expected
+The ZERO-COMMIT check should count commits REACHABLE from the epic branch that
+were authored on the worker branch (e.g. `git log epic..` is the wrong
+direction; use merge-base ancestry of the worker's recorded commits), or the
+close flow should record the commit SHAs at the MERGE REQUIRED rejection and
+accept them as satisfied once they become ancestors of the epic branch.
+
+## Notes
+Known-adjacent: cas-52ec was the same false-positive pattern. The bypass
+workaround functions but downgrades the code-review gate to manual supervisor
+discipline on every single code task, which is exactly what the gate exists to
+enforce automatically.
+
+
+## Completion
+
+- **completed:** 2026-07-21
+- **epic:** cas-887b — Factory reliability: open docs/requests bugs → main
+- **completed_by:** cas-127f
+- **status:** Fixed on epic tip; report archived from `docs/requests/`.

--- a/docs/requests/completed/2026-07-21-spawn-workers-task-preassign-not-applied.md
+++ b/docs/requests/completed/2026-07-21-spawn-workers-task-preassign-not-applied.md
@@ -1,0 +1,46 @@
+# spawn_workers task_id pre-assignment not applied at worker boot
+
+**Date:** 2026-07-21
+**Reporter:** nimble-octopus-55 (supervisor, ozer project)
+**Severity:** minor (workaround exists) / annoying (breaks unattended assignment)
+
+## Symptom
+`mcp__cas__coordination action=spawn_workers` with `task_id=<id>` acks with
+"Task: <id> will be pre-assigned once the worker boots", but the worker boots
+idle with 0 tasks and the director emits "idle with no assigned tasks" pings.
+Supervisor must then manually `task action=update id=<id> assignee=<worker>`.
+
+## Repro (2/2 today, same session)
+1. Request 387: `spawn_workers count=1 cli=codex model=gpt-5.6-codex effort=medium isolate=true task_id=cas-7f61 worker_names=recipes-fixer` → booted, `agent_list` shows `recipes-fixer ... 0 tasks`.
+2. Request 389: same but `model=gpt-5.6-sol worker_names=recipes-fixer-2` → same result.
+
+Possibly related: request 377 (`claude` cli, `task_id=cas-5f5e`, no isolate) DID
+end up working the task, but that worker may have self-claimed from ready rather
+than receiving a pre-assignment — can't distinguish from my side.
+
+## Expected
+Worker boots with the task leased/assigned, starts without supervisor round-trip.
+
+## Update (same day): the inverse bug on the claude path
+For `cli=claude` spawns the pre-assignment DOES apply — and then SURVIVES
+`shutdown_workers` issued before the worker starts. Observed: cas-3d23 stayed
+assigned to dead worker sow-auditor and cas-5d7a to dead ui-bugs-fixer
+(status=InProgress, no live agent, no active lease — `transfer` fails with
+"No active lease found"; only `reset` clears them). Blocked reassignment with a
+confusing ownership error on the next worker's `start`. shutdown_workers should
+release pre-assignments/leases of workers that never started.
+
+## Notes
+- Both failing spawns used `cli=codex` + `isolate=true`; the succeeding one was
+  `cli=claude` without isolate. Suspect the pre-assign hook isn't wired for the
+  codex boot path or races the worktree provisioning.
+- Workaround in use: explicit `task update assignee=` + coordination message
+  after the idle ping.
+
+
+## Completion
+
+- **completed:** 2026-07-21
+- **epic:** cas-887b — Factory reliability: open docs/requests bugs → main
+- **completed_by:** cas-7a94
+- **status:** Fixed on epic tip; report archived from `docs/requests/`.

--- a/docs/requests/completed/2026-07-21-sync-all-workers-clone-path-race.md
+++ b/docs/requests/completed/2026-07-21-sync-all-workers-clone-path-race.md
@@ -1,0 +1,42 @@
+# sync_all_workers skips freshly-spawned workers: "missing clone_path metadata"
+
+**Date:** 2026-07-21
+**Reporter:** warm-falcon-13 (supervisor, ozer project, session ozer-nimble-panda-75)
+**Severity:** minor (manual git fallback works) / hits the critical first minute of every epic
+
+## Symptom
+Immediately after `spawn_workers` (4 × codex, isolate=true) acked and `worker_status` already displayed all four workers WITH clone paths (`Clone: .../.cas/worktrees/worker-ios` etc.), a `sync_all_workers branch=epic/...` call skipped every worker:
+
+```
+Sync target: epic/epic-ozer-sleep-rhythm-routine-native-audio-engine-cas-96cb
+Skipped:
+  - worker-ios (missing clone_path metadata)
+  - worker-android (missing clone_path metadata)
+  - worker-backend (missing clone_path metadata)
+  - worker-frontend (missing clone_path metadata)
+```
+
+So `worker_status` and `sync_all_workers` read different metadata stores (or the latter reads before registration completes — the workers had spawned <60s earlier).
+
+## Why it matters
+This is exactly the moment sync is needed: workers spawn based on trunk (staging @ 0cfa3864) while the epic branch already carries frozen contract files. If the supervisor doesn't notice the skip, all workers start WITHOUT the contracts they were told to implement.
+
+## Expected
+Either resolve clone_path the same way worker_status does, or return a retryable "registration in progress" status instead of a silent skip — a skip reads like "nothing to do".
+
+## Workaround used
+```
+for w in worker-*; do
+  git -C .cas/worktrees/$w fetch origin <epic-branch> -q
+  git -C .cas/worktrees/$w merge --ff-only origin/<epic-branch>
+done
+```
+(clean because fresh workers have zero commits; verified all four at the contracts commit afterwards).
+
+
+## Completion
+
+- **completed:** 2026-07-21
+- **epic:** cas-887b — Factory reliability: open docs/requests bugs → main
+- **completed_by:** cas-f53c
+- **status:** Fixed on epic tip; report archived from `docs/requests/`.

--- a/docs/requests/completed/2026-07-21-version-string-breaks-freshness-check-recipe.md
+++ b/docs/requests/completed/2026-07-21-version-string-breaks-freshness-check-recipe.md
@@ -1,0 +1,35 @@
+# `cas --version` format breaks the supervisor-checklist binary-freshness recipe
+
+**Date:** 2026-07-21
+**Reporter:** warm-falcon-13 (supervisor, ozer project)
+**Severity:** trivial (docs/CLI mismatch), but it's step 0 of every factory session
+
+## Symptom
+The cas-supervisor-checklist skill (cas-d0f9 pre-flight) says:
+
+```
+cas --version | awk '{print $NF}'   # hash the running binary was built from
+```
+
+Actual output today:
+
+```
+$ cas --version
+cas 2.27.0 (9b52e17-dirty 2026-07-16)
+$ cas --version | awk '{print $NF}'
+2026-07-16)
+```
+
+`$NF` now grabs the build date + stray paren, so the follow-up
+`git log --oneline HEAD --not <running-hash>` dies with `fatal: bad revision '2026-07-16)'`.
+
+## Expected
+Either the checklist recipe updates to extract the hash (e.g. `sed -E 's/.*\(([0-9a-f]+).*/\1/'`), or better: add `cas --version --short-hash` (or `cas factory freshness-check` doing the whole comparison server-side) so the recipe can't drift again. Also worth deciding what `-dirty` should mean for the check — today the hash matches HEAD but the binary was built from a dirty tree, which the recipe silently treats as fresh.
+
+
+## Completion
+
+- **completed:** 2026-07-21
+- **epic:** cas-887b — Factory reliability: open docs/requests bugs → main
+- **completed_by:** cas-5a01
+- **status:** Fixed on epic tip; report archived from `docs/requests/`.

--- a/docs/requests/completed/2026-07-21-zero-commit-close-gate-after-epic-merge.md
+++ b/docs/requests/completed/2026-07-21-zero-commit-close-gate-after-epic-merge.md
@@ -1,0 +1,27 @@
+# ZERO-COMMIT CLOSE gate false-positive after supervisor merges the worker branch
+
+**Date:** 2026-07-21
+**Reporter:** warm-falcon-13 (supervisor, ozer project, session ozer-nimble-panda-75)
+**Severity:** minor (supervisor escape-hatch close works) / hits every supervisor-merged task, so it's a per-task tax
+
+## Symptom
+Standard factory flow: worker pushes → close attempt → `MERGE REQUIRED` → supervisor merges worker branch into the epic branch → worker retries close. The retry is rejected with `ZERO-COMMIT CLOSE ON CODE TASK`.
+
+Observed on cas-05af: worker commit 0b52e266 exists on factory/worker-android AND is merged into the epic (merge f7f16f40); fresh proof notes on the task; retry close → zero-commit rejection. Worker (correctly) refused to bypass and escalated; supervisor closed manually.
+
+## Likely cause
+The zero-commit check appears to count commits on the worker branch **not reachable from the epic branch**. Before the merge that count is >0 (hence MERGE REQUIRED); after the merge it becomes 0 — which the gate misreads as "this code task produced no commits" instead of "all commits are merged".
+
+## Why it matters
+The two gates are mutually contradictory in the canonical flow: MERGE REQUIRED forces the merge, and the merge triggers ZERO-COMMIT. Every supervisor-merged task therefore needs a supervisor close, defeating worker self-close and adding a round-trip per task (observed on cas-cab1, cas-8805b, cas-05af in one epic).
+
+## Expected
+Zero-commit detection should distinguish "no commits ever" from "commits exist and are already reachable from the epic branch" — e.g. count commits on the worker branch since the task started (task-window `git log`), or treat `merged_count > 0` as satisfying the gate.
+
+
+## Completion
+
+- **completed:** 2026-07-21
+- **epic:** cas-887b — Factory reliability: open docs/requests bugs → main
+- **completed_by:** cas-127f
+- **status:** Fixed on epic tip; report archived from `docs/requests/`.


### PR DESCRIPTION
## Summary
- Restore eight cas-887b factory bug reports from supervisor stash WIP
- Append completion footers (epic cas-887b + fix task ids)
- Move from `docs/requests/` to `docs/requests/completed/`

## Test plan
- [x] `ls docs/requests/` has no 2026-07-16/21 factory bug reports
- [x] All eight files present under `docs/requests/completed/` with Completion sections

Task: cas-f5a7