### PR TITLE
ci(cas-2b1b): keep required checks off heavy CI path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,10 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: scripts/run-scoped-tests.sh -p cas --lib --no-fail-fast
 
-  # The required check is a fan-in over three independent lanes. The old
-  # single job took 8–9 minutes: its full-suite step spent most of its time
-  # compiling test binaries, not executing tests. Two nextest partitions
-  # compile/run concurrently while preflight and doctests are also independent.
-  # Together they still execute every test that the old full suite did.
+  # The required check is a fan-in over independent lanes. The full suite is
+  # deliberately one lane: nextest partitions rebuild the same test graph on
+  # separate runners, which made the measured PR slower rather than faster.
+  # Preflight and doctests remain independent, so neither extends suite time.
   fast-validation-preflight:
     name: Fast Validation — preflight (no test suite)
     if: >-
@@ -119,7 +118,7 @@ jobs:
         run: cargo build -p cas --no-default-features
 
   fast-validation-suite:
-    name: Fast Validation — suite (shard ${{ matrix.shard }}/2)
+    name: Fast Validation — full suite
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request'
@@ -127,10 +126,6 @@ jobs:
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/')))
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -139,17 +134,17 @@ jobs:
 
       - uses: ./.github/actions/setup-rust-linux
         with:
-          cache-key: fast-validation-suite-${{ matrix.shard }}
+          cache-key: fast-validation-suite
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
-      # count:1/2 and count:2/2 are disjoint and exhaustive. Keep
-      # --no-fail-fast on each partition so failures never mask later binaries.
-      - name: Test full suite partition ${{ matrix.shard }}/2
+      # Keep --no-fail-fast so failures never mask later binaries. This runs
+      # every test binary; the doctest lane below covers what nextest cannot.
+      - name: Test full suite
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: cargo nextest run -p cas --no-fail-fast --partition count:${{ matrix.shard }}/2
+        run: cargo nextest run -p cas --no-fail-fast
 
   fast-validation-docs:
     name: Fast Validation — doctests
@@ -217,9 +212,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -314,9 +307,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -352,9 +343,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -378,9 +367,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -412,9 +399,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'push'
-      && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
-      || startsWith(github.ref, 'refs/tags/')))
+      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     # This job measures a genuinely cold compiler. Letting the repaired remote
     # sccache serve objects after `cargo clean` would turn the benchmark into a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,14 @@ env:
   SCCACHE_GHA_VERSION: "cas-v2"
 
 jobs:
-  # Factory pushes and pull requests get one cheap target-scoped lane. The
-  # integration/full tier below starts only after a merge reaches epic/*,
-  # main, a release tag, or an explicit/scheduled gate.
+  # Factory pushes and PRs that do not target the protected default branch get
+  # one cheap target-scoped lane. Main PRs use the full required lanes below;
+  # do not spend an additional runner on this redundant subset there.
   scoped-validation:
     name: Scoped Validation (factory/PR)
     if: >-
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request'
+      && github.base_ref != github.event.repository.default_branch)
       || (github.event_name == 'push'
       && startsWith(github.ref, 'refs/heads/factory/'))
     runs-on: ubuntu-latest
@@ -68,22 +69,20 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: scripts/run-scoped-tests.sh -p cas --lib --no-fail-fast
 
-  fast-validation:
-    name: Fast Validation
+  # The required check is a fan-in over three independent lanes. The old
+  # single job took 8–9 minutes: its full-suite step spent most of its time
+  # compiling test binaries, not executing tests. Two nextest partitions
+  # compile/run concurrently while preflight and doctests are also independent.
+  # Together they still execute every test that the old full suite did.
+  fast-validation-preflight:
+    name: Fast Validation — preflight (no test suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
       || startsWith(github.ref, 'refs/tags/')))
-    # An epic head can emit both push and pull_request events for one SHA.
-    # Deduplicate this required check by head SHA without coupling it to the
-    # independent macOS required check below.
-    concurrency:
-      group: fast-validation-${{ github.event.pull_request.head.sha || github.sha }}
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -119,25 +118,96 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo build -p cas --no-default-features
 
-      # These two steps together execute exactly what bare `cargo test -p cas`
-      # executed before: nextest runs the lib + every integration test binary,
-      # and `--doc` runs the doctests, which nextest does not support. Dropping
-      # the doctest step would silently shrink executed coverage.
-      - name: Test (full suite — the only job that executes it)
+  fast-validation-suite:
+    name: Fast Validation — suite (shard ${{ matrix.shard }}/2)
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
+      || (github.event_name == 'push'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/')))
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: fast-validation-suite-${{ matrix.shard }}
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      # count:1/2 and count:2/2 are disjoint and exhaustive. Keep
+      # --no-fail-fast on each partition so failures never mask later binaries.
+      - name: Test full suite partition ${{ matrix.shard }}/2
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: cargo nextest run -p cas --no-fail-fast
+        run: cargo nextest run -p cas --no-fail-fast --partition count:${{ matrix.shard }}/2
 
-      # `!cancelled()` so a failure in the step above cannot hide this one's
-      # result. Letting it skip would re-create, one step later, exactly the
-      # under-reporting this job was changed to fix: `cargo test` used to abort
-      # after the first failing test BINARY, so main went red having executed
-      # 4401 of 4594 tests and never said so (GH #142).
-      - name: Test (doctests — the part nextest cannot run)
-        if: ${{ !cancelled() }}
+  fast-validation-docs:
+    name: Fast Validation — doctests
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
+      || (github.event_name == 'push'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/')))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust-linux
+        with:
+          cache-key: fast-validation-docs
+
+      # nextest does not run doctests; keep this separate so it never waits
+      # behind the partitioned suite.
+      - name: Test doctests
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo test -p cas --doc
+
+  # The repository ruleset requires this exact check name. It reports success
+  # only after preflight, both exhaustive nextest partitions, and doctests pass.
+  # Queue (rather than cancel) matching head-SHA checks per cas-9eaf; because
+  # this fan-in does no compilation, a duplicate cannot inflate the PR path.
+  fast-validation:
+    name: Fast Validation
+    if: >-
+      always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
+      || (github.event_name == 'push'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/'))))
+    needs:
+      - fast-validation-preflight
+      - fast-validation-suite
+      - fast-validation-docs
+    concurrency:
+      group: fast-validation-${{ github.event.pull_request.head.sha || github.sha }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every Fast Validation lane to pass
+        env:
+          PREFLIGHT: ${{ needs.fast-validation-preflight.result }}
+          SUITE: ${{ needs.fast-validation-suite.result }}
+          DOCS: ${{ needs.fast-validation-docs.result }}
+        run: |
+          test "$PREFLIGHT" = success
+          test "$SUITE" = success
+          test "$DOCS" = success
 
   # Advisory lint, split out of Fast Validation so a lint pass never sits on the
   # critical path of the job that answers "do the tests pass?" (GH #142).
@@ -176,7 +246,6 @@ jobs:
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/heads/epic/')
       || startsWith(github.ref, 'refs/tags/')))
     concurrency:
       group: macos-check-${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,12 +139,14 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
-      # Keep --no-fail-fast so failures never mask later binaries. This runs
-      # every test binary; the doctest lane below covers what nextest cannot.
+      # Keep --no-fail-fast so failures never mask later binaries. Four test
+      # processes suit the I/O-heavy integration mix better than the hosted
+      # runner's CPU-default, while still running every test binary; the
+      # doctest lane below covers what nextest cannot.
       - name: Test full suite
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: cargo nextest run -p cas --no-fail-fast
+        run: cargo nextest run -p cas --no-fail-fast --test-threads 4
 
   fast-validation-docs:
     name: Fast Validation — doctests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,14 @@ only be removed during a maintenance window. Set
 `CAS_FACTORY_DISABLE_TARGET_SEED=1` to skip seeding. Do not replace this with a
 shared live `CARGO_TARGET_DIR`: its Cargo lock serializes the worker fleet.
 
+**Standing operator CI-load policy:** factory/* pushes run only Scoped
+Validation; protected-default PRs run only the required Fast Validation and
+macOS Check lanes. The non-required full/heavy tier (Clippy, Test Compile
+Guard, Build Benchmark, and both Panic Isolation profiles) belongs only to
+supervisor-controlled main pushes, schedules, or manual dispatches—never
+factory/*, epic/*, tags, or pull requests. Keep this policy pinned by
+`scripts/test-ci-test-tiers.sh`, rather than relying on convention.
+
 Local sccache 0.10.0 does not produce cross-worktree Rust hits because absolute
 checkout paths remain in its cache keys (measured 0/45 hits even with
 `--remap-path-prefix`). Keep sccache enabled for same-path/CI reuse and for when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,14 @@ only be removed during a maintenance window. Set
 `CAS_FACTORY_DISABLE_TARGET_SEED=1` to skip seeding. Do not replace this with a
 shared live `CARGO_TARGET_DIR`: its Cargo lock serializes the worker fleet.
 
+**Standing operator CI-load policy:** factory/* pushes run only Scoped
+Validation; protected-default PRs run only the required Fast Validation and
+macOS Check lanes. The non-required full/heavy tier (Clippy, Test Compile
+Guard, Build Benchmark, and both Panic Isolation profiles) belongs only to
+supervisor-controlled main pushes, schedules, or manual dispatches—never
+factory/*, epic/*, tags, or pull requests. Keep this policy pinned by
+`scripts/test-ci-test-tiers.sh`, rather than relying on convention.
+
 Local sccache 0.10.0 does not produce cross-worktree Rust hits because absolute
 checkout paths remain in its cache keys (measured 0/45 hits even with
 `--remap-path-prefix`). Keep sccache enabled for same-path/CI reuse and for when

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -38,10 +38,14 @@ require_text "$ci_text" '- "v*"' 'release tags trigger CI'
 scoped="$(job_block scoped-validation)"
 require_text "$scoped" "refs/heads/factory/" 'scoped tier selects factory branches'
 require_text "$scoped" "github.event_name == 'pull_request'" 'pull requests use scoped tier'
+require_text "$scoped" 'github.base_ref != github.event.repository.default_branch' 'scoped tier skips protected-default PRs'
 require_text "$scoped" 'cargo check -p cas --lib --tests' 'scoped tier checks target surface'
 require_text "$scoped" 'scripts/run-scoped-tests.sh -p cas --lib' 'scoped tier runs one test binary'
 
 full_jobs=(
+    fast-validation-preflight
+    fast-validation-suite
+    fast-validation-docs
     fast-validation
     clippy
     macos-check
@@ -53,7 +57,6 @@ full_jobs=(
 for job in "${full_jobs[@]}"; do
     block="$(job_block "$job")"
     require_text "$block" "refs/heads/main" "$job runs on main"
-    require_text "$block" "refs/heads/epic/" "$job runs on epic merges"
     require_text "$block" "refs/tags/" "$job runs on release tags"
     if grep -qF 'refs/heads/factory/' <<<"$block"; then
         printf 'FAIL %s leaks into factory pushes\n' "$job"
@@ -71,6 +74,36 @@ for job in "${required_pr_jobs[@]}"; do
     require_text "$block" 'github.base_ref == github.event.repository.default_branch' "$job targets the default PR base"
     require_text "$block" 'github.event.pull_request.head.sha || github.sha' "$job deduplicates push/PR runs by head SHA"
     require_text "$block" 'cancel-in-progress: false' "$job queues duplicate required-check runs without cancellation"
+done
+
+preflight="$(job_block fast-validation-preflight)"
+suite="$(job_block fast-validation-suite)"
+docs="$(job_block fast-validation-docs)"
+fan_in="$(job_block fast-validation)"
+require_text "$suite" 'shard: [1, 2]' 'suite uses two parallel shards'
+require_text "$suite" '--partition count:${{ matrix.shard }}/2' 'suite shards are exhaustive count partitions'
+require_text "$suite" 'cargo nextest run -p cas --no-fail-fast' 'suite retains full nextest coverage'
+require_text "$docs" 'cargo test -p cas --doc' 'doctest coverage remains in Fast Validation'
+require_text "$fan_in" 'fast-validation-preflight' 'required Fast Validation waits for preflight'
+require_text "$fan_in" 'fast-validation-suite' 'required Fast Validation waits for both suite shards'
+require_text "$fan_in" 'fast-validation-docs' 'required Fast Validation waits for doctests'
+require_text "$fan_in" 'test "$PREFLIGHT" = success' 'required Fast Validation rejects a failed preflight'
+require_text "$fan_in" 'test "$SUITE" = success' 'required Fast Validation rejects a failed suite shard'
+require_text "$fan_in" 'test "$DOCS" = success' 'required Fast Validation rejects failed doctests'
+
+# Main PRs schedule only the required Fast Validation lanes and macOS Check.
+# The scoped subset is deliberately excluded, and advisory/release jobs remain
+# push/schedule-only, so a non-required job cannot consume a PR runner first.
+require_text "$scoped" 'github.base_ref != github.event.repository.default_branch' 'non-required scoped lane skips main PRs'
+for job in clippy test-compile-guard panic-isolation-release panic-isolation-release-fast build-benchmark; do
+    block="$(job_block "$job")"
+    if grep -qF "github.event_name == 'pull_request'" <<<"$block"; then
+        printf 'FAIL %s can run on a main PR\n' "$job"
+        fail=$((fail + 1))
+    else
+        printf 'ok   %s cannot run on a main PR\n' "$job"
+        pass=$((pass + 1))
+    fi
 done
 
 all_actions="$(<"$setup")$(<"$ci")$(<"$release")"

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -21,6 +21,17 @@ require_text() {
     fi
 }
 
+require_absent() {
+    local haystack="$1" needle="$2" label="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        printf 'FAIL %s (unexpected %s)\n' "$label" "$needle"
+        fail=$((fail + 1))
+    else
+        printf 'ok   %s\n' "$label"
+        pass=$((pass + 1))
+    fi
+}
+
 job_block() {
     local job="$1"
     awk -v header="  ${job}:" '
@@ -42,29 +53,23 @@ require_text "$scoped" 'github.base_ref != github.event.repository.default_branc
 require_text "$scoped" 'cargo check -p cas --lib --tests' 'scoped tier checks target surface'
 require_text "$scoped" 'scripts/run-scoped-tests.sh -p cas --lib' 'scoped tier runs one test binary'
 
-full_jobs=(
+required_jobs=(
     fast-validation-preflight
     fast-validation-suite
     fast-validation-docs
     fast-validation
-    clippy
     macos-check
-    test-compile-guard
-    panic-isolation-release
-    panic-isolation-release-fast
-    build-benchmark
 )
-for job in "${full_jobs[@]}"; do
+for job in "${required_jobs[@]}"; do
     block="$(job_block "$job")"
     require_text "$block" "refs/heads/main" "$job runs on main"
+    require_absent "$block" 'refs/heads/epic/' "$job is not double-run from epic pushes"
+    require_absent "$block" 'refs/heads/factory/' "$job is absent from factory pushes"
+done
+
+for job in fast-validation-preflight fast-validation-suite fast-validation-docs fast-validation macos-check; do
+    block="$(job_block "$job")"
     require_text "$block" "refs/tags/" "$job runs on release tags"
-    if grep -qF 'refs/heads/factory/' <<<"$block"; then
-        printf 'FAIL %s leaks into factory pushes\n' "$job"
-        fail=$((fail + 1))
-    else
-        printf 'ok   %s is absent from factory pushes\n' "$job"
-        pass=$((pass + 1))
-    fi
 done
 
 required_pr_jobs=(fast-validation macos-check)
@@ -80,15 +85,14 @@ preflight="$(job_block fast-validation-preflight)"
 suite="$(job_block fast-validation-suite)"
 docs="$(job_block fast-validation-docs)"
 fan_in="$(job_block fast-validation)"
-require_text "$suite" 'shard: [1, 2]' 'suite uses two parallel shards'
-require_text "$suite" '--partition count:${{ matrix.shard }}/2' 'suite shards are exhaustive count partitions'
 require_text "$suite" 'cargo nextest run -p cas --no-fail-fast' 'suite retains full nextest coverage'
+require_absent "$suite" '--partition' 'suite avoids duplicate test-graph compilation across runners'
 require_text "$docs" 'cargo test -p cas --doc' 'doctest coverage remains in Fast Validation'
 require_text "$fan_in" 'fast-validation-preflight' 'required Fast Validation waits for preflight'
-require_text "$fan_in" 'fast-validation-suite' 'required Fast Validation waits for both suite shards'
+require_text "$fan_in" 'fast-validation-suite' 'required Fast Validation waits for the full suite'
 require_text "$fan_in" 'fast-validation-docs' 'required Fast Validation waits for doctests'
 require_text "$fan_in" 'test "$PREFLIGHT" = success' 'required Fast Validation rejects a failed preflight'
-require_text "$fan_in" 'test "$SUITE" = success' 'required Fast Validation rejects a failed suite shard'
+require_text "$fan_in" 'test "$SUITE" = success' 'required Fast Validation rejects a failed full suite'
 require_text "$fan_in" 'test "$DOCS" = success' 'required Fast Validation rejects failed doctests'
 
 # Main PRs schedule only the required Fast Validation lanes and macOS Check.
@@ -97,13 +101,13 @@ require_text "$fan_in" 'test "$DOCS" = success' 'required Fast Validation reject
 require_text "$scoped" 'github.base_ref != github.event.repository.default_branch' 'non-required scoped lane skips main PRs'
 for job in clippy test-compile-guard panic-isolation-release panic-isolation-release-fast build-benchmark; do
     block="$(job_block "$job")"
-    if grep -qF "github.event_name == 'pull_request'" <<<"$block"; then
-        printf 'FAIL %s can run on a main PR\n' "$job"
-        fail=$((fail + 1))
-    else
-        printf 'ok   %s cannot run on a main PR\n' "$job"
-        pass=$((pass + 1))
-    fi
+    require_text "$block" "refs/heads/main" "$job runs on main"
+    require_text "$block" "github.event_name == 'schedule'" "$job runs on schedule"
+    require_text "$block" "github.event_name == 'workflow_dispatch'" "$job supports supervisor dispatch"
+    require_absent "$block" "github.event_name == 'pull_request'" "$job cannot run on PRs"
+    require_absent "$block" 'refs/heads/epic/' "$job cannot run on epic pushes"
+    require_absent "$block" 'refs/heads/factory/' "$job cannot run on factory pushes"
+    require_absent "$block" 'refs/tags/' "$job cannot run on tag pushes"
 done
 
 all_actions="$(<"$setup")$(<"$ci")$(<"$release")"

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -86,6 +86,7 @@ suite="$(job_block fast-validation-suite)"
 docs="$(job_block fast-validation-docs)"
 fan_in="$(job_block fast-validation)"
 require_text "$suite" 'cargo nextest run -p cas --no-fail-fast' 'suite retains full nextest coverage'
+require_text "$suite" '--test-threads 4' 'suite uses measured I/O-friendly test concurrency'
 require_absent "$suite" '--partition' 'suite avoids duplicate test-graph compilation across runners'
 require_text "$docs" 'cargo test -p cas --doc' 'doctest coverage remains in Fast Validation'
 require_text "$fan_in" 'fast-validation-preflight' 'required Fast Validation waits for preflight'


### PR DESCRIPTION
Measurement PR for cas-2b1b. Keeps complete nextest and doctest coverage, separates concurrent non-test preflight, and restricts heavy non-required work to main/schedule/dispatch. Please do not merge until the required-check timing receipt is captured.