### PR TITLE
Fix v2.62.0 release lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.61.1"
+version = "2.62.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.61.1"
+version = "2.62.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.61.1"
+version = "2.62.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.61.1"
+version = "2.62.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.61.1"
+version = "2.62.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.61.1"
+version = "2.62.0"
 dependencies = [
  "chrono",
  "glob",

--- a/docs/RELEASE_SLACK_RUBRIC.md
+++ b/docs/RELEASE_SLACK_RUBRIC.md
@@ -99,6 +99,7 @@ compatibility snapshot. Neither includes factory plumbing or ticket IDs.
 
 - [ ] Version/changelog commit landed on `main` through a reviewed PR with required checks green
 - [ ] PR URL + required-check status surfaced before the explicit merge (no `--auto` / admin bypass)
+- [ ] After every release-train version bump, regenerate `Cargo.lock` and verify `cargo metadata --locked` before tagging.
 - [ ] Release tag points at the fetched `origin/main` landing and is pushed
 - [ ] Post 1 (user): punch (was→now) + plain-language details
 - [ ] Post 2 (dev): punch (was→now) + technical details


### PR DESCRIPTION
Regenerate workspace release-train Cargo.lock versions and require lockfile validation before tagging.