### PR TITLE
chore: bump v2.63.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.62.0"
+version = "2.63.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.62.0"
+version = "2.63.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"


### PR DESCRIPTION
Version bump + lockfile for the v2.63.0 release carrying today's v12 landing (delivery liveness, trust provisioning, canonical hooks.json, sccache resilience, description slimming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)