### PR TITLE
Release v2.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.62.0] - 2026-08-11
+
+### Added
+- **CAS now includes cross-harness data-visualization guidance.** The built-in skill and its quality checks make it easier to turn repository data into readable, reviewable visual artifacts.
+
+### Changed
+- **Pull-request validation is faster while preserving the release gate.** A focused warm suite now protects merge requests, while heavier checks remain available on main, schedules, and manual dispatch.
+- **Workers and release flows now give clearer, more reliable handoffs.** The checked-in guidance covers the supported task surfaces, artifact evidence, and protected-main release sequence.
+
+### Fixed
+- **Hub restarts now complete with live viewers attached.** Existing viewer connections drain within a bounded window, then CAS safely closes any remaining stale connections before the replacement hub starts.
+- **Runtime coordination and cloud sync report actionable truth more consistently.** Stale CI failures no longer trigger misleading alerts, weak ambient matches cannot dominate recall, supervisor memory writes use the intended gate, and rejected cloud records retain itemized reasons.
+
 ## [2.61.1] - 2026-08-10
 
 ### Fixed

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.61.1"
+version = "2.62.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.61.1"
+version = "2.62.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.61.1"
+version = "2.62.0"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.61.1"
+version = "2.62.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.61.1"
+version = "2.62.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.61.1"
+version = "2.62.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-11-v2.62.0-slack.md
+++ b/docs/release-notes/2026-08-11-v2.62.0-slack.md
@@ -1,0 +1,26 @@
+# v2.62.0 — runtime release posts
+
+Channel: #cas-internal (`C0B44GUKDK2`)
+
+Publish after the `v2.62.0` tag has landed and the official release assets are
+available. These are two distinct top-level posts, not replies. This release
+does not install binaries or restart any daemon or hub.
+
+---
+
+## User — top-level post
+
+**Live on production · User · Was: a hub restart could get stuck while people were watching it. Now: it finishes the handoff and brings the hub back without leaving viewers stranded.**
+
+- Was: an active viewer connection could hold a restart open. Now: CAS gives existing viewers a brief chance to finish, then safely clears only the stale connection needed for the replacement to start.
+- Was: some background status and sync problems were vague or distracting. Now: outdated alerts stay quiet, relevant context remains easier to find, and cloud rejections say exactly which records need attention.
+
+---
+
+## Dev — top-level post
+
+**Live on production · Dev · Was: a live WebSocket could prevent Commander restart completion. Now: restart uses bounded drain plus forced stale-session closure before launching the replacement hub.**
+
+- Was: the restart path waited indefinitely for attached viewer sessions. Now: it drains the connection set to a deadline, force-closes residual viewers, and proceeds with a single replacement owner.
+- Was: CI relays could surface stale failures, ambient lexical fallback could outrank stronger context, and invalid cloud push rows were collapsed. Now: branch/commit freshness suppresses obsolete relays, weak lexical candidates are capped, and rejected cloud rows remain itemized.
+- Was: pull-request validation spent the critical path on broad work. Now: the merge gate uses a focused warm suite while heavier validation remains on main, schedules, and manual dispatch.


### PR DESCRIPTION
Release v2.62.0: version train bump, changelog, and #cas-internal runtime post draft.