### PR TITLE
fix: `cas claude <profile>` launches the factory, not bare Claude Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- **Choosing a Claude account starts CAS again.** `cas claude <profile>` resolved the account directory and then exec'd Claude Code directly, so the factory never started — selecting a second subscription and running CAS became two separate commands to be combined by hand with an environment variable. The account is now exported into the launching process before any thread or pane exists, and the command delegates to the same factory path as the other provider shortcuts with Claude pinned as the supervisor, so the supervisor and every worker it spawns land on the chosen account. Bare `cas claude` launches the factory on the ambient account, matching its siblings; the account listing moved to `--list-profiles`, and `--bare` keeps the plain Claude Code launcher with argument passthrough. Explicitly selecting an account now also scrubs an inherited `ANTHROPIC_API_KEY` on this path, which could otherwise override subscription OAuth and silently defeat the selection.
+
 ## [2.40.0] - 2026-08-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ cargo build --release
 ```bash
 cas                   # Launch the factory TUI
 cas -w 3              # Launch with 3 workers
-cas claude alt --continue  # Launch Claude Code using ~/.claude-alt
+cas claude alt        # Factory + Claude supervisor on the ~/.claude-alt account
+cas claude --list-profiles  # Show detected Claude accounts and login state
 cas serve             # Start MCP server for Claude Code
 cas init              # Initialize CAS in your project
 cas attach            # Attach to a running factory session

--- a/cas-cli/src/cli/claude.rs
+++ b/cas-cli/src/cli/claude.rs
@@ -1,4 +1,17 @@
-//! `cas claude` — launch Claude Code with an explicitly selected account profile.
+//! `cas claude` — launch the CAS factory with a Claude supervisor on an
+//! explicitly selected account profile.
+//!
+//! `cas claude alt` is the operator-facing spelling for "run CAS, supervised by
+//! Claude, signed in as my alt subscription". It is the Claude sibling of
+//! `cas codex` / `cas grok`, with one extra positional: the account profile.
+//!
+//! Account selection works by exporting `CLAUDE_CONFIG_DIR` into this process
+//! before the factory starts. Panes inherit it (`cas-pty` never calls
+//! `env_clear`), so the supervisor runs on the chosen account, and
+//! `spawn_workers` captures the same value as `requester_config_dir` so workers
+//! land on that account too.
+//!
+//! `--bare` keeps the plain "just open Claude Code on this profile" launcher.
 
 use std::ffi::OsString;
 use std::io;
@@ -6,15 +19,28 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
-use clap::Args;
+use clap::{Args, FromArgMatches};
 
-/// Arguments for `cas claude <profile> [claude-args...]`.
+use super::factory::FactoryArgs;
+use super::Cli;
+
+/// Arguments for `cas claude [profile] [factory-args...]`.
 #[derive(Args, Clone, Debug)]
 pub struct ClaudeArgs {
     /// Account profile: `main` maps to ~/.claude; any other name maps to ~/.claude-<name>.
+    ///
+    /// Omit to use whichever account the current environment already selects.
     pub profile: Option<String>,
 
-    /// Arguments passed directly to Claude Code.
+    /// List detected account profiles with login state and exit.
+    #[arg(long = "list-profiles")]
+    pub list_profiles: bool,
+
+    /// Launch plain Claude Code on this profile instead of the CAS factory.
+    #[arg(long = "bare")]
+    pub bare: bool,
+
+    /// Remaining arguments: `cas factory` flags, or Claude Code flags with `--bare`.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<OsString>,
 }
@@ -79,8 +105,9 @@ fn profile_for(name: &str, directory: PathBuf, active_dir: Option<&Path>) -> Pro
 fn profile_listing(home: &Path, active_dir: Option<&Path>) -> Result<String> {
     let profiles = scan_profiles(home, active_dir)
         .with_context(|| format!("could not inspect Claude profiles under {}", home.display()))?;
-    let mut output =
-        String::from("Usage: cas claude <profile> [claude-args...]\n\nDetected Claude profiles:\n");
+    let mut output = String::from(
+        "Usage: cas claude <profile> [factory-args...]\n\nDetected Claude profiles:\n",
+    );
 
     for profile in profiles {
         let login = if profile.logged_in {
@@ -99,7 +126,7 @@ fn profile_listing(home: &Path, active_dir: Option<&Path>) -> Result<String> {
     Ok(output)
 }
 
-/// Build the command used for a profile launch without executing it.
+/// Build the command used for a `--bare` profile launch without executing it.
 pub(crate) fn build_claude_command(profile_dir: &Path, args: &[OsString]) -> Command {
     let mut command = Command::new("claude");
     command
@@ -111,16 +138,8 @@ pub(crate) fn build_claude_command(profile_dir: &Path, args: &[OsString]) -> Com
     command
 }
 
-/// Run the selected profile. On Unix this replaces the CAS process with Claude.
-pub fn execute(args: &ClaudeArgs) -> Result<()> {
-    let home = dirs::home_dir().context("cannot determine home directory for Claude profiles")?;
-    let Some(profile) = args.profile.as_deref() else {
-        let active_dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
-        print!("{}", profile_listing(&home, active_dir.as_deref())?);
-        return Ok(());
-    };
-
-    let profile_dir = resolve_profile_dir(&home, profile);
+/// Warn about a profile directory that Claude will have to bootstrap or log in.
+fn warn_about_profile_state(profile_dir: &Path) {
     if !profile_dir.is_dir() {
         eprintln!(
             "Note: {} does not exist yet; Claude will create it and prompt you to /login.",
@@ -132,6 +151,87 @@ pub fn execute(args: &ClaudeArgs) -> Result<()> {
             profile_dir.display()
         );
     }
+}
+
+/// Export the selected account into this process before anything spawns a
+/// thread or a pane.
+///
+/// This MUST run before `initialize_telemetry` — `std::env::set_var` in a
+/// multi-threaded process is UB, and telemetry spawns a background thread. The
+/// factory supervisor pane and every `spawn_workers` request then inherit the
+/// value through ordinary process environment inheritance.
+pub fn apply_profile_env(args: &ClaudeArgs) -> Result<()> {
+    if args.list_profiles || args.bare {
+        return Ok(());
+    }
+    let Some(profile) = args.profile.as_deref() else {
+        return Ok(());
+    };
+
+    let home = dirs::home_dir().context("cannot determine home directory for Claude profiles")?;
+    let profile_dir = resolve_profile_dir(&home, profile);
+    warn_about_profile_state(&profile_dir);
+    eprintln!("Using Claude account config: {}", profile_dir.display());
+
+    // SAFETY: called from `cli::run` before `initialize_telemetry` spawns any
+    // thread, so the process is still single-threaded here.
+    unsafe {
+        std::env::set_var("CLAUDE_CONFIG_DIR", &profile_dir);
+        // An inherited API key overrides subscription OAuth entirely, which
+        // would silently defeat the profile the operator just asked for.
+        std::env::remove_var("ANTHROPIC_API_KEY");
+    }
+
+    Ok(())
+}
+
+/// Run `cas claude`: factory with a Claude supervisor by default, plain Claude
+/// Code under `--bare`, profile listing under `--list-profiles`.
+pub fn execute(args: &ClaudeArgs, cli: &Cli, cas_root: Option<&Path>) -> Result<()> {
+    if args.list_profiles {
+        let home =
+            dirs::home_dir().context("cannot determine home directory for Claude profiles")?;
+        let active_dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from);
+        print!("{}", profile_listing(&home, active_dir.as_deref())?);
+        return Ok(());
+    }
+
+    if args.bare {
+        return execute_bare(args);
+    }
+
+    // `apply_profile_env` already exported CLAUDE_CONFIG_DIR for this process.
+    let mut factory_args = parse_factory_args(&args.args);
+    factory_args.supervisor_cli = "claude".to_string();
+    factory_args.supervisor_cli_explicit = true;
+    super::factory::execute(&factory_args, cli, cas_root)
+}
+
+/// Parse the trailing arguments as `cas factory` flags.
+///
+/// Kept separate from `ClaudeArgs` because `FactoryArgs` carries a subcommand,
+/// which clap cannot disambiguate from the leading `profile` positional.
+fn parse_factory_args(args: &[OsString]) -> FactoryArgs {
+    let command = FactoryArgs::augment_args(clap::Command::new("cas claude"));
+    let matches = match command.try_get_matches_from(
+        std::iter::once(OsString::from("cas claude")).chain(args.iter().cloned()),
+    ) {
+        Ok(matches) => matches,
+        Err(err) => err.exit(),
+    };
+    match FactoryArgs::from_arg_matches(&matches) {
+        Ok(parsed) => parsed,
+        Err(err) => err.exit(),
+    }
+}
+
+/// Plain Claude Code launch. On Unix this replaces the CAS process with Claude.
+fn execute_bare(args: &ClaudeArgs) -> Result<()> {
+    let home = dirs::home_dir().context("cannot determine home directory for Claude profiles")?;
+    let profile = args.profile.as_deref().unwrap_or("main");
+    let profile_dir = resolve_profile_dir(&home, profile);
+
+    warn_about_profile_state(&profile_dir);
     eprintln!("Using Claude account config: {}", profile_dir.display());
 
     let mut command = build_claude_command(&profile_dir, &args.args);
@@ -151,7 +251,7 @@ fn exec_claude(command: &mut Command) -> Result<()> {
 
 #[cfg(not(unix))]
 fn exec_claude(_command: &mut Command) -> Result<()> {
-    anyhow::bail!("`cas claude` is supported on Unix only")
+    anyhow::bail!("`cas claude --bare` is supported on Unix only")
 }
 
 #[cfg(test)]
@@ -208,7 +308,7 @@ mod tests {
     }
 
     #[test]
-    fn launch_command_sets_profile_scrubs_api_key_and_forwards_args() {
+    fn bare_launch_command_sets_profile_scrubs_api_key_and_forwards_args() {
         let args = vec![OsString::from("--continue"), OsString::from("--verbose")];
         let command = build_claude_command(Path::new("/tmp/.claude-alt"), &args);
 
@@ -223,5 +323,26 @@ mod tests {
             Some(OsStr::new("/tmp/.claude-alt"))
         )));
         assert!(envs.contains(&(OsStr::new("ANTHROPIC_API_KEY"), None)));
+    }
+
+    #[test]
+    fn trailing_args_parse_as_factory_flags() {
+        let parsed = parse_factory_args(&[
+            OsString::from("--workers"),
+            OsString::from("3"),
+            OsString::from("--new"),
+        ]);
+
+        assert_eq!(parsed.workers, 3);
+        assert!(parsed.start_new);
+    }
+
+    #[test]
+    fn no_trailing_args_yields_factory_defaults() {
+        let parsed = parse_factory_args(&[]);
+
+        assert_eq!(parsed.workers, 0);
+        assert!(!parsed.start_new);
+        assert!(!parsed.set_default);
     }
 }

--- a/cas-cli/src/cli/mod.rs
+++ b/cas-cli/src/cli/mod.rs
@@ -125,9 +125,12 @@ pub enum Commands {
     /// Launch factory session (bare `cas` runs factory with defaults)
     Factory(FactoryArgs),
 
-    /// Launch Claude Code under an explicit account profile.
+    /// Launch factory with Claude as the supervisor on a chosen account profile
     ///
-    /// `main` uses ~/.claude; any other profile uses ~/.claude-<profile>.
+    /// `cas claude alt` runs CAS supervised by Claude, signed in as the account
+    /// in ~/.claude-alt; `main` uses ~/.claude. Spawned workers inherit the same
+    /// account. All `cas factory` flags pass through. Use `--list-profiles` to
+    /// see detected accounts, or `--bare` to open plain Claude Code instead.
     Claude(ClaudeArgs),
 
     /// Launch factory with Codex as the supervisor (shortcut for `cas factory --supervisor-cli=codex`)
@@ -328,10 +331,18 @@ pub fn run(cli: Cli) -> anyhow::Result<()> {
         Some(Commands::Factory(_))
             | Some(Commands::Codex(_))
             | Some(Commands::Grok(_))
+            | Some(Commands::Claude(_))
             | None
     ) {
         let early_cas_root = find_cas_root().ok();
         factory::apply_resource_contention_env(early_cas_root.as_deref());
+    }
+
+    // Select the Claude account for `cas claude <profile>` here, for the same
+    // reason: `set_var` must land while the process is still single-threaded.
+    // The factory supervisor pane and every spawned worker inherit it.
+    if let Some(Commands::Claude(claude_args)) = &cli.command {
+        claude::apply_profile_env(claude_args)?;
     }
 
     initialize_telemetry();
@@ -492,7 +503,7 @@ fn run_command(cli: &Cli, cas_root: Option<&Path>) -> anyhow::Result<()> {
         Commands::Factory(args) => factory::execute(args, cli, cas_root),
         // cas-7f2c: provider shortcuts — preset supervisor_cli + explicit flag,
         // then delegate to the same factory::execute path.
-        Commands::Claude(args) => claude::execute(args),
+        Commands::Claude(args) => claude::execute(args, cli, cas_root),
         Commands::Codex(args) => {
             let mut a = args.clone();
             a.supervisor_cli = "codex".to_string();

--- a/cas-cli/tests/claude_profile_test.rs
+++ b/cas-cli/tests/claude_profile_test.rs
@@ -1,4 +1,4 @@
-//! CLI wiring tests for `cas claude` account-profile launching.
+//! CLI wiring tests for `cas claude` — factory launch on a chosen Claude account.
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -13,17 +13,24 @@ fn cas_cmd(home: &std::path::Path) -> Command {
     cmd
 }
 
-#[test]
-fn bare_claude_lists_usage_and_detected_profiles() {
+/// A home dir with `~/.claude-alt` logged in and `~/.claude-work` not.
+fn home_with_profiles() -> TempDir {
     let home = TempDir::new().unwrap();
     let alt = home.path().join(".claude-alt");
     std::fs::create_dir_all(&alt).unwrap();
     std::fs::write(alt.join(".credentials.json"), "{}").unwrap();
     std::fs::create_dir_all(home.path().join(".claude-work")).unwrap();
+    home
+}
+
+#[test]
+fn list_profiles_shows_detected_accounts_and_login_state() {
+    let home = home_with_profiles();
+    let alt = home.path().join(".claude-alt");
 
     cas_cmd(home.path())
         .env("CLAUDE_CONFIG_DIR", &alt)
-        .arg("claude")
+        .args(["claude", "--list-profiles"])
         .assert()
         .success()
         .stdout(predicate::str::contains("Usage: cas claude <profile>"))
@@ -33,4 +40,94 @@ fn bare_claude_lists_usage_and_detected_profiles() {
         .stdout(predicate::str::contains("(active)"))
         .stdout(predicate::str::contains("work"))
         .stdout(predicate::str::contains("not logged in"));
+}
+
+/// The headline behavior: `cas claude alt` selects the alt account and then
+/// hands off to the factory launcher (which bails here only because the test
+/// harness has no TTY).
+#[test]
+fn named_profile_selects_account_then_launches_factory() {
+    let home = home_with_profiles();
+
+    cas_cmd(home.path())
+        .args(["claude", "alt"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Using Claude account config:"))
+        .stderr(predicate::str::contains(".claude-alt"))
+        .stderr(predicate::str::contains(
+            "Factory mode requires an interactive terminal",
+        ));
+}
+
+/// `main` resolves to `~/.claude`, not `~/.claude-main`.
+#[test]
+fn main_profile_resolves_to_default_config_dir() {
+    let home = home_with_profiles();
+
+    cas_cmd(home.path())
+        .args(["claude", "main"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Using Claude account config:"))
+        .stderr(predicate::str::contains(".claude\n").or(predicate::str::contains(".claude ")))
+        .stderr(predicate::str::contains(
+            "Factory mode requires an interactive terminal",
+        ));
+}
+
+/// Factory flags pass through after the profile positional.
+#[test]
+fn factory_flags_pass_through_after_profile() {
+    let home = home_with_profiles();
+
+    cas_cmd(home.path())
+        .args(["claude", "alt", "--workers", "2", "--new"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Factory mode requires an interactive terminal",
+        ));
+}
+
+/// An unknown factory flag is rejected by the factory parser, not silently eaten.
+#[test]
+fn unknown_trailing_flag_is_rejected() {
+    let home = home_with_profiles();
+
+    cas_cmd(home.path())
+        .args(["claude", "alt", "--definitely-not-a-flag"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument"));
+}
+
+/// Omitting the profile leaves the ambient account untouched and still launches
+/// the factory — symmetric with `cas codex` / `cas grok`.
+#[test]
+fn bare_claude_launches_factory_without_touching_account() {
+    let home = home_with_profiles();
+
+    cas_cmd(home.path())
+        .args(["claude"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Factory mode requires an interactive terminal",
+        ))
+        .stderr(predicate::str::contains("Using Claude account config:").not());
+}
+
+#[test]
+fn help_documents_profile_and_factory_passthrough() {
+    let home = home_with_profiles();
+
+    cas_cmd(home.path())
+        .args(["claude", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("supervisor"))
+        .stdout(predicate::str::contains("PROFILE"))
+        .stdout(predicate::str::contains("--list-profiles"))
+        .stdout(predicate::str::contains("--bare"));
 }

--- a/docs/release-notes/2026-08-04-claude-profile-factory-launch-slack.md
+++ b/docs/release-notes/2026-08-04-claude-profile-factory-launch-slack.md
@@ -1,0 +1,29 @@
+# Slack draft — 2026-08-04 `cas claude <profile>` launches the factory again
+
+Channel: #cas-internal (C0B44GUKDK2). Two top-level posts per runtime rubric.
+
+Follow-up to the same-day Claude account profiles post, which shipped `cas claude`
+as a bare Claude Code launcher. That was not the intended surface.
+
+## Post 1 — User
+
+Live on main — **User**
+
+Picking your second Claude account should start CAS, not just open a chat window. `cas claude alt` now launches the full factory — supervisor and workers — signed in as your alt subscription.
+
+- **Was → Now:** `cas claude alt` opened a plain Claude Code session with no CAS around it → `cas claude alt` starts CAS with a Claude supervisor running on the alt account, and every worker it spawns stays on that same account.
+- **Was → Now:** choosing an account and choosing to run CAS were two different commands you had to combine by hand with an environment variable → one command does both, and it prints which account directory it picked before anything starts.
+- **Was → Now:** typing `cas claude` with no account name printed a list instead of starting anything → it starts the factory on whatever account you are already using, matching how `cas codex` and `cas grok` behave. The account list moved to `cas claude --list-profiles`.
+- Still want just a chat window on a chosen account? `cas claude alt --bare` does exactly that, and passes your flags straight through.
+
+## Post 2 — Dev
+
+Live on main — **Dev**
+
+`cas claude` is a factory provider shortcut with an account positional, not a `claude` exec wrapper.
+
+- **Was → Now:** `cas claude <profile>` built a `Command::new("claude")` and `exec`'d it, so the factory never started → it exports the resolved `CLAUDE_CONFIG_DIR` into its own process, then delegates to the same `factory::execute` path as `cas codex` / `cas grok` with `supervisor_cli = "claude"` and the explicit flag set.
+- The export happens in `cli::run` before `initialize_telemetry` spawns its background thread, alongside the existing resource-contention env bridge — `set_var` in a multi-threaded process is UB, and the daemon is produced by a bare `fork()`, so it inherits the value. Pane spawns snapshot `std::env::vars_os()` at `CommandBuilder::new`, which is how the supervisor lands on the chosen account; `spawn_workers` captures the same value as `requester_config_dir`, so workers follow without extra plumbing.
+- **Was → Now:** an inherited `ANTHROPIC_API_KEY` was scrubbed only on the exec path, leaving the ambient-env route able to silently override subscription OAuth → the profile-selection path removes it too.
+- Trailing arguments are parsed as `FactoryArgs` through `augment_args` + `from_arg_matches` rather than `#[command(flatten)]`, because `FactoryArgs` carries a subcommand that clap cannot disambiguate from the leading profile positional. Unknown flags exit through clap's own error path instead of being swallowed.
+- `--list-profiles` keeps the account/login/active listing; `--bare` keeps the previous exec-Claude-Code behavior with argument passthrough.


### PR DESCRIPTION
## Problem

`cas claude <profile>` resolved the account config dir and then `exec`'d Claude Code directly (`Command::new("claude")`), so the factory never started. Selecting a second subscription and running CAS were two separate actions that had to be combined by hand with a `CLAUDE_CONFIG_DIR=` prefix.

The intended surface is: `cas claude alt` runs CAS, supervised by Claude, signed in as the alt subscription — supervisor *and* workers.

## Change

`cas claude` becomes the Claude sibling of `cas codex` / `cas grok`, with one extra positional (the account profile).

| Command | Behavior |
|---|---|
| `cas claude alt` | Factory + Claude supervisor on `~/.claude-alt`; workers inherit it |
| `cas claude main` | Same, on `~/.claude` |
| `cas claude` | Factory + Claude supervisor, ambient account untouched |
| `cas claude --list-profiles` | Account / login / active listing |
| `cas claude alt --bare --continue` | Previous behavior: plain Claude Code, args forwarded |

All `cas factory` flags pass through after the profile (`cas claude alt --workers 3 --new`).

## How the account propagates

Traced rather than assumed:

- `cli::run` exports `CLAUDE_CONFIG_DIR` **before** `initialize_telemetry` spawns its thread — `set_var` in a multi-threaded process is UB. This sits next to the existing `apply_resource_contention_env` guard, which exists for the same reason.
- The daemon comes from a bare `fork()` (`daemon/fork_first.rs:98`), so it inherits the value.
- `portable-pty`'s `CommandBuilder::new` snapshots `std::env::vars_os()` (`cmdbuilder.rs:75`) — that's how the supervisor pane lands on the chosen account.
- `spawn_workers` captures the same var as `requester_config_dir` (`factory_ops.rs:543`), so workers follow with no extra plumbing.

## Security-adjacent fix

`ANTHROPIC_API_KEY` was scrubbed only on the exec path. An inherited key overrides subscription OAuth entirely, so the ambient-env route could silently defeat the account the operator just selected. It is now removed whenever a profile is explicitly chosen.

## Implementation note

Trailing args parse as `FactoryArgs` via `augment_args` + `from_arg_matches` rather than `#[command(flatten)]`: `FactoryArgs` carries a subcommand that clap cannot disambiguate from the leading profile positional. Unknown flags exit through clap's own error path instead of being swallowed.

## Testing

- 7 integration tests (`cas-cli/tests/claude_profile_test.rs`) — profile listing, named-profile → factory handoff, `main` → `~/.claude`, factory flag passthrough, unknown-flag rejection, bare launch, help.
- 5 unit tests in `cli::claude` — profile resolution, scanning, `--bare` command construction, trailing-arg parsing.
- Full lib suite: 2 failures in `hooks::context`, confirmed pre-existing by stashing this branch's changes and re-running on clean `main`. Unrelated to this change.

## Breaking change

Bare `cas claude` no longer prints the profile listing — it launches the factory, matching `cas codex` / `cas grok`. The listing moved to `cas claude --list-profiles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)