### PR TITLE
test(cas-6706): remove proxy future-skew race

### DIFF
--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -1311,14 +1311,15 @@ mod tests {
             super::ProxySnapshotReadErrorKind::ConfigMismatch
         );
 
-        snapshot.generated_at_ms = super::now_millis().unwrap().saturating_add(30_001);
+        // Stay a full minute beyond the accepted 30s skew so serialization,
+        // filesystem I/O, and scheduler delay cannot cross the boundary.
+        snapshot.generated_at_ms = super::now_millis().unwrap().saturating_add(90_000);
         snapshot.health.generated_at_ms = snapshot.generated_at_ms;
         std::fs::write(
             tmp.path().join(super::PROXY_SNAPSHOT_CACHE),
             serde_json::to_vec(&snapshot).unwrap(),
         )
         .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(2));
         assert_eq!(
             super::read_proxy_snapshot_cache(tmp.path())
                 .unwrap_err()

--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -1318,6 +1318,7 @@ mod tests {
             serde_json::to_vec(&snapshot).unwrap(),
         )
         .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2));
         assert_eq!(
             super::read_proxy_snapshot_cache(tmp.path())
                 .unwrap_err()


### PR DESCRIPTION
Fixes the proxy snapshot future-skew test's 1ms race by moving its fixture timestamp 90s into the future, leaving a full 60s margin beyond the unchanged production tolerance.\n\nProof:\n- deterministic 2ms-delay red reproduction committed before the fix\n- three full cargo test -p cas --lib runs: 3125 passed, 0 failed each\n- sanitized serialized cargo test --no-fail-fast: exit 0\n- nearby timestamp sweep complete; sibling past-age assertion is monotonic-safe\n\nTask: cas-6706