### PR TITLE
fix(factory): isolate nested LLM identity

### DIFF
--- a/cas-cli/src/hooks/context.rs
+++ b/cas-cli/src/hooks/context.rs
@@ -722,7 +722,9 @@ fn parse_ai_selection(response: &str) -> Vec<String> {
 
 /// Call Claude to select context items
 fn call_claude_for_selection(prompt: &str, model: &str) -> Result<String, MemError> {
-    let output = Command::new("claude")
+    let mut command = Command::new("claude");
+    crate::internal_llm::isolate_command(&mut command);
+    let output = command
         .args([
             "-p",
             prompt,

--- a/cas-cli/src/hooks/mod.rs
+++ b/cas-cli/src/hooks/mod.rs
@@ -108,6 +108,13 @@ pub(crate) fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
 /// This is the single entry point that resolves cas_root once and passes it
 /// to all handlers, eliminating redundant find_cas_root() calls.
 pub fn handle_hook(event_name: &str, input: HookInput) -> Result<HookOutput, MemError> {
+    // CAS-owned headless model calls are implementation details, not user
+    // sessions. Their prompts must never be captured as memory and their
+    // short-lived harnesses must never register as factory workers.
+    if crate::internal_llm::is_internal_invocation() {
+        return Ok(HookOutput::empty());
+    }
+
     // Resolve cas_root once at entry point using full discovery logic:
     // 1. CAS_ROOT env var (factory workers use this to share main repo's .cas)
     // 2. Git worktree detection (worktrees share main repo's .cas)
@@ -137,6 +144,88 @@ pub fn handle_hook(event_name: &str, input: HookInput) -> Result<HookOutput, Mem
             // Unknown hook, just pass through
             Ok(HookOutput::empty())
         }
+    }
+}
+
+#[cfg(test)]
+mod internal_llm_tests {
+    use super::*;
+    use crate::test_support::TestEnvGuard;
+
+    #[test]
+    fn internal_model_hooks_create_neither_agents_nor_prompt_memories() {
+        let project = tempfile::tempdir().expect("project");
+        let cas_root = crate::store::init_cas_dir(project.path()).expect("cas root");
+        let mut env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_ROOT", Some(cas_root.to_str().expect("utf8 cas root"))),
+            (crate::internal_llm::INTERNAL_LLM_ENV, Some("1")),
+            ("CAS_AGENT_ROLE", Some("worker")),
+            ("CAS_AGENT_NAME", Some("parent-worker")),
+            ("CAS_SESSION_ID", Some("parent-session")),
+            ("CAS_FACTORY_MODE", Some("1")),
+        ]);
+
+        let analyzer = "Analyze this user prompt and determine if it expresses a coding preference or rule that should be remembered.";
+        let internal_session = HookInput {
+            session_id: "nested-child-session".into(),
+            cwd: project.path().to_string_lossy().into_owned(),
+            hook_event_name: "SessionStart".into(),
+            source: Some("startup".into()),
+            ..HookInput::default()
+        };
+        handle_hook("SessionStart", internal_session).expect("internal session start");
+        handle_hook(
+            "UserPromptSubmit",
+            HookInput {
+                session_id: "nested-child-session".into(),
+                cwd: project.path().to_string_lossy().into_owned(),
+                hook_event_name: "UserPromptSubmit".into(),
+                user_prompt: Some(analyzer.into()),
+                ..HookInput::default()
+            },
+        )
+        .expect("internal prompt hook");
+
+        let agents = crate::store::open_agent_store(&cas_root).expect("agent store");
+        assert!(agents.list(None).expect("agents").is_empty());
+        let memories = crate::store::open_store(&cas_root).expect("memory store");
+        assert!(memories.list().expect("memories").is_empty());
+        let events = crate::store::open_event_store(&cas_root).expect("event store");
+        assert!(
+            events
+                .list_recent(20)
+                .expect("internal activity")
+                .is_empty(),
+            "nested SessionStart/UserPromptSubmit must emit neither registration nor memory activity"
+        );
+
+        // The marker is the boundary, not the prompt shape: a real user turn
+        // still follows the ordinary memory path.
+        env.remove(crate::internal_llm::INTERNAL_LLM_ENV);
+        handle_hook(
+            "UserPromptSubmit",
+            HookInput {
+                session_id: "real-user-session".into(),
+                cwd: project.path().to_string_lossy().into_owned(),
+                hook_event_name: "UserPromptSubmit".into(),
+                user_prompt: Some(
+                    "Please implement durable user memory capture for this project.".into(),
+                ),
+                ..HookInput::default()
+            },
+        )
+        .expect("real prompt hook");
+        let stored = memories.list().expect("stored memories");
+        assert_eq!(stored.len(), 1);
+        assert!(stored[0].content.contains("durable user memory capture"));
+        assert!(
+            events
+                .list_recent(20)
+                .expect("real activity")
+                .iter()
+                .any(|event| event.summary.contains("Memory stored")),
+            "a real user prompt must retain the ordinary memory/activity path"
+        );
     }
 }
 

--- a/cas-cli/src/internal_llm.rs
+++ b/cas-cli/src/internal_llm.rs
@@ -1,0 +1,86 @@
+//! Isolation contract for CAS-owned, headless LLM subprocesses.
+//!
+//! These subprocesses are implementation details (knowledge distillation,
+//! prompt classification, session summaries), not new user or factory-agent
+//! sessions.  They must not inherit the caller's durable CAS identity.
+
+use std::process::Command;
+
+/// Marks a process as an internal completion whose Claude hooks must be inert.
+pub const INTERNAL_LLM_ENV: &str = "CAS_INTERNAL_LLM";
+
+/// Factory identity inherited by a nested harness would make it impersonate
+/// the parent worker.  Keep this list narrow: credentials and ordinary CAS
+/// configuration are intentionally unaffected.
+pub const FACTORY_IDENTITY_ENV: &[&str] = &[
+    "CAS_AGENT_NAME",
+    "CAS_AGENT_ROLE",
+    "CAS_SESSION_ID",
+    "CAS_FACTORY_MODE",
+    "CAS_FACTORY_SESSION",
+    "CAS_CLONE_PATH",
+    "CAS_SUPERVISOR_NAME",
+    "CAS_FACTORY_WORKER_CLI",
+    "CAS_FACTORY_WORKER_MODEL",
+    "CAS_FACTORY_WORKER_EFFORT",
+];
+
+/// Apply the isolation contract to a directly-spawned command.
+pub fn isolate_command(command: &mut Command) {
+    command.env(INTERNAL_LLM_ENV, "1");
+    for key in FACTORY_IDENTITY_ENV {
+        command.env_remove(key);
+    }
+}
+
+/// Environment overrides for SDKs which can add/override child variables but
+/// cannot express `env_remove`. Empty values are rejected by every factory
+/// identity reader and prevent eager MCP registration (`CAS_SESSION_ID`).
+pub fn sdk_environment() -> std::collections::HashMap<String, String> {
+    let mut env = std::collections::HashMap::from([(INTERNAL_LLM_ENV.to_string(), "1".into())]);
+    env.extend(
+        FACTORY_IDENTITY_ENV
+            .iter()
+            .map(|key| ((*key).to_string(), String::new())),
+    );
+    env
+}
+
+/// True only inside a CAS-owned headless completion.
+pub fn is_internal_invocation() -> bool {
+    std::env::var(INTERNAL_LLM_ENV).as_deref() == Ok("1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_commands_remove_factory_identity_and_mark_internal() {
+        let mut command = Command::new("claude");
+        isolate_command(&mut command);
+        let env: std::collections::HashMap<_, _> = command
+            .get_envs()
+            .map(|(key, value)| {
+                (
+                    key.to_string_lossy().into_owned(),
+                    value.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect();
+
+        assert_eq!(env.get(INTERNAL_LLM_ENV), Some(&Some("1".to_string())));
+        for key in FACTORY_IDENTITY_ENV {
+            assert_eq!(env.get(*key), Some(&None), "{key} must be removed");
+        }
+    }
+
+    #[test]
+    fn sdk_environment_blanks_every_factory_identity() {
+        let env = sdk_environment();
+        assert_eq!(env.get(INTERNAL_LLM_ENV).map(String::as_str), Some("1"));
+        for key in FACTORY_IDENTITY_ENV {
+            assert_eq!(env.get(*key).map(String::as_str), Some(""), "{key}");
+        }
+    }
+}

--- a/cas-cli/src/knowledge/llm.rs
+++ b/cas-cli/src/knowledge/llm.rs
@@ -123,6 +123,7 @@ impl LlmRunner for ClaudeCliRunner {
             .map_err(|error| LlmError::Failed(format!("capture stderr: {error}")))?;
 
         let mut command = Command::new(&self.binary);
+        crate::internal_llm::isolate_command(&mut command);
         command
             .arg("-p")
             .arg("--output-format")

--- a/cas-cli/src/lib.rs
+++ b/cas-cli/src/lib.rs
@@ -45,6 +45,7 @@ pub mod harness_policy;
 pub mod history;
 pub mod hooks;
 pub mod hybrid_search;
+pub(crate) mod internal_llm;
 pub mod knowledge;
 pub mod logging;
 pub mod memory_migration;

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -47,6 +47,48 @@ fn short_session(session_id: &str) -> &str {
     &session_id[..8.min(session_id.len())]
 }
 
+/// Collapse accidental duplicate registrations for one logical factory
+/// identity. The first harness registration is authoritative while it is
+/// alive; a later live registration wins only when the original process is
+/// gone (legitimate same-name respawn).
+fn dedupe_authoritative_agents(
+    agents: Vec<cas_types::Agent>,
+) -> (Vec<cas_types::Agent>, usize) {
+    let original_len = agents.len();
+    let mut by_identity = std::collections::BTreeMap::<
+        (Option<String>, String, String),
+        cas_types::Agent,
+    >::new();
+
+    for candidate in agents {
+        let key = (
+            candidate.factory_session.clone(),
+            candidate.role.to_string(),
+            candidate.name.clone(),
+        );
+        match by_identity.get_mut(&key) {
+            None => {
+                by_identity.insert(key, candidate);
+            }
+            Some(current) => {
+                let candidate_alive = agent_process_is_alive(&candidate);
+                let current_alive = agent_process_is_alive(current);
+                let candidate_wins = (candidate_alive && !current_alive)
+                    || (candidate_alive == current_alive
+                        && candidate.registered_at < current.registered_at);
+                if candidate_wins {
+                    *current = candidate;
+                }
+            }
+        }
+    }
+
+    let mut deduped: Vec<_> = by_identity.into_values().collect();
+    deduped.sort_by_key(|agent| agent.registered_at);
+    let removed = original_len.saturating_sub(deduped.len());
+    (deduped, removed)
+}
+
 fn worker_effort_from_agent(agent: &cas_types::Agent) -> Option<cas_mux::Effort> {
     agent
         .metadata
@@ -1400,6 +1442,7 @@ impl CasService {
             .into_iter()
             .filter(|a| a.visible_to_factory_session(factory_session.as_deref()))
             .collect();
+        let (agents, duplicate_registrations_filtered) = dedupe_authoritative_agents(agents);
 
         // cas-2e81: always surface recently-died-while-leased even when the
         // Active roster is empty — "None active" must not hide a mid-P0 crash.
@@ -1454,6 +1497,11 @@ impl CasService {
         let owned = supervisor_owned_workers();
         let mut output = String::from("Worker Status\n=============\n\n");
         output.push_str(&undelivered_section);
+        if duplicate_registrations_filtered > 0 {
+            output.push_str(&format!(
+                "Filtered duplicate factory registration(s): {duplicate_registrations_filtered}\n\n"
+            ));
+        }
 
         // cas-d165 (Finding 2): assignees of currently InProgress tasks,
         // resolved ONCE for the whole roster. `has_in_progress_task` below
@@ -6681,6 +6729,29 @@ mod spawn_lifecycle_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn worker_status_identity_dedupe_keeps_one_authoritative_factory_row() {
+        let mut parent = cas_types::Agent::new("parent-session".into(), "worker-one".into());
+        parent.role = cas_types::AgentRole::Worker;
+        parent.factory_session = Some("factory-a".into());
+        parent.registered_at = chrono::Utc::now() - chrono::Duration::minutes(2);
+
+        let mut nested = parent.clone();
+        nested.id = "nested-knowledge-session".into();
+        nested.cc_session_id = Some("nested-transcript".into());
+        nested.registered_at = chrono::Utc::now();
+
+        let mut other = cas_types::Agent::new("other-session".into(), "worker-two".into());
+        other.role = cas_types::AgentRole::Worker;
+        other.factory_session = Some("factory-a".into());
+
+        let (rows, removed) = dedupe_authoritative_agents(vec![nested, other, parent]);
+        assert_eq!(removed, 1);
+        assert_eq!(rows.len(), 2);
+        let worker_one = rows.iter().find(|row| row.name == "worker-one").unwrap();
+        assert_eq!(worker_one.id, "parent-session");
+    }
 
     #[cfg(target_os = "linux")]
     struct SyntheticProcessGroup {

--- a/cas-cli/src/tracing/claude_wrapper.rs
+++ b/cas-cli/src/tracing/claude_wrapper.rs
@@ -31,7 +31,7 @@ use crate::tracing::dev_tracer::DevTracer;
 /// "extraction", "hook_summary").
 pub async fn traced_prompt(
     prompt: &str,
-    options: QueryOptions,
+    mut options: QueryOptions,
     caller: &str,
 ) -> Result<ResultMessage, claude_rs::Error> {
     let timer = TraceTimer::new();
@@ -39,6 +39,10 @@ pub async fn traced_prompt(
     // Extract model from options if possible (we'll use a default if not)
     let model = "claude"; // QueryOptions doesn't expose model getter easily
 
+    options
+        .env
+        .get_or_insert_with(Default::default)
+        .extend(crate::internal_llm::sdk_environment());
     let result = claude_rs::prompt(prompt, options).await;
 
     let duration_ms = timer.elapsed_ms();
@@ -88,12 +92,16 @@ pub async fn traced_prompt(
 /// Use this when you know the model name and want it recorded accurately.
 pub async fn traced_prompt_with_model(
     prompt: &str,
-    options: QueryOptions,
+    mut options: QueryOptions,
     model: &str,
     caller: &str,
 ) -> Result<ResultMessage, claude_rs::Error> {
     let timer = TraceTimer::new();
 
+    options
+        .env
+        .get_or_insert_with(Default::default)
+        .extend(crate::internal_llm::sdk_environment());
     let result = claude_rs::prompt(prompt, options).await;
 
     let duration_ms = timer.elapsed_ms();

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -29,6 +29,25 @@ fn bool_prop(value: bool) -> &'static str {
     if value { "true" } else { "false" }
 }
 
+fn worker_registry_rows_for_shutdown<'a>(
+    agents: &'a [cas_types::Agent],
+    name: &str,
+    factory_session: Option<&str>,
+) -> Vec<&'a cas_types::Agent> {
+    let mut matching: Vec<_> = agents
+        .iter()
+        .filter(|agent| {
+            agent.name == name
+                && agent.role == cas_types::AgentRole::Worker
+                && factory_session.is_none_or(|session| {
+                    agent.factory_session.as_deref() == Some(session)
+                })
+        })
+        .collect();
+    matching.sort_by_key(|agent| agent.registered_at);
+    matching
+}
+
 /// Resolve the current worker harness from the live on-disk `LlmConfig`.
 ///
 /// Exists as a standalone function so unit tests can verify the on-disk
@@ -1371,7 +1390,12 @@ impl FactoryApp {
         // instead of silently leaving stale idle agents in director panels.
         let agent_store = open_agent_store(self.cas_dir())?;
         let agents = agent_store.list(None)?;
-        let agent = agents.iter().find(|a| a.name == name).ok_or_else(|| {
+        let matching_agents = worker_registry_rows_for_shutdown(
+            &agents,
+            name,
+            self.factory_session.as_deref(),
+        );
+        let agent = matching_agents.first().copied().ok_or_else(|| {
             let known_workers: Vec<String> = agents
                 .iter()
                 .filter(|a| a.role == cas_types::AgentRole::Worker)
@@ -1395,18 +1419,28 @@ impl FactoryApp {
         let has_open_tasks = worker_has_open_tasks(&cas_dir, name)
             || worker_has_open_tasks(&cas_dir, &agent_id);
 
-        if let Err(e) = agent_store.graceful_shutdown(&agent.id) {
-            // Best effort fallback to stale state for consistency, but still surface original failure.
-            let fallback = agent_store.mark_stale(&agent.id);
+        // Retire every same-name row in this factory session. Older builds
+        // allowed nested headless Claude calls to register child session IDs
+        // under the parent worker name; shutting down only `.find()` left the
+        // remaining rows fresh/Active after the pane and worktree were gone.
+        let mut retirement_failures = Vec::new();
+        for matching in &matching_agents {
+            if let Err(error) = agent_store.graceful_shutdown(&matching.id) {
+                let fallback = agent_store.mark_stale(&matching.id);
+                retirement_failures.push(format!(
+                    "{}: {error} (fallback: {})",
+                    matching.id,
+                    match fallback {
+                        Ok(()) => "marked stale".to_string(),
+                        Err(mark_error) => format!("failed: {mark_error}"),
+                    }
+                ));
+            }
+        }
+        if !retirement_failures.is_empty() {
             anyhow::bail!(
-                "Failed to gracefully shutdown worker '{}' (agent_id={}): {}. Fallback mark_stale: {}",
-                name,
-                agent.id,
-                e,
-                match fallback {
-                    Ok(()) => "ok".to_string(),
-                    Err(mark_err) => format!("failed ({mark_err})"),
-                }
+                "Failed to retire all CAS identities for worker '{name}': {}",
+                retirement_failures.join("; ")
             );
         }
 
@@ -2883,6 +2917,31 @@ mod tests {
         t.assignee = assignee.map(str::to_string);
         t.status = status;
         t
+    }
+
+    #[test]
+    fn targeted_shutdown_selects_every_same_session_duplicate_identity() {
+        let worker = |id: &str, session: &str| {
+            let mut agent = cas_types::Agent::new(id.into(), "knowledge-worker".into());
+            agent.role = cas_types::AgentRole::Worker;
+            agent.factory_session = Some(session.into());
+            agent
+        };
+        let rows = vec![
+            worker("parent", "factory-a"),
+            worker("nested-1", "factory-a"),
+            worker("nested-2", "factory-a"),
+            worker("other-factory", "factory-b"),
+        ];
+
+        let selected =
+            worker_registry_rows_for_shutdown(&rows, "knowledge-worker", Some("factory-a"));
+        let ids: std::collections::HashSet<_> =
+            selected.iter().map(|agent| agent.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            std::collections::HashSet::from(["parent", "nested-1", "nested-2"])
+        );
     }
 
     #[test]

--- a/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
@@ -985,7 +985,10 @@ impl FactoryDaemon {
             // to ensure we find all agents, including those registered after cache refresh
             if let Ok(all_agents) = agent_store.list(None) {
                 for name in &names_to_unregister {
-                    if let Some(agent) = all_agents.iter().find(|a| a.name == *name) {
+                    for agent in all_agents.iter().filter(|a| {
+                        a.name == *name
+                            && a.factory_session.as_deref() == Some(self.session_name.as_str())
+                    }) {
                         if let Err(e) = agent_store.unregister(&agent.id) {
                             tracing::warn!("Failed to unregister agent {}: {}", name, e);
                         }

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -1795,6 +1795,47 @@ async fn test_worker_status_shows_agents() {
     assert!(text.contains("effort: high"), "Should show effort: {text}");
 }
 
+/// cas-fa38: a headless knowledge-build child used to inherit the parent
+/// worker name/factory session and create another Active row. Even after the
+/// worktree disappeared, every row rendered independently with a fresh-looking
+/// heartbeat. Status must expose one authoritative identity.
+#[tokio::test]
+async fn test_worker_status_dedupes_nested_identity_with_missing_worktree() {
+    let _guard = EnvGuard::set(&[("CAS_FACTORY_SESSION", "session-fa38")]);
+    let env = FactoryTestEnv::new();
+    let missing = env.cas_root.join("worktrees/knowledge-worker");
+    let store = env.agent_store();
+
+    let mut parent = Agent::new("parent-factory-id".into(), "knowledge-worker".into());
+    parent.role = AgentRole::Worker;
+    parent.factory_session = Some("session-fa38".into());
+    parent.registered_at = chrono::Utc::now() - chrono::Duration::minutes(1);
+    parent
+        .metadata
+        .insert("clone_path".into(), missing.to_string_lossy().into_owned());
+    store.register(&parent).unwrap();
+
+    let mut nested = parent.clone();
+    nested.id = "nested-knowledge-id".into();
+    nested.cc_session_id = Some("nested-transcript-id".into());
+    nested.registered_at = chrono::Utc::now();
+    store.register(&nested).unwrap();
+
+    let text = get_text(
+        &env.service
+            .factory(Parameters(factory_req("worker_status")))
+            .await
+            .expect("worker_status"),
+    );
+    assert!(text.contains("Workers (1)"), "{text}");
+    assert_eq!(text.matches("• knowledge-worker").count(), 1, "{text}");
+    assert!(
+        text.contains("Filtered duplicate factory registration(s): 1"),
+        "{text}"
+    );
+    assert!(text.contains("[missing-worktree]"), "{text}");
+}
+
 /// cas-e728 (GH #105) defect 1 — stale task attribution.
 ///
 /// A lease is a fixed-duration row that nothing renews and that not every

--- a/crates/cas-store/src/agent_store/ops_agent.rs
+++ b/crates/cas-store/src/agent_store/ops_agent.rs
@@ -185,7 +185,11 @@ impl SqliteAgentStore {
 
             let rows = tx.execute("DELETE FROM agents WHERE id = ?", params![id])?;
             if rows == 0 {
-                return Err(StoreError::NotFound(format!("Agent not found: {id}")));
+                // SessionEnd, MCP shutdown, and factory teardown can all race
+                // to retire the same identity. Repeating unregister is a
+                // successful no-op and must not emit another activity event.
+                tx.commit()?;
+                return Ok(());
             }
 
             // Record event for sidecar activity feed (use name if available, else id)

--- a/crates/cas-store/src/agent_store/tests.rs
+++ b/crates/cas-store/src/agent_store/tests.rs
@@ -74,6 +74,7 @@ fn test_agent_crud() {
 
     // Unregister
     store.unregister("agent-test").unwrap();
+    store.unregister("agent-test").unwrap();
     assert!(store.get("agent-test").is_err());
 }
 


### PR DESCRIPTION
## Summary
- isolate CAS-owned headless LLM subprocesses from factory identity and make their hooks inert
- preserve real user memory capture while blocking internal analyzer/distillation prompt ingestion
- deduplicate authoritative worker status and retire duplicate same-name rows during shutdown
- make agent unregister idempotent and add deterministic nested/missing-worktree regressions

## Verification
- fresh chained targeted proof: 7 tests passed, 0 failed
- clean tree at ca88202d0797a4959d350b9244e1afe951b400a1

Task: cas-fa38
Independent schema follow-up: cas-4ada