### PR TITLE
ci: shard required validation critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,18 @@ jobs:
     name: Fast Validation
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/heads/epic/')
       || startsWith(github.ref, 'refs/tags/')))
+    # An epic head can emit both push and pull_request events for one SHA.
+    # Deduplicate this required check by head SHA without coupling it to the
+    # independent macOS required check below.
+    concurrency:
+      group: fast-validation-${{ github.event.pull_request.head.sha || github.sha }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -164,10 +172,15 @@ jobs:
     name: macOS Check
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/heads/epic/')
       || startsWith(github.ref, 'refs/tags/')))
+    concurrency:
+      group: macos-check-${{ github.event.pull_request.head.sha || github.sha }}
+      cancel-in-progress: true
     # Zig 0.15.2 cannot link its build runner with the Xcode 26.6 / macOS 26.5
     # SDK that macos-latest selected in 2026-07. Keep the known-good Xcode 26.3
     # / macOS 26.2 SDK explicit until Zig is upgraded and verified against it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     # independent macOS required check below.
     concurrency:
       group: fast-validation-${{ github.event.pull_request.head.sha || github.sha }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -180,7 +180,7 @@ jobs:
       || startsWith(github.ref, 'refs/tags/')))
     concurrency:
       group: macos-check-${{ github.event.pull_request.head.sha || github.sha }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     # Zig 0.15.2 cannot link its build runner with the Xcode 26.6 / macOS 26.5
     # SDK that macos-latest selected in 2026-07. Keep the known-good Xcode 26.3
     # / macOS 26.2 SDK explicit until Zig is upgraded and verified against it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,7 @@ jobs:
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -125,8 +124,7 @@ jobs:
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     strategy:
       fail-fast: false
       matrix:
@@ -158,8 +156,7 @@ jobs:
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -188,8 +185,7 @@ jobs:
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/tags/'))))
+      && github.ref == 'refs/heads/main'))
     needs:
       - fast-validation-preflight
       - fast-validation-suite
@@ -245,8 +241,7 @@ jobs:
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     concurrency:
       group: macos-check-${{ github.event.pull_request.head.sha || github.sha }}
       cancel-in-progress: false
@@ -352,9 +347,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -378,9 +371,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -412,9 +403,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     # This job measures a genuinely cold compiler. Letting the repaired remote
     # sccache serve objects after `cargo clean` would turn the benchmark into a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,14 @@ env:
   SCCACHE_GHA_VERSION: "cas-v2"
 
 jobs:
-  # Factory pushes and pull requests get one cheap target-scoped lane. The
-  # integration/full tier below starts only after a merge reaches epic/*,
-  # main, a release tag, or an explicit/scheduled gate.
+  # Factory pushes and PRs that do not target the protected default branch get
+  # one cheap target-scoped lane. Main PRs use the full required lanes below;
+  # do not spend an additional runner on this redundant subset there.
   scoped-validation:
     name: Scoped Validation (factory/PR)
     if: >-
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request'
+      && github.base_ref != github.event.repository.default_branch)
       || (github.event_name == 'push'
       && startsWith(github.ref, 'refs/heads/factory/'))
     runs-on: ubuntu-latest
@@ -68,22 +69,20 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: scripts/run-scoped-tests.sh -p cas --lib --no-fail-fast
 
-  fast-validation:
-    name: Fast Validation
+  # The required check is a fan-in over three independent lanes. The old
+  # single job took 8–9 minutes: its full-suite step spent most of its time
+  # compiling test binaries, not executing tests. Two nextest partitions
+  # compile/run concurrently while preflight and doctests are also independent.
+  # Together they still execute every test that the old full suite did.
+  fast-validation-preflight:
+    name: Fast Validation — preflight (no test suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
       || startsWith(github.ref, 'refs/tags/')))
-    # An epic head can emit both push and pull_request events for one SHA.
-    # Deduplicate this required check by head SHA without coupling it to the
-    # independent macOS required check below.
-    concurrency:
-      group: fast-validation-${{ github.event.pull_request.head.sha || github.sha }}
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -119,25 +118,96 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo build -p cas --no-default-features
 
-      # These two steps together execute exactly what bare `cargo test -p cas`
-      # executed before: nextest runs the lib + every integration test binary,
-      # and `--doc` runs the doctests, which nextest does not support. Dropping
-      # the doctest step would silently shrink executed coverage.
-      - name: Test (full suite — the only job that executes it)
+  fast-validation-suite:
+    name: Fast Validation — suite (shard ${{ matrix.shard }}/2)
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
+      || (github.event_name == 'push'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/')))
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: fast-validation-suite-${{ matrix.shard }}
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      # count:1/2 and count:2/2 are disjoint and exhaustive. Keep
+      # --no-fail-fast on each partition so failures never mask later binaries.
+      - name: Test full suite partition ${{ matrix.shard }}/2
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: cargo nextest run -p cas --no-fail-fast
+        run: cargo nextest run -p cas --no-fail-fast --partition count:${{ matrix.shard }}/2
 
-      # `!cancelled()` so a failure in the step above cannot hide this one's
-      # result. Letting it skip would re-create, one step later, exactly the
-      # under-reporting this job was changed to fix: `cargo test` used to abort
-      # after the first failing test BINARY, so main went red having executed
-      # 4401 of 4594 tests and never said so (GH #142).
-      - name: Test (doctests — the part nextest cannot run)
-        if: ${{ !cancelled() }}
+  fast-validation-docs:
+    name: Fast Validation — doctests
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
+      || (github.event_name == 'push'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/')))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: fast-validation-docs
+
+      # nextest does not run doctests; keep this separate so it never waits
+      # behind the partitioned suite.
+      - name: Test doctests
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo test -p cas --doc
+
+  # The repository ruleset requires this exact check name. It reports success
+  # only after preflight, both exhaustive nextest partitions, and doctests pass.
+  # Queue (rather than cancel) matching head-SHA checks per cas-9eaf; because
+  # this fan-in does no compilation, a duplicate cannot inflate the PR path.
+  fast-validation:
+    name: Fast Validation
+    if: >-
+      always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
+      || (github.event_name == 'push'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/'))))
+    needs:
+      - fast-validation-preflight
+      - fast-validation-suite
+      - fast-validation-docs
+    concurrency:
+      group: fast-validation-${{ github.event.pull_request.head.sha || github.sha }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every Fast Validation lane to pass
+        env:
+          PREFLIGHT: ${{ needs.fast-validation-preflight.result }}
+          SUITE: ${{ needs.fast-validation-suite.result }}
+          DOCS: ${{ needs.fast-validation-docs.result }}
+        run: |
+          test "$PREFLIGHT" = success
+          test "$SUITE" = success
+          test "$DOCS" = success
 
   # Advisory lint, split out of Fast Validation so a lint pass never sits on the
   # critical path of the job that answers "do the tests pass?" (GH #142).
@@ -176,7 +246,6 @@ jobs:
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
       || startsWith(github.ref, 'refs/tags/')))
     concurrency:
       group: macos-check-${{ github.event.pull_request.head.sha || github.sha }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,14 @@ not serialize. An existing `RUSTC_WRAPPER` wins; set
 `CAS_FACTORY_DISABLE_SCCACHE=1` for the emergency opt-out. CI uses the GitHub
 cache-v2 backend and keeps the cold Build Benchmark explicitly uncached.
 
+**CI speed is a standing operator requirement.** A `factory/*` push must run
+only Scoped Validation; the protected-default-branch PR event is the canonical
+Fast Validation/macOS gate, so non-main pushes must not duplicate required
+checks for the same SHA. Build Benchmark and both release-profile panic jobs
+run only on `main` pushes, scheduled runs, or manual dispatch. Preserve all
+coverage on `main` and scheduled runs; enforce this policy in
+`scripts/test-ci-test-tiers.sh`, never by convention alone.
+
 New isolated workers also seed their private `target/` from compiled artifacts
 hardlinked out of the quiescent snapshot named by `.cas/build-cache/current`;
 small Cargo dep-info files are copied with their target root rebased. Refresh that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,14 @@ not serialize. An existing `RUSTC_WRAPPER` wins; set
 `CAS_FACTORY_DISABLE_SCCACHE=1` for the emergency opt-out. CI uses the GitHub
 cache-v2 backend and keeps the cold Build Benchmark explicitly uncached.
 
+**CI speed is a standing operator requirement.** A `factory/*` push must run
+only Scoped Validation; the protected-default-branch PR event is the canonical
+Fast Validation/macOS gate, so non-main pushes must not duplicate required
+checks for the same SHA. Build Benchmark and both release-profile panic jobs
+run only on `main` pushes, scheduled runs, or manual dispatch. Preserve all
+coverage on `main` and scheduled runs; enforce this policy in
+`scripts/test-ci-test-tiers.sh`, never by convention alone.
+
 New isolated workers also seed their private `target/` from compiled artifacts
 hardlinked out of the quiescent snapshot named by `.cas/build-cache/current`;
 small Cargo dep-info files are copied with their target root rebased. Refresh that

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -38,10 +38,14 @@ require_text "$ci_text" '- "v*"' 'release tags trigger CI'
 scoped="$(job_block scoped-validation)"
 require_text "$scoped" "refs/heads/factory/" 'scoped tier selects factory branches'
 require_text "$scoped" "github.event_name == 'pull_request'" 'pull requests use scoped tier'
+require_text "$scoped" 'github.base_ref != github.event.repository.default_branch' 'scoped tier skips protected-default PRs'
 require_text "$scoped" 'cargo check -p cas --lib --tests' 'scoped tier checks target surface'
 require_text "$scoped" 'scripts/run-scoped-tests.sh -p cas --lib' 'scoped tier runs one test binary'
 
 full_jobs=(
+    fast-validation-preflight
+    fast-validation-suite
+    fast-validation-docs
     fast-validation
     clippy
     macos-check
@@ -53,7 +57,6 @@ full_jobs=(
 for job in "${full_jobs[@]}"; do
     block="$(job_block "$job")"
     require_text "$block" "refs/heads/main" "$job runs on main"
-    require_text "$block" "refs/heads/epic/" "$job runs on epic merges"
     require_text "$block" "refs/tags/" "$job runs on release tags"
     if grep -qF 'refs/heads/factory/' <<<"$block"; then
         printf 'FAIL %s leaks into factory pushes\n' "$job"
@@ -71,6 +74,36 @@ for job in "${required_pr_jobs[@]}"; do
     require_text "$block" 'github.base_ref == github.event.repository.default_branch' "$job targets the default PR base"
     require_text "$block" 'github.event.pull_request.head.sha || github.sha' "$job deduplicates push/PR runs by head SHA"
     require_text "$block" 'cancel-in-progress: false' "$job queues duplicate required-check runs without cancellation"
+done
+
+preflight="$(job_block fast-validation-preflight)"
+suite="$(job_block fast-validation-suite)"
+docs="$(job_block fast-validation-docs)"
+fan_in="$(job_block fast-validation)"
+require_text "$suite" 'shard: [1, 2]' 'suite uses two parallel shards'
+require_text "$suite" '--partition count:${{ matrix.shard }}/2' 'suite shards are exhaustive count partitions'
+require_text "$suite" 'cargo nextest run -p cas --no-fail-fast' 'suite retains full nextest coverage'
+require_text "$docs" 'cargo test -p cas --doc' 'doctest coverage remains in Fast Validation'
+require_text "$fan_in" 'fast-validation-preflight' 'required Fast Validation waits for preflight'
+require_text "$fan_in" 'fast-validation-suite' 'required Fast Validation waits for both suite shards'
+require_text "$fan_in" 'fast-validation-docs' 'required Fast Validation waits for doctests'
+require_text "$fan_in" 'test "$PREFLIGHT" = success' 'required Fast Validation rejects a failed preflight'
+require_text "$fan_in" 'test "$SUITE" = success' 'required Fast Validation rejects a failed suite shard'
+require_text "$fan_in" 'test "$DOCS" = success' 'required Fast Validation rejects failed doctests'
+
+# Main PRs schedule only the required Fast Validation lanes and macOS Check.
+# The scoped subset is deliberately excluded, and advisory/release jobs remain
+# push/schedule-only, so a non-required job cannot consume a PR runner first.
+require_text "$scoped" 'github.base_ref != github.event.repository.default_branch' 'non-required scoped lane skips main PRs'
+for job in clippy test-compile-guard panic-isolation-release panic-isolation-release-fast build-benchmark; do
+    block="$(job_block "$job")"
+    if grep -qF "github.event_name == 'pull_request'" <<<"$block"; then
+        printf 'FAIL %s can run on a main PR\n' "$job"
+        fail=$((fail + 1))
+    else
+        printf 'ok   %s cannot run on a main PR\n' "$job"
+        pass=$((pass + 1))
+    fi
 done
 
 all_actions="$(<"$setup")$(<"$ci")$(<"$release")"

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -70,7 +70,7 @@ for job in "${required_pr_jobs[@]}"; do
     require_text "$block" "github.event_name == 'pull_request'" "$job runs for pull requests"
     require_text "$block" 'github.base_ref == github.event.repository.default_branch' "$job targets the default PR base"
     require_text "$block" 'github.event.pull_request.head.sha || github.sha' "$job deduplicates push/PR runs by head SHA"
-    require_text "$block" 'cancel-in-progress: true' "$job cancels the duplicate required-check run"
+    require_text "$block" 'cancel-in-progress: false' "$job queues duplicate required-check runs without cancellation"
 done
 
 all_actions="$(<"$setup")$(<"$ci")$(<"$release")"

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -42,7 +42,7 @@ require_text "$scoped" 'github.base_ref != github.event.repository.default_branc
 require_text "$scoped" 'cargo check -p cas --lib --tests' 'scoped tier checks target surface'
 require_text "$scoped" 'scripts/run-scoped-tests.sh -p cas --lib' 'scoped tier runs one test binary'
 
-full_jobs=(
+all_non_scoped_jobs=(
     fast-validation-preflight
     fast-validation-suite
     fast-validation-docs
@@ -54,10 +54,9 @@ full_jobs=(
     panic-isolation-release-fast
     build-benchmark
 )
-for job in "${full_jobs[@]}"; do
+for job in "${all_non_scoped_jobs[@]}"; do
     block="$(job_block "$job")"
     require_text "$block" "refs/heads/main" "$job runs on main"
-    require_text "$block" "refs/tags/" "$job runs on release tags"
     if grep -qF 'refs/heads/factory/' <<<"$block"; then
         printf 'FAIL %s leaks into factory pushes\n' "$job"
         fail=$((fail + 1))
@@ -67,11 +66,15 @@ for job in "${full_jobs[@]}"; do
     fi
 done
 
-required_pr_jobs=(fast-validation macos-check)
-for job in "${required_pr_jobs[@]}"; do
+required_pr_lanes=(fast-validation-preflight fast-validation-suite fast-validation-docs fast-validation macos-check)
+for job in "${required_pr_lanes[@]}"; do
     block="$(job_block "$job")"
     require_text "$block" "github.event_name == 'pull_request'" "$job runs for pull requests"
     require_text "$block" 'github.base_ref == github.event.repository.default_branch' "$job targets the default PR base"
+done
+
+for job in fast-validation macos-check; do
+    block="$(job_block "$job")"
     require_text "$block" 'github.event.pull_request.head.sha || github.sha' "$job deduplicates push/PR runs by head SHA"
     require_text "$block" 'cancel-in-progress: false' "$job queues duplicate required-check runs without cancellation"
 done
@@ -91,6 +94,19 @@ require_text "$fan_in" 'test "$PREFLIGHT" = success' 'required Fast Validation r
 require_text "$fan_in" 'test "$SUITE" = success' 'required Fast Validation rejects a failed suite shard'
 require_text "$fan_in" 'test "$DOCS" = success' 'required Fast Validation rejects failed doctests'
 
+# PR is the canonical non-main required gate. No non-main push can launch one
+# of its lanes, so the same SHA never duplicates a costly required check.
+for job in fast-validation-preflight fast-validation-suite fast-validation-docs fast-validation macos-check; do
+    block="$(job_block "$job")"
+    if grep -qF 'refs/heads/epic/' <<<"$block" || grep -qF 'refs/tags/' <<<"$block"; then
+        printf 'FAIL %s can run required work on a non-main push\n' "$job"
+        fail=$((fail + 1))
+    else
+        printf 'ok   %s is PR/main/schedule/manual only\n' "$job"
+        pass=$((pass + 1))
+    fi
+done
+
 # Main PRs schedule only the required Fast Validation lanes and macOS Check.
 # The scoped subset is deliberately excluded, and advisory/release jobs remain
 # push/schedule-only, so a non-required job cannot consume a PR runner first.
@@ -102,6 +118,19 @@ for job in clippy test-compile-guard panic-isolation-release panic-isolation-rel
         fail=$((fail + 1))
     else
         printf 'ok   %s cannot run on a main PR\n' "$job"
+        pass=$((pass + 1))
+    fi
+done
+
+# Benchmark and release-profile panic work is a main/scheduled/manual verdict,
+# never a worker or epic/tag-push cost.
+for job in panic-isolation-release panic-isolation-release-fast build-benchmark; do
+    block="$(job_block "$job")"
+    if grep -qF 'refs/heads/epic/' <<<"$block" || grep -qF 'refs/tags/' <<<"$block"; then
+        printf 'FAIL %s leaks into an epic or tag push\n' "$job"
+        fail=$((fail + 1))
+    else
+        printf 'ok   %s is main/schedule/manual only\n' "$job"
         pass=$((pass + 1))
     fi
 done

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -64,6 +64,15 @@ for job in "${full_jobs[@]}"; do
     fi
 done
 
+required_pr_jobs=(fast-validation macos-check)
+for job in "${required_pr_jobs[@]}"; do
+    block="$(job_block "$job")"
+    require_text "$block" "github.event_name == 'pull_request'" "$job runs for pull requests"
+    require_text "$block" 'github.base_ref == github.event.repository.default_branch' "$job targets the default PR base"
+    require_text "$block" 'github.event.pull_request.head.sha || github.sha' "$job deduplicates push/PR runs by head SHA"
+    require_text "$block" 'cancel-in-progress: true' "$job cancels the duplicate required-check run"
+done
+
 all_actions="$(<"$setup")$(<"$ci")$(<"$release")"
 require_text "$all_actions" 'mozilla-actions/sccache-action@v0.0.11' 'cache-v2-capable sccache action is pinned'
 if grep -qF 'mozilla-actions/sccache-action@v0.0.5' <<<"$all_actions"; then

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -30,6 +30,29 @@ job_block() {
     ' "$ci"
 }
 
+job_ids() {
+    awk '
+        /^jobs:$/ { inside_jobs = 1; next }
+        inside_jobs && /^  [A-Za-z0-9_-]+:$/ {
+            sub(/^  /, "")
+            sub(/:$/, "")
+            print
+        }
+    ' "$ci"
+}
+
+only_main_push_ref() {
+    local job="$1" block="$2" ref
+    require_text "$block" "github.ref == 'refs/heads/main'" "$job runs push work only on main"
+    while IFS= read -r ref; do
+        [[ -z "$ref" ]] && continue
+        if [[ "$ref" != 'refs/heads/main' ]]; then
+            printf 'FAIL %s permits non-main push ref %s\n' "$job" "$ref"
+            fail=$((fail + 1))
+        fi
+    done < <(grep -oE 'refs/(heads|tags)/[^'"'"' )]+' <<<"$block" | sort -u)
+}
+
 ci_text="$(<"$ci")"
 require_text "$ci_text" '- "factory/**"' 'factory pushes trigger CI'
 require_text "$ci_text" '- "epic/**"' 'epic pushes trigger CI'
@@ -42,19 +65,8 @@ require_text "$scoped" 'github.base_ref != github.event.repository.default_branc
 require_text "$scoped" 'cargo check -p cas --lib --tests' 'scoped tier checks target surface'
 require_text "$scoped" 'scripts/run-scoped-tests.sh -p cas --lib' 'scoped tier runs one test binary'
 
-all_non_scoped_jobs=(
-    fast-validation-preflight
-    fast-validation-suite
-    fast-validation-docs
-    fast-validation
-    clippy
-    macos-check
-    test-compile-guard
-    panic-isolation-release
-    panic-isolation-release-fast
-    build-benchmark
-)
-for job in "${all_non_scoped_jobs[@]}"; do
+while IFS= read -r job; do
+    [[ "$job" == 'scoped-validation' ]] && continue
     block="$(job_block "$job")"
     require_text "$block" "refs/heads/main" "$job runs on main"
     if grep -qF 'refs/heads/factory/' <<<"$block"; then
@@ -64,7 +76,7 @@ for job in "${all_non_scoped_jobs[@]}"; do
         printf 'ok   %s is absent from factory pushes\n' "$job"
         pass=$((pass + 1))
     fi
-done
+done < <(job_ids)
 
 required_pr_lanes=(fast-validation-preflight fast-validation-suite fast-validation-docs fast-validation macos-check)
 for job in "${required_pr_lanes[@]}"; do
@@ -98,13 +110,9 @@ require_text "$fan_in" 'test "$DOCS" = success' 'required Fast Validation reject
 # of its lanes, so the same SHA never duplicates a costly required check.
 for job in fast-validation-preflight fast-validation-suite fast-validation-docs fast-validation macos-check; do
     block="$(job_block "$job")"
-    if grep -qF 'refs/heads/epic/' <<<"$block" || grep -qF 'refs/tags/' <<<"$block"; then
-        printf 'FAIL %s can run required work on a non-main push\n' "$job"
-        fail=$((fail + 1))
-    else
-        printf 'ok   %s is PR/main/schedule/manual only\n' "$job"
-        pass=$((pass + 1))
-    fi
+    only_main_push_ref "$job" "$block"
+    require_text "$block" "github.event_name == 'schedule'" "$job runs on schedule"
+    require_text "$block" "github.event_name == 'workflow_dispatch'" "$job runs by manual dispatch"
 done
 
 # Main PRs schedule only the required Fast Validation lanes and macOS Check.
@@ -126,8 +134,11 @@ done
 # never a worker or epic/tag-push cost.
 for job in panic-isolation-release panic-isolation-release-fast build-benchmark; do
     block="$(job_block "$job")"
-    if grep -qF 'refs/heads/epic/' <<<"$block" || grep -qF 'refs/tags/' <<<"$block"; then
-        printf 'FAIL %s leaks into an epic or tag push\n' "$job"
+    only_main_push_ref "$job" "$block"
+    require_text "$block" "github.event_name == 'schedule'" "$job runs on schedule"
+    require_text "$block" "github.event_name == 'workflow_dispatch'" "$job runs by manual dispatch"
+    if grep -qF "github.event_name == 'pull_request'" <<<"$block"; then
+        printf 'FAIL %s runs on a pull request\n' "$job"
         fail=$((fail + 1))
     else
         printf 'ok   %s is main/schedule/manual only\n' "$job"


### PR DESCRIPTION
## Summary
- fan Fast Validation into independent preflight, two exhaustive nextest partitions, and doctests
- retain the protected Fast Validation check as a no-cancel fan-in
- exclude redundant scoped/advisory lanes from protected-main PRs

## Validation
- scripts/test-ci-test-tiers.sh (66 checks)