### PR TITLE
Commander: hub restart completes with live viewers attached (bounded drain + force-close)

### DIFF
--- a/cas-cli/src/cli/hub.rs
+++ b/cas-cli/src/cli/hub.rs
@@ -18,6 +18,7 @@ use crate::hub::{
 };
 
 const HUB_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(10);
+const HUB_CONNECTION_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Args, Debug, Clone)]
 pub struct HubArgs {
@@ -350,10 +351,7 @@ fn serve_foreground(args: &HubServeArgs, tailscale_serve: bool, tailscale_port: 
         let result = if let Some(proxy_listener) = tailscale_listener {
             serve_with_trusted_tls_proxy(listener, state, proxy_listener).await
         } else {
-            axum::serve(listener, router(state))
-                .with_graceful_shutdown(shutdown_signal())
-                .await
-                .context("Commander hub server failed")
+            serve_with_bounded_connection_drain(listener, router(state)).await
         };
         event_task.abort();
         paths.remove_process_record()?;
@@ -367,6 +365,39 @@ fn serve_foreground(args: &HubServeArgs, tailscale_serve: bool, tailscale_port: 
         let _ = tailscale_manager.disable_owned();
         result
     })
+}
+
+async fn serve_with_bounded_connection_drain(
+    listener: tokio::net::TcpListener,
+    app: axum::Router,
+) -> Result<()> {
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let server = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_requested(shutdown_rx))
+        .into_future();
+    tokio::pin!(server);
+
+    tokio::select! {
+        result = &mut server => result.context("Commander hub server failed"),
+        _ = shutdown_signal() => {
+            let _ = shutdown_tx.send(true);
+            match tokio::time::timeout(HUB_CONNECTION_DRAIN_TIMEOUT, &mut server).await {
+                Ok(result) => result.context("Commander hub server failed"),
+                Err(_) => {
+                    // Axum's graceful shutdown deliberately waits for upgraded
+                    // WebSockets and other active requests forever. Returning
+                    // drops the server future; the enclosing runtime then closes
+                    // those tasks so Commander clients observe a non-normal close
+                    // and reconnect to the replacement hub.
+                    tracing::warn!(
+                        timeout_seconds = HUB_CONNECTION_DRAIN_TIMEOUT.as_secs_f64(),
+                        "Commander connection drain expired; force-closing live clients"
+                    );
+                    Ok(())
+                }
+            }
+        }
+    }
 }
 
 #[cfg(debug_assertions)]
@@ -432,9 +463,22 @@ async fn serve_with_trusted_tls_proxy<R: crate::hub::SessionReadModel>(
 
     match first {
         FirstExit::Shutdown => {
-            let (plaintext, trusted_proxy) = tokio::join!(plaintext, trusted_proxy);
-            plaintext.context("Commander loopback listener failed")?;
-            trusted_proxy.context("Commander trusted proxy listener failed")?;
+            match tokio::time::timeout(HUB_CONNECTION_DRAIN_TIMEOUT, async {
+                tokio::join!(&mut plaintext, &mut trusted_proxy)
+            })
+            .await
+            {
+                Ok((plaintext, trusted_proxy)) => {
+                    plaintext.context("Commander loopback listener failed")?;
+                    trusted_proxy.context("Commander trusted proxy listener failed")?;
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        timeout_seconds = HUB_CONNECTION_DRAIN_TIMEOUT.as_secs_f64(),
+                        "Commander connection drain expired; force-closing live clients"
+                    );
+                }
+            }
             Ok(())
         }
         FirstExit::Plaintext(result) => {

--- a/cas-cli/tests/hub_clean_home_test.rs
+++ b/cas-cli/tests/hub_clean_home_test.rs
@@ -1,5 +1,7 @@
 use std::ffi::{OsStr, OsString};
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpStream;
 use std::path::Path;
 use std::process::Stdio;
 use std::sync::{Arc, Barrier};
@@ -492,6 +494,81 @@ esac
     assert!(paths.acquire_instance_lock().is_ok());
     assert!(!home.path().join(".cas/hub/process.json").exists());
     assert!(!home.path().join("mock-serve").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn restart_force_closes_a_held_client_and_starts_the_replacement() {
+    let home = private_home();
+    let path = system_path();
+    let initial = start_hub(home.path(), &path, false);
+    let old_pid = initial["pid"].as_u64().unwrap();
+    let port = initial["port"].as_u64().unwrap() as u16;
+    let machine_id = fs::read_to_string(home.path().join(".cas/hub/machine-id")).unwrap();
+
+    // Keep a real accepted HTTP request active by declaring a body and withholding
+    // most of it. This has the same server-lifecycle shape as an upgraded viewer:
+    // graceful shutdown cannot finish until the client goes away.
+    let mut held = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    held.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+    write!(
+        held,
+        "POST /v1/auth/pairing/exchange HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nOrigin: http://127.0.0.1:{port}\r\nContent-Type: application/json\r\nContent-Length: 1024\r\n\r\n{{"
+    )
+    .unwrap();
+    held.flush().unwrap();
+    thread::sleep(Duration::from_millis(100));
+
+    let started = Instant::now();
+    let restart = cas_command(home.path(), &path)
+        .args([
+            "--json",
+            "hub",
+            "restart",
+            "--port",
+            &port.to_string(),
+        ])
+        .output()
+        .expect("restart hub with held client");
+    let elapsed = started.elapsed();
+
+    if !restart.status.success() {
+        let stderr = String::from_utf8_lossy(&restart.stderr).into_owned();
+        drop(held);
+        let _ = cas_command(home.path(), &path)
+            .args(["--json", "hub", "stop"])
+            .output();
+        panic!("held client blocked restart for {elapsed:?}: {stderr}");
+    }
+    assert!(
+        elapsed < Duration::from_secs(8),
+        "restart exceeded its bounded drain window: {elapsed:?}"
+    );
+
+    let mut closed = [0_u8; 1];
+    assert!(
+        matches!(held.read(&mut closed), Ok(0) | Err(_)),
+        "old hub left the held connection silently live"
+    );
+    let status = cas_command(home.path(), &path)
+        .args(["--json", "hub", "status"])
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+    let status: Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert_ne!(status["record"]["pid"].as_u64().unwrap(), old_pid);
+    assert_eq!(status["record"]["port"].as_u64().unwrap(), u64::from(port));
+    assert_eq!(
+        fs::read_to_string(home.path().join(".cas/hub/machine-id")).unwrap(),
+        machine_id,
+        "restart must preserve the stable machine identity"
+    );
+
+    let stop = cas_command(home.path(), &path)
+        .args(["--json", "hub", "stop"])
+        .output()
+        .unwrap();
+    assert!(stop.status.success());
 }
 
 #[cfg(unix)]

--- a/cas-cli/tests/hub_clean_home_test.rs
+++ b/cas-cli/tests/hub_clean_home_test.rs
@@ -241,6 +241,19 @@ esac
     );
     assert_hsts(&preflight);
 
+    let mut held_proxy_client = TcpStream::connect(("127.0.0.1", trusted_backend_port)).unwrap();
+    held_proxy_client
+        .set_read_timeout(Some(Duration::from_secs(3)))
+        .unwrap();
+    write!(
+        held_proxy_client,
+        "POST /v1/auth/pairing/exchange HTTP/1.1\r\nHost: 127.0.0.1:{trusted_backend_port}\r\nOrigin: https://clean-host.tail.example\r\nContent-Type: application/json\r\nContent-Length: 1024\r\n\r\n{{"
+    )
+    .unwrap();
+    held_proxy_client.flush().unwrap();
+    thread::sleep(Duration::from_millis(100));
+
+    let restart_started = Instant::now();
     let restart = cas_command(home.path(), bin.as_os_str())
         .args([
             "--json",
@@ -256,6 +269,15 @@ esac
         restart.status.success(),
         "trusted proxy restart failed: {}",
         String::from_utf8_lossy(&restart.stderr)
+    );
+    assert!(
+        restart_started.elapsed() < Duration::from_secs(8),
+        "trusted-proxy restart exceeded its bounded drain window"
+    );
+    let mut closed = [0_u8; 1];
+    assert!(
+        matches!(held_proxy_client.read(&mut closed), Ok(0) | Err(_)),
+        "old trusted proxy left the held client silently live"
     );
     let status = cas_command(home.path(), bin.as_os_str())
         .args(["--json", "hub", "status"])
@@ -521,13 +543,7 @@ fn restart_force_closes_a_held_client_and_starts_the_replacement() {
 
     let started = Instant::now();
     let restart = cas_command(home.path(), &path)
-        .args([
-            "--json",
-            "hub",
-            "restart",
-            "--port",
-            &port.to_string(),
-        ])
+        .args(["--json", "hub", "restart", "--port", &port.to_string()])
         .output()
         .expect("restart hub with held client");
     let elapsed = started.elapsed();


### PR DESCRIPTION
Lands the cas-017a P1 fix found by the H7 acceptance gate against public v2.61.1 (**Fixes #217**):

- Red regression first (`1949e1cf`): held-open client across `cas hub restart` reproduced the exact live failure (old hub/lock alive past 10s, no replacement).
- Fix (`e2f93c8b`): loopback and Tailscale trusted-proxy listeners get a 2s graceful drain; on expiry the server futures drop and remaining upgraded clients force-close, so the machine lock releases and the replacement starts well inside the lifecycle deadline. Browser reconnect path preserved; singleton/lock safety (cas-bb90 rows) unchanged.
- Proof: 7/7 affected nextest including held clients on both listener paths; lane CI green (run 31496708259).

Next: release cut ships this publicly, then the H7 gate (GH #217's reporter) reruns against that artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)