### PR TITLE
Landing batch: PR-flow tooling, CI PR-condition fix, receipt artifact paths, routing docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,18 @@ jobs:
     name: Fast Validation
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/heads/epic/')
       || startsWith(github.ref, 'refs/tags/')))
+    # An epic head can emit both push and pull_request events for one SHA.
+    # Deduplicate this required check by head SHA without coupling it to the
+    # independent macOS required check below.
+    concurrency:
+      group: fast-validation-${{ github.event.pull_request.head.sha || github.sha }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -164,10 +172,15 @@ jobs:
     name: macOS Check
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/heads/epic/')
       || startsWith(github.ref, 'refs/tags/')))
+    concurrency:
+      group: macos-check-${{ github.event.pull_request.head.sha || github.sha }}
+      cancel-in-progress: true
     # Zig 0.15.2 cannot link its build runner with the Xcode 26.6 / macOS 26.5
     # SDK that macos-latest selected in 2026-07. Keep the known-good Xcode 26.3
     # / macOS 26.2 SDK explicit until Zig is upgraded and verified against it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     # independent macOS required check below.
     concurrency:
       group: fast-validation-${{ github.event.pull_request.head.sha || github.sha }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -180,7 +180,7 @@ jobs:
       || startsWith(github.ref, 'refs/tags/')))
     concurrency:
       group: macos-check-${{ github.event.pull_request.head.sha || github.sha }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     # Zig 0.15.2 cannot link its build runner with the Xcode 26.6 / macOS 26.5
     # SDK that macos-latest selected in 2026-07. Keep the known-good Xcode 26.3
     # / macOS 26.2 SDK explicit until Zig is upgraded and verified against it.

--- a/cas-cli/src/builtins/codex/skills/cas-github-issues/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-github-issues/SKILL.md
@@ -17,6 +17,8 @@ every hour is noise.
 
 ## Why you may be here: the unfiled-reports banner
 
+`docs/requests/` is **deprecated for new outbound actionable requests**. Do not create a new file there: file directly on the receiving Richards-LLC team's issue board and save a CAS memory receipt (issue URL, one-line ask, date). This skill still sweeps pre-existing staged legacy files so they are not lost; history and inbound `RESPONSE-*.md` files remain readable. Prose-heavy specifications and design documents may remain there until cross-project task proposals ship.
+
 CAS emits a SessionStart banner when `BUG-*.md` / `FEATURE-*.md` files are
 staged at the `docs/requests/` root — reports the write-first flow wrote but
 never pushed, so nobody outside that checkout can see them. Sweeping those

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor.md
@@ -46,6 +46,10 @@ Match controls via [model-selection.md](cas-supervisor/references/model-selectio
 
 Open the focused file in `cas-supervisor/references/`: preflight, intake, planning, workflow, model-selection, [reminders.md](cas-supervisor/references/reminders.md), worker-recovery, reference, code-review-queue, or filing-cas-bugs.
 
+## Cross-team routing
+
+File CAS defects in `pippenz/cas`, even when a downstream project exposed them. File actionable Richards-LLC team requests directly on that team's issue board, never in its checkout, and save a CAS memory receipt (URL, ask, date). `docs/requests/` is legacy-only for outbound actionable work; see `filing-cas-bugs` for the full policy.
+
 ## Context budgeting
 
 `project_session_start_truncation.md`: **Immutable Core** (this body, 8 KB cap), **Task Context** (on demand), and **Ephemeral** output. Add here only what every session needs; put detail in `references/`.

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/filing-cas-bugs.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/filing-cas-bugs.md
@@ -7,7 +7,7 @@ A standing directive: **file every CAS-system bug you observe, by reflex.** Do n
 ## Canonical routing
 
 - **CAS-system defect, from any repository:** file a public-safe GitHub issue in
-  `pippenz/cas`. In cas-src, create the corresponding in-repo task; downstream
+  the configured CAS issue repository. In cas-src, create the corresponding in-repo task; downstream
   repositories consume CAS and must not patch it locally.
 - **Actionable request for a Richards-LLC-controlled team:** file directly on
   that team's repository issue board (for example,
@@ -17,9 +17,15 @@ A standing directive: **file every CAS-system bug you observe, by reflex.** Do n
   URL, one-line ask, and date. Recent examples are cloud-to-CAS GH #215 and
   CAS-to-cloud `Richards-LLC/petra-stella-cloud#44`.
 
-Use `gh issue create --repo <owner/repo>` with a complete public-safe body.
-If filing cannot complete, report the exact failure and ask the operator for
-access or direction; do not silently substitute a new outbound request file.
+Configure the target with `[issues] repo = "owner/repo"`; inspect it with
+`cas config get issues.repo` and set it with `cas config set issues.repo <owner/repo>`.
+Do not derive the target from a downstream git `origin`.
+
+Before filing, check `command -v gh` and `gh auth status`. Use
+`gh issue create --repo <owner/repo>` with a complete public-safe body. If `gh`
+is not installed or not authenticated, preserve the report in the task or CAS
+memory, report the exact failure, and ask the operator for access or direction;
+do not silently substitute a new outbound request file.
 
 `docs/requests/` is deprecated for new outbound actionable work. Preserve its
 history and read inbound `RESPONSE-*.md` files as legacy material. It remains

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/filing-cas-bugs.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/filing-cas-bugs.md
@@ -4,75 +4,24 @@ A standing directive: **file every CAS-system bug you observe, by reflex.** Do n
 
 "CAS-system" means a defect in CAS itself: the verifier, hooks, factory/director orchestration, MCP dispatch, the task-verifier agent, worker/supervisor prompts, or builtin skills — regardless of which downstream project surfaced it.
 
-## Route by repository
+## Canonical routing
 
-- **If this repository is the CAS source:** create an in-repo task (`task action=create task_type=bug`) and let a worker fix it there.
-- **In any downstream project:** use the configured GitHub issue intake below. Other projects consume CAS; they do not modify it locally.
+- **CAS-system defect, from any repository:** file a public-safe GitHub issue in
+  `pippenz/cas`. In cas-src, create the corresponding in-repo task; downstream
+  repositories consume CAS and must not patch it locally.
+- **Actionable request for a Richards-LLC-controlled team:** file directly on
+  that team's repository issue board (for example,
+  `Richards-LLC/petra-stella-cloud`). Never write, commit, or push in that
+  team's checkout from this repository.
+- **Receipt:** after every cross-team filing, save a CAS memory with the issue
+  URL, one-line ask, and date. Recent examples are cloud-to-CAS GH #215 and
+  CAS-to-cloud `Richards-LLC/petra-stella-cloud#44`.
 
-## Configure the upstream issue target
+Use `gh issue create --repo <owner/repo>` with a complete public-safe body.
+If filing cannot complete, report the exact failure and ask the operator for
+access or direction; do not silently substitute a new outbound request file.
 
-The target is project-local configuration in `.cas/config.toml`:
-
-```toml
-[issues]
-repo = "owner/repo"
-```
-
-Set or inspect it with:
-
-```sh
-cas config set issues.repo owner/repo
-cas config get issues.repo
-```
-
-**Do not derive this value from the current repository's `origin` remote.** In a downstream project, `origin` normally identifies the consumer's repository, not its CAS upstream; inferring it would silently send a CAS-system bug to the wrong tracker. Never hardcode one installation's repository in a builtin skill.
-
-## File without risking report loss
-
-1. First write the complete, public-safe report to a new, uniquely named `docs/requests/BUG-<slug>.md` in the current repository. Create the directory if needed; never overwrite an existing report. Include a concise title, environment/version, reproduction steps, expected and actual behavior, and relevant evidence. Redact credentials, tokens, private URLs, customer names, and unrelated-product details before any upload.
-2. Read the target with `issues_repo="$(cas config get issues.repo 2>/dev/null || true)"`.
-3. If `issues_repo` is empty, **do not guess a target**. Keep the local report and follow the durable fallback below. Tell the user to run `cas config set issues.repo owner/repo`.
-4. If `command -v gh >/dev/null 2>&1` fails because `gh` is not installed, keep the report and use the durable fallback.
-5. If `gh auth status` fails because `gh` is not authenticated for the target host, keep the report and use the durable fallback.
-6. Only after those checks, file the staged body:
-
-   ```sh
-   gh issue create \
-     --repo "$issues_repo" \
-     --title "<concise CAS-system bug title>" \
-     --body-file "docs/requests/BUG-<slug>.md"
-   ```
-
-7. Capture and report the issue URL. Remove the local staging file only after `gh issue create` succeeds and the URL is known. If the command fails for any reason, preserve the file and use the fallback.
-
-## Detectors that surface a missed filing
-
-Two SessionStart banners make the two silent failure modes of this flow
-deterministic instead of recall-based, following the same detector pattern as
-the codemap and project-overview freshness gates:
-
-- **Unfiled staged reports** — any `BUG-*.md` / `FEATURE-*.md` sitting at the
-  `docs/requests/` root (the archive in `completed/` never counts) is reported
-  with its count and file names. A single report gets the direct
-  `gh issue create` command; several get the `cas-github-issues` sweep skill.
-  Clear it by filing the reports and removing the staged files.
-- **Unset issue target** — if `[issues] repo` is unset while `docs/requests/`
-  exists, the banner names `cas config set issues.repo owner/repo`. It never
-  proposes a value, because the correct target is the one the receiving team
-  gave you, not this repository's `origin`.
-
-Both go quiet the moment their condition clears. Seeing either one means the
-work below was started and never finished — not that a new report is needed.
-
-## Durable fallback
-
-Unset configuration, `gh` not installed, `gh` not authenticated, and GitHub command failures all take the same safe path: preserve `docs/requests/BUG-<slug>.md` in the current repository and make it visible to collaborators.
-
-If committing is within the current task's authorization:
-
-```sh
-git add "docs/requests/BUG-<slug>.md"
-git commit -m "docs: preserve CAS bug report"
-```
-
-If a commit is not authorized or cannot be created, stop and tell the user the exact uncommitted path and why GitHub filing failed. Do not claim the report was filed, delete it, or continue silently. A local fallback that is neither committed nor explicitly handed off is still a lost report.
+`docs/requests/` is deprecated for new outbound actionable work. Preserve its
+history and read inbound `RESPONSE-*.md` files as legacy material. It remains
+appropriate only for prose-heavy specifications or design documents until
+cross-project task proposals ship.

--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -51,6 +51,8 @@ Null = use your judgment. No other posture keywords exist.
 
 Your scope is locked at assignment:
 
+- **Cross-team routing.** Report CAS defects to `pippenz/cas`; route actionable Richards-LLC team requests to that team's GitHub issue board, never by editing its checkout or creating a new outbound `docs/requests` file. Save a CAS memory receipt with issue URL, ask, and date. `docs/requests` is legacy-only for outbound actionable work.
+
 - **Never self-dispatch.** Start only a task assigned by `action=mine` or named explicitly by the supervisor. `ready`/`available` are backlog *visibility*, never authorization to `start` a task yourself. Idle means wait.
 - **One task at a time.** Complete the current task before taking another.
 - **Scope is frozen.** Build exactly the spec; note related improvements without implementing them.

--- a/cas-cli/src/builtins/grok/skills/cas-github-issues/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-github-issues/SKILL.md
@@ -17,6 +17,8 @@ every hour is noise.
 
 ## Why you may be here: the unfiled-reports banner
 
+`docs/requests/` is **deprecated for new outbound actionable requests**. Do not create a new file there: file directly on the receiving Richards-LLC team's issue board and save a CAS memory receipt (issue URL, one-line ask, date). This skill still sweeps pre-existing staged legacy files so they are not lost; history and inbound `RESPONSE-*.md` files remain readable. Prose-heavy specifications and design documents may remain there until cross-project task proposals ship.
+
 CAS emits a SessionStart banner when `BUG-*.md` / `FEATURE-*.md` files are
 staged at the `docs/requests/` root — reports the write-first flow wrote but
 never pushed, so nobody outside that checkout can see them. Sweeping those

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor.md
@@ -46,6 +46,10 @@ Match controls via [model-selection.md](cas-supervisor/references/model-selectio
 
 Open the focused file in `cas-supervisor/references/`: preflight, intake, planning, workflow, model-selection, [reminders.md](cas-supervisor/references/reminders.md), worker-recovery, reference, code-review-queue, or filing-cas-bugs.
 
+## Cross-team routing
+
+File CAS defects in `pippenz/cas`, even when a downstream project exposed them. File actionable Richards-LLC team requests directly on that team's issue board, never in its checkout, and save a CAS memory receipt (URL, ask, date). `docs/requests/` is legacy-only for outbound actionable work; see `filing-cas-bugs` for the full policy.
+
 ## Context budgeting
 
 `project_session_start_truncation.md`: **Immutable Core** (this body, 8 KB cap), **Task Context** (on demand), and **Ephemeral** output. Add here only what every session needs; put detail in `references/`.

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor/references/filing-cas-bugs.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor/references/filing-cas-bugs.md
@@ -7,7 +7,7 @@ A standing directive: **file every CAS-system bug you observe, by reflex.** Do n
 ## Canonical routing
 
 - **CAS-system defect, from any repository:** file a public-safe GitHub issue in
-  `pippenz/cas`. In cas-src, create the corresponding in-repo task; downstream
+  the configured CAS issue repository. In cas-src, create the corresponding in-repo task; downstream
   repositories consume CAS and must not patch it locally.
 - **Actionable request for a Richards-LLC-controlled team:** file directly on
   that team's repository issue board (for example,
@@ -17,9 +17,15 @@ A standing directive: **file every CAS-system bug you observe, by reflex.** Do n
   URL, one-line ask, and date. Recent examples are cloud-to-CAS GH #215 and
   CAS-to-cloud `Richards-LLC/petra-stella-cloud#44`.
 
-Use `gh issue create --repo <owner/repo>` with a complete public-safe body.
-If filing cannot complete, report the exact failure and ask the operator for
-access or direction; do not silently substitute a new outbound request file.
+Configure the target with `[issues] repo = "owner/repo"`; inspect it with
+`cas config get issues.repo` and set it with `cas config set issues.repo <owner/repo>`.
+Do not derive the target from a downstream git `origin`.
+
+Before filing, check `command -v gh` and `gh auth status`. Use
+`gh issue create --repo <owner/repo>` with a complete public-safe body. If `gh`
+is not installed or not authenticated, preserve the report in the task or CAS
+memory, report the exact failure, and ask the operator for access or direction;
+do not silently substitute a new outbound request file.
 
 `docs/requests/` is deprecated for new outbound actionable work. Preserve its
 history and read inbound `RESPONSE-*.md` files as legacy material. It remains

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor/references/filing-cas-bugs.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor/references/filing-cas-bugs.md
@@ -4,75 +4,24 @@ A standing directive: **file every CAS-system bug you observe, by reflex.** Do n
 
 "CAS-system" means a defect in CAS itself: the verifier, hooks, factory/director orchestration, MCP dispatch, the task-verifier agent, worker/supervisor prompts, or builtin skills — regardless of which downstream project surfaced it.
 
-## Route by repository
+## Canonical routing
 
-- **If this repository is the CAS source:** create an in-repo task (`task action=create task_type=bug`) and let a worker fix it there.
-- **In any downstream project:** use the configured GitHub issue intake below. Other projects consume CAS; they do not modify it locally.
+- **CAS-system defect, from any repository:** file a public-safe GitHub issue in
+  `pippenz/cas`. In cas-src, create the corresponding in-repo task; downstream
+  repositories consume CAS and must not patch it locally.
+- **Actionable request for a Richards-LLC-controlled team:** file directly on
+  that team's repository issue board (for example,
+  `Richards-LLC/petra-stella-cloud`). Never write, commit, or push in that
+  team's checkout from this repository.
+- **Receipt:** after every cross-team filing, save a CAS memory with the issue
+  URL, one-line ask, and date. Recent examples are cloud-to-CAS GH #215 and
+  CAS-to-cloud `Richards-LLC/petra-stella-cloud#44`.
 
-## Configure the upstream issue target
+Use `gh issue create --repo <owner/repo>` with a complete public-safe body.
+If filing cannot complete, report the exact failure and ask the operator for
+access or direction; do not silently substitute a new outbound request file.
 
-The target is project-local configuration in `.cas/config.toml`:
-
-```toml
-[issues]
-repo = "owner/repo"
-```
-
-Set or inspect it with:
-
-```sh
-cas config set issues.repo owner/repo
-cas config get issues.repo
-```
-
-**Do not derive this value from the current repository's `origin` remote.** In a downstream project, `origin` normally identifies the consumer's repository, not its CAS upstream; inferring it would silently send a CAS-system bug to the wrong tracker. Never hardcode one installation's repository in a builtin skill.
-
-## File without risking report loss
-
-1. First write the complete, public-safe report to a new, uniquely named `docs/requests/BUG-<slug>.md` in the current repository. Create the directory if needed; never overwrite an existing report. Include a concise title, environment/version, reproduction steps, expected and actual behavior, and relevant evidence. Redact credentials, tokens, private URLs, customer names, and unrelated-product details before any upload.
-2. Read the target with `issues_repo="$(cas config get issues.repo 2>/dev/null || true)"`.
-3. If `issues_repo` is empty, **do not guess a target**. Keep the local report and follow the durable fallback below. Tell the user to run `cas config set issues.repo owner/repo`.
-4. If `command -v gh >/dev/null 2>&1` fails because `gh` is not installed, keep the report and use the durable fallback.
-5. If `gh auth status` fails because `gh` is not authenticated for the target host, keep the report and use the durable fallback.
-6. Only after those checks, file the staged body:
-
-   ```sh
-   gh issue create \
-     --repo "$issues_repo" \
-     --title "<concise CAS-system bug title>" \
-     --body-file "docs/requests/BUG-<slug>.md"
-   ```
-
-7. Capture and report the issue URL. Remove the local staging file only after `gh issue create` succeeds and the URL is known. If the command fails for any reason, preserve the file and use the fallback.
-
-## Detectors that surface a missed filing
-
-Two SessionStart banners make the two silent failure modes of this flow
-deterministic instead of recall-based, following the same detector pattern as
-the codemap and project-overview freshness gates:
-
-- **Unfiled staged reports** — any `BUG-*.md` / `FEATURE-*.md` sitting at the
-  `docs/requests/` root (the archive in `completed/` never counts) is reported
-  with its count and file names. A single report gets the direct
-  `gh issue create` command; several get the `cas-github-issues` sweep skill.
-  Clear it by filing the reports and removing the staged files.
-- **Unset issue target** — if `[issues] repo` is unset while `docs/requests/`
-  exists, the banner names `cas config set issues.repo owner/repo`. It never
-  proposes a value, because the correct target is the one the receiving team
-  gave you, not this repository's `origin`.
-
-Both go quiet the moment their condition clears. Seeing either one means the
-work below was started and never finished — not that a new report is needed.
-
-## Durable fallback
-
-Unset configuration, `gh` not installed, `gh` not authenticated, and GitHub command failures all take the same safe path: preserve `docs/requests/BUG-<slug>.md` in the current repository and make it visible to collaborators.
-
-If committing is within the current task's authorization:
-
-```sh
-git add "docs/requests/BUG-<slug>.md"
-git commit -m "docs: preserve CAS bug report"
-```
-
-If a commit is not authorized or cannot be created, stop and tell the user the exact uncommitted path and why GitHub filing failed. Do not claim the report was filed, delete it, or continue silently. A local fallback that is neither committed nor explicitly handed off is still a lost report.
+`docs/requests/` is deprecated for new outbound actionable work. Preserve its
+history and read inbound `RESPONSE-*.md` files as legacy material. It remains
+appropriate only for prose-heavy specifications or design documents until
+cross-project task proposals ship.

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -51,6 +51,8 @@ Null = use your judgment. No other posture keywords exist.
 
 Your scope is locked at assignment:
 
+- **Cross-team routing.** Report CAS defects to `pippenz/cas`; route actionable Richards-LLC team requests to that team's GitHub issue board, never by editing its checkout or creating a new outbound `docs/requests` file. Save a CAS memory receipt with issue URL, ask, and date. `docs/requests` is legacy-only for outbound actionable work.
+
 - **Never self-dispatch.** Start only a task assigned by `action=mine` or named explicitly by the supervisor. `ready`/`available` are backlog *visibility*, never authorization to `start` a task yourself. Idle means wait.
 - **One task at a time.** Complete the current task before taking another.
 - **Scope is frozen.** Build exactly the spec; note related improvements without implementing them.

--- a/cas-cli/src/builtins/skills/cas-github-issues/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-github-issues/SKILL.md
@@ -17,6 +17,8 @@ every hour is noise.
 
 ## Why you may be here: the unfiled-reports banner
 
+`docs/requests/` is **deprecated for new outbound actionable requests**. Do not create a new file there: file directly on the receiving Richards-LLC team's issue board and save a CAS memory receipt (issue URL, one-line ask, date). This skill still sweeps pre-existing staged legacy files so they are not lost; history and inbound `RESPONSE-*.md` files remain readable. Prose-heavy specifications and design documents may remain there until cross-project task proposals ship.
+
 CAS emits a SessionStart banner when `BUG-*.md` / `FEATURE-*.md` files are
 staged at the `docs/requests/` root — reports the write-first flow wrote but
 never pushed, so nobody outside that checkout can see them. Sweeping those

--- a/cas-cli/src/builtins/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor.md
@@ -46,6 +46,10 @@ Match controls via [model-selection.md](cas-supervisor/references/model-selectio
 
 Open the focused file in `cas-supervisor/references/`: preflight, intake, planning, workflow, model-selection, [reminders.md](cas-supervisor/references/reminders.md), worker-recovery, reference, code-review-queue, or filing-cas-bugs.
 
+## Cross-team routing
+
+File CAS defects in `pippenz/cas`, even when a downstream project exposed them. File actionable Richards-LLC team requests directly on that team's issue board, never in its checkout, and save a CAS memory receipt (URL, ask, date). `docs/requests/` is legacy-only for outbound actionable work; see `filing-cas-bugs` for the full policy.
+
 ## Context budgeting
 
 `project_session_start_truncation.md`: **Immutable Core** (this body, 8 KB cap), **Task Context** (on demand), and **Ephemeral** output. Add here only what every session needs; put detail in `references/`.

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/filing-cas-bugs.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/filing-cas-bugs.md
@@ -7,7 +7,7 @@ A standing directive: **file every CAS-system bug you observe, by reflex.** Do n
 ## Canonical routing
 
 - **CAS-system defect, from any repository:** file a public-safe GitHub issue in
-  `pippenz/cas`. In cas-src, create the corresponding in-repo task; downstream
+  the configured CAS issue repository. In cas-src, create the corresponding in-repo task; downstream
   repositories consume CAS and must not patch it locally.
 - **Actionable request for a Richards-LLC-controlled team:** file directly on
   that team's repository issue board (for example,
@@ -17,9 +17,15 @@ A standing directive: **file every CAS-system bug you observe, by reflex.** Do n
   URL, one-line ask, and date. Recent examples are cloud-to-CAS GH #215 and
   CAS-to-cloud `Richards-LLC/petra-stella-cloud#44`.
 
-Use `gh issue create --repo <owner/repo>` with a complete public-safe body.
-If filing cannot complete, report the exact failure and ask the operator for
-access or direction; do not silently substitute a new outbound request file.
+Configure the target with `[issues] repo = "owner/repo"`; inspect it with
+`cas config get issues.repo` and set it with `cas config set issues.repo <owner/repo>`.
+Do not derive the target from a downstream git `origin`.
+
+Before filing, check `command -v gh` and `gh auth status`. Use
+`gh issue create --repo <owner/repo>` with a complete public-safe body. If `gh`
+is not installed or not authenticated, preserve the report in the task or CAS
+memory, report the exact failure, and ask the operator for access or direction;
+do not silently substitute a new outbound request file.
 
 `docs/requests/` is deprecated for new outbound actionable work. Preserve its
 history and read inbound `RESPONSE-*.md` files as legacy material. It remains

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/filing-cas-bugs.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/filing-cas-bugs.md
@@ -4,75 +4,24 @@ A standing directive: **file every CAS-system bug you observe, by reflex.** Do n
 
 "CAS-system" means a defect in CAS itself: the verifier, hooks, factory/director orchestration, MCP dispatch, the task-verifier agent, worker/supervisor prompts, or builtin skills — regardless of which downstream project surfaced it.
 
-## Route by repository
+## Canonical routing
 
-- **If this repository is the CAS source:** create an in-repo task (`task action=create task_type=bug`) and let a worker fix it there.
-- **In any downstream project:** use the configured GitHub issue intake below. Other projects consume CAS; they do not modify it locally.
+- **CAS-system defect, from any repository:** file a public-safe GitHub issue in
+  `pippenz/cas`. In cas-src, create the corresponding in-repo task; downstream
+  repositories consume CAS and must not patch it locally.
+- **Actionable request for a Richards-LLC-controlled team:** file directly on
+  that team's repository issue board (for example,
+  `Richards-LLC/petra-stella-cloud`). Never write, commit, or push in that
+  team's checkout from this repository.
+- **Receipt:** after every cross-team filing, save a CAS memory with the issue
+  URL, one-line ask, and date. Recent examples are cloud-to-CAS GH #215 and
+  CAS-to-cloud `Richards-LLC/petra-stella-cloud#44`.
 
-## Configure the upstream issue target
+Use `gh issue create --repo <owner/repo>` with a complete public-safe body.
+If filing cannot complete, report the exact failure and ask the operator for
+access or direction; do not silently substitute a new outbound request file.
 
-The target is project-local configuration in `.cas/config.toml`:
-
-```toml
-[issues]
-repo = "owner/repo"
-```
-
-Set or inspect it with:
-
-```sh
-cas config set issues.repo owner/repo
-cas config get issues.repo
-```
-
-**Do not derive this value from the current repository's `origin` remote.** In a downstream project, `origin` normally identifies the consumer's repository, not its CAS upstream; inferring it would silently send a CAS-system bug to the wrong tracker. Never hardcode one installation's repository in a builtin skill.
-
-## File without risking report loss
-
-1. First write the complete, public-safe report to a new, uniquely named `docs/requests/BUG-<slug>.md` in the current repository. Create the directory if needed; never overwrite an existing report. Include a concise title, environment/version, reproduction steps, expected and actual behavior, and relevant evidence. Redact credentials, tokens, private URLs, customer names, and unrelated-product details before any upload.
-2. Read the target with `issues_repo="$(cas config get issues.repo 2>/dev/null || true)"`.
-3. If `issues_repo` is empty, **do not guess a target**. Keep the local report and follow the durable fallback below. Tell the user to run `cas config set issues.repo owner/repo`.
-4. If `command -v gh >/dev/null 2>&1` fails because `gh` is not installed, keep the report and use the durable fallback.
-5. If `gh auth status` fails because `gh` is not authenticated for the target host, keep the report and use the durable fallback.
-6. Only after those checks, file the staged body:
-
-   ```sh
-   gh issue create \
-     --repo "$issues_repo" \
-     --title "<concise CAS-system bug title>" \
-     --body-file "docs/requests/BUG-<slug>.md"
-   ```
-
-7. Capture and report the issue URL. Remove the local staging file only after `gh issue create` succeeds and the URL is known. If the command fails for any reason, preserve the file and use the fallback.
-
-## Detectors that surface a missed filing
-
-Two SessionStart banners make the two silent failure modes of this flow
-deterministic instead of recall-based, following the same detector pattern as
-the codemap and project-overview freshness gates:
-
-- **Unfiled staged reports** — any `BUG-*.md` / `FEATURE-*.md` sitting at the
-  `docs/requests/` root (the archive in `completed/` never counts) is reported
-  with its count and file names. A single report gets the direct
-  `gh issue create` command; several get the `cas-github-issues` sweep skill.
-  Clear it by filing the reports and removing the staged files.
-- **Unset issue target** — if `[issues] repo` is unset while `docs/requests/`
-  exists, the banner names `cas config set issues.repo owner/repo`. It never
-  proposes a value, because the correct target is the one the receiving team
-  gave you, not this repository's `origin`.
-
-Both go quiet the moment their condition clears. Seeing either one means the
-work below was started and never finished — not that a new report is needed.
-
-## Durable fallback
-
-Unset configuration, `gh` not installed, `gh` not authenticated, and GitHub command failures all take the same safe path: preserve `docs/requests/BUG-<slug>.md` in the current repository and make it visible to collaborators.
-
-If committing is within the current task's authorization:
-
-```sh
-git add "docs/requests/BUG-<slug>.md"
-git commit -m "docs: preserve CAS bug report"
-```
-
-If a commit is not authorized or cannot be created, stop and tell the user the exact uncommitted path and why GitHub filing failed. Do not claim the report was filed, delete it, or continue silently. A local fallback that is neither committed nor explicitly handed off is still a lost report.
+`docs/requests/` is deprecated for new outbound actionable work. Preserve its
+history and read inbound `RESPONSE-*.md` files as legacy material. It remains
+appropriate only for prose-heavy specifications or design documents until
+cross-project task proposals ship.

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -51,6 +51,8 @@ Null = use your judgment. No other posture keywords exist.
 
 Your scope is locked at assignment:
 
+- **Cross-team routing.** Report CAS defects to `pippenz/cas`; route actionable Richards-LLC team requests to that team's GitHub issue board, never by editing its checkout or creating a new outbound `docs/requests` file. Save a CAS memory receipt with issue URL, ask, and date. `docs/requests` is legacy-only for outbound actionable work.
+
 - **Never self-dispatch.** Start only a task assigned by `action=mine` or named explicitly by the supervisor. `ready`/`available` are backlog *visibility*, never authorization to `start` a task yourself. Idle means wait.
 - **One task at a time.** Complete the current task before taking another.
 - **Scope is frozen.** Build exactly the spec; note related improvements without implementing them.

--- a/cas-cli/src/cli/limits.rs
+++ b/cas-cli/src/cli/limits.rs
@@ -1,0 +1,459 @@
+//! Machine-local provider capacity snapshots for worker routing.
+//!
+//! This deliberately reads credentials only long enough to make the Claude
+//! usage request. Tokens are never included in errors or output.
+
+use std::fs;
+use std::path::Path;
+
+use chrono::{DateTime, Local, TimeZone, Utc};
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use walkdir::WalkDir;
+
+use crate::cli::Cli;
+
+const CLAUDE_USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct LimitsArgs {
+    /// Print a compact single-line summary suitable for a factory strip
+    #[arg(long)]
+    compact: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+struct LimitsReport {
+    accounts: Vec<AccountLimit>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+struct AccountLimit {
+    account: String,
+    provider: String,
+    plan: Option<String>,
+    state: String,
+    source: String,
+    windows: Vec<LimitWindow>,
+    detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+struct LimitWindow {
+    name: String,
+    used_percent: Option<f64>,
+    reset_at: Option<String>,
+    spend_dollars: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeCredentials {
+    #[serde(rename = "claudeAiOauth")]
+    oauth: Option<ClaudeOauth>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeOauth {
+    #[serde(rename = "accessToken")]
+    access_token: String,
+    #[serde(rename = "subscriptionType")]
+    subscription_type: Option<String>,
+}
+
+pub fn execute(args: &LimitsArgs, cli: &Cli) -> anyhow::Result<()> {
+    let report = collect_limits();
+    if cli.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else if args.compact {
+        println!("{}", compact_line(&report));
+    } else {
+        print_human(&report);
+    }
+    Ok(())
+}
+
+fn collect_limits() -> LimitsReport {
+    let home = dirs::home_dir().unwrap_or_default();
+    let mut accounts = Vec::new();
+    accounts.push(collect_claude("claude-main", &home.join(".claude")));
+    accounts.push(collect_claude("claude-alt", &home.join(".claude-alt")));
+    accounts.push(collect_codex(&home.join(".codex")));
+    accounts.push(collect_exa());
+    LimitsReport { accounts }
+}
+
+fn collect_claude(account: &str, config_dir: &Path) -> AccountLimit {
+    let credentials_path = config_dir.join(".credentials.json");
+    let credentials: ClaudeCredentials = match fs::read_to_string(&credentials_path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+    {
+        Some(value) => value,
+        None => return unavailable(account, "claude", "absent", "credential file not found"),
+    };
+    let Some(oauth) = credentials.oauth else {
+        return unavailable(
+            account,
+            "claude",
+            "auth-needed",
+            "OAuth credentials not available",
+        );
+    };
+    let plan = oauth.subscription_type;
+    let response = ureq::get(CLAUDE_USAGE_URL)
+        .set("Authorization", &format!("Bearer {}", oauth.access_token))
+        .set("Accept", "application/json")
+        .set("anthropic-version", "2023-06-01")
+        .set("anthropic-beta", "oauth-2025-04-20")
+        .timeout(std::time::Duration::from_secs(8))
+        .call();
+    match response {
+        Ok(response) => match response.into_json::<Value>().ok().map(parse_claude_usage) {
+            Some(windows) if !windows.is_empty() => AccountLimit {
+                account: account.to_string(),
+                provider: "claude".to_string(),
+                plan,
+                state: "active".to_string(),
+                source: "live".to_string(),
+                windows,
+                detail: None,
+            },
+            _ => unavailable_with_plan(
+                account,
+                "claude",
+                plan,
+                "unavailable",
+                "usage response had no recognized windows",
+            ),
+        },
+        Err(ureq::Error::Status(401, _)) | Err(ureq::Error::Status(403, _)) => {
+            unavailable_with_plan(
+                account,
+                "claude",
+                plan,
+                "auth-needed",
+                "OAuth token rejected; run claude login",
+            )
+        }
+        Err(_) => unavailable_with_plan(
+            account,
+            "claude",
+            plan,
+            "unavailable",
+            "usage endpoint unavailable",
+        ),
+    }
+}
+
+fn collect_codex(root: &Path) -> AccountLimit {
+    let Some((plan, windows)) = latest_codex_limits(root) else {
+        return unavailable("codex", "codex", "absent", "no rollout rate_limits found");
+    };
+    AccountLimit {
+        account: "codex".to_string(),
+        provider: "codex".to_string(),
+        plan,
+        state: "active".to_string(),
+        source: "live transcript".to_string(),
+        windows,
+        detail: None,
+    }
+}
+
+fn collect_exa() -> AccountLimit {
+    if std::env::var_os("EXA_API_KEY").is_none() {
+        return unavailable("exa", "exa", "auth-needed", "EXA_API_KEY is not configured");
+    }
+    let windows = dirs::home_dir()
+        .as_deref()
+        .and_then(load_exa_ledger_spend)
+        .map(|spend_dollars| LimitWindow {
+            name: "local spend".to_string(),
+            used_percent: None,
+            reset_at: None,
+            spend_dollars: Some(spend_dollars),
+        })
+        .into_iter()
+        .collect();
+    AccountLimit {
+        account: "exa".to_string(),
+        provider: "exa".to_string(),
+        plan: None,
+        state: "unavailable".to_string(),
+        source: "ESTIMATE ledger".to_string(),
+        windows,
+        detail: Some(
+            "API key configured; no supported balance endpoint (cost is a local estimate)"
+                .to_string(),
+        ),
+    }
+}
+
+/// Sum response costs written by callers to the optional machine-local ledger.
+/// The ledger is best-effort: a missing file is not a zero balance.
+fn load_exa_ledger_spend(home: &Path) -> Option<f64> {
+    let content = fs::read_to_string(home.join(".cas/exa-cost-ledger.jsonl")).ok()?;
+    let mut found = false;
+    let total = content
+        .lines()
+        .filter_map(|line| {
+            serde_json::from_str::<Value>(line).ok().and_then(|value| {
+                let cost = parse_exa_cost(&value)?;
+                found = true;
+                Some(cost)
+            })
+        })
+        .sum::<f64>();
+    found.then_some(total)
+}
+
+/// Exa v2 returns `costDollars.total`; keep scalar compatibility for old captures.
+fn parse_exa_cost(value: &Value) -> Option<f64> {
+    value
+        .pointer("/costDollars/total")
+        .and_then(Value::as_f64)
+        .or_else(|| value.get("costDollars").and_then(Value::as_f64))
+        .or_else(|| value.get("cost_dollars").and_then(Value::as_f64))
+}
+
+fn unavailable(account: &str, provider: &str, state: &str, detail: &str) -> AccountLimit {
+    unavailable_with_plan(account, provider, None, state, detail)
+}
+
+fn unavailable_with_plan(
+    account: &str,
+    provider: &str,
+    plan: Option<String>,
+    state: &str,
+    detail: &str,
+) -> AccountLimit {
+    AccountLimit {
+        account: account.to_string(),
+        provider: provider.to_string(),
+        plan,
+        state: state.to_string(),
+        source: "none".to_string(),
+        windows: Vec::new(),
+        detail: Some(detail.to_string()),
+    }
+}
+
+fn parse_claude_usage(value: Value) -> Vec<LimitWindow> {
+    let mut windows = Vec::new();
+    for (key, label) in [
+        ("five_hour", "5h"),
+        ("seven_day", "weekly"),
+        ("seven_day_opus", "weekly opus"),
+        ("seven_day_sonnet", "weekly sonnet"),
+    ] {
+        let Some(bucket) = value.get(key).filter(|v| !v.is_null()) else {
+            continue;
+        };
+        windows.push(LimitWindow {
+            name: label.to_string(),
+            used_percent: bucket.get("utilization").and_then(Value::as_f64),
+            reset_at: bucket
+                .get("resets_at")
+                .and_then(Value::as_str)
+                .and_then(local_rfc3339),
+            spend_dollars: None,
+        });
+    }
+    if let Some(extra) = value.get("extra_usage").filter(|v| !v.is_null()) {
+        windows.push(LimitWindow {
+            name: "extra usage".to_string(),
+            used_percent: extra.get("utilization").and_then(Value::as_f64),
+            reset_at: None,
+            spend_dollars: extra.get("used_credits").and_then(Value::as_f64),
+        });
+    }
+    windows
+}
+
+fn latest_codex_limits(root: &Path) -> Option<(Option<String>, Vec<LimitWindow>)> {
+    let sessions = root.join("sessions");
+    let newest = WalkDir::new(sessions)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry.path().extension().is_some_and(|ext| ext == "jsonl")
+        })
+        .filter_map(|entry| {
+            entry.metadata().ok().and_then(|meta| {
+                meta.modified()
+                    .ok()
+                    .map(|modified| (modified, entry.into_path()))
+            })
+        })
+        .max_by_key(|(modified, _)| *modified)?
+        .1;
+    let contents = fs::read_to_string(newest).ok()?;
+    for line in contents.lines().rev() {
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let Some(limits) = find_rate_limits(&value) else {
+            continue;
+        };
+        let windows = parse_codex_limits(limits);
+        if !windows.is_empty() {
+            return Some((
+                limits
+                    .get("plan_type")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                windows,
+            ));
+        }
+    }
+    None
+}
+
+fn find_rate_limits(value: &Value) -> Option<&Value> {
+    value
+        .get("rate_limits")
+        .or_else(|| value.pointer("/payload/rate_limits"))
+}
+
+fn parse_codex_limits(limits: &Value) -> Vec<LimitWindow> {
+    ["primary", "secondary"]
+        .into_iter()
+        .filter_map(|key| {
+            let window = limits.get(key)?;
+            let minutes = window.get("window_minutes")?.as_i64()?;
+            Some(LimitWindow {
+                name: if minutes == 300 {
+                    "5h".to_string()
+                } else if minutes == 10080 {
+                    "weekly".to_string()
+                } else {
+                    format!("{minutes}m")
+                },
+                used_percent: window.get("used_percent").and_then(Value::as_f64),
+                reset_at: window
+                    .get("resets_at")
+                    .and_then(Value::as_i64)
+                    .and_then(local_unix),
+                spend_dollars: None,
+            })
+        })
+        .collect()
+}
+
+fn local_unix(timestamp: i64) -> Option<String> {
+    Local
+        .timestamp_opt(timestamp, 0)
+        .single()
+        .map(|time| time.format("%Y-%m-%d %H:%M %Z").to_string())
+}
+
+fn local_rfc3339(timestamp: &str) -> Option<String> {
+    timestamp.parse::<DateTime<Utc>>().ok().map(|time| {
+        time.with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M %Z")
+            .to_string()
+    })
+}
+
+fn compact_line(report: &LimitsReport) -> String {
+    report
+        .accounts
+        .iter()
+        .map(|account| {
+            let windows = account
+                .windows
+                .iter()
+                .map(|window| format!("{}:{:.0}%", window.name, window.used_percent.unwrap_or(0.0)))
+                .collect::<Vec<_>>()
+                .join(",");
+            if windows.is_empty() {
+                format!("{}:{}", account.account, account.state)
+            } else {
+                format!("{} {}", account.account, windows)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+fn print_human(report: &LimitsReport) {
+    println!("CAS provider limits");
+    for account in &report.accounts {
+        let plan = account
+            .plan
+            .as_deref()
+            .map(|plan| format!(" ({plan})"))
+            .unwrap_or_default();
+        println!(
+            "\n{}{} — {} [{}]",
+            account.account, plan, account.state, account.source
+        );
+        for window in &account.windows {
+            let used = window
+                .used_percent
+                .map(|value| format!("{value:.1}% used"))
+                .unwrap_or_else(|| "usage unavailable".to_string());
+            let reset = window
+                .reset_at
+                .as_deref()
+                .map(|value| format!(", resets {value}"))
+                .unwrap_or_default();
+            let spend = window
+                .spend_dollars
+                .map(|value| format!(", ${value:.2} spent"))
+                .unwrap_or_default();
+            println!("  {}: {}{}{}", window.name, used, spend, reset);
+        }
+        if let Some(detail) = &account.detail {
+            println!("  {detail}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_codex_primary_and_secondary_windows() {
+        let value: Value = serde_json::json!({"primary":{"used_percent":26.0,"window_minutes":10080,"resets_at":1787011690},"secondary":{"used_percent":7.0,"window_minutes":300,"resets_at":1786651690},"plan_type":"pro"});
+        let windows = parse_codex_limits(&value);
+        assert_eq!(windows.len(), 2);
+        assert_eq!(windows[0].name, "weekly");
+        assert_eq!(windows[1].name, "5h");
+        assert_eq!(windows[0].used_percent, Some(26.0));
+    }
+
+    #[test]
+    fn finds_nested_codex_rate_limits() {
+        let value: Value = serde_json::json!({"payload":{"rate_limits":{"primary":{"used_percent":1.0,"window_minutes":300,"resets_at":100}}}});
+        assert_eq!(
+            parse_codex_limits(find_rate_limits(&value).unwrap()).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn parses_claude_windows_and_optional_model_caps() {
+        let value: Value = serde_json::json!({"five_hour":{"utilization":6.0,"resets_at":"2026-04-08T18:59:59Z"},"seven_day":null,"seven_day_opus":{"utilization":12.0,"resets_at":"2026-04-14T17:59:59Z"},"extra_usage":{"utilization":12.5,"used_credits":12.5}});
+        let windows = parse_claude_usage(value);
+        assert_eq!(
+            windows
+                .iter()
+                .map(|window| window.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["5h", "weekly opus", "extra usage"]
+        );
+        assert_eq!(windows[2].spend_dollars, Some(12.5));
+    }
+
+    #[test]
+    fn parses_exa_cost_shape_without_secrets() {
+        let v2: Value = serde_json::json!({"costDollars":{"total":0.007}});
+        let legacy: Value = serde_json::json!({"costDollars":0.003});
+        assert_eq!(parse_exa_cost(&v2), Some(0.007));
+        assert_eq!(parse_exa_cost(&legacy), Some(0.003));
+    }
+}

--- a/cas-cli/src/cli/mod.rs
+++ b/cas-cli/src/cli/mod.rs
@@ -43,6 +43,7 @@ pub(crate) mod hook;
 mod init;
 pub mod integrate;
 pub mod interactive;
+mod limits;
 mod list;
 mod mcp_cmd;
 pub mod memory;
@@ -72,6 +73,7 @@ pub use factory::{AttachArgs, FactoryArgs, KillAllArgs, KillArgs};
 pub use hook::HookArgs;
 pub use hub::HubArgs;
 pub use init::InitArgs;
+pub use limits::LimitsArgs;
 pub use list::ListArgs;
 pub use mcp_cmd::McpCommands;
 pub use provider_default::DefaultArgs;
@@ -192,6 +194,9 @@ pub enum Commands {
 
     /// Show session status
     Status(StatusArgs),
+
+    /// Show local provider rate-limit and credit availability
+    Limits(LimitsArgs),
 
     /// Output status line for Claude Code integration
     #[command(alias = "statusline")]
@@ -336,6 +341,7 @@ fn auth_requirement(command: &Option<Commands>) -> AuthRequirement {
         | Commands::Hub(_)
         | Commands::Config(_)
         | Commands::Status(_)
+        | Commands::Limits(_)
         | Commands::StatusLine(_)
         | Commands::Mcp(_)
         | Commands::Queue(_)
@@ -512,6 +518,7 @@ fn get_command_name(cmd: &Option<Commands>) -> String {
         Commands::Doctor(_) => "doctor".to_string(),
         Commands::Config(_) => "config".to_string(),
         Commands::Status(_) => "status".to_string(),
+        Commands::Limits(_) => "limits".to_string(),
         Commands::StatusLine(_) => "statusline".to_string(),
         Commands::Hook(_) => "hook".to_string(),
         Commands::Auth(_) => "auth".to_string(),
@@ -589,6 +596,7 @@ fn run_command(cli: &Cli, cas_root: Option<&Path>) -> anyhow::Result<()> {
         Commands::Doctor(args) => doctor::execute(args, cli, cas_root),
         Commands::Config(cmd) => config::execute_subcommand(cmd, cli, require_cas_root(cas_root)?),
         Commands::Status(args) => status::execute(args, cli, require_cas_root(cas_root)?),
+        Commands::Limits(args) => limits::execute(args, cli),
         Commands::StatusLine(args) => statusline::execute(args, cli, require_cas_root(cas_root)?),
         Commands::Hook(args) => hook::execute(args, cli),
         Commands::Auth(cmd) => auth::execute(cmd, cli),

--- a/cas-cli/src/config/settings.rs
+++ b/cas-cli/src/config/settings.rs
@@ -282,6 +282,23 @@ impl Default for FactoryConfig {
     }
 }
 
+/// Resolve the durable artifact parent shared by the factory workspace
+/// contract and completion-receipt boundary. `~/.cas/artifacts` is a
+/// real-disk fallback, never `/tmp`.
+pub fn resolved_factory_artifacts_root(configured: Option<&str>) -> std::path::PathBuf {
+    let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
+    match configured.map(str::trim).filter(|value| !value.is_empty()) {
+        Some("~") => home.unwrap_or_else(|| std::path::PathBuf::from(".cas/artifacts")),
+        Some(value) if value.starts_with("~/") => home
+            .map(|base| base.join(&value[2..]))
+            .unwrap_or_else(|| std::path::PathBuf::from(value)),
+        Some(value) => std::path::PathBuf::from(value),
+        None => home
+            .map(|base| base.join(".cas/artifacts"))
+            .unwrap_or_else(|| std::path::PathBuf::from(".cas/artifacts")),
+    }
+}
+
 /// Code indexing configuration for background code indexing
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CodeConfig {

--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -301,7 +301,9 @@ pub fn handle_pre_tool_use(
             &factory.artifacts_root,
             crate::harness_policy::is_supervisor(input),
         ) {
-            let artifacts = resolved_factory_artifacts_root(factory.artifacts_root.as_deref());
+            let artifacts = crate::config::resolved_factory_artifacts_root(
+                factory.artifacts_root.as_deref(),
+            );
             return Ok(HookOutput::with_pre_tool_permission(
                 "deny",
                 &format!(
@@ -1229,22 +1231,6 @@ pub(crate) const FACTORY_AUTO_APPROVE_TOOLS: &[&str] = &[
     "NotebookEdit",
 ];
 
-/// Resolve the durable artifact parent used by the factory workspace contract.
-/// `~/.cas/artifacts` is deliberately a real-disk fallback, not `/tmp`.
-fn resolved_factory_artifacts_root(configured: Option<&str>) -> std::path::PathBuf {
-    let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
-    match configured.map(str::trim).filter(|value| !value.is_empty()) {
-        Some("~") => home.unwrap_or_else(|| std::path::PathBuf::from(".cas/artifacts")),
-        Some(value) if value.starts_with("~/") => home
-            .map(|base| base.join(&value[2..]))
-            .unwrap_or_else(|| std::path::PathBuf::from(value)),
-        Some(value) => std::path::PathBuf::from(value),
-        None => home
-            .map(|base| base.join(".cas/artifacts"))
-            .unwrap_or_else(|| std::path::PathBuf::from(".cas/artifacts")),
-    }
-}
-
 #[derive(Debug, PartialEq, Eq)]
 enum ShellToken {
     Word(String),
@@ -1465,7 +1451,7 @@ fn unsanctioned_factory_path(
 ) -> Option<std::path::PathBuf> {
     let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
     let mut sanctioned = vec![std::path::PathBuf::from(&input.cwd)];
-    sanctioned.push(resolved_factory_artifacts_root(
+    sanctioned.push(crate::config::resolved_factory_artifacts_root(
         configured_artifacts_root.as_deref(),
     ));
     for key in ["CAS_SCRATCHPAD", "CAS_SCRATCHPAD_PATH", "CLAUDE_SCRATCHPAD"] {

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -1116,6 +1116,7 @@ mod amendment_reassignment_tests {
                 target_sha: "c".repeat(40),
                 proof_reference: "cargo test --lib".into(),
                 scope_summary: "amendment regression".into(),
+                artifact_path: None,
             },
             "original-worker",
             Utc::now(),

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -115,6 +115,63 @@ fn tmpfs_receipt_path_in_close_reason(reason: &str) -> Option<String> {
     })
 }
 
+/// Validate the optional durable artifact selected for a completion receipt.
+///
+/// This is deliberately performed before new receipt persistence:
+/// receipt metadata is immutable, so accepting an out-of-contract path would
+/// make the durable audit record itself misleading. Canonical paths prevent a
+/// `..` component or symlink from escaping either the configured root or this
+/// task's dedicated directory.
+fn validate_completion_artifact_path(
+    cas_root: &std::path::Path,
+    task_id: &str,
+    artifact_path: &str,
+) -> Result<(), String> {
+    if artifact_path.trim().is_empty() || artifact_path.len() > 4096 {
+        return Err(
+            "artifact_path must be a non-empty path no longer than 4096 bytes.".to_string(),
+        );
+    }
+    let artifact_path = std::path::Path::new(artifact_path);
+    if !artifact_path.is_absolute() {
+        return Err(
+            "artifact_path must be an absolute path under the configured [factory] artifacts_root/<task-id>/."
+                .to_string(),
+        );
+    }
+
+    let config = crate::config::Config::load(cas_root)
+        .map_err(|error| format!("could not load [factory] artifacts_root: {error}"))?;
+    let configured_root = crate::config::resolved_factory_artifacts_root(
+        config.factory().artifacts_root.as_deref(),
+    );
+    let canonical_root = configured_root.canonicalize().map_err(|_| {
+        "configured [factory] artifacts_root must exist before a completion artifact can be recorded."
+            .to_string()
+    })?;
+    let canonical_task_root = canonical_root.join(task_id).canonicalize().map_err(|_| {
+        "artifact_path requires an existing per-task directory at configured [factory] artifacts_root/<task-id>/."
+            .to_string()
+    })?;
+    if !canonical_task_root.is_dir() || !canonical_task_root.starts_with(&canonical_root) {
+        return Err(
+            "artifact_path task directory must be a real directory directly beneath the configured [factory] artifacts_root."
+                .to_string(),
+        );
+    }
+    let canonical_artifact = artifact_path.canonicalize().map_err(|_| {
+        "artifact_path must name an existing durable file or directory under configured [factory] artifacts_root/<task-id>/."
+            .to_string()
+    })?;
+    if !canonical_artifact.starts_with(&canonical_task_root) {
+        return Err(
+            "artifact_path must resolve beneath configured [factory] artifacts_root/<task-id>/."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 fn request_changes_role_gate(is_supervisor: bool, task_id: &str) -> Result<(), String> {
     if is_supervisor {
         Ok(())
@@ -129,7 +186,7 @@ fn request_changes_role_gate(is_supervisor: bool, task_id: &str) -> Result<(), S
 mod delivery_audit_text_tests {
     use super::{
         delivery_audit_text_is_portable, request_changes_role_gate,
-        tmpfs_receipt_path_in_close_reason,
+        tmpfs_receipt_path_in_close_reason, validate_completion_artifact_path,
     };
 
     #[test]
@@ -174,6 +231,50 @@ mod delivery_audit_text_tests {
             tmpfs_receipt_path_in_close_reason("This task discusses /tmp storage policy"),
             None
         );
+    }
+
+    #[test]
+    fn completion_artifact_path_is_scoped_to_the_configured_task_directory() {
+        let cas_root = tempfile::tempdir().unwrap();
+        let artifacts_root = cas_root.path().join("artifacts");
+        let task_id = "cas-artifact";
+        let artifact = artifacts_root.join(task_id).join("proof.json");
+        std::fs::create_dir_all(artifact.parent().unwrap()).unwrap();
+        std::fs::write(&artifact, "durable proof").unwrap();
+        std::fs::create_dir_all(artifacts_root.join("cas-other")).unwrap();
+        std::fs::write(
+            cas_root.path().join("config.toml"),
+            format!(
+                "[factory]\nartifacts_root = {:?}\n",
+                artifacts_root.display().to_string()
+            ),
+        )
+        .unwrap();
+
+        validate_completion_artifact_path(
+            cas_root.path(),
+            task_id,
+            artifact.to_str().unwrap(),
+        )
+        .expect("an existing task-owned artifact is durable receipt metadata");
+
+        let wrong_task = artifacts_root.join("cas-other");
+        assert!(validate_completion_artifact_path(
+            cas_root.path(),
+            task_id,
+            wrong_task.to_str().unwrap(),
+        )
+        .expect_err("another task's artifact must not become this receipt's proof")
+        .contains("<task-id>"));
+
+        let tmpfs_artifact = tempfile::NamedTempFile::new().unwrap();
+        assert!(validate_completion_artifact_path(
+            cas_root.path(),
+            task_id,
+            tmpfs_artifact.path().to_str().unwrap(),
+        )
+        .expect_err("an existing tmpfs file is not durable task receipt metadata")
+        .contains("resolve beneath"));
     }
 }
 
@@ -577,6 +678,21 @@ impl CasCore {
                     data: None,
                 },
             )?;
+        // Exact retries re-use an immutable receipt, so do not make their
+        // recovery dependent on the current config or a later artifact-GC
+        // outcome. New receipts still validate before any state is written.
+        if existing_delivery.is_none()
+            && let Some(artifact_path) = input.artifact_path.as_deref()
+            && let Err(message) = validate_completion_artifact_path(
+                &self.cas_root,
+                &task.id,
+                artifact_path,
+            )
+        {
+            return Ok(Self::tool_error(format!(
+                "DELIVERY RECEIPT REJECTED: invalid artifact_path: {message}"
+            )));
+        }
         if existing_delivery
             .as_ref()
             .is_some_and(|(_, transaction)| {

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/proof_scope.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/proof_scope.rs
@@ -410,6 +410,7 @@ mod tests {
             target_sha: "c".repeat(40),
             proof_reference: "proof:scope".into(),
             scope_summary: "locked delivery scope".into(),
+            artifact_path: None,
         }
     }
 

--- a/cas-cli/src/mcp/tools/core/task/query.rs
+++ b/cas-cli/src/mcp/tools/core/task/query.rs
@@ -60,6 +60,9 @@ impl CasCore {
                     "\nTransactional delivery: {}\n  Receipt: {}\n  Commit: {}\n  Next action: {}",
                     transaction.state, receipt.id, receipt.commit_sha, next_action
                 ));
+                if let Some(artifact_path) = receipt.artifact_path {
+                    output.push_str(&format!("\n  Durable artifact: {artifact_path}"));
+                }
                 if let Some(detail) = transaction.last_error_detail {
                     output.push_str(&format!("\n  Recovery detail: {detail}"));
                 }

--- a/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
+++ b/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
@@ -352,6 +352,20 @@ pub(crate) fn describe_target_push_state(
             "\nPush state: pushed {target_branch} -> origin/{target_branch} ({}).",
             short_sha(sha)
         ),
+        TargetPushOutcome::ProtectedDefaultBranch {
+            sha,
+            remote_sha,
+            reason,
+        } => {
+            let remote = remote_sha.as_deref().map(short_sha).unwrap_or("unresolved");
+            format!(
+                "\n\nPROTECTED_DEFAULT_BRANCH_REQUIRES_PR: GitHub rules rejected the direct \
+                 push of {target_branch} at {} (origin/{target_branch}: {remote}). Retry the \
+                 landing through a pull request; repeating `git push origin {target_branch}` \
+                 cannot satisfy the ruleset.\nGitHub evidence: {reason}",
+                short_sha(sha)
+            )
+        }
         TargetPushOutcome::NotPushed {
             sha,
             remote_sha,
@@ -375,6 +389,47 @@ pub(crate) fn describe_target_push_state(
             )
         }
     }
+}
+
+/// Render the typed, resumable PR handoff for a GH013-protected default branch.
+///
+/// This is deliberately a refusal rather than implicit PR creation/merge: the
+/// interactive supervisor must see the PR URL and required-check status before
+/// choosing to merge it. No `--auto` or admin bypass is prescribed.
+fn protected_default_branch_pr_error(
+    source_branch: &str,
+    target_branch: &str,
+    outcome: &crate::worktree::git::TargetPushOutcome,
+) -> Option<String> {
+    use crate::worktree::git::TargetPushOutcome;
+
+    let TargetPushOutcome::ProtectedDefaultBranch {
+        sha,
+        remote_sha,
+        reason,
+    } = outcome
+    else {
+        return None;
+    };
+    let remote = remote_sha.as_deref().map(short_sha).unwrap_or("unresolved");
+
+    Some(format!(
+        "PROTECTED_DEFAULT_BRANCH_REQUIRES_PR\n\n\
+         The local merge completed, but GitHub rules rejected the direct push to the \
+         protected default branch `{target_branch}`. Local {target_branch}: {}; \
+         origin/{target_branch}: {remote}. Repeating `git push origin {target_branch}` \
+         cannot satisfy this ruleset. Use the source branch for the PR route.\n\n\
+         Run these commands from the repository root:\n\
+         1. `git push -u origin {source_branch}`\n\
+         2. `PR_URL=$(gh pr create --base {target_branch} --head {source_branch} --fill)`\n\
+         3. `gh pr view \"$PR_URL\" --json url,number,statusCheckRollup`\n\
+         4. Surface that PR URL and required-check status to the supervisor.\n\
+         5. After the required checks are green: `gh pr merge \"$PR_URL\" --merge`\n\
+         6. `git fetch origin {target_branch}`, then retry this `worktree_merge` so CAS \
+         can reconcile and close the delivery.\n\n\
+         GitHub evidence:\n{reason}",
+        short_sha(sha)
+    ))
 }
 
 /// Translate worktree merge failures into supervisor-actionable MCP errors.
@@ -2409,12 +2464,37 @@ impl CasCore {
             // guaranteed close-rejection loop that only a manual
             // `git push origin <target>` could break. Publishing before the
             // close is what makes the receipt and the guard agree.
-            target_push = Some((
-                receipt.target_branch.clone(),
-                manager
+            // A protected-default-branch PR may have landed between attempts.
+            // Once a fresh `origin/<target>` contains the immutable receipt
+            // commit, do not retry the rejected direct push of the different
+            // local merge commit; the remote ancestry is the authoritative PR
+            // landing proof and the delivery can reconcile normally.
+            let default_branch = manager.git().detect_default_branch();
+            let remote_target = format!("origin/{}", receipt.target_branch);
+            let pr_landed_sha = (receipt.target_branch == default_branch)
+                .then(|| manager.git().resolve_commit(&remote_target))
+                .flatten()
+                .filter(|_| {
+                    crate::mcp::tools::core::task::lifecycle::close_ops::git_commit_is_ancestor(
+                        &cwd,
+                        &receipt.commit_sha,
+                        &remote_target,
+                    )
+                });
+            let push_outcome = match pr_landed_sha {
+                Some(sha) => crate::worktree::git::TargetPushOutcome::AlreadyCurrent { sha },
+                None => manager
                     .git()
                     .publish_branch_to_origin(&receipt.target_branch),
-            ));
+            };
+            if let Some(error) = protected_default_branch_pr_error(
+                &receipt.source_branch,
+                &receipt.target_branch,
+                &push_outcome,
+            ) {
+                return Ok(Self::tool_error(format!("{ci_prefix}{error}")));
+            }
+            target_push = Some((receipt.target_branch.clone(), push_outcome));
 
             if transaction.state != cas_types::WorkerDeliveryState::CloseReady {
                 cas_store::transition_worker_delivery(
@@ -2546,6 +2626,11 @@ impl CasCore {
             let outcome = manager.git().publish_branch_to_origin(&branch);
             (branch, outcome)
         });
+        if let Some(error) =
+            protected_default_branch_pr_error(&worktree.branch, &push_branch, &push_outcome)
+        {
+            return Ok(Self::tool_error(format!("{ci_prefix}{error}")));
+        }
         let push_note = describe_target_push_state(&push_branch, &push_outcome);
 
         if !reconciled_delivery {
@@ -2727,7 +2812,8 @@ mod tests {
         classify_delivery_merge_preflight, derive_delivery_supervisor_authority,
         describe_branch_ci_state, describe_target_push_state, is_cas_pattern_worktree,
         is_factory_style_worktree, is_git_worktree, lookup_branch_ci_with, path_is_under,
-        resolve_worktree_merge_cleanup, worktree_merge_mcp_error,
+        protected_default_branch_pr_error, resolve_worktree_merge_cleanup,
+        worktree_merge_mcp_error,
     };
     use crate::worktree::git::TargetPushOutcome;
     use crate::worktree::{GitError, WorktreeError};
@@ -2811,6 +2897,44 @@ mod tests {
         // Short SHAs on both sides so the two tips are visibly different.
         assert!(note.contains("42d81bd9aaaa"), "{note}");
         assert!(note.contains("c2698df216cd"), "{note}");
+    }
+
+    #[test]
+    fn protected_default_branch_error_names_the_interactive_pr_route() {
+        let error = protected_default_branch_pr_error(
+            "factory/warm-cheetah-6",
+            "main",
+            &TargetPushOutcome::ProtectedDefaultBranch {
+                sha: "42d81bd9aaaabbbbccccddddeeeeffff00001111".to_string(),
+                remote_sha: Some("c2698df216cd9abe7db530ec1d035f6a378d1d06".to_string()),
+                reason:
+                    "remote: error: GH013: Repository rule violations found for refs/heads/main."
+                        .to_string(),
+            },
+        )
+        .expect("protected branch must produce a typed PR handoff");
+
+        assert!(
+            error.starts_with("PROTECTED_DEFAULT_BRANCH_REQUIRES_PR"),
+            "{error}"
+        );
+        assert!(
+            error.contains("git push -u origin factory/warm-cheetah-6"),
+            "{error}"
+        );
+        assert!(
+            error.contains("gh pr create --base main --head factory/warm-cheetah-6 --fill"),
+            "{error}"
+        );
+        assert!(error.contains("statusCheckRollup"), "{error}");
+        assert!(
+            error.contains("Surface that PR URL and required-check status"),
+            "{error}"
+        );
+        assert!(error.contains("gh pr merge \"$PR_URL\" --merge"), "{error}");
+        assert!(!error.contains("--auto"), "{error}");
+        assert!(error.contains("git fetch origin main"), "{error}");
+        assert!(error.contains("GH013"), "{error}");
     }
 
     #[test]

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -3310,7 +3310,9 @@ impl CasService {
             .map(|task| task.id)
             .collect();
         let artifact_report = factory_artifact_inventory(
-            factory_artifacts_root(config.factory().artifacts_root.as_deref()),
+            crate::config::resolved_factory_artifacts_root(
+                config.factory().artifacts_root.as_deref(),
+            ),
             &closed_task_ids,
         );
         let target_cache_report = {
@@ -3901,7 +3903,9 @@ impl CasService {
             .into_iter()
             .map(|task| task.id)
             .collect();
-        let artifact_root = factory_artifacts_root(config.factory().artifacts_root.as_deref());
+        let artifact_root = crate::config::resolved_factory_artifacts_root(
+            config.factory().artifacts_root.as_deref(),
+        );
         // Durable receipts are deleted only after their task is closed, and
         // only through the same explicit destructive gate as cache reclamation.
         // Unknown directories are inventory-only: an operator must review them.
@@ -4080,20 +4084,6 @@ impl FactoryArtifactInventory {
             ));
         }
         out
-    }
-}
-
-fn factory_artifacts_root(configured: Option<&str>) -> std::path::PathBuf {
-    let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
-    match configured.map(str::trim).filter(|value| !value.is_empty()) {
-        Some("~") => home.unwrap_or_else(|| std::path::PathBuf::from(".cas/artifacts")),
-        Some(value) if value.starts_with("~/") => home
-            .map(|base| base.join(&value[2..]))
-            .unwrap_or_else(|| std::path::PathBuf::from(value)),
-        Some(value) => std::path::PathBuf::from(value),
-        None => home
-            .map(|base| base.join(".cas/artifacts"))
-            .unwrap_or_else(|| std::path::PathBuf::from(".cas/artifacts")),
     }
 }
 

--- a/cas-cli/src/migration/migrations/m212_worker_delivery_transactions.rs
+++ b/cas-cli/src/migration/migrations/m212_worker_delivery_transactions.rs
@@ -21,6 +21,7 @@ pub const MIGRATION: Migration = Migration {
             target_sha TEXT NOT NULL,
             proof_reference TEXT NOT NULL,
             scope_summary TEXT NOT NULL,
+            artifact_path TEXT,
             created_at TEXT NOT NULL
         )",
         "CREATE INDEX idx_worker_completion_receipts_task

--- a/cas-cli/src/migration/migrations/m232_worker_completion_receipts_add_artifact_path.rs
+++ b/cas-cli/src/migration/migrations/m232_worker_completion_receipts_add_artifact_path.rs
@@ -1,0 +1,49 @@
+//! Migration: retain structured durable completion artifacts (cas-96f9).
+
+use crate::migration::{Migration, Subsystem};
+
+pub const MIGRATION: Migration = Migration {
+    id: 232,
+    name: "worker_completion_receipts_add_artifact_path",
+    subsystem: Subsystem::Tasks,
+    description: "Add immutable durable artifact paths to worker completion receipts (cas-96f9)",
+    up: &["ALTER TABLE worker_completion_receipts ADD COLUMN artifact_path TEXT"],
+    detect: Some(
+        "SELECT CASE WHEN (SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='worker_completion_receipts') = 0 THEN 1 ELSE (SELECT COUNT(*) FROM pragma_table_info('worker_completion_receipts') WHERE name = 'artifact_path') END",
+    ),
+};
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    #[test]
+    fn migration_adds_nullable_artifact_path_to_existing_receipts() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE worker_completion_receipts (
+                id TEXT PRIMARY KEY,
+                task_id TEXT NOT NULL
+            )",
+        )
+        .unwrap();
+        assert_eq!(
+            conn.query_row(super::MIGRATION.detect.unwrap(), [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        for statement in super::MIGRATION.up {
+            conn.execute(statement, []).unwrap();
+        }
+        assert_eq!(
+            conn.query_row(super::MIGRATION.detect.unwrap(), [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        conn.execute(
+            "INSERT INTO worker_completion_receipts (id, task_id, artifact_path) VALUES ('legacy', 'cas-legacy', NULL)",
+            [],
+        )
+        .unwrap();
+    }
+}

--- a/cas-cli/src/migration/migrations/mod.rs
+++ b/cas-cli/src/migration/migrations/mod.rs
@@ -207,6 +207,7 @@ mod m228_history_epochs_create_table;
 mod m229_code_vector_state;
 mod m230_verification_repository_proof;
 mod m231_sync_conflicts_create_table;
+mod m232_worker_completion_receipts_add_artifact_path;
 
 /// All migrations in order. IDs must be sequential and never reused.
 pub const MIGRATIONS: &[Migration] = &[
@@ -447,6 +448,7 @@ pub const MIGRATIONS: &[Migration] = &[
     m229_code_vector_state::MIGRATION,
     m230_verification_repository_proof::MIGRATION,
     m231_sync_conflicts_create_table::MIGRATION,
+    m232_worker_completion_receipts_add_artifact_path::MIGRATION,
 ];
 
 #[cfg(test)]

--- a/cas-cli/src/migration/mod.rs
+++ b/cas-cli/src/migration/mod.rs
@@ -930,7 +930,7 @@ mod tests {
 
     fn assert_repaired_v225_knowledge_gap(cas_dir: &Path, expected_m226_ledger: &str) {
         let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
-        for id in [225, 226, 227, 228, 229, 230, 231] {
+        for id in [225, 226, 227, 228, 229, 230, 231, 232] {
             assert_eq!(
                 conn.query_row(
                     "SELECT COUNT(*) FROM cas_migrations WHERE id = ?1",
@@ -997,7 +997,7 @@ mod tests {
         assert_eq!(pages[0].origin_project_id, None);
 
         let status = check_migrations(cas_dir).unwrap();
-        assert_eq!(status.current_version, 231);
+        assert_eq!(status.current_version, 232);
         assert!(status.pending.is_empty());
         let second = run_migrations(cas_dir, false).unwrap();
         assert_eq!(second.applied_count, 0, "repeated open must be idempotent");
@@ -1019,7 +1019,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 227, 228, 229, 230, 231],
+                vec![225, 226, 227, 228, 229, 230, 231, 232],
                 "recorded m225 and missing m226 must order all later work behind them"
             );
 
@@ -1106,7 +1106,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 230, 231]
+                vec![225, 226, 230, 231, 232]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();
@@ -1148,7 +1148,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 227, 228, 229, 230, 231]
+                vec![225, 227, 228, 229, 230, 231, 232]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();

--- a/cas-cli/src/worktree/git/branch_ops.rs
+++ b/cas-cli/src/worktree/git/branch_ops.rs
@@ -45,6 +45,19 @@ pub enum TargetPushOutcome {
     AlreadyCurrent { sha: String },
     /// The push ran and succeeded; `origin/<branch>` now carries the tip.
     Pushed { sha: String },
+    /// GitHub rejected a push to the repository's default branch because an
+    /// active repository ruleset requires the change to land through a pull
+    /// request. This is distinct from an ordinary push failure: retrying the
+    /// same `git push` cannot succeed, and the caller must preserve the source
+    /// branch for the PR route.
+    ProtectedDefaultBranch {
+        /// Local tip that the rejected push attempted to publish.
+        sha: String,
+        /// Remote default-branch tip observed before the rejected push.
+        remote_sha: Option<String>,
+        /// GitHub's GH013 diagnostic, retained as evidence.
+        reason: String,
+    },
     /// The merge is LOCAL ONLY. `reason` says why the push did not land.
     NotPushed {
         /// Local tip of the target branch, or `None` if it did not resolve.
@@ -67,6 +80,38 @@ impl TargetPushOutcome {
                 | Self::AlreadyCurrent { .. }
                 | Self::Pushed { .. }
         )
+    }
+}
+
+fn classify_push_rejection(
+    branch: &str,
+    default_branch: &str,
+    local_sha: String,
+    remote_sha: Option<String>,
+    stderr: &str,
+) -> TargetPushOutcome {
+    let reason = stderr.trim();
+    if branch == default_branch
+        && reason.contains("GH013")
+        && reason.contains("Repository rule violations")
+    {
+        return TargetPushOutcome::ProtectedDefaultBranch {
+            sha: local_sha,
+            remote_sha,
+            reason: reason.to_string(),
+        };
+    }
+
+    let reason = reason
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("git push failed with no diagnostic output")
+        .to_string();
+    TargetPushOutcome::NotPushed {
+        sha: Some(local_sha),
+        remote_sha,
+        reason,
     }
 }
 
@@ -703,22 +748,20 @@ impl GitOperations {
             Ok(output) if output.status.success() => TargetPushOutcome::Pushed { sha: local_sha },
             Ok(output) => {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                let reason = stderr
-                    .lines()
-                    .map(str::trim)
-                    .find(|line| !line.is_empty())
-                    .unwrap_or("git push failed with no diagnostic output")
-                    .to_string();
+                let remote_sha = self.resolve_commit(&remote_ref);
+                let outcome = classify_push_rejection(
+                    branch,
+                    &self.detect_default_branch(),
+                    local_sha,
+                    remote_sha,
+                    &stderr,
+                );
                 tracing::warn!(
                     branch = %branch,
-                    reason = %reason,
+                    reason = %stderr.trim(),
                     "cas-5ee0: merge target was not published to origin"
                 );
-                TargetPushOutcome::NotPushed {
-                    sha: Some(local_sha),
-                    remote_sha: self.resolve_commit(&remote_ref),
-                    reason,
-                }
+                outcome
             }
             Err(e) => {
                 let reason = if e.kind() == std::io::ErrorKind::TimedOut {
@@ -817,5 +860,46 @@ impl GitOperations {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod protected_branch_tests {
+    use super::{TargetPushOutcome, classify_push_rejection};
+
+    const RECORDED_GH013: &str = "remote: error: GH013: Repository rule violations found for refs/heads/main.\nremote: - 2 of 2 required status checks are expected.\nTo github.com:pippenz/cas.git\n ! [remote rejected] main -> main (push declined due to repository rule violations)";
+
+    #[test]
+    fn recorded_gh013_on_default_branch_is_typed_as_pr_required() {
+        let outcome = classify_push_rejection(
+            "main",
+            "main",
+            "local-sha".to_string(),
+            Some("remote-sha".to_string()),
+            RECORDED_GH013,
+        );
+
+        assert_eq!(
+            outcome,
+            TargetPushOutcome::ProtectedDefaultBranch {
+                sha: "local-sha".to_string(),
+                remote_sha: Some("remote-sha".to_string()),
+                reason: RECORDED_GH013.to_string(),
+            }
+        );
+        assert!(!outcome.is_published());
+    }
+
+    #[test]
+    fn gh013_on_non_default_target_keeps_the_existing_failure_shape() {
+        let outcome = classify_push_rejection(
+            "epic/release",
+            "main",
+            "local-sha".to_string(),
+            Some("remote-sha".to_string()),
+            RECORDED_GH013,
+        );
+
+        assert!(matches!(outcome, TargetPushOutcome::NotPushed { .. }));
     }
 }

--- a/cas-cli/tests/delivery_target_cas_test.rs
+++ b/cas-cli/tests/delivery_target_cas_test.rs
@@ -212,9 +212,13 @@ async fn arm_delivery(slug: &str, repo_host: &str) -> DeliveryFixture {
         &repo.root,
     );
     let cas_root = init_cas_dir(&repo.root).expect("init CAS");
+    let artifact_root = cas_root.join("durable-artifacts");
     std::fs::write(
         cas_root.join("config.toml"),
-        "[worktrees]\nenabled = false\n",
+        format!(
+            "[worktrees]\nenabled = false\n\n[factory]\nartifacts_root = {:?}\n",
+            artifact_root.display().to_string()
+        ),
     )
     .expect("write config");
 
@@ -256,6 +260,9 @@ async fn arm_delivery(slug: &str, repo_host: &str) -> DeliveryFixture {
         target_branch: "main".to_string(),
     });
     task_store.add(&task).expect("add task");
+    let artifact = artifact_root.join(&task.id).join("proof.json");
+    std::fs::create_dir_all(artifact.parent().unwrap()).expect("create durable artifact directory");
+    std::fs::write(&artifact, "transactional delivery proof\n").expect("write durable artifact");
     assert!(matches!(
         open_agent_store(&cas_root)
             .expect("agent store")
@@ -283,6 +290,7 @@ async fn arm_delivery(slug: &str, repo_host: &str) -> DeliveryFixture {
         target_sha: git_stdout(&repo.root, &["rev-parse", "main"]),
         proof_reference: format!("proof:{slug}"),
         scope_summary: "transactional delivery target CAS".to_string(),
+        artifact_path: Some(artifact.display().to_string()),
     };
 
     // Worker submits the immutable receipt, supervisor approves it.
@@ -385,6 +393,16 @@ async fn delivery_merge_accepts_task_id_and_reaches_target_resolution() {
     let mut env = TestEnvGuard::new();
     env.set("HOME", home.path());
     let fixture = arm_delivery("taskidaccepted", "task-id-accepted").await;
+
+    assert_eq!(
+        cas_store::get_latest_worker_delivery(&fixture.cas_root, &fixture.task_id)
+            .expect("delivery lookup")
+            .expect("persisted delivery")
+            .0
+            .artifact_path,
+        fixture.receipt.artifact_path,
+        "close must retain its configured durable artifact as queryable receipt metadata"
+    );
 
     env.set_current_dir(&fixture.repo.root);
     let output = run_merge(&fixture).await;

--- a/cas-cli/tests/issue_intake_directive_test.rs
+++ b/cas-cli/tests/issue_intake_directive_test.rs
@@ -22,10 +22,6 @@ fn assert_config_driven_issue_intake(harness: SupervisorCli, content: &str) {
         "gh auth status",
         "gh issue create",
         "--repo",
-        "--body-file",
-        "docs/requests/BUG-<slug>.md",
-        "git add",
-        "git commit",
     ] {
         assert!(
             content.contains(required),

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -7,10 +7,10 @@ cas doctor
 ──────────────────────────────────────────────────
 [OK] cas directory: Found at [TEMP_PATH]
 [OK] database: SQLite database found
-[OK] schema: v231 (up to date)
+[OK] schema: v232 (up to date)
 [OK] supervisor relay: no undelivered lifecycle relays
 [OK] delivery retries: no pending message has spent 3+ attempts
-[OK] tables: [N] tables, 715 columns, 194 rows total
+[OK] tables: [N] tables, 716 columns, 195 rows total
 [OK] entry store: [N] entries accessible
 [WARN] search index: Index not found. Will be created on first search.
 [WARN] symbol index: nothing indexed for this project (0 symbol(s) in the store across all repositories); the code search index is missing. The daemon only indexes while idle — run `cas index code` to catch up now.

--- a/cas-cli/tests/worktree_surface_test.rs
+++ b/cas-cli/tests/worktree_surface_test.rs
@@ -347,6 +347,7 @@ fn seed_direct_close_delivery(
         target_sha: commit_sha.to_string(),
         proof_reference: "proof:direct-close-state".to_string(),
         scope_summary: "direct close delivery-state fixture".to_string(),
+        artifact_path: None,
     };
     let receipt = cas_store::build_worker_completion_receipt(
         &input,
@@ -2914,6 +2915,7 @@ fn delivery_receipt(
         target_sha: git_stdout(&repo.root, &["rev-parse", "main"]),
         proof_reference: "proof:serialized-workspace-1".to_string(),
         scope_summary: "transactional delivery integration".to_string(),
+        artifact_path: None,
     }
 }
 
@@ -3951,6 +3953,7 @@ async fn pending_delivery_proof_rejects_review_scope_update_but_allows_notes() {
         target_sha: "c".repeat(40),
         proof_reference: "proof:scope-lock".to_string(),
         scope_summary: "immutable review boundary".to_string(),
+        artifact_path: None,
     };
     let receipt = cas_store::build_worker_completion_receipt(&input, "alice", chrono::Utc::now());
     let (transaction, dispatch) = cas_store::create_worker_delivery_with_dispatch(
@@ -4727,6 +4730,7 @@ async fn terminal_task_rejects_fresh_completion_receipt_without_any_mutation() {
         target_sha: git_stdout(&repo.root, &["rev-parse", "main"]),
         proof_reference: "proof:terminal-replay".to_string(),
         scope_summary: "stale post-close receipt".to_string(),
+        artifact_path: None,
     };
     let receipt_id =
         cas_store::build_worker_completion_receipt(&receipt, "alice", chrono::Utc::now()).id;

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -291,8 +291,10 @@ pub struct TaskRequest {
     #[schemars(
         description = "Serialized WorkerCompletionReceiptInput JSON. CAS revalidates \
                        the registered worker, task, repository, branch, commit/base/target \
-                       tips and proof reference before persisting an immutable delivery \
-                       transaction. Omit to use the legacy close path unchanged."
+                       tips, proof reference, and optional artifact_path before persisting an \
+                       immutable delivery transaction. artifact_path must be an existing file \
+                       or directory under configured [factory] artifacts_root/<task-id>/. \
+                       Omit to use the legacy close path unchanged."
     )]
     #[serde(default)]
     pub completion_receipt: Option<String>,

--- a/crates/cas-store/src/delivery_store.rs
+++ b/crates/cas-store/src/delivery_store.rs
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS worker_completion_receipts (
     target_sha TEXT NOT NULL,
     proof_reference TEXT NOT NULL,
     scope_summary TEXT NOT NULL,
+    artifact_path TEXT,
     created_at TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_worker_completion_receipts_task
@@ -94,7 +95,7 @@ pub fn build_worker_completion_receipt(
     worker_name: &str,
     created_at: DateTime<Utc>,
 ) -> WorkerCompletionReceipt {
-    let hash = digest(&[
+    let mut parts = vec![
         &input.task_id,
         &input.worker_agent_id,
         worker_name,
@@ -106,7 +107,14 @@ pub fn build_worker_completion_receipt(
         &input.target_sha,
         &input.proof_reference,
         &input.scope_summary,
-    ]);
+    ];
+    // Preserve legacy receipt IDs when no artifact was supplied. That keeps
+    // old retried completion JSON idempotent while binding a new path into the
+    // immutable proof identity whenever it is present.
+    if let Some(path) = input.artifact_path.as_deref() {
+        parts.push(path);
+    }
+    let hash = digest(&parts);
     WorkerCompletionReceipt {
         id: format!("wcr-{}", &hash[..24]),
         task_id: input.task_id.clone(),
@@ -120,6 +128,7 @@ pub fn build_worker_completion_receipt(
         target_sha: input.target_sha.clone(),
         proof_reference: input.proof_reference.clone(),
         scope_summary: input.scope_summary.clone(),
+        artifact_path: input.artifact_path.clone(),
         created_at,
     }
 }
@@ -156,7 +165,8 @@ fn receipt_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorkerCompletio
         target_sha: row.get(9)?,
         proof_reference: row.get(10)?,
         scope_summary: row.get(11)?,
-        created_at: parse_time(row.get(12)?)?,
+        artifact_path: row.get(12)?,
+        created_at: parse_time(row.get(13)?)?,
     })
 }
 
@@ -224,8 +234,8 @@ fn create_worker_delivery_with_conn(
         "INSERT OR IGNORE INTO worker_completion_receipts
          (id, task_id, worker_agent_id, worker_name, repo_selector, source_branch,
           commit_sha, merge_base_sha, target_branch, target_sha, proof_reference,
-          scope_summary, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+          scope_summary, artifact_path, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
         params![
             receipt.id,
             receipt.task_id,
@@ -239,13 +249,14 @@ fn create_worker_delivery_with_conn(
             receipt.target_sha,
             receipt.proof_reference,
             receipt.scope_summary,
+            receipt.artifact_path,
             receipt.created_at.to_rfc3339(),
         ],
     )?;
     let persisted = conn.query_row(
         "SELECT id, task_id, worker_agent_id, worker_name, repo_selector, source_branch,
                 commit_sha, merge_base_sha, target_branch, target_sha, proof_reference,
-                scope_summary, created_at
+                scope_summary, artifact_path, created_at
          FROM worker_completion_receipts WHERE id = ?1",
         params![receipt.id],
         receipt_from_row,
@@ -261,7 +272,8 @@ fn create_worker_delivery_with_conn(
         && persisted.target_branch == receipt.target_branch
         && persisted.target_sha == receipt.target_sha
         && persisted.proof_reference == receipt.proof_reference
-        && persisted.scope_summary == receipt.scope_summary;
+        && persisted.scope_summary == receipt.scope_summary
+        && persisted.artifact_path == receipt.artifact_path;
     if !same_immutable_payload {
         return Err(StoreError::Parse(
             "immutable worker completion receipt mismatch".to_string(),
@@ -411,7 +423,7 @@ pub fn get_worker_delivery_by_receipt(
     conn.query_row(
         "SELECT r.id, r.task_id, r.worker_agent_id, r.worker_name, r.repo_selector,
                 r.source_branch, r.commit_sha, r.merge_base_sha, r.target_branch,
-                r.target_sha, r.proof_reference, r.scope_summary, r.created_at,
+                r.target_sha, r.proof_reference, r.scope_summary, r.artifact_path, r.created_at,
                 t.id, t.receipt_id, t.task_id, t.state, t.supervisor_agent_id,
                 t.verification_id, t.merge_commit_sha, t.last_error_code,
                 t.last_error_detail, t.created_at, t.updated_at
@@ -422,17 +434,17 @@ pub fn get_worker_delivery_by_receipt(
         |row| {
             let receipt = receipt_from_row(row)?;
             let transaction = WorkerDeliveryTransaction {
-                id: row.get(13)?,
-                receipt_id: row.get(14)?,
-                task_id: row.get(15)?,
-                state: parse_state(row.get(16)?)?,
-                supervisor_agent_id: row.get(17)?,
-                verification_id: row.get(18)?,
-                merge_commit_sha: row.get(19)?,
-                last_error_code: row.get(20)?,
-                last_error_detail: row.get(21)?,
-                created_at: parse_time(row.get(22)?)?,
-                updated_at: parse_time(row.get(23)?)?,
+                id: row.get(14)?,
+                receipt_id: row.get(15)?,
+                task_id: row.get(16)?,
+                state: parse_state(row.get(17)?)?,
+                supervisor_agent_id: row.get(18)?,
+                verification_id: row.get(19)?,
+                merge_commit_sha: row.get(20)?,
+                last_error_code: row.get(21)?,
+                last_error_detail: row.get(22)?,
+                created_at: parse_time(row.get(23)?)?,
+                updated_at: parse_time(row.get(24)?)?,
             };
             Ok((receipt, transaction))
         },
@@ -449,7 +461,7 @@ pub fn get_latest_worker_delivery(
     conn.query_row(
         "SELECT r.id, r.task_id, r.worker_agent_id, r.worker_name, r.repo_selector,
                 r.source_branch, r.commit_sha, r.merge_base_sha, r.target_branch,
-                r.target_sha, r.proof_reference, r.scope_summary, r.created_at,
+                r.target_sha, r.proof_reference, r.scope_summary, r.artifact_path, r.created_at,
                 t.id, t.receipt_id, t.task_id, t.state, t.supervisor_agent_id,
                 t.verification_id, t.merge_commit_sha, t.last_error_code,
                 t.last_error_detail, t.created_at, t.updated_at
@@ -460,17 +472,17 @@ pub fn get_latest_worker_delivery(
         |row| {
             let receipt = receipt_from_row(row)?;
             let transaction = WorkerDeliveryTransaction {
-                id: row.get(13)?,
-                receipt_id: row.get(14)?,
-                task_id: row.get(15)?,
-                state: parse_state(row.get(16)?)?,
-                supervisor_agent_id: row.get(17)?,
-                verification_id: row.get(18)?,
-                merge_commit_sha: row.get(19)?,
-                last_error_code: row.get(20)?,
-                last_error_detail: row.get(21)?,
-                created_at: parse_time(row.get(22)?)?,
-                updated_at: parse_time(row.get(23)?)?,
+                id: row.get(14)?,
+                receipt_id: row.get(15)?,
+                task_id: row.get(16)?,
+                state: parse_state(row.get(17)?)?,
+                supervisor_agent_id: row.get(18)?,
+                verification_id: row.get(19)?,
+                merge_commit_sha: row.get(20)?,
+                last_error_code: row.get(21)?,
+                last_error_detail: row.get(22)?,
+                created_at: parse_time(row.get(23)?)?,
+                updated_at: parse_time(row.get(24)?)?,
             };
             Ok((receipt, transaction))
         },
@@ -709,6 +721,7 @@ mod tests {
             target_sha: "c".repeat(40),
             proof_reference: "proof:workspace-1".into(),
             scope_summary: "bounded delivery change".into(),
+            artifact_path: None,
         }
     }
 
@@ -1174,6 +1187,28 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn durable_artifact_path_is_persisted_and_part_of_the_receipt_identity() {
+        let root = TempDir::new().unwrap();
+        let legacy = build_worker_completion_receipt(&input(), "worker", Utc::now());
+        let mut with_artifact = input();
+        with_artifact.artifact_path = Some("/durable/cas-delivery/proof.json".into());
+        let receipt = build_worker_completion_receipt(&with_artifact, "worker", Utc::now());
+        assert_ne!(receipt.id, legacy.id, "a durable artifact binds the proof identity");
+
+        create_worker_delivery(
+            root.path(),
+            &receipt,
+            WorkerDeliveryState::AwaitingVerification,
+            "worker-session",
+        )
+        .unwrap();
+        let (persisted, _) = get_worker_delivery_by_receipt(root.path(), &receipt.id)
+            .unwrap()
+            .expect("persisted receipt");
+        assert_eq!(persisted.artifact_path, with_artifact.artifact_path);
     }
 
     #[test]

--- a/crates/cas-types/src/delivery.rs
+++ b/crates/cas-types/src/delivery.rs
@@ -20,6 +20,11 @@ pub struct WorkerCompletionReceiptInput {
     pub target_sha: String,
     pub proof_reference: String,
     pub scope_summary: String,
+    /// Optional durable proof artifact stored under the configured factory
+    /// artifacts root. The close boundary validates its location before this
+    /// immutable receipt is accepted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -36,6 +41,8 @@ pub struct WorkerCompletionReceipt {
     pub target_sha: String,
     pub proof_reference: String,
     pub scope_summary: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_path: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 

--- a/docs/RELEASE_SLACK_RUBRIC.md
+++ b/docs/RELEASE_SLACK_RUBRIC.md
@@ -15,6 +15,26 @@ After a release is pushed + tagged, post to **#cas-internal** (`C0B44GUKDK2`). A
 1. **User-perspective post**
 2. **Dev-perspective post**
 
+### Protected-main landing before the tag
+
+`main` is protected by required checks. Prepare the version bump, changelog,
+and release-note draft on a source branch; do not merge or push that commit
+directly to `main`, and do not create the release tag before the PR lands.
+
+1. Push the source branch: `git push -u origin <source-branch>`.
+2. Open the release PR: `PR_URL=$(gh pr create --base main --head <source-branch> --fill)`.
+3. Surface its URL and required checks to the operator/supervisor:
+   `gh pr view "$PR_URL" --json url,number,statusCheckRollup`.
+4. After the required checks are green, merge explicitly:
+   `gh pr merge "$PR_URL" --merge`. Do not use `--auto` or an admin bypass.
+5. Fetch the landed commit (`git fetch origin main`), tag that exact
+   `origin/main` commit, then run the artifact/release flow and push the tag.
+
+If `coordination action=worktree_merge ... allow_trunk=true` encounters the
+ruleset first, it returns `PROTECTED_DEFAULT_BRANCH_REQUIRES_PR` with the
+source/target-specific form of these commands. Follow that handoff and retry
+the merge action after fetching the PR landing so CAS can reconcile delivery.
+
 ### Shape (identical for both posts)
 
 1. **Open with the punch** — one or two lines of plain, punchy language framed as **how it was → how it is now**. Lead with the change in experience, not the mechanism.
@@ -77,7 +97,9 @@ compatibility snapshot. Neither includes factory plumbing or ticket IDs.
 
 ### Runtime release
 
-- [ ] Release pushed to `origin/main` + tag pushed
+- [ ] Version/changelog commit landed on `main` through a reviewed PR with required checks green
+- [ ] PR URL + required-check status surfaced before the explicit merge (no `--auto` / admin bypass)
+- [ ] Release tag points at the fetched `origin/main` landing and is pushed
 - [ ] Post 1 (user): punch (was→now) + plain-language details
 - [ ] Post 2 (dev): punch (was→now) + technical details
 - [ ] Both: zero ticket numbers, zero internal-agent narration

--- a/docs/requests/README.md
+++ b/docs/requests/README.md
@@ -1,10 +1,13 @@
 # Request Intake and Archive
 
-GitHub Issues is the primary intake and system of record for cross-team requests. Use the repository's [bug](../../.github/ISSUE_TEMPLATE/bug.yml) or [feature](../../.github/ISSUE_TEMPLATE/feature.yml) template when filing in the browser.
+> **Deprecated for new outbound actionable requests.** File CAS defects in
+> [`pippenz/cas`](https://github.com/pippenz/cas/issues) and file requests for
+> a Richards-LLC-controlled team directly on that team's GitHub issue board
+> (for example, [`Richards-LLC/petra-stella-cloud`](https://github.com/Richards-LLC/petra-stella-cloud/issues)). Never write, commit, or push in another team's checkout. Save a CAS memory receipt with the issue URL, one-line ask, and date. Examples: cloud-to-CAS GH #215; CAS-to-cloud [#44](https://github.com/Richards-LLC/petra-stella-cloud/issues/44).
 
-This directory remains the durable staging area for reports written before GitHub filing and the historical archive for completed file-based requests.
+This directory is a historical archive and legacy inbound-response reader. It remains acceptable for prose-heavy specifications or design documents until cross-project task proposals ship.
 
-## Configure the Issue Target
+## Legacy staged files
 
 The destination is project-local configuration in `.cas/config.toml`:
 
@@ -20,7 +23,7 @@ cas config set issues.repo owner/repo
 cas config get issues.repo
 ```
 
-Use the issue tracker explicitly provided by the receiving team. Do not derive the target from the current repository's `origin`, and do not route requests through another machine's checkout or home-directory path.
+Do not create a new staged report for actionable work. This material only explains how to preserve and sweep a file that was already staged under the former workflow.
 
 ## Durable Write-First Flow
 

--- a/docs/requests/README.md
+++ b/docs/requests/README.md
@@ -25,7 +25,10 @@ cas config get issues.repo
 
 Do not create a new staged report for actionable work. This material only explains how to preserve and sweep a file that was already staged under the former workflow.
 
-## Durable Write-First Flow
+## Legacy write-first flow for existing staged files only
+
+This former workflow is retained solely to migrate a report that already
+exists; it is not authorization to create a new outbound request file.
 
 1. Write the complete, public-safe report to a new, uniquely named staging file in this directory:
 

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -70,7 +70,7 @@ for job in "${required_pr_jobs[@]}"; do
     require_text "$block" "github.event_name == 'pull_request'" "$job runs for pull requests"
     require_text "$block" 'github.base_ref == github.event.repository.default_branch' "$job targets the default PR base"
     require_text "$block" 'github.event.pull_request.head.sha || github.sha' "$job deduplicates push/PR runs by head SHA"
-    require_text "$block" 'cancel-in-progress: true' "$job cancels the duplicate required-check run"
+    require_text "$block" 'cancel-in-progress: false' "$job queues duplicate required-check runs without cancellation"
 done
 
 all_actions="$(<"$setup")$(<"$ci")$(<"$release")"

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -64,6 +64,15 @@ for job in "${full_jobs[@]}"; do
     fi
 done
 
+required_pr_jobs=(fast-validation macos-check)
+for job in "${required_pr_jobs[@]}"; do
+    block="$(job_block "$job")"
+    require_text "$block" "github.event_name == 'pull_request'" "$job runs for pull requests"
+    require_text "$block" 'github.base_ref == github.event.repository.default_branch' "$job targets the default PR base"
+    require_text "$block" 'github.event.pull_request.head.sha || github.sha' "$job deduplicates push/PR runs by head SHA"
+    require_text "$block" 'cancel-in-progress: true' "$job cancels the duplicate required-check run"
+done
+
 all_actions="$(<"$setup")$(<"$ci")$(<"$release")"
 require_text "$all_actions" 'mozilla-actions/sccache-action@v0.0.11' 'cache-v2-capable sccache action is pinned'
 if grep -qF 'mozilla-actions/sccache-action@v0.0.5' <<<"$all_actions"; then


### PR DESCRIPTION
Batched landing of four accepted standalone deliveries (protected-main flow):

- **cas-96ce** — worktree_merge/release path return typed `PROTECTED_DEFAULT_BRANCH_REQUIRES_PR` guidance on GH013 instead of a raw git failure; retry reconciliation once the PR lands; release rubric updated to the PR route (13/13 scoped proofs)
- **cas-9eaf** — Fast Validation + macOS Check now also run on pull_request into the default branch, with per-job head-SHA concurrency dedupe (47/47 CI-contract assertions; **Fixes #219**)
- **cas-96f9** — durable completion-receipt `artifact_path`: additive schema + m232 migration + close-boundary validation against artifacts_root
- **cas-8921** — canonical cross-team/issue routing encoded across tracked + builtin (codex/grok) guidance; docs/requests intake deprecated

Combined-tree compile check green; each lane carries its own scoped proofs. Required checks run on this PR via both the epic/*-named push and (once merged, for future PRs) the cas-9eaf conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)