### PR TITLE
ci(cas-096e): CI wall-clock 51m -> 18m via job fan-out, nextest + doctests, cache de-poisoning

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,29 @@
+# cargo-nextest configuration.
+#
+# Why nextest is used at all: `cargo test` runs the 66 integration test binaries
+# ONE BINARY AT A TIME (parallel only within a binary). nextest schedules every
+# test across all binaries into one global pool, which is the shape this repo
+# needs. See GH #142.
+
+[profile.default]
+# NO RETRIES, deliberately. A retry policy turns a deterministic failure into an
+# intermittent one and buys back exactly the "is it flaky or is it broken?"
+# confusion that GH #136 cost a day to untangle. If a test is flaky, fix it.
+retries = 0
+
+# Report anything that has been running this long so a hang is visible as a hang
+# rather than as a job timeout with no attribution.
+slow-timeout = { period = "60s", terminate-after = 10 }
+
+# Print the full output of failures at the end of the run instead of only the
+# last one, so a CI log answers "what broke?" without a re-run.
+failure-output = "immediate-final"
+fail-fast = false
+
+[profile.ci]
+retries = 0
+slow-timeout = { period = "60s", terminate-after = 10 }
+failure-output = "immediate-final"
+fail-fast = false
+status-level = "fail"
+final-status-level = "slow"

--- a/.github/actions/setup-rust-linux/action.yml
+++ b/.github/actions/setup-rust-linux/action.yml
@@ -1,0 +1,49 @@
+name: Setup Rust (Linux)
+description: >-
+  Shared toolchain setup for every ubuntu-latest CI job: apt deps aligned with
+  .cargo/config.toml, stable Rust, Zig (ghostty_vt_sys builds its native library
+  with Zig even for cargo check), sccache, and the cargo cache.
+
+inputs:
+  cache-key:
+    description: >-
+      Discriminator appended to the cargo cache key. Jobs that compile a
+      DIFFERENT profile or feature set must pass a distinct value so they do not
+      evict each other's artifacts through one shared key.
+    required: true
+  save-cache:
+    description: >-
+      Set to "false" for jobs that run `cargo clean` mid-job. Saving from such a
+      job persists an empty target dir and makes every subsequent run pay a cold
+      build (see the Build Benchmark job).
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        # Keep this aligned with .cargo/config.toml's gcc + mold toolchain.
+        sudo apt-get install -y gcc mold
+        gcc --version
+        mold --version
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Install Zig
+      shell: bash
+      run: ./scripts/bootstrap-zig.sh
+
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.5
+
+    - name: Cache cargo
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ inputs.cache-key }}
+        cache-on-failure: true
+        save-if: ${{ inputs.save-cache == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,13 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo nextest run -p cas --no-fail-fast
 
+      # `!cancelled()` so a failure in the step above cannot hide this one's
+      # result. Letting it skip would re-create, one step later, exactly the
+      # under-reporting this job was changed to fix: `cargo test` used to abort
+      # after the first failing test BINARY, so main went red having executed
+      # 4401 of 4594 tests and never said so (GH #142).
       - name: Test (doctests — the part nextest cannot run)
+        if: ${{ !cancelled() }}
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo test -p cas --doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,69 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo test -p cas --doc
 
+  # TEMPORARY (cas-096e, AC-2). Proves on ONE commit that switching the runner
+  # did not change WHICH tests execute, by listing both sets without running
+  # them. Deliberately its own job so it cannot inflate Fast Validation's
+  # wall-clock, which is the number under measurement. Delete once the receipt
+  # is recorded in the task notes.
+  coverage-parity-receipt:
+    name: Coverage Parity Receipt (lists tests, executes none)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: coverage-parity
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: List what cargo test would execute
+        env:
+          ZIG: ${{ github.workspace }}/.context/zig/zig
+        run: |
+          set -o pipefail
+          # `-- --list` builds the harnesses and enumerates them; runs nothing.
+          cargo test -p cas -- --list 2>/dev/null | tee /tmp/cargo-list.txt >/dev/null
+          echo "cargo_test_tests=$(grep -cE ': test$' /tmp/cargo-list.txt)"
+          cargo test -p cas --doc -- --list 2>/dev/null | tee /tmp/cargo-doc-list.txt >/dev/null
+          echo "cargo_doctests=$(grep -cE ': test$' /tmp/cargo-doc-list.txt)"
+
+      - name: List what nextest would execute
+        env:
+          ZIG: ${{ github.workspace }}/.context/zig/zig
+        run: |
+          set -o pipefail
+          cargo nextest list -p cas --message-format json 2>/dev/null > /tmp/nextest-list.json
+          python3 - <<'PY'
+          import json
+          d = json.load(open("/tmp/nextest-list.json"))
+          n = sum(len(s["testcases"]) for s in d["rust-suites"].values())
+          print(f"nextest_tests={n}")
+          PY
+
+      - name: Compare the two sets
+        run: |
+          set -o pipefail
+          # cargo's list is "binary: test" lines; nextest's is binary-id + name.
+          # Compare bare test names as sets so an ordering or prefix difference
+          # cannot masquerade as parity.
+          grep -E ': test$' /tmp/cargo-list.txt | sed 's/: test$//' | sort > /tmp/a.txt
+          python3 - <<'PY'
+          import json
+          d = json.load(open("/tmp/nextest-list.json"))
+          names = [t for s in d["rust-suites"].values() for t in s["testcases"]]
+          open("/tmp/b.txt","w").write("\n".join(sorted(names))+"\n")
+          PY
+          echo "cargo_test_count=$(wc -l < /tmp/a.txt)  nextest_count=$(wc -l < /tmp/b.txt)"
+          echo "--- in cargo test but NOT in nextest (expect: empty) ---"
+          comm -23 /tmp/a.txt /tmp/b.txt | head -50
+          echo "--- in nextest but NOT in cargo test (expect: empty) ---"
+          comm -13 /tmp/a.txt /tmp/b.txt | head -50
+
   # Advisory lint, split out of Fast Validation so a lint pass never sits on the
   # critical path of the job that answers "do the tests pass?" (GH #142).
   # It compiles its own --all-targets artifacts; it executes no tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,16 @@
 name: CI
 
+# ┌───────────────────────────────────────────────────────────────────────────┐
+# │ WHAT EXECUTES THE TEST SUITE: exactly one job — `Fast Validation`.        │
+# │ Every other job in this file COMPILES things or runs a narrow, named      │
+# │ subset. Read job names literally; they are kept honest on purpose (#138). │
+# └───────────────────────────────────────────────────────────────────────────┘
+#
+# Wall-clock shape (GH #142): total run time is max(job), not sum(job), so the
+# jobs below are deliberately fanned out rather than chained inside one job.
+# The four release/benchmark workloads used to run in series in a single job
+# and cost ~51m; they are independent and now run concurrently.
+
 on:
   pull_request:
   push:
@@ -25,27 +36,12 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          # Keep this aligned with .cargo/config.toml's gcc + mold toolchain.
-          sudo apt-get install -y gcc mold
-          gcc --version
-          mold --version
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Zig
-        run: ./scripts/bootstrap-zig.sh
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/setup-rust-linux
         with:
-          cache-on-failure: true
+          cache-key: fast-validation
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
 
       - name: Check
         env:
@@ -57,13 +53,34 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo build -p cas --no-default-features
 
-      # This is the ONLY step in the entire workflow that executes the test
-      # suite. If you want to know whether the tests pass on a commit, read
-      # this job — no other job's green answers that question (GH #138).
+      # These two steps together execute exactly what bare `cargo test -p cas`
+      # executed before: nextest runs the lib + every integration test binary,
+      # and `--doc` runs the doctests, which nextest does not support. Dropping
+      # the doctest step would silently shrink executed coverage.
       - name: Test (full suite — the only job that executes it)
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: cargo test -p cas
+        run: cargo nextest run -p cas --no-fail-fast
+
+      - name: Test (doctests — the part nextest cannot run)
+        env:
+          ZIG: ${{ github.workspace }}/.context/zig/zig
+        run: cargo test -p cas --doc
+
+  # Advisory lint, split out of Fast Validation so a lint pass never sits on the
+  # critical path of the job that answers "do the tests pass?" (GH #142).
+  # It compiles its own --all-targets artifacts; it executes no tests.
+  clippy:
+    name: Clippy (advisory, compiles only — no test suite)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: clippy
 
       - name: Clippy (report warnings)
         env:
@@ -124,56 +141,30 @@ jobs:
         run: cargo check -p cas --no-default-features
 
   # ┌───────────────────────────────────────────────────────────────────────┐
-  # │ THIS JOB RUNS NO TEST SUITE. Its green means "everything compiles and │
-  # │ the release profiles still isolate panics" — nothing more.            │
+  # │ THIS JOB RUNS NO TESTS. Its green means "the test binaries still      │
+  # │ compile" — nothing about whether they pass.                           │
   # └───────────────────────────────────────────────────────────────────────┘
   #
-  # It executes exactly two things, and neither is the suite:
-  #   - `cargo test -p cas --no-run` — COMPILES the test binaries, runs none.
-  #   - `make -C cas-cli test-release-panic` — four targeted invocations only
-  #     (--lib panic_regression and --test search_utf8_regression_test, each
-  #     under --release and --profile release-fast). See cas-cli/Makefile.
-  #
-  # `Fast Validation` is the ONLY job that executes the test suite (its "Test"
-  # step runs bare `cargo test -p cas`). If you are asking "did the tests
-  # pass?", that is the job to read — a green here cannot answer it.
-  #
-  # Why this warning exists (GH #138): a green here was read as suite coverage
-  # while Fast Validation was red on the same commit, which turned a 100%
-  # deterministic failure (GH #136) into a day-long "flaky test" hunt. The two
-  # results never actually disagreed — one job simply never ran the tests.
+  # Why the warning exists (GH #138): a green compile-only job was read as
+  # suite coverage while Fast Validation was red on the same commit, turning a
+  # 100% deterministic failure (GH #136) into a day-long "flaky test" hunt.
+  # `Fast Validation` is the ONLY job that executes the suite.
   #
   # If you add a step here that DOES execute tests, rename this job to match.
-  release-profile-and-build-guard:
-    name: Release-Profile & Build Guard (compile-only, no test suite)
-    if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'
+  test-compile-guard:
+    name: Test Compile Guard (compile-only, executes nothing)
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          # Keep this aligned with .cargo/config.toml's gcc + mold toolchain.
-          sudo apt-get install -y gcc mold
-          gcc --version
-          mold --version
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Zig
-        run: ./scripts/bootstrap-zig.sh
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/setup-rust-linux
         with:
-          cache-on-failure: true
+          cache-key: test-compile-guard
 
       # --no-run COMPILES the test binaries and executes nothing. A green here
       # says the tests still build; it says nothing about whether they pass.
@@ -182,14 +173,82 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo test -p cas --no-run
 
-      # EPIC cas-c351 / cas-9e02: run A2/A3/B3 panic-isolation tests
-      # under --release and --profile release-fast to catch any future
-      # profile change that silently re-introduces panic=abort or any
-      # release-mode codegen that breaks the tokio::spawn panic catcher.
-      - name: Panic-isolation tests (release profiles)
+  # EPIC cas-c351 / cas-9e02: run the A2/A3/B3 panic-isolation tests under the
+  # release profiles to catch any future profile change that silently
+  # re-introduces panic=abort, or any release-mode codegen that breaks the
+  # tokio::spawn panic catcher.
+  #
+  # `--release` and `--profile release-fast` are two independent full LTO
+  # builds. They ran back-to-back inside one job (~30m in series); as two jobs
+  # they run concurrently and each keeps its own warm cargo cache. Between them
+  # they execute exactly the four invocations `make test-release-panic` always
+  # ran, and that Makefile target still runs both for local use.
+  #
+  # These execute a NAMED SUBSET (panic_regression + search_utf8_regression_test),
+  # not the suite. Green here is not suite coverage.
+  panic-isolation-release:
+    name: Panic Isolation — release profile (named subset, not the suite)
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: panic-isolation-release
+
+      - name: Panic-isolation tests (--release)
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: make -C cas-cli test-release-panic
+        run: make -C cas-cli test-release-panic-release
+
+  panic-isolation-release-fast:
+    name: Panic Isolation — release-fast profile (named subset, not the suite)
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: panic-isolation-release-fast
+
+      - name: Panic-isolation tests (--profile release-fast)
+        env:
+          ZIG: ${{ github.workspace }}/.context/zig/zig
+        run: make -C cas-cli test-release-panic-release-fast
+
+  # Build-time measurement only. This job executes no tests.
+  #
+  # save-cache: false is load-bearing. scripts/benchmark-build.sh starts with
+  # `cargo clean` — that is the point, it measures clean builds — so saving the
+  # cargo cache from this job would persist an empty target dir. While these
+  # steps lived in the same job as the release/compile work, that clean was
+  # wiping the cache those steps depended on and every run paid a near-cold
+  # build.
+  build-benchmark:
+    name: Build Benchmark & Timings (measurement only, no test suite)
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: build-benchmark
+          save-cache: "false"
 
       - name: Benchmark build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,69 +73,6 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo test -p cas --doc
 
-  # TEMPORARY (cas-096e, AC-2). Proves on ONE commit that switching the runner
-  # did not change WHICH tests execute, by listing both sets without running
-  # them. Deliberately its own job so it cannot inflate Fast Validation's
-  # wall-clock, which is the number under measurement. Delete once the receipt
-  # is recorded in the task notes.
-  coverage-parity-receipt:
-    name: Coverage Parity Receipt (lists tests, executes none)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - uses: ./.github/actions/setup-rust-linux
-        with:
-          cache-key: coverage-parity
-
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: List what cargo test would execute
-        env:
-          ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: |
-          set -o pipefail
-          # `-- --list` builds the harnesses and enumerates them; runs nothing.
-          cargo test -p cas -- --list 2>/dev/null | tee /tmp/cargo-list.txt >/dev/null
-          echo "cargo_test_tests=$(grep -cE ': test$' /tmp/cargo-list.txt)"
-          cargo test -p cas --doc -- --list 2>/dev/null | tee /tmp/cargo-doc-list.txt >/dev/null
-          echo "cargo_doctests=$(grep -cE ': test$' /tmp/cargo-doc-list.txt)"
-
-      - name: List what nextest would execute
-        env:
-          ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: |
-          set -o pipefail
-          cargo nextest list -p cas --message-format json 2>/dev/null > /tmp/nextest-list.json
-          python3 - <<'PY'
-          import json
-          d = json.load(open("/tmp/nextest-list.json"))
-          n = sum(len(s["testcases"]) for s in d["rust-suites"].values())
-          print(f"nextest_tests={n}")
-          PY
-
-      - name: Compare the two sets
-        run: |
-          set -o pipefail
-          # cargo's list is "binary: test" lines; nextest's is binary-id + name.
-          # Compare bare test names as sets so an ordering or prefix difference
-          # cannot masquerade as parity.
-          grep -E ': test$' /tmp/cargo-list.txt | sed 's/: test$//' | sort > /tmp/a.txt
-          python3 - <<'PY'
-          import json
-          d = json.load(open("/tmp/nextest-list.json"))
-          names = [t for s in d["rust-suites"].values() for t in s["testcases"]]
-          open("/tmp/b.txt","w").write("\n".join(sorted(names))+"\n")
-          PY
-          echo "cargo_test_count=$(wc -l < /tmp/a.txt)  nextest_count=$(wc -l < /tmp/b.txt)"
-          echo "--- in cargo test but NOT in nextest (expect: empty) ---"
-          comm -23 /tmp/a.txt /tmp/b.txt | head -50
-          echo "--- in nextest but NOT in cargo test (expect: empty) ---"
-          comm -13 /tmp/a.txt /tmp/b.txt | head -50
-
   # Advisory lint, split out of Fast Validation so a lint pass never sits on the
   # critical path of the job that answers "do the tests pass?" (GH #142).
   # It compiles its own --all-targets artifacts; it executes no tests.

--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -25,7 +25,7 @@
 # - [ ] Status line updates correctly
 # - [ ] No visual artifacts or flickering
 
-.PHONY: test test-full test-clean-env coverage coverage-html clean build build-full release release-fast test-release-panic check check-full lint dev-build dev-test timings benchmark-build check-build-regression
+.PHONY: test test-full test-clean-env coverage coverage-html clean build build-full release release-fast test-release-panic test-release-panic-release test-release-panic-release-fast check check-full lint dev-build dev-test timings benchmark-build check-build-regression
 
 CARGO ?= cargo
 
@@ -147,9 +147,18 @@ release-fast:
 # Run A2/A3/B3 panic-isolation tests under release profiles (EPIC cas-c351).
 # Verifies the MCP panic catcher survives release-mode LTO + inlining and
 # that the release-fast profile has not re-introduced panic=abort.
-test-release-panic:
+#
+# Split into one target per profile so CI can run the two profiles as parallel
+# jobs (they are two independent full LTO builds; in series they were a 30-min
+# step). `test-release-panic` still runs both, so the local command documented
+# in CLAUDE.md is unchanged.
+test-release-panic: test-release-panic-release test-release-panic-release-fast
+
+test-release-panic-release:
 	$(CARGO) test -p cas --release --lib panic_regression
 	$(CARGO) test -p cas --release --test search_utf8_regression_test
+
+test-release-panic-release-fast:
 	$(CARGO) test -p cas --profile release-fast --lib panic_regression
 	$(CARGO) test -p cas --profile release-fast --test search_utf8_regression_test
 


### PR DESCRIPTION
Closes the CI wall-clock work for cas-096e (GH #142). **51-53m -> 18.3m**, with the executed test set proven identical.

## The premise in the ticket was wrong

CI was *not* "dominated by Fast Validation running bare `cargo test`" — that job was 6-8m warm the whole time. All ~51m was **one** job (`Release-Profile & Build Guard`) running four independent workloads **in series**. A run costs `max(job)`, not `sum(job)`, so fanning them out is the entire win.

Second root cause, not in the ticket: `scripts/benchmark-build.sh` runs `cargo clean` mid-job, so `Swatinem/rust-cache`'s post-job save persisted an **empty** target dir. Every guard run paid a near-cold build (cache restore 1s vs 23s in Fast Validation; compile 574s vs 302s). Now isolated with `save-cache: false`.

## Measurements

| job | before | after (run 31185617556) |
|---|---|---|
| Build Benchmark & Timings | (in the 51m serial job) | 1096s ← max |
| Panic Isolation — release | " | 850s |
| Panic Isolation — release-fast | " | 594s |
| Fast Validation | 477s | 416s |
| Test Compile Guard | " | 236s |
| macOS Check | 139s | 207s |
| Clippy | (inside Fast Validation) | 155s |
| **total** | **51m** / 53m | **18.3m** |

Baselines: [31137269229](https://github.com/pippenz/cas/actions/runs/31137269229) 51m, [31142945287](https://github.com/pippenz/cas/actions/runs/31142945287) 53m. After: [31185617556](https://github.com/pippenz/cas/actions/runs/31185617556) 18.3m, [31184001944](https://github.com/pippenz/cas/actions/runs/31184001944) 18.1m.

## `cargo test` was hiding failures

`cargo test` **aborts after the first failing test binary**. Main was red having executed 4401 of 4594 tests and reporting 1 of 3 real failures — two `team_pull_wiring_test` failures had never once appeared in CI. Verified against main's own log ([31180761843](https://github.com/pippenz/cas/actions/runs/31180761843), plain `cargo test`, none of these changes). `cargo nextest run --no-fail-fast` executes all 4594 and reports all three.

So nextest is adopted for **correctness** as much as for the 4x execute-phase speedup (65.4s vs 251s).

## Coverage parity (proven by name, not by count)

A temporary job listed both runners on one commit without executing either:

- `cargo test -p cas -- --list` → **4694**
- `cargo nextest list -p cas` → **4667**
- `cargo test -p cas --doc -- --list` → **27**

`4667 + 27 = 4694`. The nextest-minus-cargo diff is **empty**; the cargo-minus-nextest diff is **exactly the 27 doctests**, which the dedicated `cargo test -p cas --doc` step runs. Identical set, both directions. That job has been removed.

## Honesty (GH #138) preserved

Exactly one job claims suite execution (`Fast Validation`). Every other says in its **name** that it does not: "compile-only, executes nothing", "named subset, not the suite", "advisory, compiles only — no test suite", "measurement only, no test suite".

## Unchanged on purpose

`macOS Check` byte-identical. Panic-isolation guard runs the same four invocations, split across two jobs; `make test-release-panic` still runs both. Release profiles untouched — relaxing LTO to buy time would gut the guard's purpose. `release.yml` untouched.

## Known red

Fast Validation is red on exactly two tests, both GH #150 / cas-0bea and neither introduced here: `execute_sync_does_not_hit_team_pull_when_no_team_configured` and `execute_sync_hits_each_pull_endpoint_exactly_once_when_team_configured`.

## Residual, stated plainly

Margin is ~2m and the binding job **moves** between runs (run 2 max = release 1086s w/ benchmark 794s; run 3 max = benchmark 1096s w/ release 850s). Two independent jobs sit near the ceiling, so this is not one hotspot away from 12m. Build Benchmark is structurally cold every run by design. If the budget must hold as the crate grows, next levers are moving it to the weekly schedule (a cadence change needing sign-off — deliberately not done unilaterally) or sharding the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)