### PR TITLE
Harness-aware hook decision emitter: fix Codex rejecting permissionDecision:allow

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -4,7 +4,7 @@
       {
         "hooks": [
           {
-            "command": "cas hook PreToolUse",
+            "command": "CAS_HOOK_HARNESS=codex cas hook PreToolUse",
             "timeout": 3,
             "type": "command"
           }

--- a/cas-cli/src/hooks/handlers/handlers_tests/formatter_scope_guard.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/formatter_scope_guard.rs
@@ -107,7 +107,9 @@ fn codex_routes_unified_exec_through_the_pre_tool_hook() {
             && entry["hooks"].as_array().is_some_and(|handlers| {
                 handlers
                     .iter()
-                    .any(|handler| handler["command"] == "cas hook PreToolUse")
+                    .any(|handler| {
+                        handler["command"] == "CAS_HOOK_HARNESS=codex cas hook PreToolUse"
+                    })
             })
     }));
 }

--- a/crates/cas-core/src/hooks/types.rs
+++ b/crates/cas-core/src/hooks/types.rs
@@ -4,6 +4,32 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The hook runner that will interpret a PreToolUse response.
+///
+/// Claude Code accepts `permissionDecision: "allow"`; Codex 0.147 accepts
+/// the deny form but rejects an explicit allow, where an empty response is the
+/// accepted allow/no-op. The command wrapper selects Codex explicitly with
+/// `CAS_HOOK_HARNESS=codex`; unknown callers preserve Claude's established
+/// protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreToolUseHarness {
+    ClaudeCode,
+    Codex,
+}
+
+impl PreToolUseHarness {
+    fn current() -> Self {
+        if std::env::var("CAS_HOOK_HARNESS")
+            .ok()
+            .is_some_and(|value| value.eq_ignore_ascii_case("codex"))
+        {
+            Self::Codex
+        } else {
+            Self::ClaudeCode
+        }
+    }
+}
+
 /// Input received from Claude Code hooks via stdin
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct HookInput {
@@ -511,15 +537,12 @@ impl HookOutput {
     /// migration is trivial; deferred from the enum refactor to keep that diff
     /// focused.
     pub fn with_pre_tool_permission(decision: &str, reason: &str) -> Self {
-        Self {
-            hook_specific_output: Some(HookSpecificOutput::PreToolUse {
-                permission_decision: Some(decision.to_string()),
-                permission_decision_reason: Some(reason.to_string()),
-                updated_input: None,
-                additional_context: None,
-            }),
-            ..Default::default()
-        }
+        Self::with_pre_tool_permission_for_harness(
+            PreToolUseHarness::current(),
+            decision,
+            reason,
+            None,
+        )
     }
 
     /// PreToolUse permission decision with `additionalContext` for Claude.
@@ -533,12 +556,39 @@ impl HookOutput {
         reason: &str,
         additional_context: &str,
     ) -> Self {
+        Self::with_pre_tool_permission_for_harness(
+            PreToolUseHarness::current(),
+            decision,
+            reason,
+            Some(additional_context),
+        )
+    }
+
+    /// The single PreToolUse permission-decision emitter.
+    ///
+    /// Claude Code 2.1.227 live captures establish that decisions must be
+    /// nested under `hookSpecificOutput`, tagged with
+    /// `hookEventName: "PreToolUse"`. Keeping both ordinary decisions and
+    /// success receipts here prevents those paths from drifting apart.
+    pub fn with_pre_tool_permission_for_harness(
+        harness: PreToolUseHarness,
+        decision: &str,
+        reason: &str,
+        additional_context: Option<&str>,
+    ) -> Self {
+        // Codex executes a PreToolUse call when the hook emits no decision.
+        // Its runner rejects the Claude-only `permissionDecision:"allow"`,
+        // so an empty response is its captured allow shape. Its deny shape is
+        // accepted and intentionally continues below for safety gates.
+        if harness == PreToolUseHarness::Codex && decision == "allow" {
+            return Self::empty();
+        }
         Self {
             hook_specific_output: Some(HookSpecificOutput::PreToolUse {
                 permission_decision: Some(decision.to_string()),
                 permission_decision_reason: Some(reason.to_string()),
                 updated_input: None,
-                additional_context: Some(additional_context.to_string()),
+                additional_context: additional_context.map(str::to_string),
             }),
             ..Default::default()
         }

--- a/crates/cas-core/tests/hook_schema.rs
+++ b/crates/cas-core/tests/hook_schema.rs
@@ -25,7 +25,7 @@
 //! absence of forbidden fields so that either direction of regression fails
 //! the test.
 
-use cas_core::hooks::types::HookOutput;
+use cas_core::hooks::types::{HookOutput, PreToolUseHarness};
 use serde_json::Value;
 
 // ---------------------------------------------------------------------------
@@ -177,19 +177,94 @@ fn pretooluse_permission_with_context_emits_additional_context() {
 }
 
 #[test]
-fn pretooluse_permission_decision_valid_enum() {
-    // The schema constrains permissionDecision to allow | deny | ask. Every
-    // value we emit must round-trip as one of those — catch regressions that
-    // introduce a misspelled / new variant.
+fn pretooluse_claude_code_2_1_227_captured_decision_contract() {
+    // Captured with real Claude Code 2.1.227 PreToolUse invocations on
+    // 2026-08-11. `allow` executed the tool, `deny` blocked it, and `ask`
+    // reached the harness permission path. The accepted shape is nested and
+    // event-tagged; the legacy top-level `decision: "approve"` is inert and
+    // must not become CAS's auto-approval fallback.
+    //
+    // Durable raw transcripts: artifacts/cas-a53c/live-contract/.
     for decision in ["allow", "deny", "ask"] {
-        let output = HookOutput::with_pre_tool_permission(decision, "reason");
+        let output = HookOutput::with_pre_tool_permission_for_harness(
+            PreToolUseHarness::ClaudeCode,
+            decision,
+            "captured-contract",
+            None,
+        );
         let value = to_value(&output);
-        let hso = hook_specific(&value, "PreToolUse.enum");
         assert_eq!(
-            hso.get("permissionDecision").and_then(Value::as_str),
-            Some(decision)
+            value,
+            serde_json::json!({
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": decision,
+                    "permissionDecisionReason": "captured-contract",
+                }
+            }),
+            "Claude Code 2.1.227 captured PreToolUse contract regressed for {decision}"
+        );
+        assert!(
+            value.get("decision").is_none(),
+            "legacy top-level decision must remain absent for {decision}: {value}"
         );
     }
+
+    // The SendMessage receipt path formerly constructed this separately. Its
+    // additionalContext is accepted by the same 2.1.227 live contract, while
+    // the decision envelope must remain byte-for-byte identical to the normal
+    // allow path above.
+    assert_eq!(
+        to_value(&HookOutput::with_pre_tool_permission_for_harness(
+            PreToolUseHarness::ClaudeCode,
+            "allow",
+            "captured-contract",
+            Some("CAS receipt"),
+        )),
+        serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "permissionDecisionReason": "captured-contract",
+                "additionalContext": "CAS receipt",
+            }
+        }),
+        "Claude Code 2.1.227 captured context-bearing allow contract regressed"
+    );
+}
+
+#[test]
+fn pretooluse_codex_0_147_captured_decision_contract() {
+    // Captured from the Codex 0.147 runner on 2026-08-11. It rejects the
+    // Claude-only `permissionDecision:"allow"` response, but accepts the
+    // nested deny response used by workspace and formatter safety gates. An
+    // empty object is its accepted allow/no-op response.
+    assert_eq!(
+        to_value(&HookOutput::with_pre_tool_permission_for_harness(
+            PreToolUseHarness::Codex,
+            "allow",
+            "captured-contract",
+            None,
+        )),
+        serde_json::json!({}),
+        "Codex allow must be a no-op rather than Claude's rejected allow vocabulary"
+    );
+    assert_eq!(
+        to_value(&HookOutput::with_pre_tool_permission_for_harness(
+            PreToolUseHarness::Codex,
+            "deny",
+            "captured-contract",
+            None,
+        )),
+        serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": "captured-contract",
+            }
+        }),
+        "Codex deny must preserve the accepted protection-gate response"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Lands cas-a53c (Fixes #232): Codex hook replies use the captured Codex contract (allow = empty response = proceed; deny keeps the nested shape, live-proven to block), Claude 2.1.227 keeps its captured nested-allow shape; one shared emitter behind CAS_HOOK_HARNESS, contract tests per harness family (hook_schema 20/20, workspace_contract 4/4). Ends the 'PreToolUse hook (failed) — unsupported permissionDecision:allow' noise on every codex worker and restores allow-path semantics there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)