### PR TITLE
GitHub issue burn-down v11: handoff backlog, workflow-args fix, cross-project design, seeding lock fix

### DIFF
--- a/cas-cli/src/cli/auth.rs
+++ b/cas-cli/src/cli/auth.rs
@@ -12,7 +12,7 @@ use crate::cli::cloud::{
     select_cached_team_after_login,
 };
 use crate::cloud::{
-    FetchTeamsOutcome, default_endpoint, fetch_and_cache_teams, is_acceptable_endpoint,
+    CloudConfig, FetchTeamsOutcome, default_endpoint, fetch_and_cache_teams, is_acceptable_endpoint,
     maybe_apply_team_backfill,
 };
 use crate::ui::components::{

--- a/cas-cli/src/cli/auth.rs
+++ b/cas-cli/src/cli/auth.rs
@@ -7,9 +7,14 @@ use std::io;
 use clap::{Parser, Subcommand};
 
 use crate::cli::Cli;
-use crate::cli::cloud::print_backfill_notice;
-use crate::cloud::{FetchTeamsOutcome, default_endpoint, fetch_and_cache_teams,
-    is_acceptable_endpoint, maybe_apply_team_backfill};
+use crate::cli::cloud::{
+    LoginTeamSelection, print_backfill_notice, print_login_team_selection,
+    select_cached_team_after_login,
+};
+use crate::cloud::{
+    FetchTeamsOutcome, default_endpoint, fetch_and_cache_teams, is_acceptable_endpoint,
+    maybe_apply_team_backfill,
+};
 use crate::ui::components::{
     Component, Formatter, Spinner, SpinnerMsg, clear_inline, render_inline_view, rerender_inline,
 };
@@ -329,7 +334,9 @@ fn execute_device_flow_login(args: &LoginArgs, cli: &Cli) -> anyhow::Result<()> 
                         // Best-effort: fetch team membership from /api/me and
                         // cache into ~/.cas/cloud.json so T3's resolution chain
                         // works offline immediately after login.
-                        match fetch_and_cache_teams(&args.endpoint, access_token) {
+                        let membership_outcome =
+                            fetch_and_cache_teams(&args.endpoint, access_token);
+                        match &membership_outcome {
                             FetchTeamsOutcome::Updated { team_count } => {
                                 tracing::debug!(
                                     team_count,
@@ -351,6 +358,13 @@ fn execute_device_flow_login(args: &LoginArgs, cli: &Cli) -> anyhow::Result<()> 
                                      Team auto-scope will work after the next `cas cloud sync`."
                                 );
                             }
+                        }
+
+                        if matches!(
+                            membership_outcome,
+                            FetchTeamsOutcome::Updated { .. } | FetchTeamsOutcome::Empty
+                        ) {
+                            apply_login_team_selection(cli);
                         }
 
                         // T6: first-run backfill — auto-promote to team scope on first
@@ -532,7 +546,8 @@ fn execute_login_with_token(token: &str, endpoint: &str, cli: &Cli) -> anyhow::R
 
     // Best-effort: fetch team membership from /api/me and cache into
     // ~/.cas/cloud.json so T3's resolution chain works immediately.
-    match fetch_and_cache_teams(endpoint, token) {
+    let membership_outcome = fetch_and_cache_teams(endpoint, token);
+    match &membership_outcome {
         FetchTeamsOutcome::Updated { team_count } => {
             tracing::debug!(
                 team_count,
@@ -548,6 +563,13 @@ fn execute_login_with_token(token: &str, endpoint: &str, cli: &Cli) -> anyhow::R
             // will retry via the lazy-refresh path.
             tracing::warn!("could not fetch team membership from /api/me during token login (non-fatal)");
         }
+    }
+
+    if matches!(
+        membership_outcome,
+        FetchTeamsOutcome::Updated { .. } | FetchTeamsOutcome::Empty
+    ) {
+        apply_login_team_selection(cli);
     }
 
     // T6: first-run backfill — auto-promote to team scope on first login when
@@ -566,6 +588,34 @@ fn execute_login_with_token(token: &str, endpoint: &str, cli: &Cli) -> anyhow::R
     }
 
     Ok(())
+}
+
+/// Use the cached-membership resolver behind `cas cloud team set` to make a
+/// sole team membership active for the project that just logged in. Failures
+/// remain non-fatal, matching the surrounding best-effort membership refresh.
+fn apply_login_team_selection(cli: &Cli) {
+    let user_config = match crate::cloud::user_level_cloud_json_path()
+        .and_then(|path| CloudConfig::load_from(&path).ok())
+    {
+        Some(config) => config,
+        None => return,
+    };
+    let mut project_config = match CloudConfig::load() {
+        Ok(config) => config,
+        Err(error) => {
+            tracing::warn!(%error, "could not load project cloud config after login");
+            return;
+        }
+    };
+
+    let outcome = select_cached_team_after_login(&mut project_config, &user_config);
+    if matches!(outcome, LoginTeamSelection::Activated(_))
+        && let Err(error) = project_config.save()
+    {
+        tracing::warn!(%error, "could not save active team selected after login");
+        return;
+    }
+    print_login_team_selection(cli, &outcome);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -316,6 +316,15 @@ enum TeamSetTarget {
     },
 }
 
+/// Result of applying the zero-argument `cas cloud team set` resolution to a
+/// project immediately after login refreshed the user's membership cache.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LoginTeamSelection {
+    Activated(TeamInfo),
+    NoMembership,
+    MultipleMemberships,
+}
+
 impl TeamSetTarget {
     fn uuid(&self) -> &str {
         match self {
@@ -393,6 +402,78 @@ fn resolve_team_set_target(
             "Multiple cached teams found; pass one explicitly.\n{}\nRun `cas cloud login` to refresh team membership.",
             cached_team_options(user_config)
         ),
+    }
+}
+
+/// Activate the sole cached team for the current project.
+///
+/// This deliberately delegates the one/zero/many decision to the resolver
+/// behind `cas cloud team set` (cas-8850), so login and the explicit command
+/// cannot drift into separate membership-resolution rules. The caller persists
+/// `project_config` only after an [`LoginTeamSelection::Activated`] result.
+pub(crate) fn select_cached_team_after_login(
+    project_config: &mut CloudConfig,
+    user_config: &CloudConfig,
+) -> LoginTeamSelection {
+    match resolve_team_set_target(None, user_config, false) {
+        Ok(TeamSetTarget::CachedTeam { team, .. }) => {
+            project_config.team_id = Some(team.id.clone());
+            project_config.team_slug = Some(team.slug.clone());
+            LoginTeamSelection::Activated(team)
+        }
+        Ok(TeamSetTarget::Uuid(_)) => unreachable!("zero-argument resolution never yields UUID"),
+        Err(_) if user_config.teams.is_empty() => LoginTeamSelection::NoMembership,
+        Err(_) => LoginTeamSelection::MultipleMemberships,
+    }
+}
+
+/// Render the post-login team-selection result.
+///
+/// Zero and multiple memberships retain the existing manual team-set path;
+/// only a sole cached membership becomes the active project team.
+pub(crate) fn print_login_team_selection(cli: &Cli, outcome: &LoginTeamSelection) {
+    match outcome {
+        LoginTeamSelection::Activated(team) if cli.json => eprintln!(
+            "{}",
+            serde_json::json!({
+                "event": "login_team_activated",
+                "team_id": team.id,
+                "team_slug": team.slug,
+                "team_name": team.name,
+            })
+        ),
+        LoginTeamSelection::Activated(team) => {
+            eprintln!();
+            eprintln!("  ✓ Active team set from your only membership");
+            eprintln!("    Team: {} ({})", team.name, team.slug);
+            eprintln!("    UUID: {}", team.id);
+        }
+        LoginTeamSelection::NoMembership if cli.json => eprintln!(
+            "{}",
+            serde_json::json!({
+                "event": "login_team_selection_required",
+                "reason": "no_memberships",
+                "hint": "cas cloud team set <uuid>",
+            })
+        ),
+        LoginTeamSelection::MultipleMemberships if cli.json => eprintln!(
+            "{}",
+            serde_json::json!({
+                "event": "login_team_selection_required",
+                "reason": "multiple_memberships",
+                "hint": "cas cloud team set <uuid>",
+            })
+        ),
+        LoginTeamSelection::NoMembership => {
+            eprintln!(
+                "  No team membership found. Run `cas cloud team set <uuid>` to set the active team."
+            );
+        }
+        LoginTeamSelection::MultipleMemberships => {
+            eprintln!(
+                "  Multiple team memberships found. Run `cas cloud team set <uuid>` to set the active team."
+            );
+        }
     }
 }
 
@@ -3910,6 +3991,49 @@ mod team_cmd_tests {
             .to_string();
         assert!(err.contains("No cached team memberships"));
         assert!(err.contains("cas cloud login"));
+    }
+
+    #[test]
+    fn login_team_selection_activates_the_single_cached_team() {
+        let team = make_team_info(
+            "550e8400-e29b-41d4-a716-446655440000",
+            "petra-stella",
+            "Petra Stella",
+        );
+        let user_config = config_with_teams(vec![team.clone()]);
+        let mut project_config = CloudConfig::default();
+
+        let outcome = select_cached_team_after_login(&mut project_config, &user_config);
+
+        assert_eq!(outcome, LoginTeamSelection::Activated(team.clone()));
+        assert_eq!(project_config.team_id.as_deref(), Some(team.id.as_str()));
+        assert_eq!(
+            project_config.team_slug.as_deref(),
+            Some(team.slug.as_str())
+        );
+    }
+
+    #[test]
+    fn login_team_selection_keeps_existing_team_for_zero_or_many_memberships() {
+        let mut project_config = CloudConfig::default();
+        project_config.set_team("existing-team", "existing-slug");
+
+        assert_eq!(
+            select_cached_team_after_login(&mut project_config, &config_with_teams(vec![])),
+            LoginTeamSelection::NoMembership
+        );
+        assert_eq!(project_config.team_id.as_deref(), Some("existing-team"));
+
+        let many = config_with_teams(vec![
+            make_team_info("team-one", "one", "Team One"),
+            make_team_info("team-two", "two", "Team Two"),
+        ]);
+        assert_eq!(
+            select_cached_team_after_login(&mut project_config, &many),
+            LoginTeamSelection::MultipleMemberships
+        );
+        assert_eq!(project_config.team_id.as_deref(), Some("existing-team"));
+        assert_eq!(project_config.team_slug.as_deref(), Some("existing-slug"));
     }
 
     #[test]

--- a/cas-cli/src/cli/factory/doctor.rs
+++ b/cas-cli/src/cli/factory/doctor.rs
@@ -1,0 +1,414 @@
+//! Read-only readiness checks for `cas factory doctor` (cas-a487).
+//!
+//! This intentionally stays smaller and more actionable than the broad
+//! `cas factory preflight` report.  It answers the question an operator has
+//! immediately before selecting a harness: can this project launch Claude or
+//! Codex workers, and does Codex have the project-local CAS MCP registration
+//! it needs?  It never spawns workers or starts an MCP server.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use anyhow::Result;
+use cas_factory::spec_resolver::{ConfigSources, resolve_specs, resolve_supervisor_spec};
+use cas_mux::SupervisorCli;
+use serde::Serialize;
+
+use crate::bounded_process::{BoundedCommandError, Deadline, run_command};
+use crate::cli::Cli;
+
+use super::FactoryArgs;
+
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct DoctorRow {
+    name: &'static str,
+    state: DoctorState,
+    required: bool,
+    detail: String,
+    remediation: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum DoctorState {
+    Ok,
+    Missing,
+    Stale,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct FactoryDoctorReport {
+    rows: Vec<DoctorRow>,
+}
+
+impl FactoryDoctorReport {
+    fn has_required_failure(&self) -> bool {
+        self.rows
+            .iter()
+            .any(|row| row.required && row.state != DoctorState::Ok)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CliProbe {
+    Ok { path: PathBuf, version: String },
+    Missing,
+    TimedOut { path: PathBuf },
+}
+
+/// Execute the narrowly-scoped, no-spawn factory readiness report.
+pub(super) fn execute(args: &FactoryArgs, cli: &Cli, cas_root: Option<&Path>) -> Result<()> {
+    let project_root = std::env::current_dir()?;
+    let required = required_harnesses(args, &project_root)?;
+    let report = collect_report(
+        &project_root,
+        required.contains(&SupervisorCli::Claude),
+        required.contains(&SupervisorCli::Codex),
+        &probe_cli("claude"),
+        &probe_cli("codex"),
+        cas_factory::probe::codex_auth_present(),
+        cas_mcp_registration(&project_root, cas_root),
+    );
+
+    if cli.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human(&report);
+    }
+
+    if report.has_required_failure() {
+        anyhow::bail!(
+            "factory doctor found missing required backend(s); fix the issue above and rerun `cas factory doctor`"
+        );
+    }
+    Ok(())
+}
+
+/// Resolve the same cascade used for a factory launch, but do not apply the
+/// Codex fallback: doctor must name Codex as *required* when configuration
+/// explicitly requests it, rather than hiding the condition it is reporting.
+fn required_harnesses(args: &FactoryArgs, project_root: &Path) -> Result<Vec<SupervisorCli>> {
+    let worker_cli = parse_cli(&args.worker_cli)?;
+    let supervisor_cli = parse_cli(&args.supervisor_cli)?;
+    let project_config = Some(project_root.join(".cas").join("config.toml"));
+    let sources = ConfigSources {
+        cli_flag: (worker_cli != SupervisorCli::Claude).then_some(worker_cli),
+        worker_spec_jsons: args.worker_spec.clone(),
+        project_config: project_config.clone(),
+        ..ConfigSources::default()
+    };
+    let worker = resolve_specs(1, sources).map_err(|error| {
+        anyhow::anyhow!("failed to resolve worker config for factory doctor: {error}")
+    })?;
+    let sources = ConfigSources {
+        cli_flag: (supervisor_cli != SupervisorCli::Claude).then_some(supervisor_cli),
+        supervisor_spec_json: args.supervisor_spec.clone(),
+        project_config,
+        ..ConfigSources::default()
+    };
+    let supervisor = resolve_supervisor_spec(sources).map_err(|error| {
+        anyhow::anyhow!("failed to resolve supervisor config for factory doctor: {error}")
+    })?;
+
+    let mut required = Vec::new();
+    for harness in worker
+        .into_iter()
+        .map(|spec| spec.cli)
+        .chain(std::iter::once(supervisor.cli))
+    {
+        if !required.contains(&harness) {
+            required.push(harness);
+        }
+    }
+    Ok(required)
+}
+
+fn parse_cli(value: &str) -> Result<SupervisorCli> {
+    value.parse::<SupervisorCli>().map_err(|_| {
+        anyhow::anyhow!("invalid CLI {value:?}; expected 'claude', 'codex', or 'grok'")
+    })
+}
+
+fn collect_report(
+    project_root: &Path,
+    claude_required: bool,
+    codex_required: bool,
+    claude: &CliProbe,
+    codex: &CliProbe,
+    codex_auth_present: bool,
+    cas_mcp_registered: bool,
+) -> FactoryDoctorReport {
+    // A project-local Codex registration is required only when Codex is one
+    // of the resolved harnesses. Claude reads `.mcp.json` instead, so a
+    // Claude-only factory must not fail this Codex-specific setup check.
+    let cas_mcp_required = codex_required;
+    FactoryDoctorReport {
+        rows: vec![
+            cli_row(
+                "Claude",
+                claude_required,
+                claude,
+                "Install Claude Code, then rerun `cas factory doctor`.",
+            ),
+            codex_row(codex_required, codex, codex_auth_present),
+            cas_mcp_row(project_root, cas_mcp_required, cas_mcp_registered),
+        ],
+    }
+}
+
+fn cli_row(
+    name: &'static str,
+    required: bool,
+    probe: &CliProbe,
+    missing_remediation: &str,
+) -> DoctorRow {
+    match probe {
+        CliProbe::Ok { path, version } => DoctorRow {
+            name,
+            state: DoctorState::Ok,
+            required,
+            detail: format!("{} ({version})", path.display()),
+            remediation: None,
+        },
+        CliProbe::Missing => DoctorRow {
+            name,
+            state: DoctorState::Missing,
+            required,
+            detail: format!("missing {name} on PATH"),
+            remediation: Some(missing_remediation.to_string()),
+        },
+        CliProbe::TimedOut { path } => DoctorRow {
+            name,
+            state: DoctorState::Stale,
+            required,
+            detail: format!(
+                "stale {} at {} (version probe timed out)",
+                name.to_ascii_lowercase(),
+                path.display()
+            ),
+            remediation: Some(format!(
+                "Repair or reinstall {name}, then rerun `cas factory doctor`."
+            )),
+        },
+    }
+}
+
+fn codex_row(required: bool, probe: &CliProbe, auth_present: bool) -> DoctorRow {
+    // Name a missing/broken executable before discussing its credential file:
+    // a host that has neither needs installation, not a login attempt against
+    // a binary it cannot invoke.
+    if !matches!(probe, CliProbe::Ok { .. }) {
+        return cli_row(
+            "Codex",
+            required,
+            probe,
+            "Install Codex, then rerun `cas factory doctor`.",
+        );
+    }
+    if !auth_present {
+        return DoctorRow {
+            name: "Codex",
+            state: DoctorState::Missing,
+            required,
+            detail: "missing ~/.codex/auth.json (ChatGPT login)".to_string(),
+            remediation: Some(
+                "Run `codex login` (an OPENAI_API_KEY alone is not accepted for factory workers)."
+                    .to_string(),
+            ),
+        };
+    }
+    cli_row(
+        "Codex",
+        required,
+        probe,
+        "Install Codex, then rerun `cas factory doctor`.",
+    )
+}
+
+fn cas_mcp_row(project_root: &Path, required: bool, registered: bool) -> DoctorRow {
+    let path = project_root.join(".codex").join("config.toml");
+    if registered {
+        DoctorRow {
+            name: "CAS MCP",
+            state: DoctorState::Ok,
+            required,
+            detail: format!("{} registered (server=cs)", path.display()),
+            remediation: None,
+        }
+    } else {
+        DoctorRow {
+            name: "CAS MCP",
+            state: if path.exists() { DoctorState::Stale } else { DoctorState::Missing },
+            required,
+            detail: format!(
+                "{} is missing [mcp_servers.cs] command = \"cas\" with args including \"serve\"",
+                path.display()
+            ),
+            remediation: Some("Run `cas sync codex` (or register the project-local `cs` MCP server) and rerun `cas factory doctor`.".to_string()),
+        }
+    }
+}
+
+fn probe_cli(program: &str) -> CliProbe {
+    let Some(path) = find_on_path(program) else {
+        return CliProbe::Missing;
+    };
+    match run_command(
+        Command::new(&path).arg("--version"),
+        Deadline::after(VERSION_PROBE_TIMEOUT),
+        VERSION_PROBE_TIMEOUT,
+    ) {
+        Ok(output) if output.status.success() => CliProbe::Ok {
+            path,
+            version: first_line(&output.stdout),
+        },
+        Ok(_) | Err(BoundedCommandError::Io) => CliProbe::Missing,
+        Err(BoundedCommandError::TimedOut) => CliProbe::TimedOut { path },
+    }
+}
+
+fn find_on_path(program: &str) -> Option<PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths)
+            .map(|directory| directory.join(program))
+            .find(|candidate| candidate.is_file())
+    })
+}
+
+fn first_line(output: &[u8]) -> String {
+    String::from_utf8_lossy(output)
+        .lines()
+        .next()
+        .unwrap_or("version unavailable")
+        .trim()
+        .to_string()
+}
+
+fn cas_mcp_registration(project_root: &Path, _cas_root: Option<&Path>) -> bool {
+    let config_path = project_root.join(".codex").join("config.toml");
+    let Ok(contents) = std::fs::read_to_string(config_path) else {
+        return false;
+    };
+    let Ok(value) = toml::from_str::<toml::Value>(&contents) else {
+        return false;
+    };
+    let Some(server) = value
+        .get("mcp_servers")
+        .and_then(|servers| servers.get("cs"))
+    else {
+        return false;
+    };
+    let command_ok = server.get("command").and_then(toml::Value::as_str) == Some("cas");
+    let serve_arg = server
+        .get("args")
+        .and_then(toml::Value::as_array)
+        .is_some_and(|args| args.iter().any(|arg| arg.as_str() == Some("serve")));
+    command_ok && serve_arg
+}
+
+fn print_human(report: &FactoryDoctorReport) {
+    for row in &report.rows {
+        let status = match row.state {
+            DoctorState::Ok => "ok",
+            DoctorState::Missing => "missing",
+            DoctorState::Stale => "stale",
+        };
+        println!(
+            "{:<9} {:<7} {}",
+            format!("{}:", row.name),
+            status,
+            row.detail
+        );
+        if let Some(remediation) = &row.remediation {
+            println!("           hint: {remediation}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ready(path: &str) -> CliProbe {
+        CliProbe::Ok {
+            path: PathBuf::from(path),
+            version: "v1.2.3".to_string(),
+        }
+    }
+
+    #[test]
+    fn doctor_is_green_when_all_required_codex_components_are_ready() {
+        let report = collect_report(
+            Path::new("/project"),
+            true,
+            true,
+            &ready("/bin/claude"),
+            &ready("/bin/codex"),
+            true,
+            true,
+        );
+        assert!(!report.has_required_failure());
+        assert_eq!(report.rows[1].state, DoctorState::Ok);
+        assert_eq!(report.rows[2].state, DoctorState::Ok);
+    }
+
+    #[test]
+    fn optional_missing_codex_does_not_fail_a_claude_only_factory() {
+        let report = collect_report(
+            Path::new("/project"),
+            true,
+            false,
+            &ready("/bin/claude"),
+            &CliProbe::Missing,
+            false,
+            false,
+        );
+        assert!(!report.has_required_failure());
+        assert!(!report.rows[1].required);
+        assert!(!report.rows[2].required);
+    }
+
+    #[test]
+    fn required_missing_codex_auth_fails_with_chatgpt_login_hint() {
+        let report = collect_report(
+            Path::new("/project"),
+            false,
+            true,
+            &CliProbe::Missing,
+            &ready("/bin/codex"),
+            false,
+            true,
+        );
+        assert!(report.has_required_failure());
+        assert_eq!(report.rows[1].state, DoctorState::Missing);
+        assert!(
+            report.rows[1]
+                .remediation
+                .as_deref()
+                .unwrap()
+                .contains("codex login")
+        );
+    }
+
+    #[test]
+    fn codex_mcp_registration_requires_the_cs_server_command() {
+        let directory = tempfile::tempdir().unwrap();
+        let codex_dir = directory.path().join(".codex");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::write(
+            codex_dir.join("config.toml"),
+            "[mcp_servers.cs]\ncommand = \"other\"\n",
+        )
+        .unwrap();
+        assert!(!cas_mcp_registration(directory.path(), None));
+        std::fs::write(
+            codex_dir.join("config.toml"),
+            "[mcp_servers.cs]\ncommand = \"cas\"\nargs = [\"serve\"]\n",
+        )
+        .unwrap();
+        assert!(cas_mcp_registration(directory.path(), None));
+    }
+}

--- a/cas-cli/src/cli/factory/mod.rs
+++ b/cas-cli/src/cli/factory/mod.rs
@@ -1113,7 +1113,7 @@ pub fn execute(args: &FactoryArgs, cli: &Cli, cas_root: Option<&std::path::Path>
 
     // Resolve per-worker specs from the cascade (cas-2992): config files,
     // CLI flags, and per-worker JSON overrides in priority order.
-    let mut resolved_worker_specs = {
+    let (mut resolved_worker_specs, worker_fallback_model) = {
         // EPIC cas-8888 (cas-9a31, Phase 1) SILENT SITE — audited: this
         // `!= Claude` check is harness-agnostic by construction ("only pass
         // an explicit override when it's not the Claude default"), so Grok
@@ -1134,9 +1134,12 @@ pub fn execute(args: &FactoryArgs, cli: &Cli, cas_root: Option<&std::path::Path>
             user_config: None, // auto-resolve from home dir
             project_config: Some(cwd.join(".cas").join("config.toml")),
         };
-        resolve_specs(args.workers as usize, sources).map_err(|e| {
+        let fallback_model = cas_factory::configured_factory_default_model(&sources)
+            .map_err(|e| anyhow::anyhow!("Failed to resolve factory defaults: {e}"))?;
+        let specs = resolve_specs(args.workers as usize, sources).map_err(|e| {
             anyhow::anyhow!("Failed to resolve worker specs: {e}")
-        })?
+        })?;
+        (specs, fallback_model)
     };
 
     // cas-7199 / cas-a487: any resolved worker spec that landed on Codex
@@ -1145,14 +1148,15 @@ pub fn execute(args: &FactoryArgs, cli: &Cli, cas_root: Option<&std::path::Path>
     // post-cascade check catches all of those regardless of which layer
     // set it) must actually be usable. Default mode rewrites to Claude
     // with a loud, non-suppressible notice; --strict-cli / [factory]
-    // strict_cli bails instead. `default_model: None` on fallback — an
-    // incompatible codex model name is dropped in favor of Claude's own
-    // built-in default rather than trying to re-derive a specific
-    // fallback model from a separate config surface.
+    // strict_cli bails instead. An incompatible Codex model is replaced by
+    // the cascaded `[factory.defaults].model`, if configured.
     let strict_cli = args.strict_cli || cas_config.factory().strict_cli;
-    let codex_fallback_notices =
-        cas_factory::apply_codex_fallback(&mut resolved_worker_specs, strict_cli, None)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let codex_fallback_notices = cas_factory::apply_codex_fallback(
+        &mut resolved_worker_specs,
+        strict_cli,
+        worker_fallback_model.as_deref(),
+    )
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
     for notice in &codex_fallback_notices {
         tracing::warn!(target: "cas::factory", "{notice}");
     }
@@ -1167,7 +1171,7 @@ pub fn execute(args: &FactoryArgs, cli: &Cli, cas_root: Option<&std::path::Path>
 
     // Resolve supervisor spec from the cascade (cas-1948): [factory.supervisor] TOML
     // + --supervisor-cli/model/effort CLI flags + --supervisor-spec JSON override.
-    let mut resolved_supervisor_spec = {
+    let (mut resolved_supervisor_spec, supervisor_fallback_model) = {
         // EPIC cas-8888 (cas-9a31, Phase 1) SILENT SITE — audited, same as
         // resolved_worker_specs above: harness-agnostic, Grok flows through
         // as Some(Grok) correctly.
@@ -1186,9 +1190,12 @@ pub fn execute(args: &FactoryArgs, cli: &Cli, cas_root: Option<&std::path::Path>
             user_config: None, // auto-resolve from home dir
             project_config: Some(cwd.join(".cas").join("config.toml")),
         };
-        resolve_supervisor_spec(sources).map_err(|e| {
+        let fallback_model = cas_factory::configured_factory_default_model(&sources)
+            .map_err(|e| anyhow::anyhow!("Failed to resolve factory defaults: {e}"))?;
+        let spec = resolve_supervisor_spec(sources).map_err(|e| {
             anyhow::anyhow!("Failed to resolve supervisor spec: {e}")
-        })?
+        })?;
+        (spec, fallback_model)
     };
 
     // cas-7199 / cas-a487: same Codex-availability fallback as
@@ -1202,7 +1209,7 @@ pub fn execute(args: &FactoryArgs, cli: &Cli, cas_root: Option<&std::path::Path>
     let supervisor_codex_fallback_notices = cas_factory::apply_codex_fallback_for_supervisor(
         &mut resolved_supervisor_spec,
         strict_cli,
-        None,
+        supervisor_fallback_model.as_deref(),
     )
     .map_err(|e| anyhow::anyhow!("{e}"))?;
     for notice in &supervisor_codex_fallback_notices {

--- a/cas-cli/src/cli/factory/mod.rs
+++ b/cas-cli/src/cli/factory/mod.rs
@@ -7,6 +7,7 @@
 
 mod cloud_attach;
 mod daemon;
+mod doctor;
 mod lifecycle;
 pub(crate) mod parity;
 pub(crate) mod probe_comm;
@@ -357,6 +358,9 @@ pub struct KillAllArgs {
 /// Internal factory subcommands (hidden from help)
 #[derive(Subcommand, Debug, Clone)]
 pub enum FactoryCommands {
+    /// Report local Claude/Codex/CAS-MCP readiness without spawning workers.
+    Doctor,
+
     /// Run the bounded unified factory readiness report without spawning workers
     Preflight {
         /// Explicit CAS root (.cas directory)
@@ -706,6 +710,7 @@ pub enum FactoryCommands {
 pub fn execute(args: &FactoryArgs, cli: &Cli, cas_root: Option<&std::path::Path>) -> Result<()> {
     if let Some(ref cmd) = args.command {
         return match cmd {
+            FactoryCommands::Doctor => doctor::execute(args, cli, cas_root),
             FactoryCommands::Preflight {
                 cas_root: sub_cas_root,
             } => execute_unified_preflight(cli, sub_cas_root.as_deref().or(cas_root)),

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -236,6 +236,13 @@ fn hardlink_seed_tree_inner(
                 stats,
             )?;
         } else if file_type.is_file() {
+            // Cargo coordinates writes through target/**/.cargo-lock.  A
+            // hardlink would make independently seeded worker targets share
+            // that inode, serializing their otherwise private builds. Cargo
+            // recreates the lock file on first use, so omit it at every depth.
+            if entry.file_name() == ".cargo-lock" {
+                continue;
+            }
             let metadata = entry.metadata()?;
             if entry.path().extension().is_some_and(|extension| extension == "d") {
                 let dep_info = std::fs::read_to_string(entry.path())?;
@@ -5155,6 +5162,67 @@ mod spawn_isolation_tests {
             std::fs::metadata(seeded_dep_info).unwrap().ino(),
             "rebased dep-info must not mutate the immutable baseline hardlink"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn target_seed_skips_cargo_lock_so_workers_hold_private_locks() {
+        use std::fs::OpenOptions;
+        use std::os::fd::AsRawFd;
+        use std::os::unix::fs::MetadataExt;
+
+        let tmp = TempDir::new().unwrap();
+        let snapshot = tmp.path().join("snapshot");
+        let source_lock = snapshot.join("debug").join(".cargo-lock");
+        let source_artifact = snapshot.join("debug").join("deps").join("libwarm.rlib");
+        std::fs::create_dir_all(source_lock.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(source_artifact.parent().unwrap()).unwrap();
+        std::fs::write(&source_lock, b"Cargo lock").unwrap();
+        std::fs::write(&source_artifact, b"warm artifact").unwrap();
+
+        let worker_a = tmp.path().join("worker-a-target");
+        let worker_b = tmp.path().join("worker-b-target");
+        for worker_target in [&worker_a, &worker_b] {
+            let mut stats = TargetSeedStats::default();
+            hardlink_seed_tree(&snapshot, worker_target, worker_target, &mut stats).unwrap();
+            assert_eq!(stats.files, 1, "only the reusable artifact is seeded");
+            assert!(
+                !worker_target.join("debug/.cargo-lock").exists(),
+                "a seeded target must not inherit the snapshot Cargo lock"
+            );
+        }
+
+        let worker_a_lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(worker_a.join("debug/.cargo-lock"))
+            .unwrap();
+        let worker_b_lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(worker_b.join("debug/.cargo-lock"))
+            .unwrap();
+        assert_ne!(
+            worker_a_lock.metadata().unwrap().ino(),
+            worker_b_lock.metadata().unwrap().ino(),
+            "Cargo must recreate a private lock inode for each seeded target"
+        );
+        // Non-blocking exclusive locks succeeding on both files prove the
+        // seeded targets cannot serialize each other through a shared inode.
+        assert_eq!(
+            unsafe { libc::flock(worker_a_lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+            0
+        );
+        assert_eq!(
+            unsafe { libc::flock(worker_b_lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+            0
+        );
+        unsafe {
+            libc::flock(worker_a_lock.as_raw_fd(), libc::LOCK_UN);
+            libc::flock(worker_b_lock.as_raw_fd(), libc::LOCK_UN);
+        }
     }
 
     /// WorkerSpawnPrep::run() must return the worktree path as cwd for N=4

--- a/crates/cas-factory/src/lib.rs
+++ b/crates/cas-factory/src/lib.rs
@@ -55,6 +55,7 @@ pub use session::state::{
 };
 pub use spec_resolver::{
     ConfigSources, SpecResolverError, apply_codex_fallback, apply_codex_fallback_for_supervisor,
+    configured_factory_default_model,
     resolve_specs, resolve_supervisor_spec, worker_slot_cli_configured,
     worker_slot_effort_configured,
 };

--- a/crates/cas-factory/src/spec_resolver.rs
+++ b/crates/cas-factory/src/spec_resolver.rs
@@ -170,6 +170,35 @@ pub struct ConfigSources {
     pub supervisor_spec_json: Option<String>,
 }
 
+/// Return the cascaded `[factory.defaults].model` value without applying
+/// per-worker or CLI model overrides.  Callers use this as the safe Claude
+/// replacement when an explicitly Codex-only model cannot survive a
+/// `codex -> claude` fallback.
+pub fn configured_factory_default_model(
+    sources: &ConfigSources,
+) -> Result<Option<String>, SpecResolverError> {
+    let user_path = sources
+        .user_config
+        .clone()
+        .or_else(|| dirs::home_dir().map(|h| h.join(".cas").join("config.toml")));
+    let mut model = None;
+    if let Some(path) = user_path
+        && let Some((defaults, _, _)) = load_config_file(&path)?
+        && let Some(defaults) = defaults
+        && defaults.model.is_some()
+    {
+        model = defaults.model;
+    }
+    if let Some(path) = &sources.project_config
+        && let Some((defaults, _, _)) = load_config_file(path)?
+        && let Some(defaults) = defaults
+        && defaults.model.is_some()
+    {
+        model = defaults.model;
+    }
+    Ok(model)
+}
+
 /// Resolve `workers` [`WorkerSpec`] slots from the layered config sources.
 ///
 /// Returns a `Vec<WorkerSpec>` of length `workers`.  Returns an empty vec
@@ -1044,5 +1073,27 @@ mod codex_fallback_tests {
         };
         let notices = apply_codex_fallback_for_supervisor(&mut spec, false, None).unwrap();
         assert!(notices.is_empty(), "claude spec must never be touched");
+    }
+
+    #[test]
+    fn configured_factory_default_model_reads_the_project_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        std::fs::write(
+            &config,
+            "[factory.defaults]\nmodel = \"claude-sonnet-4-5\"\n",
+        )
+        .unwrap();
+        let sources = ConfigSources {
+            user_config: Some(dir.path().join("missing-user.toml")),
+            project_config: Some(config),
+            ..ConfigSources::default()
+        };
+        assert_eq!(
+            configured_factory_default_model(&sources)
+                .unwrap()
+                .as_deref(),
+            Some("claude-sonnet-4-5")
+        );
     }
 }


### PR DESCRIPTION
Lands epic cas-6302 (10/10 tasks closed):

- Workflow args-as-string tolerance with loud invalid-args envelope (Fixes #208)
- Worktree seeding skips .cargo-lock — private lock inode per seeded target (Fixes #216)
- Cross-team handoff backlog: codex effort verification, TUI backend tags, factory doctor + launch-path model fallback, agents-md generator + gated CLAUDE.md/AGENTS.md, login single-membership auto-pick (#215)
- Cross-project task proposals design (binding spec + cloud contract petra-stella-cloud#44; implementation gated in cas-e0c9) (#171)
- Branch protection applied per operator decision (ruleset 20698019) (#142)

Epic verification: full suite 5448/5448 green on the synced branch; every lane individually reviewed and merged by the supervisor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)