### PR TITLE
chore: complete v2.63.0 bump across workspace crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.62.0"
+version = "2.63.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.62.0"
+version = "2.63.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.62.0"
+version = "2.63.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.62.0"
+version = "2.63.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.62.0"
+version = "2.63.0"
 dependencies = [
  "chrono",
  "glob",

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.62.0"
+version = "2.63.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.62.0"
+version = "2.63.0"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.62.0"
+version = "2.63.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.62.0"
+version = "2.63.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.62.0"
+version = "2.63.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"


### PR DESCRIPTION
Release preflight (run 31530860139) caught the incomplete bump: cas-cli was 2.63.0 but cas-core/mcp/search/store/types were still 2.62.0. Bumps all five + lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)