### PR TITLE
Land burn-down v14: decision-time signals — recall at write moments, honest terminal states, fresh relays (epic cas-7020)

### DIFF
--- a/.claude/CODEMAP.md
+++ b/.claude/CODEMAP.md
@@ -9,7 +9,7 @@ Rust workspace for the CAS coding-agent system. Product/domain material belongs 
 - `contrib/shell-helpers/` — installable `cas-update` wrapper plus its shell-test harness.
 - `docs/` — plans, specs, reports, release notes, research, guides, and operational records.
 - `fixtures/retrieval-parity/` — checked-in retrieval benchmark baseline and query set.
-- `scripts/` — install, release, migration, scoped-test, build-regression, worktree, portable-ISA, and release-preflight checks.
+- `scripts/` — install, release, migration, scoped-test, build-regression, worktree, portable-ISA, release-preflight, and worker build-cache (`refresh-worker-build-cache.sh`) helpers.
 - `migration/` — historical cloud-move logs and systemd material; not the active database migration tree.
 - `homebrew/` — Homebrew formula and formula update helper.
 - `slack-bridge/` — standalone Node/TypeScript service routing Slack traffic to CAS daemons.
@@ -20,7 +20,7 @@ Rust workspace for the CAS coding-agent system. Product/domain material belongs 
 - `.cargo/` — workspace Cargo configuration.
 - `.github/` — CI/release workflows, including portable ISA validation, and public issue templates.
 - `.config/` — local development/editor configuration.
-- Root docs — `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `CAS-DEEP-DIVE.md`, `CHANGELOG.md`, and `investigation-mcp-worktree.md`.
+- Root docs — `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `AGENTS.md`, `CAS-DEEP-DIVE.md`, `CHANGELOG.md`, and `investigation-mcp-worktree.md`.
 - Root config/assets — `Cargo.toml`, `.mcp.json`, `.env.worktree.template`, `casdemo.png`, and licensing files.
 
 ## Workspace / packages
@@ -44,16 +44,20 @@ Rust workspace for the CAS coding-agent system. Product/domain material belongs 
 ## cas-cli/src — application hub
 `main.rs` starts the CLI; `lib.rs` exports application modules and the canonical `TestEnvGuard`.
 - `cli/mod.rs` — clap command dispatch; use this first to locate a CLI subcommand.
-- `cli/factory/` — `cas factory` launch/configuration, lifecycle, worktree, liveness, parity, and communication probes.
+- `cli/factory/` — `cas factory` launch/configuration, lifecycle, worktree, liveness, parity, communication probes, and `doctor.rs` diagnostics.
+- `cli/{hub,hub_service,hub_reverse_pairing}.rs` — `cas hub` fleet-control CLI: launch, launchd/systemd service install, reverse pairing.
+- `cli/limits.rs` — `cas limits` usage/limit reporting.
+- `cli/sync/agents_md.rs` — managed `AGENTS.md` sync command (core logic in `crates/cas-core/src/sync/agents_md.rs`).
 - `cli/{codemap_cmd,project_overview_cmd,knowledge_cmd}.rs` — documentation freshness gates and knowledge commands.
 - `cli/history_cmd.rs` — history index/search/status/repair command surface.
 - `cli/{hook,update,integrate,config,config_tui,init}.rs` — hook dispatch, managed-file sync, integrations, configuration, and setup.
 - `cli/{claude,claude_md}.rs` — Claude profile launch/login commands and managed `CLAUDE.md` material.
 - `cli/{doctor,status,index_cmd}.rs` — diagnostics, status, and index operations.
+- `hub/` — machine-local Commander hub (EPIC cas-bec9): `server.rs`/`runtime.rs`, `discovery.rs`, `tailscale.rs`, `auth.rs`/`identity.rs`, event stream, death detection.
 - `mcp/{daemon,socket,server}/` — always-available MCP daemon, Unix socket, and request routing.
 - `mcp/tools/core/` — task, memory, knowledge, search, rules, skills, and coordination MCP handlers.
 - `mcp/tools/service/` — factory operations, supervisor queue, messaging, history/code search, liveness, and recovery handlers.
-- `ui/factory/` — bare-`cas` TUI, factory daemon runtime, director events/prompts, app state, and rendering.
+- `ui/factory/` — bare-`cas` TUI, factory daemon runtime (incl. `runtime/ci_watch.rs` CI red-run relays), director events/prompts, app state, and rendering.
 - `bridge/server/` — HTTP bridge server used by `cas bridge serve`.
 - `hooks/handlers/` — SessionStart, PreToolUse, PostToolUse, and session-stop hook behavior.
 - `builtins/` — embedded Claude/Codex/Grok skills, agents, and workflows synced into harness directories; `skills/cli-routing/` routes CLI work and `skills/cas-code-review/` carries review personas/workflows.
@@ -63,7 +67,7 @@ Rust workspace for the CAS coding-agent system. Product/domain material belongs 
 - `history/` — incremental Git history index, FTS search, provenance, symbol links, and epoch tracking.
 - `ambient_recall.rs` — bounded, scope-gated hook recall contracts and ranking.
 - `hybrid_search/` — lexical/semantic/code/knowledge search composition and capability-aware weighting.
-- `migration/migrations/` — numbered SQLite migrations; current additions include history epochs, code-vector state, and `m231_sync_conflicts_create_table.rs`.
+- `migration/migrations/` — numbered SQLite migrations; current tip `m232_worker_completion_receipts_add_artifact_path.rs`.
 - `daemon/` — background maintenance, filesystem watching, and indexing scheduling.
 - `sync/` — managed artifact rendering from builtins into `.claude/` and harness mirrors.
 - `worktree/` — create, manage, salvage, sweep, and clean worktrees.

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/planning.md
@@ -149,6 +149,8 @@ When breaking an epic into subtasks, apply these patterns:
 
 **Spikes** — If a task's primary output is understanding (not code), create it as a spike: `task_type=spike`. Spikes have question-based acceptance criteria (e.g., "Which auth library fits our constraints?") and produce a decision or recommendation, not implementation.
 
+**Gates** — If a task represents a promotion, rollout, flag flip, or sign-off decision owned by the supervisor, create it as a gate: `task_type=gate`. Start the gate yourself, record the outcome with `task action=notes note_type=decision`, then close it without borrowing commit evidence. An open gate can block downstream tasks through `blocked_by` like any other task.
+
 **Fit checks** — When multiple approaches exist, create a spike first to compare options. Document the comparison in the spec's `design_notes` before committing to an approach. This prevents wasted implementation effort on the wrong path.
 
 **Model tier** — Decide each task's worker tier while breaking down: default standard; tag deviations with `labels="tier:light"` / `"tier:heavy"` / `"tier:frontier"` and note non-obvious rationale in `design`. Tier rubric, spawn mix, and escalation workflow in [model-selection.md](model-selection.md).

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor/references/planning.md
@@ -149,6 +149,8 @@ When breaking an epic into subtasks, apply these patterns:
 
 **Spikes** — If a task's primary output is understanding (not code), create it as a spike: `task_type=spike`. Spikes have question-based acceptance criteria (e.g., "Which auth library fits our constraints?") and produce a decision or recommendation, not implementation.
 
+**Gates** — If a task represents a promotion, rollout, flag flip, or sign-off decision owned by the supervisor, create it as a gate: `task_type=gate`. Start the gate yourself, record the outcome with `task action=notes note_type=decision`, then close it without borrowing commit evidence. An open gate can block downstream tasks through `blocked_by` like any other task.
+
 **Fit checks** — When multiple approaches exist, create a spike first to compare options. Document the comparison in the spec's `design_notes` before committing to an approach. This prevents wasted implementation effort on the wrong path.
 
 **Model tier** — Decide each task's worker tier while breaking down: default standard; tag deviations with `labels="tier:light"` / `"tier:heavy"` / `"tier:frontier"` and note non-obvious rationale in `design`. Tier rubric, spawn mix, and escalation workflow in [model-selection.md](model-selection.md).

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/planning.md
@@ -149,6 +149,8 @@ When breaking an epic into subtasks, apply these patterns:
 
 **Spikes** — If a task's primary output is understanding (not code), create it as a spike: `task_type=spike`. Spikes have question-based acceptance criteria (e.g., "Which auth library fits our constraints?") and produce a decision or recommendation, not implementation.
 
+**Gates** — If a task represents a promotion, rollout, flag flip, or sign-off decision owned by the supervisor, create it as a gate: `task_type=gate`. Start the gate yourself, record the outcome with `task action=notes note_type=decision`, then close it without borrowing commit evidence. An open gate can block downstream tasks through `blocked_by` like any other task.
+
 **Fit checks** — When multiple approaches exist, create a spike first to compare options. Document the comparison in the spec's `design_notes` before committing to an approach. This prevents wasted implementation effort on the wrong path.
 
 **Model tier** — Decide each task's worker tier while breaking down: default standard; tag deviations with `labels="tier:light"` / `"tier:heavy"` / `"tier:frontier"` and note non-obvious rationale in `design`. Tier rubric, spawn mix, and escalation workflow in [model-selection.md](model-selection.md).

--- a/cas-cli/src/hooks/handlers/handlers_state.rs
+++ b/cas-cli/src/hooks/handlers/handlers_state.rs
@@ -403,7 +403,7 @@ pub(crate) fn get_exit_blockers(
             for lease in &leases {
                 if let Ok(task) = task_store.get(&lease.task_id) {
                     // Only include open tasks as blockers
-                    if task.status != TaskStatus::Closed {
+                    if !task.is_terminal() {
                         // Track epics for subtask check (directly claimed epics)
                         if task.task_type == TaskType::Epic {
                             epic_ids.insert(task.id.clone());
@@ -438,7 +438,7 @@ pub(crate) fn get_exit_blockers(
     for epic_id in &epic_ids {
         // Skip epics that are already closed
         if let Ok(epic) = task_store.get(epic_id) {
-            if epic.status == TaskStatus::Closed {
+            if epic.is_terminal() {
                 // Clean up stale working_epics entry
                 if let Some(ref agent) = agent {
                     let _ = agent_store.remove_working_epic(&agent.id, epic_id);
@@ -450,9 +450,7 @@ pub(crate) fn get_exit_blockers(
         if let Ok(subtasks) = task_store.get_subtasks(epic_id) {
             for subtask in subtasks {
                 // Include all non-closed subtasks - agent must complete the entire epic
-                if subtask.status != TaskStatus::Closed
-                    && !claimed_ids.contains(subtask.id.as_str())
-                {
+                if !subtask.is_terminal() && !claimed_ids.contains(subtask.id.as_str()) {
                     blockers.epic_subtasks.push(subtask);
                 }
             }

--- a/cas-cli/src/hooks/handlers/session_hygiene.rs
+++ b/cas-cli/src/hooks/handlers/session_hygiene.rs
@@ -269,7 +269,7 @@ pub fn write_current_state_snapshot(cas_root: &Path) -> Result<(), String> {
 
     let mut open_epics: Vec<_> = tasks
         .iter()
-        .filter(|task| task.task_type == TaskType::Epic && task.status != TaskStatus::Closed)
+        .filter(|task| task.task_type == TaskType::Epic && !task.is_terminal())
         .collect();
     open_epics.sort_by(|left, right| left.id.cmp(&right.id));
 
@@ -280,7 +280,7 @@ pub fn write_current_state_snapshot(cas_root: &Path) -> Result<(), String> {
             .map_err(|error| format!("could not list subtasks for {}: {error}", epic.id))?;
         let remaining = subtasks
             .iter()
-            .filter(|task| task.status != TaskStatus::Closed)
+            .filter(|task| !task.is_terminal())
             .count();
         epic_lines.push(format!(
             "- {} — {} ({} subtasks; {} open)",

--- a/cas-cli/src/mcp/server/resources.rs
+++ b/cas-cli/src/mcp/server/resources.rs
@@ -4,7 +4,7 @@ use rmcp::ErrorData as McpError;
 use rmcp::model::{AnnotateAble, ErrorCode, RawResource, Resource};
 
 use crate::mcp::server::CasCore;
-use crate::types::{RuleStatus, SkillStatus, TaskStatus};
+use crate::types::{RuleStatus, SkillStatus};
 
 impl CasCore {
     /// Build list of available resources
@@ -33,11 +33,7 @@ impl CasCore {
 
         if let Ok(store) = self.open_task_store() {
             if let Ok(tasks) = store.list(None) {
-                for task in tasks
-                    .iter()
-                    .filter(|t| t.status != TaskStatus::Closed)
-                    .take(50)
-                {
+                for task in tasks.iter().filter(|t| !t.is_terminal()).take(50) {
                     resources.push(
                         RawResource {
                             uri: format!("cas://task/{}", task.id),

--- a/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
@@ -16,10 +16,10 @@ impl CasCore {
             data: None,
         })?;
 
-        if task.status == TaskStatus::Closed {
+        if task.is_terminal() {
             return Err(McpError {
                 code: ErrorCode::INVALID_PARAMS,
-                message: Cow::from("Cannot claim a closed task"),
+                message: Cow::from("Cannot claim a terminal task (closed or cancelled)"),
                 data: None,
             });
         }
@@ -372,7 +372,7 @@ impl CasCore {
                         // pending. Resetting a PSR task to Open would silently erase
                         // the worker's completed close and remove it from the
                         // supervisor review queue.
-                        if task.status != TaskStatus::Closed
+                        if !task.is_terminal()
                             && task.status != TaskStatus::Open
                             && task.status != TaskStatus::PendingSupervisorReview
                             && task.status != TaskStatus::AwaitingMerge
@@ -459,11 +459,11 @@ impl CasCore {
             data: None,
         })?;
 
-        if task.status == TaskStatus::Closed {
+        if task.is_terminal() {
             return Err(McpError {
                 code: ErrorCode::INVALID_PARAMS,
                 message: Cow::from(format!(
-                    "Cannot reset closed task {} — use `action=reopen` instead",
+                    "Cannot reset terminal task {} — use `action=reopen` instead",
                     req.task_id
                 )),
                 data: None,
@@ -922,7 +922,7 @@ impl CasCore {
             .unwrap_or_default()
             .into_iter()
             .filter(|t| {
-                if t.status == TaskStatus::Closed {
+                if t.is_terminal() {
                     return false;
                 }
                 match t.assignee.as_deref() {

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -443,7 +443,7 @@ impl CasCore {
             data: None,
         })?;
 
-        if task.status == TaskStatus::Closed {
+        if task.is_terminal() {
             // cas-3c23: this message used to tell EVERY caller "Use reopen
             // first" — a factory worker follows that verbatim, reopens an
             // already-merged task, re-verifies already-shipped code, and
@@ -456,15 +456,15 @@ impl CasCore {
             return Err(Self::error(
                 ErrorCode::INVALID_PARAMS,
                 if crate::harness_policy::is_supervisor_from_env() {
-                    "Cannot start a closed task. Use reopen first if this task \
+                    "Cannot start a terminal task. Use reopen first if this task \
                      genuinely needs rework."
                         .to_string()
                 } else {
                     format!(
-                        "Cannot start a closed task. Task {} is closed — do not \
+                        "Cannot start a terminal task. Task {} is {} — do not \
                          reopen it; report to your supervisor if you believe \
                          this task needs rework.",
-                        req.id
+                        req.id, task.status
                     )
                 },
             ));

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -46,55 +46,66 @@ const RELATED_RECALL_CHAR_CAP: usize = 1_200;
 /// Uses the same unified BM25 index as `search`; failures deliberately add no
 /// noise or friction to task creation/spawning.
 impl CasCore {
-pub(crate) fn related_recall(&self, query: &str) -> Option<String> {
+    pub(crate) fn related_recall(&self, query: &str) -> Option<String> {
         use cas_core::search::{DocType, SearchOptions};
 
-    let query = query.trim();
-    if query.is_empty() {
-        return None;
-    }
-    let search = self.open_search_index().ok()?;
-    let results = search
-        .search_unified(&SearchOptions {
-            query: query.chars().take(600).collect(),
-            limit: RELATED_RECALL_LIMIT * 3,
-            doc_types: vec![DocType::Entry, DocType::Task],
-            ..Default::default()
-        })
-        .ok()?;
-    let store = self.open_store().ok();
-    let tasks = self.open_task_store().ok();
-    let mut lines = Vec::new();
+        let query = query.trim();
+        if query.is_empty() {
+            return None;
+        }
+        let search = self.open_search_index().ok()?;
+        let results = search
+            .search_unified(&SearchOptions {
+                query: query.chars().take(600).collect(),
+                limit: RELATED_RECALL_LIMIT * 3,
+                doc_types: vec![DocType::Entry, DocType::Task],
+                ..Default::default()
+            })
+            .ok()?;
+        let store = self.open_store().ok();
+        let tasks = self.open_task_store().ok();
+        let mut lines = Vec::new();
 
-    for hit in results {
-        if lines.len() == RELATED_RECALL_LIMIT {
-            break;
-        }
-        let line = match hit.doc_type {
-            DocType::Entry => store.as_ref().and_then(|store| {
-                store.get(&hit.id).ok().map(|entry| {
-                    let title = entry.title.as_deref().unwrap_or("untitled memory");
-                    format!("- Memory [{}]: {} — {}", entry.id, title, entry.preview(140))
-                })
-            }),
-            DocType::Task => tasks.as_ref().and_then(|tasks| {
-                tasks.get(&hit.id).ok().and_then(|task| {
-                    (task.task_type == crate::types::TaskType::Epic).then(|| {
-                        let detail = task.description.lines().next().unwrap_or_default();
-                        format!("- Past epic [{}]: {} — {}", task.id, task.title, truncate_str(detail, 140))
+        for hit in results {
+            if lines.len() == RELATED_RECALL_LIMIT {
+                break;
+            }
+            let line = match hit.doc_type {
+                DocType::Entry => store.as_ref().and_then(|store| {
+                    store.get(&hit.id).ok().map(|entry| {
+                        let title = entry.title.as_deref().unwrap_or("untitled memory");
+                        format!(
+                            "- Memory [{}]: {} — {}",
+                            entry.id,
+                            title,
+                            entry.preview(140)
+                        )
                     })
-                })
-            }),
-            _ => None,
-        };
-        if let Some(line) = line
-            && lines.iter().map(String::len).sum::<usize>() + line.len() <= RELATED_RECALL_CHAR_CAP
-        {
-            lines.push(line);
+                }),
+                DocType::Task => tasks.as_ref().and_then(|tasks| {
+                    tasks.get(&hit.id).ok().and_then(|task| {
+                        (task.task_type == crate::types::TaskType::Epic).then(|| {
+                            let detail = task.description.lines().next().unwrap_or_default();
+                            format!(
+                                "- Past epic [{}]: {} — {}",
+                                task.id,
+                                task.title,
+                                truncate_str(detail, 140)
+                            )
+                        })
+                    })
+                }),
+                _ => None,
+            };
+            if let Some(line) = line
+                && lines.iter().map(String::len).sum::<usize>() + line.len()
+                    <= RELATED_RECALL_CHAR_CAP
+            {
+                lines.push(line);
+            }
         }
+        (!lines.is_empty()).then(|| format!("\n\nRelated prior context:\n{}", lines.join("\n")))
     }
-    (!lines.is_empty()).then(|| format!("\n\nRelated prior context:\n{}", lines.join("\n")))
-}
 }
 
 impl CasCore {
@@ -295,6 +306,13 @@ impl CasCore {
                 }
             })?;
 
+        // Recall before indexing this task so an epic cannot surface itself as
+        // "prior context" and turn an otherwise clean create receipt noisy.
+        let related_context = (task.task_type == crate::types::TaskType::Epic)
+            .then(|| self.related_recall(&format!("{} {}", task.title, task.description)))
+            .flatten()
+            .unwrap_or_default();
+
         if let Ok(search) = self.open_search_index() {
             let _ = search.index_task(&task);
         }
@@ -394,11 +412,6 @@ impl CasCore {
         } else {
             None
         };
-
-        let related_context = (task.task_type == crate::types::TaskType::Epic)
-            .then(|| self.related_recall(&format!("{} {}", task.title, task.description)))
-            .flatten()
-            .unwrap_or_default();
 
         Ok(Self::success(format!(
             "Created task: {} - {} (P{}){}",
@@ -1112,6 +1125,140 @@ mod factory_epic_owner_tests {
             resolve_factory_epic_owner(Some("  agent-uuid  ".into()), Some("display".into()), None)
                 .unwrap();
         assert_eq!(owner, "agent-uuid");
+    }
+}
+
+/// Response-level regression coverage for GH #257. Recall must be useful at
+/// the decision point, but a project with no prior context must receive the
+/// exact legacy create receipt rather than a permanent empty heading.
+#[cfg(test)]
+mod related_recall_response_tests {
+    use super::*;
+    use cas_types::Entry;
+    use tempfile::TempDir;
+
+    fn text(result: CallToolResult) -> String {
+        result
+            .content
+            .into_iter()
+            .filter_map(|content| match content.raw {
+                rmcp::model::RawContent::Text(text) => Some(text.text),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn epic_request(title: &str, description: &str) -> TaskCreateRequest {
+        TaskCreateRequest {
+            title: title.to_string(),
+            description: Some(description.to_string()),
+            priority: 2,
+            task_type: "epic".to_string(),
+            labels: None,
+            notes: None,
+            blocked_by: None,
+            design: None,
+            acceptance_criteria: None,
+            external_ref: None,
+            assignee: None,
+            demo_statement: None,
+            execution_note: None,
+            epic: None,
+            depth: None,
+        }
+    }
+
+    fn add_memory(core: &CasCore, id: &str, title: &str, content: &str) {
+        let mut entry = Entry::new(id.to_string(), content.to_string());
+        entry.title = Some(title.to_string());
+        let store = core.open_store().expect("open memory store");
+        store.add(&entry).expect("add memory");
+        core.open_search_index()
+            .expect("open search index")
+            .index_entry(&entry)
+            .expect("index memory");
+    }
+
+    #[tokio::test]
+    async fn epic_create_surfaces_matching_memory_in_its_response() {
+        let temp = TempDir::new().expect("temp project");
+        let core = CasCore::with_daemon(temp.path().to_path_buf(), None, None);
+        add_memory(
+            &core,
+            "m-recall-memory",
+            "Avoid duplicate timeline work",
+            "The timeline import plan is already implemented; verify it before creating work.",
+        );
+
+        let response = text(
+            core.cas_task_create(Parameters(epic_request(
+                "Timeline import follow-up",
+                "Plan timeline import work for the next release.",
+            )))
+            .await
+            .expect("create epic"),
+        );
+
+        assert!(response.contains("Related prior context:"), "{response}");
+        assert!(response.contains("m-recall-memory"), "{response}");
+        assert!(
+            response.contains("Avoid duplicate timeline work"),
+            "{response}"
+        );
+    }
+
+    #[tokio::test]
+    async fn epic_create_with_no_prior_match_preserves_legacy_response_shape() {
+        let temp = TempDir::new().expect("temp project");
+        let core = CasCore::with_daemon(temp.path().to_path_buf(), None, None);
+
+        let response = text(
+            core.cas_task_create(Parameters(epic_request(
+                "Unique no-match epic",
+                "This phrase has no prior matching context.",
+            )))
+            .await
+            .expect("create epic"),
+        );
+
+        let task = core
+            .open_task_store()
+            .expect("open task store")
+            .list(None)
+            .expect("list created task")
+            .into_iter()
+            .find(|task| task.title == "Unique no-match epic")
+            .expect("created epic");
+        assert_eq!(
+            response,
+            format!("Created task: {} - Unique no-match epic (P2)", task.id),
+            "no-match receipt must remain byte-identical to the legacy response"
+        );
+    }
+
+    #[test]
+    fn related_recall_is_bounded_by_result_count_and_character_cap() {
+        let temp = TempDir::new().expect("temp project");
+        let core = CasCore::with_daemon(temp.path().to_path_buf(), None, None);
+        for index in 0..6 {
+            add_memory(
+                &core,
+                &format!("m-recall-bound-{index}"),
+                &format!("Recall bound result {index}"),
+                &format!("bounded recall shared keyword {}", "x".repeat(700)),
+            );
+        }
+
+        let response = core
+            .related_recall("bounded recall shared keyword")
+            .expect("matching recall");
+        assert!(response.len() <= RELATED_RECALL_CHAR_CAP + 32, "{response}");
+        assert_eq!(
+            response.matches("- Memory [").count(),
+            RELATED_RECALL_LIMIT,
+            "{response}"
+        );
     }
 }
 

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -179,6 +179,7 @@ impl CasCore {
             updated_at: now,
             closed_at: None,
             close_reason: None,
+            terminal_outcome: None,
             external_ref: req.external_ref,
             content_hash: None,
             branch: None,
@@ -512,8 +513,7 @@ impl CasCore {
                          that merge fails with a genuine \
                          git conflict, CAS marks the parked task conflicted and its assigned \
                          worker can then start task {} to resolve it.",
-                        req.id,
-                        req.id
+                        req.id, req.id
                     ),
                 ));
             }
@@ -969,10 +969,7 @@ impl CasCore {
                 req.id,
                 crate::mcp::tools::truncate_str(&task.title, 509),
                 claim_info.unwrap_or_default(),
-                crate::mcp::tools::truncate_str(
-                    &unanchored_warning.unwrap_or_default(),
-                    765,
-                ),
+                crate::mcp::tools::truncate_str(&unanchored_warning.unwrap_or_default(), 765,),
                 own_notes,
                 push_note,
             );

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -619,6 +619,18 @@ impl CasCore {
 
         let agent_store = self.open_agent_store()?;
 
+        // cas-7844 / GH #259: Gate tasks are supervisor-owned decisions,
+        // not worker execution. Reuse the same live registered-supervisor
+        // resolver as the other non-delivery terminal outcomes so env-role
+        // spoofing cannot authorize the start.
+        if task.task_type == crate::types::TaskType::Gate {
+            self.resolve_live_supervisor_authority()
+                .map_err(|error| Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    close_ops::gate_supervisor_authority_error("START", error),
+                ))?;
+        }
+
         // Check agent role for supervisor/worker-specific logic
         let is_worker = agent_store
             .get(&agent_id)
@@ -651,10 +663,15 @@ impl CasCore {
             }
         }
 
-        // Check if supervisor is trying to start a non-epic task
+        // Check if supervisor is trying to start an ordinary non-epic task.
+        // Gate is the deliberate narrow exception: the authority check above
+        // already proved the caller is a live registered supervisor.
         if let Ok(agent) = agent_store.get(&agent_id) {
             if agent.role == cas_types::AgentRole::Supervisor
-                && task.task_type != crate::types::TaskType::Epic
+                && !matches!(
+                    task.task_type,
+                    crate::types::TaskType::Epic | crate::types::TaskType::Gate
+                )
             {
                 return Err(McpError {
                     code: ErrorCode::INVALID_PARAMS,

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -39,6 +39,64 @@ pub(crate) fn resolve_factory_epic_owner(
         })
 }
 
+const RELATED_RECALL_LIMIT: usize = 3;
+const RELATED_RECALL_CHAR_CAP: usize = 1_200;
+
+/// Best-effort, response-only recall for write moments that establish work.
+/// Uses the same unified BM25 index as `search`; failures deliberately add no
+/// noise or friction to task creation/spawning.
+impl CasCore {
+pub(crate) fn related_recall(&self, query: &str) -> Option<String> {
+        use cas_core::search::{DocType, SearchOptions};
+
+    let query = query.trim();
+    if query.is_empty() {
+        return None;
+    }
+    let search = self.open_search_index().ok()?;
+    let results = search
+        .search_unified(&SearchOptions {
+            query: query.chars().take(600).collect(),
+            limit: RELATED_RECALL_LIMIT * 3,
+            doc_types: vec![DocType::Entry, DocType::Task],
+            ..Default::default()
+        })
+        .ok()?;
+    let store = self.open_store().ok();
+    let tasks = self.open_task_store().ok();
+    let mut lines = Vec::new();
+
+    for hit in results {
+        if lines.len() == RELATED_RECALL_LIMIT {
+            break;
+        }
+        let line = match hit.doc_type {
+            DocType::Entry => store.as_ref().and_then(|store| {
+                store.get(&hit.id).ok().map(|entry| {
+                    let title = entry.title.as_deref().unwrap_or("untitled memory");
+                    format!("- Memory [{}]: {} — {}", entry.id, title, entry.preview(140))
+                })
+            }),
+            DocType::Task => tasks.as_ref().and_then(|tasks| {
+                tasks.get(&hit.id).ok().and_then(|task| {
+                    (task.task_type == crate::types::TaskType::Epic).then(|| {
+                        let detail = task.description.lines().next().unwrap_or_default();
+                        format!("- Past epic [{}]: {} — {}", task.id, task.title, truncate_str(detail, 140))
+                    })
+                })
+            }),
+            _ => None,
+        };
+        if let Some(line) = line
+            && lines.iter().map(String::len).sum::<usize>() + line.len() <= RELATED_RECALL_CHAR_CAP
+        {
+            lines.push(line);
+        }
+    }
+    (!lines.is_empty()).then(|| format!("\n\nRelated prior context:\n{}", lines.join("\n")))
+}
+}
+
 impl CasCore {
     pub async fn cas_task_create(
         &self,
@@ -337,12 +395,17 @@ impl CasCore {
             None
         };
 
+        let related_context = (task.task_type == crate::types::TaskType::Epic)
+            .then(|| self.related_recall(&format!("{} {}", task.title, task.description)))
+            .flatten()
+            .unwrap_or_default();
+
         Ok(Self::success(format!(
             "Created task: {} - {} (P{}){}",
             id,
             task.title,
             task.priority.0,
-            branch_info.unwrap_or_default()
+            branch_info.unwrap_or_default() + &related_context
         )))
     }
 

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -1953,7 +1953,11 @@ impl CasCore {
         // gates below; this asks only whether the receipt is ours to verify.
         if let Some(receipt) = req.commit_receipt.as_deref()
             && close_repo_verified
-            && let Some(message) = commit_receipt_repo_binding_error(&close_project_root, receipt)
+            && let Some(message) = commit_receipt_repo_binding_error(
+                &close_project_root,
+                receipt,
+                &resolved_parent_branch,
+            )
         {
             return Ok(Self::tool_error(message));
         }
@@ -6438,8 +6442,23 @@ fn unmerged_commit_shas_against_targets(
 pub(crate) fn commit_receipt_repo_binding_error(
     repo_path: &std::path::Path,
     receipt: &str,
+    target_branch: &str,
 ) -> Option<String> {
-    let reason = resolve_task_commit_receipt_sha(repo_path, receipt).err()?;
+    let reason = match resolve_task_commit_receipt_sha(repo_path, receipt) {
+        Ok(_) => return None,
+        Err(reason) => reason,
+    };
+
+    // A supervisor can merge remotely and close within seconds, before this
+    // worktree has received the new object. Refresh just the bound target
+    // branch before treating an otherwise valid receipt as foreign. The
+    // helper is bounded, prompt-free, and deliberately best-effort, so a
+    // local-only/offline repository still reaches the actionable refusal.
+    fetch_parent_branch_best_effort(repo_path, target_branch);
+    if resolve_task_commit_receipt_sha(repo_path, receipt).is_ok() {
+        return None;
+    }
+
     Some(format!(
         "⚠️ RECEIPT NOT FOUND IN THIS REPOSITORY\n\n\
          task close rejected: commit_receipt `{receipt}` does not resolve in the \
@@ -6454,7 +6473,9 @@ pub(crate) fn commit_receipt_repo_binding_error(
             target_branch=<branch>`, then retry close.\n\
          2. If the work is in this repository, re-copy the SHA \
             (`git log --oneline --all`) — full or an unambiguous abbreviation \
-            both work.",
+            both work.\n\
+         3. The commit may exist only on the remote — run `git fetch` and retry \
+            close.",
         repo_path.display(),
     ))
 }
@@ -14896,7 +14917,7 @@ mod merge_state_gate_tests {
             String::from_utf8_lossy(&out.stdout).trim().to_string()
         };
 
-        let refusal = commit_receipt_repo_binding_error(dir.path(), &foreign_sha)
+        let refusal = commit_receipt_repo_binding_error(dir.path(), &foreign_sha, "main")
             .expect("a receipt that does not exist in the bound repo must be refused");
         assert!(
             refusal.contains(&foreign_sha[..12]),
@@ -14905,6 +14926,10 @@ mod merge_state_gate_tests {
         assert!(
             refusal.contains("target_repo"),
             "refusal must point cross-repo work at the declared target repo: {refusal}"
+        );
+        assert!(
+            refusal.contains("git fetch"),
+            "refusal must explain the remote-only receipt remedy: {refusal}"
         );
 
         // A receipt that does resolve locally is not refused by this check —
@@ -14918,8 +14943,38 @@ mod merge_state_gate_tests {
             String::from_utf8_lossy(&out.stdout).trim().to_string()
         };
         assert!(
-            commit_receipt_repo_binding_error(dir.path(), &local_sha).is_none(),
+            commit_receipt_repo_binding_error(dir.path(), &local_sha, "main").is_none(),
             "a resolvable receipt must pass the repo-binding check"
+        );
+    }
+
+    #[test]
+    fn receipt_on_origin_target_branch_is_fetched_and_accepted() {
+        let (dir, origin) = init_repo_with_origin("worker");
+        let publisher_root = tempfile::tempdir().unwrap();
+        let origin_path = origin.path().to_str().expect("origin path utf-8");
+        git(publisher_root.path(), &["clone", "-q", origin_path, "publisher"]);
+        let publisher = publisher_root.path().join("publisher");
+        std::fs::write(publisher.join("merged-remotely.rs"), "// remote merge\n").unwrap();
+        git(&publisher, &["add", "merged-remotely.rs"]);
+        git(&publisher, &["commit", "-q", "-m", "feat: merged remotely"]);
+        let remote_sha = {
+            let out = Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(&publisher)
+                .output()
+                .expect("git rev-parse");
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+        git(&publisher, &["push", "-q", "origin", "HEAD:main"]);
+
+        assert!(
+            resolve_task_commit_receipt_sha(dir.path(), &remote_sha).is_err(),
+            "precondition: the remote receipt must not already exist locally"
+        );
+        assert!(
+            commit_receipt_repo_binding_error(dir.path(), &remote_sha, "main").is_none(),
+            "the bounded origin/main fetch must make a remote-only receipt resolvable"
         );
     }
 
@@ -14935,7 +14990,7 @@ mod merge_state_gate_tests {
             .expect("git rev-parse");
         let short = String::from_utf8_lossy(&out.stdout).trim().to_string();
         assert!(
-            commit_receipt_repo_binding_error(dir.path(), &short).is_none(),
+            commit_receipt_repo_binding_error(dir.path(), &short, "main").is_none(),
             "short receipt `{short}` must resolve in the bound repo"
         );
     }

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -4741,7 +4741,7 @@ impl CasCore {
         // occurrence is correct for them. The plain `update()` path re-stamps
         // from the store clock, so that branch refreshes both below.
         let mut occurrence = super::supervisor_push::occurrence_from_updated_at(task.updated_at);
-        let lifecycle_outbox = if old_status == TaskStatus::Closed {
+        let lifecycle_outbox = if matches!(old_status, TaskStatus::Closed | TaskStatus::Cancelled) {
             let agent_store = self.open_agent_store().map_err(|error| McpError {
                 code: ErrorCode::INTERNAL_ERROR,
                 message: Cow::from(format!("Failed to prepare reopen lifecycle: {error}")),
@@ -4792,10 +4792,11 @@ impl CasCore {
                 )),
                 data: None,
             })?;
-        } else if old_status == TaskStatus::Closed {
-            cas_store::reopen_closed_task_atomic(
+        } else if matches!(old_status, TaskStatus::Closed | TaskStatus::Cancelled) {
+            cas_store::reopen_terminal_task_atomic(
                 &self.cas_root,
                 &task,
+                old_status,
                 original_updated_at,
                 cas_store::ParentDependencyUpdate::Unchanged,
                 lifecycle_outbox.as_ref(),

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -110,8 +110,7 @@ fn delivery_audit_text_is_portable(value: &str) -> bool {
 fn tmpfs_receipt_path_in_close_reason(reason: &str) -> Option<String> {
     reason.split_whitespace().find_map(|token| {
         let path = token.trim_matches(|ch: char| "(),[]{}<>\"'`".contains(ch));
-        (path.starts_with("/tmp/") || path.starts_with("/private/tmp/"))
-            .then(|| path.to_string())
+        (path.starts_with("/tmp/") || path.starts_with("/private/tmp/")).then(|| path.to_string())
     })
 }
 
@@ -142,9 +141,8 @@ fn validate_completion_artifact_path(
 
     let config = crate::config::Config::load(cas_root)
         .map_err(|error| format!("could not load [factory] artifacts_root: {error}"))?;
-    let configured_root = crate::config::resolved_factory_artifacts_root(
-        config.factory().artifacts_root.as_deref(),
-    );
+    let configured_root =
+        crate::config::resolved_factory_artifacts_root(config.factory().artifacts_root.as_deref());
     let canonical_root = configured_root.canonicalize().map_err(|_| {
         "configured [factory] artifacts_root must exist before a completion artifact can be recorded."
             .to_string()
@@ -179,6 +177,33 @@ struct NegativeResultCloseReceipt {
     rationale: String,
     supervisor_id: String,
     supervisor_name: String,
+}
+
+#[derive(Debug)]
+enum SupervisorAuthorityError {
+    Identity(String),
+    Store(String),
+    NotRegistered { caller_id: String, error: String },
+    NotLive(cas_types::Agent),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TaskCloseDisposition {
+    Delivered,
+    NegativeResult,
+}
+
+impl TaskCloseDisposition {
+    fn requires_delivery_gates(self) -> bool {
+        matches!(self, Self::Delivered)
+    }
+
+    fn terminal_outcome(self) -> cas_types::TaskTerminalOutcome {
+        match self {
+            Self::Delivered => cas_types::TaskTerminalOutcome::Delivered,
+            Self::NegativeResult => cas_types::TaskTerminalOutcome::NegativeResult,
+        }
+    }
 }
 
 fn negative_result_missing_receipts(
@@ -322,27 +347,27 @@ mod delivery_audit_text_tests {
         .unwrap();
 
         validate_completion_artifact_path(cas_root.path(), task_id, artifact.to_str().unwrap())
-        .expect("an existing task-owned artifact is durable receipt metadata");
+            .expect("an existing task-owned artifact is durable receipt metadata");
 
         let wrong_task = artifacts_root.join("cas-other");
         assert!(
             validate_completion_artifact_path(
-            cas_root.path(),
-            task_id,
-            wrong_task.to_str().unwrap(),
-        )
-        .expect_err("another task's artifact must not become this receipt's proof")
+                cas_root.path(),
+                task_id,
+                wrong_task.to_str().unwrap(),
+            )
+            .expect_err("another task's artifact must not become this receipt's proof")
             .contains("<task-id>")
         );
 
         let tmpfs_artifact = tempfile::NamedTempFile::new().unwrap();
         assert!(
             validate_completion_artifact_path(
-            cas_root.path(),
-            task_id,
-            tmpfs_artifact.path().to_str().unwrap(),
-        )
-        .expect_err("an existing tmpfs file is not durable task receipt metadata")
+                cas_root.path(),
+                task_id,
+                tmpfs_artifact.path().to_str().unwrap(),
+            )
+            .expect_err("an existing tmpfs file is not durable task receipt metadata")
             .contains("resolve beneath")
         );
     }
@@ -629,8 +654,11 @@ pub(crate) fn shared_checkout_has_reviewable_changes(scope: SharedCheckoutReview
     match scope.attributable_reviewable_changes {
         Some(true) => true,
         Some(false) => {
-            let declares_no_code_work = matches!(scope.task_type, TaskType::Spike | TaskType::Chore)
-                || scope.execution_note.is_some_and(|note| !note.trim().is_empty());
+            let declares_no_code_work =
+                matches!(scope.task_type, TaskType::Spike | TaskType::Chore)
+                    || scope
+                        .execution_note
+                        .is_some_and(|note| !note.trim().is_empty());
             if declares_no_code_work {
                 false
             } else {
@@ -642,6 +670,29 @@ pub(crate) fn shared_checkout_has_reviewable_changes(scope: SharedCheckoutReview
 }
 
 impl CasCore {
+    /// Resolve the authority shared by every supervisor-owned non-delivery
+    /// outcome. Callers map the typed failure into operation-specific text,
+    /// but identity, registration, role, and liveness checks are identical.
+    fn resolve_live_supervisor_authority(
+        &self,
+    ) -> Result<cas_types::Agent, SupervisorAuthorityError> {
+        let caller_id = self
+            .get_registered_agent_id_read_only()
+            .map_err(|error| SupervisorAuthorityError::Identity(error.to_string()))?;
+        let caller = self
+            .open_agent_store()
+            .map_err(|error| SupervisorAuthorityError::Store(error.to_string()))?
+            .get(&caller_id)
+            .map_err(|error| SupervisorAuthorityError::NotRegistered {
+                caller_id,
+                error: error.to_string(),
+            })?;
+        if caller.role != cas_types::AgentRole::Supervisor || !caller.is_alive() {
+            return Err(SupervisorAuthorityError::NotLive(caller));
+        }
+        Ok(caller)
+    }
+
     fn validate_negative_result_close(
         &self,
         task_id: &str,
@@ -652,30 +703,21 @@ impl CasCore {
             return Ok(None);
         };
 
-        let caller_id = self.get_registered_agent_id_read_only().map_err(|error| {
-            format!(
+        let caller = self.resolve_live_supervisor_authority().map_err(|error| match error {
+            SupervisorAuthorityError::Identity(error) => format!(
                 "NEGATIVE RESULT CLOSE REJECTED: negative_result=true requires an authenticated registered supervisor; caller identity could not be resolved ({error})."
-            )
-        })?;
-        let caller = self
-            .open_agent_store()
-            .map_err(|error| {
-                format!(
-                    "NEGATIVE RESULT CLOSE REJECTED: supervisor authority could not be checked ({error})."
-                )
-            })?
-            .get(&caller_id)
-            .map_err(|error| {
-                format!(
-                    "NEGATIVE RESULT CLOSE REJECTED: caller `{caller_id}` is not a registered supervisor ({error})."
-                )
-            })?;
-        if caller.role != cas_types::AgentRole::Supervisor || !caller.is_alive() {
-            return Err(format!(
+            ),
+            SupervisorAuthorityError::Store(error) => format!(
+                "NEGATIVE RESULT CLOSE REJECTED: supervisor authority could not be checked ({error})."
+            ),
+            SupervisorAuthorityError::NotRegistered { caller_id, error } => format!(
+                "NEGATIVE RESULT CLOSE REJECTED: caller `{caller_id}` is not a registered supervisor ({error})."
+            ),
+            SupervisorAuthorityError::NotLive(caller) => format!(
                 "NEGATIVE RESULT CLOSE REJECTED: only a live registered supervisor may use negative_result=true. Caller `{}` has role {}. The normal MERGE REQUIRED delivery gate remains in force.",
                 caller.name, caller.role
-            ));
-        }
+            ),
+        })?;
 
         let missing = negative_result_missing_receipts(req, negative_result);
         if !missing.is_empty() {
@@ -718,6 +760,25 @@ impl CasCore {
             supervisor_id: caller.id,
             supervisor_name: caller.name,
         }))
+    }
+
+    fn cancellation_supervisor(&self) -> Result<cas_types::Agent, String> {
+        self.resolve_live_supervisor_authority()
+            .map_err(|error| match error {
+                SupervisorAuthorityError::Identity(error) => format!(
+                    "TASK CANCEL REJECTED: cancel requires an authenticated registered supervisor; caller identity could not be resolved ({error})."
+                ),
+                SupervisorAuthorityError::Store(error) => format!(
+                    "TASK CANCEL REJECTED: supervisor authority could not be checked ({error})."
+                ),
+                SupervisorAuthorityError::NotRegistered { caller_id, error } => format!(
+                    "TASK CANCEL REJECTED: caller `{caller_id}` is not a registered supervisor ({error})."
+                ),
+                SupervisorAuthorityError::NotLive(caller) => format!(
+                    "TASK CANCEL REJECTED: only a live registered supervisor may cancel or reopen cancelled work. Caller `{}` has role {}.",
+                    caller.name, caller.role
+                ),
+            })
     }
 
     async fn submit_worker_completion_receipt(
@@ -877,23 +938,17 @@ impl CasCore {
         // outcome. New receipts still validate before any state is written.
         if existing_delivery.is_none()
             && let Some(artifact_path) = input.artifact_path.as_deref()
-            && let Err(message) = validate_completion_artifact_path(
-                &self.cas_root,
-                &task.id,
-                artifact_path,
-            )
+            && let Err(message) =
+                validate_completion_artifact_path(&self.cas_root, &task.id, artifact_path)
         {
             return Ok(Self::tool_error(format!(
                 "DELIVERY RECEIPT REJECTED: invalid artifact_path: {message}"
             )));
         }
-        if existing_delivery
-            .as_ref()
-            .is_some_and(|(_, transaction)| {
-                transaction.state == cas_types::WorkerDeliveryState::Delivered
-                    && task.status != TaskStatus::Closed
-            })
-        {
+        if existing_delivery.as_ref().is_some_and(|(_, transaction)| {
+            transaction.state == cas_types::WorkerDeliveryState::Delivered
+                && task.status != TaskStatus::Closed
+        }) {
             return Ok(Self::tool_error(format!(
                 "DELIVERY RECEIPT REJECTED: receipt {} belongs to a terminal Delivered proof cycle, but task {} has been reopened. Submit a fresh cycle-bound receipt after completing and proving the new work. Task, deliverables, lease, delivery, dispatch, verdict, and events are unchanged.",
                 receipt.id, task.id
@@ -1229,47 +1284,47 @@ impl CasCore {
             // cas-ec74: `updated_at` is store-owned; derive the occurrence from
             // the stamp the store persisted, not from the pre-write value.
             Ok(persisted_at) => {
-            // cas-062d / cas-17e4: durable outbox for AwaitingMerge + close-rejected.
-            let actor = self.get_agent_id().unwrap_or_else(|_| "unknown".into());
-            let actor_name = self
-                .open_agent_store()
-                .ok()
-                .and_then(|s| s.get(&actor).ok())
-                .map(|a| a.name)
-                .unwrap_or_else(|| actor.clone());
-            let occurrence = super::supervisor_push::occurrence_from_updated_at(persisted_at);
-            if let Err(e) = self.push_task_lifecycle(
-                &task.id,
-                &task.title,
-                task.status,
-                TaskStatus::AwaitingMerge,
-                &actor_name,
-                Some(reason),
-                super::supervisor_push::LifecycleTransition::AwaitingMerge,
-                &occurrence,
-            ) {
-                tracing::error!(
-                    task_id = %task.id,
-                    error = %e,
-                    "supervisor lifecycle push failed after AwaitingMerge park (task remains AwaitingMerge; replay outbox)"
-                );
-            }
-            if let Err(e) = self.push_task_lifecycle(
-                &task.id,
-                &task.title,
-                task.status,
-                TaskStatus::AwaitingMerge,
-                &actor_name,
-                Some(reason),
-                super::supervisor_push::LifecycleTransition::CloseRejected,
-                &occurrence,
-            ) {
-                tracing::error!(
-                    task_id = %task.id,
-                    error = %e,
-                    "supervisor lifecycle push failed after close rejection (task remains AwaitingMerge; replay outbox)"
-                );
-            }
+                // cas-062d / cas-17e4: durable outbox for AwaitingMerge + close-rejected.
+                let actor = self.get_agent_id().unwrap_or_else(|_| "unknown".into());
+                let actor_name = self
+                    .open_agent_store()
+                    .ok()
+                    .and_then(|s| s.get(&actor).ok())
+                    .map(|a| a.name)
+                    .unwrap_or_else(|| actor.clone());
+                let occurrence = super::supervisor_push::occurrence_from_updated_at(persisted_at);
+                if let Err(e) = self.push_task_lifecycle(
+                    &task.id,
+                    &task.title,
+                    task.status,
+                    TaskStatus::AwaitingMerge,
+                    &actor_name,
+                    Some(reason),
+                    super::supervisor_push::LifecycleTransition::AwaitingMerge,
+                    &occurrence,
+                ) {
+                    tracing::error!(
+                        task_id = %task.id,
+                        error = %e,
+                        "supervisor lifecycle push failed after AwaitingMerge park (task remains AwaitingMerge; replay outbox)"
+                    );
+                }
+                if let Err(e) = self.push_task_lifecycle(
+                    &task.id,
+                    &task.title,
+                    task.status,
+                    TaskStatus::AwaitingMerge,
+                    &actor_name,
+                    Some(reason),
+                    super::supervisor_push::LifecycleTransition::CloseRejected,
+                    &occurrence,
+                ) {
+                    tracing::error!(
+                        task_id = %task.id,
+                        error = %e,
+                        "supervisor lifecycle push failed after close rejection (task remains AwaitingMerge; replay outbox)"
+                    );
+                }
             }
         }
 
@@ -1492,7 +1547,11 @@ impl CasCore {
                 Ok(receipt) => receipt,
                 Err(message) => return Ok(Self::tool_error(message)),
             };
-        let negative_result_close = negative_result_receipt.is_some();
+        let close_disposition = if negative_result_receipt.is_some() {
+            TaskCloseDisposition::NegativeResult
+        } else {
+            TaskCloseDisposition::Delivered
+        };
 
         if let Some(raw_receipt) = completion_receipt.as_deref() {
             if let Err(message) = super::proof_scope::guard_task_proof_scope(
@@ -1521,6 +1580,12 @@ impl CasCore {
                 "Already closed: {} - {} (closed at {}). This call did not re-close \
                  the task; closed_at and notes were left unchanged.",
                 req.id, task.title, closed_at_msg
+            )));
+        }
+        if task.status == TaskStatus::Cancelled {
+            return Ok(Self::tool_error(format!(
+                "TASK CLOSE REJECTED: {} is cancelled without delivery, not closed/delivered. Reopen it first if work should resume; otherwise leave its cancellation history intact.",
+                task.id
             )));
         }
 
@@ -1962,7 +2027,10 @@ impl CasCore {
             return Ok(Self::tool_error(message));
         }
 
-        if !negative_result_close && task.task_type != TaskType::Epic && task.assignee.is_some() {
+        if close_disposition.requires_delivery_gates()
+            && task.task_type != TaskType::Epic
+            && task.assignee.is_some()
+        {
             match run_factory_branch_merge_gate_with_attribution(
                 &task,
                 &req,
@@ -2113,7 +2181,7 @@ impl CasCore {
         // close without verification. cas-3bd4: compute the reason as a typed
         // enum so the response message cites the actual state instead of
         // defaulting to "assignee inactive" for every lookup failure.
-        let skip_reason = if negative_result_close {
+        let skip_reason = if !close_disposition.requires_delivery_gates() {
             VerificationSkipReason::SupervisorNegativeResult
         } else if verification_enabled && is_supervisor_from_env() {
             if task.task_type == TaskType::Epic && task.epic_verification_owner.is_some() {
@@ -2657,10 +2725,7 @@ impl CasCore {
                             // failure-atomic instead of leaving a pending task without a
                             // dispatch.
                             let proof_worktree = self
-                                .resolve_worker_worktree_path(
-                                    &task,
-                                    declared_repo_context.as_ref(),
-                                )
+                                .resolve_worker_worktree_path(&task, declared_repo_context.as_ref())
                                 .map_err(|error| McpError {
                                     code: ErrorCode::INVALID_PARAMS,
                                     message: Cow::from(format!(
@@ -2931,7 +2996,9 @@ impl CasCore {
 
         // Check for worktree that needs merging (only for epics or tasks with worktrees)
         // This check happens AFTER verification passes
-        if !negative_result_close && let Some(worktree_id) = &task.worktree_id {
+        if close_disposition.requires_delivery_gates()
+            && let Some(worktree_id) = &task.worktree_id
+        {
             let config = self.load_config();
 
             // Only trigger jail if worktrees are enabled and require_merge_on_epic_close is true
@@ -3005,7 +3072,7 @@ impl CasCore {
         // (task-verifier) as the quality bar — those gates operate on
         // commits / review envelopes, not on working-tree state, so
         // they're safe to run in a shared worktree.
-        let bypass_close_gates = negative_result_close
+        let bypass_close_gates = !close_disposition.requires_delivery_gates()
             || (req.bypass_code_review.unwrap_or(false) && is_supervisor_from_env());
         let worker_worktree_path =
             match self.resolve_worker_worktree_path(&task, declared_repo_context.as_ref()) {
@@ -3016,7 +3083,7 @@ impl CasCore {
         // every close path, independent of review owner/depth/bypass. This
         // keeps normal close aligned with direct update-to-closed: neither
         // may select a process-cwd or merely most-recent worker checkout.
-        let declared_hook_evidence = if negative_result_close {
+        let declared_hook_evidence = if !close_disposition.requires_delivery_gates() {
             None
         } else if let Some(context) = declared_repo_context.as_ref() {
             match run_declared_pre_close_hook(
@@ -3219,7 +3286,9 @@ impl CasCore {
         // to a legacy `git diff HEAD` path on the main worktree — that
         // path has been deleted in this commit because it reintroduced
         // the exact wrong-worktree-scope bug cas-bc1b was filed to fix.
-        if !negative_result_close && task.execution_note.as_deref() == Some("additive-only") {
+        if close_disposition.requires_delivery_gates()
+            && task.execution_note.as_deref() == Some("additive-only")
+        {
             if let Some(worker_wt) = worker_worktree_path.as_ref() {
                 // cas-7efe: use the single close-time resolver instead of
                 // an independent worktree-only lookup that fell back to a
@@ -3576,7 +3645,7 @@ impl CasCore {
         //
         // Cases 1/3/4 are handled here: docs-only, ambiguous zero-commit,
         // and deliberate no-code respectively.
-        let gate_outcome = if negative_result_close {
+        let gate_outcome = if !close_disposition.requires_delivery_gates() {
             CodeReviewGateOutcome::Proceed
         } else if depth_light {
             // cas-6538: light tasks treat the P0 code-review gate as satisfied.
@@ -3676,6 +3745,7 @@ impl CasCore {
         // cas-062d: capture pre-close status for durable lifecycle push identity.
         let old_status_for_lifecycle = task.status;
         task.status = TaskStatus::Closed;
+        task.terminal_outcome = Some(close_disposition.terminal_outcome());
         task.closed_at = Some(now);
         task.updated_at = now;
         task.deliverables.pre_close_hook = declared_hook_evidence;
@@ -4050,7 +4120,7 @@ impl CasCore {
                         let subtasks = task_store.get_subtasks(&parent.id).unwrap_or_default();
 
                         // Check if all subtasks are now closed
-                        let all_closed = subtasks.iter().all(|t| t.status == TaskStatus::Closed);
+                        let all_closed = subtasks.iter().all(Task::is_terminal);
 
                         if all_closed && !subtasks.is_empty() {
                             // In factory mode, workers shouldn't close epics - supervisor handles that
@@ -4386,6 +4456,130 @@ impl CasCore {
         VerificationSkipReason::AssigneeUnknown
     }
 
+    /// End planned work without claiming a delivery.
+    pub async fn cas_task_cancel(
+        &self,
+        Parameters(req): Parameters<TaskCancelRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let supervisor = self
+            .cancellation_supervisor()
+            .map_err(|message| Self::error(ErrorCode::INVALID_PARAMS, message))?;
+        let reason = req.reason.trim();
+        if reason.is_empty() {
+            return Err(Self::error(
+                ErrorCode::INVALID_PARAMS,
+                "TASK CANCEL REJECTED: reason is required and must not be blank.",
+            ));
+        }
+        let superseded_by = req
+            .superseded_by
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        if let Some(pointer) = superseded_by.as_deref()
+            && (pointer.len() > 512 || !delivery_audit_text_is_portable(pointer))
+        {
+            return Err(Self::error(
+                ErrorCode::INVALID_PARAMS,
+                "TASK CANCEL REJECTED: superseded_by must be portable task/commit/PR text no longer than 512 bytes, without local paths, control characters, or secret-shaped values.",
+            ));
+        }
+
+        let task_store = self.open_task_store()?;
+        let mut task = task_store.get(&req.id).map_err(|error| {
+            Self::error(
+                ErrorCode::INVALID_PARAMS,
+                format!("Task not found: {error}"),
+            )
+        })?;
+        if task.status == TaskStatus::Cancelled {
+            return Ok(Self::success(format!(
+                "Already cancelled: {} - {}. This call did not rewrite its reason or history.",
+                task.id, task.title
+            )));
+        }
+        if task.status == TaskStatus::Closed {
+            return Err(Self::error(
+                ErrorCode::INVALID_PARAMS,
+                format!(
+                    "TASK CANCEL REJECTED: task {} is already closed as a completed outcome. Reopen it first only if that outcome was mistaken.",
+                    task.id
+                ),
+            ));
+        }
+        if task.task_type == TaskType::Epic {
+            let nonterminal: Vec<String> = task_store
+                .get_subtasks(&task.id)
+                .map_err(|error| {
+                    Self::error(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("TASK CANCEL REJECTED: failed to inspect epic children: {error}"),
+                    )
+                })?
+                .into_iter()
+                .filter(|child| !child.is_terminal())
+                .map(|child| child.id)
+                .collect();
+            if !nonterminal.is_empty() {
+                return Err(Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    format!(
+                        "TASK CANCEL REJECTED: epic {} still has non-terminal child task(s): {}. Cancel or complete every child first.",
+                        task.id,
+                        nonterminal.join(", ")
+                    ),
+                ));
+            }
+        }
+
+        let now = chrono::Utc::now();
+        let pointer_note = superseded_by
+            .as_deref()
+            .map(|pointer| format!(" Superseded by: {pointer}."))
+            .unwrap_or_default();
+        let cancel_note = format!(
+            "[{}] CANCELLED: supervisor {} ({}) ended this task without delivery. Reason: {}{}",
+            now.format("%Y-%m-%d %H:%M"),
+            supervisor.name,
+            supervisor.id,
+            reason,
+            pointer_note,
+        );
+        if task.notes.is_empty() {
+            task.notes = cancel_note;
+        } else {
+            task.notes = format!("{}\n\n{}", task.notes, cancel_note);
+        }
+        task.status = TaskStatus::Cancelled;
+        task.closed_at = Some(now);
+        task.close_reason = Some(reason.to_string());
+        task.terminal_outcome = Some(cas_types::TaskTerminalOutcome::Cancelled {
+            superseded_by: superseded_by.clone(),
+        });
+        task.pending_verification = false;
+        task.pending_worktree_merge = false;
+        task.updated_at = task_store.update(&task).map_err(|error| {
+            Self::error(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to cancel task: {error}"),
+            )
+        })?;
+
+        if let Ok(agent_store) = self.open_agent_store() {
+            let _ = agent_store.release_lease_for_task(&task.id, "Task cancelled without delivery");
+        }
+
+        let pointer = superseded_by
+            .as_deref()
+            .map(|value| format!("; superseded by {value}"))
+            .unwrap_or_default();
+        Ok(Self::success(format!(
+            "Cancelled task without delivery: {} - {} (reason: {}{})",
+            task.id, task.title, reason, pointer
+        )))
+    }
+
     /// Reopen a closed/blocked task, or reset one exact approved task-only scope.
     ///
     /// cas-3c23: reopening a Closed/merged task is a supervisor-only action.
@@ -4417,7 +4611,23 @@ impl CasCore {
         &self,
         Parameters(req): Parameters<TaskReopenRequest>,
     ) -> Result<CallToolResult, McpError> {
-        if !is_supervisor_from_env() {
+        let task_store = self.open_task_store()?;
+
+        let mut task = task_store.get(&req.id).map_err(|e| McpError {
+            code: ErrorCode::INVALID_PARAMS,
+            message: Cow::from(format!("Task not found: {e}")),
+            data: None,
+        })?;
+        let original_updated_at = task.updated_at;
+
+        if task.status == TaskStatus::Cancelled {
+            self.cancellation_supervisor().map_err(|message| {
+                Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    message.replace("TASK CANCEL", "TASK REOPEN"),
+                )
+            })?;
+        } else if !is_supervisor_from_env() {
             return Err(Self::error(
                 ErrorCode::INVALID_PARAMS,
                 format!(
@@ -4429,15 +4639,6 @@ impl CasCore {
                 ),
             ));
         }
-
-        let task_store = self.open_task_store()?;
-
-        let mut task = task_store.get(&req.id).map_err(|e| McpError {
-            code: ErrorCode::INVALID_PARAMS,
-            message: Cow::from(format!("Task not found: {e}")),
-            data: None,
-        })?;
-        let original_updated_at = task.updated_at;
 
         let fresh_scope_dispatch =
             super::proof_scope::close_authoritative_task_proof_dispatch(&self.cas_root, &task.id)
@@ -4452,6 +4653,7 @@ impl CasCore {
                 })?;
 
         if task.status != TaskStatus::Closed
+            && task.status != TaskStatus::Cancelled
             && task.status != TaskStatus::Blocked
             && fresh_scope_dispatch.is_none()
         {
@@ -4482,13 +4684,14 @@ impl CasCore {
 
         let old_status = task.status;
         task.status = TaskStatus::Open;
-        if old_status == TaskStatus::Closed {
+        if matches!(old_status, TaskStatus::Closed | TaskStatus::Cancelled) {
             // cas-cd24: closed-specific resets stay gated to the closed
             // path so Closed→Open behavior is byte-for-byte unchanged
             // (AC2) — a Blocked task was never closed, so `closed_at` is
             // already `None` and clearing `factory_branch_anchor` here
             // would be a no-op at best, dead code at worst.
             task.closed_at = None;
+            task.terminal_outcome = None;
             // cas-cf64 (P2, anchor freshness — Scenario B): a stale
             // `factory_branch_anchor` from a PRIOR close/park cycle must not
             // survive a reopen. Without this, `run_factory_branch_merge_gate`
@@ -5894,7 +6097,8 @@ pub(crate) fn run_factory_branch_merge_gate_with_attribution(
     // this branch's stranded work. Unknowable git state keeps the local
     // measurement (fail closed), and a partially-merged branch now reports the
     // real remainder instead of stale-base arithmetic.
-    let remote_aware_stranded = count_unmerged_against_targets(repo_path, commit_ish, parent_branch);
+    let remote_aware_stranded =
+        count_unmerged_against_targets(repo_path, commit_ish, parent_branch);
     if remote_aware_stranded == Some(0) {
         return MergeStateGateOutcome::Proceed;
     }
@@ -6036,16 +6240,12 @@ pub(crate) fn run_factory_branch_merge_gate_with_attribution(
     // reproduced under a test fixture, so a future rejection must state the
     // exact ref state this invocation saw. This is diagnostic-only: all gate
     // decisions above remain untouched.
-    let local_target_tip = resolve_branch_sha(repo_path, parent_branch)
-        .unwrap_or_else(|| "unresolved".to_string());
+    let local_target_tip =
+        resolve_branch_sha(repo_path, parent_branch).unwrap_or_else(|| "unresolved".to_string());
     let origin_target_tip = resolve_branch_sha(repo_path, &origin_parent_branch)
         .unwrap_or_else(|| "absent".to_string());
-    let unreachable_commits = unmerged_commit_shas_against_targets(
-        repo_path,
-        commit_ish,
-        parent_branch,
-        12,
-    );
+    let unreachable_commits =
+        unmerged_commit_shas_against_targets(repo_path, commit_ish, parent_branch, 12);
     let unreachable_display = if unreachable_commits.is_empty() {
         "unresolved".to_string()
     } else {
@@ -6408,11 +6608,21 @@ fn unmerged_commit_shas_against_targets(
 
     let origin_parent = format!("origin/{parent_branch}");
     let limit = format!("--max-count={limit}");
-    let mut args = vec!["rev-list", limit.as_str(), commit_ish, "--not", parent_branch];
+    let mut args = vec![
+        "rev-list",
+        limit.as_str(),
+        commit_ish,
+        "--not",
+        parent_branch,
+    ];
     if git_ref_exists(repo_path, &origin_parent) {
         args.push(origin_parent.as_str());
     }
-    let Ok(out) = Command::new("git").args(&args).current_dir(repo_path).output() else {
+    let Ok(out) = Command::new("git")
+        .args(&args)
+        .current_dir(repo_path)
+        .output()
+    else {
         return Vec::new();
     };
     if !out.status.success() {
@@ -7413,13 +7623,15 @@ fn validate_pre_close_worktree(
     // current `project:` selector. The repository resolver already treats a
     // checkout as the full set of identities it answers to; retain that same
     // equivalence here instead of reintroducing a raw-string close-path gate.
-    let selector_matches = crate::mcp::tools::core::task::repo_context::canonical_selector(
-        &actual.repo_selector,
-    ) == crate::mcp::tools::core::task::repo_context::canonical_selector(&expected.repo_selector)
-        || crate::mcp::tools::core::task::repo_context::repo_answers_to(
-            &actual.repo_root,
-            &expected.repo_selector,
-        );
+    let selector_matches =
+        crate::mcp::tools::core::task::repo_context::canonical_selector(&actual.repo_selector)
+            == crate::mcp::tools::core::task::repo_context::canonical_selector(
+                &expected.repo_selector,
+            )
+            || crate::mcp::tools::core::task::repo_context::repo_answers_to(
+                &actual.repo_root,
+                &expected.repo_selector,
+            );
     if !selector_matches || actual.git_common_dir != expected.git_common_dir {
         return Err(format!(
             "PRE-CLOSE HOOK CONTEXT REJECTED: task targets repository `{}`, but its recorded \
@@ -8578,18 +8790,18 @@ pub(crate) fn collect_epic_branch_statuses(
             // durable close evidence, so neither the historical parked branch
             // nor the assignee's reusable live lane belongs in parent-epic
             // delivery accounting for this child.
-            let negative_result = t.deliverables.negative_result.is_some();
-            let parked_branch = (!negative_result)
+            let has_delivery = t.has_delivery_to_integrate();
+            let parked_branch = has_delivery
                 .then(|| t.deliverables.parked_branch.clone())
                 .flatten();
-            let live_factory_branch = (!negative_result)
+            let live_factory_branch = has_delivery
                 .then(|| {
                     t.assignee
-                .as_ref()
+                        .as_ref()
                         .map(|assignee| format!("factory/{assignee}"))
                 })
                 .flatten();
-            let recorded_anchor = (!negative_result)
+            let recorded_anchor = has_delivery
                 .then_some(t.deliverables.factory_branch_anchor.as_deref())
                 .flatten();
             let resolved_anchor =
@@ -9120,11 +9332,12 @@ pub(crate) fn epic_subtask_receipts_are_clean(subtasks: &[Task]) -> bool {
     }
 
     subtasks.iter().all(|t| {
-        t.deliverables
-            .review_envelope
-            .as_deref()
-            .map(worker_review_envelope_is_clean)
-            .unwrap_or(false)
+        !t.has_delivery_to_integrate()
+            || t.deliverables
+                .review_envelope
+                .as_deref()
+                .map(worker_review_envelope_is_clean)
+                .unwrap_or(false)
     })
 }
 
@@ -10109,7 +10322,14 @@ mod additive_only_tests {
         // what a supervisor's `worktree_merge` produces.
         git(
             p,
-            &["merge", "-q", "--no-ff", "-m", "Merge factory/worker", "factory/worker"],
+            &[
+                "merge",
+                "-q",
+                "--no-ff",
+                "-m",
+                "Merge factory/worker",
+                "factory/worker",
+            ],
         );
         let merge_sha = resolve_branch_sha(p, "HEAD").expect("merge sha");
 
@@ -10160,12 +10380,8 @@ mod additive_only_tests {
         assert!(note.contains(&worker_tip), "note must name the tip: {note}");
 
         // An abbreviated receipt is the same fact.
-        let abbrev = classify_commit_receipt(
-            repo.path(),
-            Some(&worker_tip),
-            &merge_sha[..8],
-            "main",
-        );
+        let abbrev =
+            classify_commit_receipt(repo.path(), Some(&worker_tip), &merge_sha[..8], "main");
         assert!(abbrev.is_merge_of_worker_tip(), "{abbrev:?}");
     }
 
@@ -10178,8 +10394,7 @@ mod additive_only_tests {
 
         // A commit that exists but predates (does not contain) the worker's
         // delivery — the misattributed-diff shape.
-        let unrelated =
-            resolve_branch_sha(repo.path(), "factory/worker~1").expect("parent commit");
+        let unrelated = resolve_branch_sha(repo.path(), "factory/worker~1").expect("parent commit");
         let provenance =
             classify_commit_receipt(repo.path(), Some(&worker_tip), &unrelated, "main");
         assert_eq!(
@@ -10775,9 +10990,7 @@ pub(crate) fn run_declared_pre_close_hook(
     let normalized_receipt = commit_receipt
         .map(|receipt| resolve_task_commit_receipt_sha(receipt_repo, receipt))
         .transpose()
-        .map_err(|error| {
-            format!("PRE-CLOSE HOOK CONTEXT REJECTED: commit_receipt {error}")
-        })?;
+        .map_err(|error| format!("PRE-CLOSE HOOK CONTEXT REJECTED: commit_receipt {error}"))?;
     let (execution_root, worktree_branch, task_tip) = match worker_worktree_path {
         Some(path) => {
             let branch = git_branch_name(path).ok_or_else(|| {
@@ -14769,7 +14982,11 @@ mod merge_state_gate_tests {
     /// Advance `origin/main` beyond the local `main` ref, optionally merging
     /// the worker's branch into it. The local `main` ref is deliberately left
     /// where it was — that staleness is the whole bug.
-    fn advance_origin_main(dir: &std::path::Path, extra_commits: usize, merge_factory: Option<&str>) {
+    fn advance_origin_main(
+        dir: &std::path::Path,
+        extra_commits: usize,
+        merge_factory: Option<&str>,
+    ) {
         git(dir, &["checkout", "-q", "-b", "origin-work", "main"]);
         for i in 0..extra_commits {
             let name = format!("other_{i}.rs");
@@ -14778,7 +14995,10 @@ mod merge_state_gate_tests {
             git(dir, &["commit", "-q", "-m", &format!("feat: other {i}")]);
         }
         if let Some(branch) = merge_factory {
-            git(dir, &["merge", "-q", "--no-ff", branch, "-m", "merge worker"]);
+            git(
+                dir,
+                &["merge", "-q", "--no-ff", branch, "-m", "merge worker"],
+            );
         }
         git(dir, &["push", "-q", "origin", "origin-work:main"]);
         git(dir, &["fetch", "-q", "origin"]);
@@ -16462,7 +16682,9 @@ mod system_b_worktree_resolution_tests {
         assert!(status.success(), "git {args:?} failed");
     }
 
-    fn pinned_repo_context_with_remote(dir: &std::path::Path) -> crate::mcp::tools::core::task::repo_context::RepoContext {
+    fn pinned_repo_context_with_remote(
+        dir: &std::path::Path,
+    ) -> crate::mcp::tools::core::task::repo_context::RepoContext {
         git(dir, &["init", "-q", "-b", "main"]);
         git(
             dir,
@@ -16962,6 +17184,39 @@ mod epic_status_gate_tests {
         ));
     }
 
+    #[test]
+    fn cancelled_child_satisfies_epic_branch_close_gate_without_counting_delivery() {
+        let dir = init_epic_repo(&[("cancelled-worker", 1)]);
+        let mut cancelled = child(
+            "cas-cancelled",
+            TaskStatus::Cancelled,
+            Some("cancelled-worker"),
+        );
+        cancelled.deliverables.factory_branch_anchor =
+            resolve_branch_sha(dir.path(), "factory/cancelled-worker");
+        cancelled.terminal_outcome = Some(cas_types::TaskTerminalOutcome::Cancelled {
+            superseded_by: Some("https://github.com/example/repo/pull/258".into()),
+        });
+
+        assert!(!cancelled.counts_as_delivered());
+        assert!(!cancelled.has_delivery_to_integrate());
+        let statuses =
+            collect_epic_branch_statuses(std::slice::from_ref(&cancelled), "main", dir.path());
+        assert_eq!(statuses[0].unmerged_count, 0);
+        assert!(statuses[0].factory_branch.is_none());
+        assert!(statuses[0].recorded_anchor.is_none());
+        assert!(matches!(
+            run_epic_close_merge_gate(
+                &epic("cas-epic"),
+                &base_req("cas-epic"),
+                "main",
+                dir.path(),
+                &[cancelled],
+            ),
+            EpicCloseGateOutcome::Proceed
+        ));
+    }
+
     // --- cas-2a99 (GH #131): dual-ref reads + spawn-base-aware anchor proof --
     //
     // Incident shape: a child's work merged into the epic, then the worker shut
@@ -17304,8 +17559,7 @@ mod epic_status_gate_tests {
         let statuses = collect_epic_branch_statuses(&subtasks, "main", dir.path());
 
         let plain = render_epic_status_report("cas-epic", "main", &statuses);
-        let empty_stack =
-            render_epic_status_report_with_stack("cas-epic", "main", &statuses, &[]);
+        let empty_stack = render_epic_status_report_with_stack("cas-epic", "main", &statuses, &[]);
 
         assert_eq!(
             plain, empty_stack,
@@ -19052,7 +19306,10 @@ mod zero_change_close_tests {
         git(dir.path(), &["checkout", "-q", "main"]);
         std::fs::write(dir.path().join("epic_progress.txt"), "epic moved on\n").unwrap();
         git(dir.path(), &["add", "epic_progress.txt"]);
-        git(dir.path(), &["commit", "-q", "-m", "unrelated epic progress"]);
+        git(
+            dir.path(),
+            &["commit", "-q", "-m", "unrelated epic progress"],
+        );
         git(dir.path(), &["checkout", "-q", "factory/test-worker"]);
         git(dir.path(), &["merge", "--no-ff", "-m", "sync only", "main"]);
 
@@ -19134,7 +19391,10 @@ mod zero_change_close_tests {
         git(dir.path(), &["checkout", "-q", "main"]);
         std::fs::write(dir.path().join("epic_progress.txt"), "epic moved on\n").unwrap();
         git(dir.path(), &["add", "epic_progress.txt"]);
-        git(dir.path(), &["commit", "-q", "-m", "unrelated epic progress"]);
+        git(
+            dir.path(),
+            &["commit", "-q", "-m", "unrelated epic progress"],
+        );
         git(dir.path(), &["checkout", "-q", "factory/test-worker"]);
         git(dir.path(), &["merge", "--no-ff", "-m", "sync only", "main"]);
 
@@ -19172,7 +19432,10 @@ mod zero_change_close_tests {
         git(dir.path(), &["checkout", "-q", "main"]);
         std::fs::write(dir.path().join("epic_progress.txt"), "epic moved on\n").unwrap();
         git(dir.path(), &["add", "epic_progress.txt"]);
-        git(dir.path(), &["commit", "-q", "-m", "unrelated epic progress"]);
+        git(
+            dir.path(),
+            &["commit", "-q", "-m", "unrelated epic progress"],
+        );
         git(dir.path(), &["checkout", "-q", "factory/test-worker"]);
         git(dir.path(), &["merge", "--no-ff", "-m", "sync only", "main"]);
 
@@ -19267,7 +19530,10 @@ mod zero_change_close_tests {
         let dir = init_worker_repo();
         std::fs::write(dir.path().join("short.rs"), "pub fn short_receipt() {}\n").unwrap();
         git(dir.path(), &["add", "short.rs"]);
-        git(dir.path(), &["commit", "-q", "-m", "fix: short receipt work"]);
+        git(
+            dir.path(),
+            &["commit", "-q", "-m", "fix: short receipt work"],
+        );
         let full_receipt = head_sha(dir.path());
         let short_receipt = &full_receipt[..8];
 
@@ -19292,26 +19558,18 @@ mod zero_change_close_tests {
             target_branch: "main".to_string(),
         };
         let task = Task::new("cas-77af".to_string(), "short receipt".to_string());
-        let evidence = run_declared_pre_close_hook(
-            &task,
-            &context,
-            Some(dir.path()),
-            Some(short_receipt),
-        )
-        .expect("short receipt must select a valid close-hook scope");
+        let evidence =
+            run_declared_pre_close_hook(&task, &context, Some(dir.path()), Some(short_receipt))
+                .expect("short receipt must select a valid close-hook scope");
         assert_eq!(
             evidence.task_tip.as_deref(),
             Some(full_receipt.as_str()),
             "durable hook evidence must store the canonical full object ID"
         );
 
-        let note = validate_task_commit_receipt(
-            dir.path(),
-            short_receipt,
-            "main",
-            &test_receipt_window(),
-        )
-        .expect("an unambiguous Git abbreviation must be valid receipt input");
+        let note =
+            validate_task_commit_receipt(dir.path(), short_receipt, "main", &test_receipt_window())
+                .expect("an unambiguous Git abbreviation must be valid receipt input");
         assert!(note.contains(short_receipt), "{note}");
         assert!(note.contains(&full_receipt), "{note}");
         assert!(
@@ -19336,13 +19594,9 @@ mod zero_change_close_tests {
         let full_receipt = head_sha(dir.path());
         let short_receipt = &full_receipt[..8];
 
-        let reason = validate_task_commit_receipt(
-            dir.path(),
-            short_receipt,
-            "main",
-            &test_receipt_window(),
-        )
-        .expect_err("a real but unmerged commit must remain invalid close evidence");
+        let reason =
+            validate_task_commit_receipt(dir.path(), short_receipt, "main", &test_receipt_window())
+                .expect_err("a real but unmerged commit must remain invalid close evidence");
         assert!(reason.contains("not an ancestor of main"), "{reason}");
         assert!(!reason.contains("40- or 64-character"), "{reason}");
 
@@ -19366,17 +19620,16 @@ mod zero_change_close_tests {
         .unwrap()
         .trim()
         .to_string();
-        let tree_error = validate_task_commit_receipt(
-            dir.path(),
-            &tree,
-            "main",
-            &test_receipt_window(),
-        )
-        .expect_err("a tree object is not immutable commit evidence");
+        let tree_error =
+            validate_task_commit_receipt(dir.path(), &tree, "main", &test_receipt_window())
+                .expect_err("a tree object is not immutable commit evidence");
         assert!(tree_error.contains("tree object"), "{tree_error}");
         assert!(tree_error.contains("not a commit"), "{tree_error}");
 
-        git(dir.path(), &["tag", "-a", "receipt-tag", "-m", "receipt tag"]);
+        git(
+            dir.path(),
+            &["tag", "-a", "receipt-tag", "-m", "receipt tag"],
+        );
         let tag = String::from_utf8(
             Command::new("git")
                 .args(["rev-parse", "receipt-tag"])
@@ -19388,13 +19641,9 @@ mod zero_change_close_tests {
         .unwrap()
         .trim()
         .to_string();
-        let tag_error = validate_task_commit_receipt(
-            dir.path(),
-            &tag,
-            "main",
-            &test_receipt_window(),
-        )
-        .expect_err("an annotated tag object is not immutable commit evidence");
+        let tag_error =
+            validate_task_commit_receipt(dir.path(), &tag, "main", &test_receipt_window())
+                .expect_err("an annotated tag object is not immutable commit evidence");
         assert!(tag_error.contains("tag object"), "{tag_error}");
         assert!(tag_error.contains("not a commit"), "{tag_error}");
     }
@@ -19544,7 +19793,10 @@ mod zero_change_close_tests {
         match outcome {
             ZeroCommitCloseOutcome::AmbiguousCodeTask(msg) => {
                 assert!(msg.contains("INVALID TASK COMMIT RECEIPT"), "{msg}");
-                assert!(msg.contains("does not uniquely resolve to a commit"), "{msg}");
+                assert!(
+                    msg.contains("does not uniquely resolve to a commit"),
+                    "{msg}"
+                );
                 assert!(msg.contains("commit_receipt=<sha>"), "{msg}");
             }
             ZeroCommitCloseOutcome::Proceed => panic!("unknown receipt must not proceed"),
@@ -20497,7 +20749,12 @@ mod zero_diff_spike_close_tests {
             "chores declare no-code work the same way spikes do"
         );
         assert!(
-            !scope(TaskType::Task, Some("characterization-first"), Some(false), true),
+            !scope(
+                TaskType::Task,
+                Some("characterization-first"),
+                Some(false),
+                true
+            ),
             "an execution_note is the task's own declaration that no code is expected"
         );
     }
@@ -20519,7 +20776,12 @@ mod zero_diff_spike_close_tests {
     #[test]
     fn task_attributable_code_always_counts_as_reviewable() {
         assert!(
-            scope(TaskType::Spike, Some("characterization-first"), Some(true), false),
+            scope(
+                TaskType::Spike,
+                Some("characterization-first"),
+                Some(true),
+                false
+            ),
             "code this task actually committed is reviewable no matter its declared shape"
         );
     }

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -180,7 +180,7 @@ struct NegativeResultCloseReceipt {
 }
 
 #[derive(Debug)]
-enum SupervisorAuthorityError {
+pub(super) enum SupervisorAuthorityError {
     Identity(String),
     Store(String),
     NotRegistered { caller_id: String, error: String },
@@ -191,6 +191,7 @@ enum SupervisorAuthorityError {
 enum TaskCloseDisposition {
     Delivered,
     NegativeResult,
+    Decision,
 }
 
 impl TaskCloseDisposition {
@@ -202,8 +203,38 @@ impl TaskCloseDisposition {
         match self {
             Self::Delivered => cas_types::TaskTerminalOutcome::Delivered,
             Self::NegativeResult => cas_types::TaskTerminalOutcome::NegativeResult,
+            Self::Decision => cas_types::TaskTerminalOutcome::Decision,
         }
     }
+}
+
+pub(super) fn gate_supervisor_authority_error(
+    operation: &str,
+    error: SupervisorAuthorityError,
+) -> String {
+    match error {
+        SupervisorAuthorityError::Identity(error) => format!(
+            "GATE {operation} REJECTED: gate tasks require an authenticated registered supervisor; caller identity could not be resolved ({error})."
+        ),
+        SupervisorAuthorityError::Store(error) => format!(
+            "GATE {operation} REJECTED: supervisor authority could not be checked ({error})."
+        ),
+        SupervisorAuthorityError::NotRegistered { caller_id, error } => format!(
+            "GATE {operation} REJECTED: caller `{caller_id}` is not a registered supervisor ({error})."
+        ),
+        SupervisorAuthorityError::NotLive(caller) => format!(
+            "GATE {operation} REJECTED: only a live registered supervisor may start or close a gate. Caller `{}` has role {}.",
+            caller.name, caller.role
+        ),
+    }
+}
+
+fn has_recorded_gate_decision(notes: &str) -> bool {
+    notes.lines().any(|line| {
+        line.strip_prefix('[')
+            .and_then(|line| line.split_once("] ✅ DECISION "))
+            .is_some_and(|(_, decision)| !decision.trim().is_empty())
+    })
 }
 
 fn negative_result_missing_receipts(
@@ -462,6 +493,9 @@ pub(crate) enum VerificationSkipReason {
     /// durable evidence and a closed-unmerged PR/branch receipt. No delivery
     /// is being approved, so delivery review/verification gates do not apply.
     SupervisorNegativeResult,
+    /// A live registered supervisor closed a Gate after recording the
+    /// decision in the task timeline. No code delivery is being approved.
+    SupervisorDecision,
     /// cas-1932 (GH #62, minor): an assignee-lookup failure would have
     /// reported "verification skipped", but a current-cycle APPROVED
     /// verification for this task already exists. The close is authorized
@@ -513,6 +547,9 @@ impl VerificationSkipReason {
                 " (measured negative result — supervisor-authorized, delivery intentionally unmerged)"
                     .to_string()
             }
+            VerificationSkipReason::SupervisorDecision => {
+                " (decision recorded — supervisor-authorized gate)".to_string()
+            }
             VerificationSkipReason::ExistingApprovedVerification { verification_id } => {
                 format!(" (verified — approved verification {verification_id} on record)")
             }
@@ -555,6 +592,11 @@ impl VerificationSkipReason {
                 "Closed as a measured negative result by a registered supervisor after durable \
                  evidence and a closed-unmerged PR/branch receipt were validated; no delivery \
                  was approved or merged."
+                    .to_string()
+            }
+            VerificationSkipReason::SupervisorDecision => {
+                "Closed as a decision by a registered supervisor after a non-empty DECISION note \
+                 was recorded; no code delivery was required or approved."
                     .to_string()
             }
             VerificationSkipReason::ExistingApprovedVerification { verification_id } => {
@@ -673,7 +715,7 @@ impl CasCore {
     /// Resolve the authority shared by every supervisor-owned non-delivery
     /// outcome. Callers map the typed failure into operation-specific text,
     /// but identity, registration, role, and liveness checks are identical.
-    fn resolve_live_supervisor_authority(
+    pub(super) fn resolve_live_supervisor_authority(
         &self,
     ) -> Result<cas_types::Agent, SupervisorAuthorityError> {
         let caller_id = self
@@ -691,6 +733,18 @@ impl CasCore {
             return Err(SupervisorAuthorityError::NotLive(caller));
         }
         Ok(caller)
+    }
+
+    fn validate_gate_decision_close(&self, task: &cas_types::Task) -> Result<(), String> {
+        self.resolve_live_supervisor_authority()
+            .map_err(|error| gate_supervisor_authority_error("CLOSE", error))?;
+        if !has_recorded_gate_decision(&task.notes) {
+            return Err(format!(
+                "GATE CLOSE REJECTED: task {} has no non-empty recorded DECISION note. Record the decision first with mcp__cas__task action=notes id={} note_type=decision notes=\"...\", then retry close.",
+                task.id, task.id
+            ));
+        }
+        Ok(())
     }
 
     fn validate_negative_result_close(
@@ -1542,12 +1596,33 @@ impl CasCore {
         // Validate its supervisor authority and all three receipts before any
         // close projection. Ordinary requests take the `None` path and retain
         // the existing gate sequence and response text unchanged.
-        let negative_result_receipt =
-            match self.validate_negative_result_close(&req.id, &req, negative_result.as_ref()) {
-                Ok(receipt) => receipt,
-                Err(message) => return Ok(Self::tool_error(message)),
-            };
-        let close_disposition = if negative_result_receipt.is_some() {
+        if task.task_type == TaskType::Gate && completion_receipt.is_some() {
+            return Ok(Self::tool_error(format!(
+                "GATE CLOSE REJECTED: task {} closes directly on a recorded DECISION note; a worker completion receipt is not applicable.",
+                task.id
+            )));
+        }
+        if task.task_type == TaskType::Gate && negative_result.is_some() {
+            return Ok(Self::tool_error(format!(
+                "GATE CLOSE REJECTED: task {} has the Decision disposition; negative_result is not applicable.",
+                task.id
+            )));
+        }
+
+        let negative_result_receipt = match self.validate_negative_result_close(
+            &req.id,
+            &req,
+            negative_result.as_ref(),
+        ) {
+            Ok(receipt) => receipt,
+            Err(message) => return Ok(Self::tool_error(message)),
+        };
+        let close_disposition = if task.task_type == TaskType::Gate {
+            if let Err(message) = self.validate_gate_decision_close(&task) {
+                return Ok(Self::tool_error(message));
+            }
+            TaskCloseDisposition::Decision
+        } else if negative_result_receipt.is_some() {
             TaskCloseDisposition::NegativeResult
         } else {
             TaskCloseDisposition::Delivered
@@ -1602,72 +1677,74 @@ impl CasCore {
         // depth, orphan, and review convenience paths. Once one exists, no
         // close projection may proceed until that exact dispatch resolves.
         // This guard also protects internal post-merge re-close calls.
-        match cas_store::get_latest_verification_dispatch(&self.cas_root, &req.id) {
-            Err(error) => {
-                return Ok(Self::tool_error(format!(
-                    "⚠️ VERIFICATION DISPATCH INVALID\n\nTask {} has unreadable exact dispatch state: {}. CAS refuses to infer close authority.",
-                    req.id, error
-                )));
-            }
-            Ok(Some(dispatch))
-                if matches!(
-                    dispatch.state,
-                    cas_types::VerificationDispatchState::Pending
-                        | cas_types::VerificationDispatchState::Claimed
-                ) =>
-            {
-                if dispatch.deadline_at <= chrono::Utc::now() {
-                    let timed_out = cas_store::timeout_verification_dispatch(
-                        &self.cas_root,
-                        &req.id,
-                        chrono::Utc::now(),
-                    )
-                    .map_err(|error| McpError {
-                        code: ErrorCode::INTERNAL_ERROR,
-                        message: Cow::from(format!(
-                            "Failed to persist exact verification timeout: {error}"
-                        )),
-                        data: None,
-                    })?
-                    .ok_or_else(|| McpError {
-                        code: ErrorCode::INTERNAL_ERROR,
-                        message: Cow::from(
-                            "Exact verification timeout changed before persistence; retry close.",
-                        ),
-                        data: None,
-                    })?;
-                    let mut timed_out_task = task.clone();
-                    timed_out_task.pending_verification = false;
-                    timed_out_task.updated_at = chrono::Utc::now();
-                    task_store
-                        .update(&timed_out_task)
+        if close_disposition != TaskCloseDisposition::Decision {
+            match cas_store::get_latest_verification_dispatch(&self.cas_root, &req.id) {
+                Err(error) => {
+                    return Ok(Self::tool_error(format!(
+                        "⚠️ VERIFICATION DISPATCH INVALID\n\nTask {} has unreadable exact dispatch state: {}. CAS refuses to infer close authority.",
+                        req.id, error
+                    )));
+                }
+                Ok(Some(dispatch))
+                    if matches!(
+                        dispatch.state,
+                        cas_types::VerificationDispatchState::Pending
+                            | cas_types::VerificationDispatchState::Claimed
+                    ) =>
+                {
+                    if dispatch.deadline_at <= chrono::Utc::now() {
+                        let timed_out = cas_store::timeout_verification_dispatch(
+                            &self.cas_root,
+                            &req.id,
+                            chrono::Utc::now(),
+                        )
                         .map_err(|error| McpError {
                             code: ErrorCode::INTERNAL_ERROR,
                             message: Cow::from(format!(
-                                "Failed to project exact verification timeout: {error}"
+                                "Failed to persist exact verification timeout: {error}"
                             )),
                             data: None,
+                        })?
+                        .ok_or_else(|| McpError {
+                            code: ErrorCode::INTERNAL_ERROR,
+                            message: Cow::from(
+                                "Exact verification timeout changed before persistence; retry close.",
+                            ),
+                            data: None,
                         })?;
-                    let sup_ver = supervisor_verification_tool();
+                        let mut timed_out_task = task.clone();
+                        timed_out_task.pending_verification = false;
+                        timed_out_task.updated_at = chrono::Utc::now();
+                        task_store
+                            .update(&timed_out_task)
+                            .map_err(|error| McpError {
+                                code: ErrorCode::INTERNAL_ERROR,
+                                message: Cow::from(format!(
+                                    "Failed to project exact verification timeout: {error}"
+                                )),
+                                data: None,
+                            })?;
+                        let sup_ver = supervisor_verification_tool();
+                        return Ok(Self::tool_error(format!(
+                            "⚠️ VERIFICATION TIMED OUT\n\nTask {} exact dispatch {} requires named registered-supervisor recovery before close.\n\nRecord the direct recovery verdict with {sup_ver} action=add task_id={} dispatch_id={} status=approved summary=\"...\", then retry close.",
+                            req.id, timed_out.id, req.id, timed_out.id
+                        )));
+                    }
                     return Ok(Self::tool_error(format!(
-                        "⚠️ VERIFICATION TIMED OUT\n\nTask {} exact dispatch {} requires named registered-supervisor recovery before close.\n\nRecord the direct recovery verdict with {sup_ver} action=add task_id={} dispatch_id={} status=approved summary=\"...\", then retry close.",
-                        req.id, timed_out.id, req.id, timed_out.id
+                        "⚠️ VERIFICATION REQUIRED\n\nTask {} cannot close until exact pending dispatch {} records its capability-bound verifier or registered supervisor-direct verdict.",
+                        req.id, dispatch.id
                     )));
                 }
-                return Ok(Self::tool_error(format!(
-                    "⚠️ VERIFICATION REQUIRED\n\nTask {} cannot close until exact pending dispatch {} records its capability-bound verifier or registered supervisor-direct verdict.",
-                    req.id, dispatch.id
-                )));
+                Ok(Some(dispatch))
+                    if dispatch.state == cas_types::VerificationDispatchState::TimedOut =>
+                {
+                    return Ok(Self::tool_error(format!(
+                        "⚠️ VERIFICATION TIMED OUT\n\nTask {} exact dispatch {} requires named registered-supervisor recovery before close.",
+                        req.id, dispatch.id
+                    )));
+                }
+                Ok(_) => {}
             }
-            Ok(Some(dispatch))
-                if dispatch.state == cas_types::VerificationDispatchState::TimedOut =>
-            {
-                return Ok(Self::tool_error(format!(
-                    "⚠️ VERIFICATION TIMED OUT\n\nTask {} exact dispatch {} requires named registered-supervisor recovery before close.",
-                    req.id, dispatch.id
-                )));
-            }
-            Ok(_) => {}
         }
 
         // cas-b269: urgent stop sets halt_task_work; block close until new start.
@@ -2181,7 +2258,9 @@ impl CasCore {
         // close without verification. cas-3bd4: compute the reason as a typed
         // enum so the response message cites the actual state instead of
         // defaulting to "assignee inactive" for every lookup failure.
-        let skip_reason = if !close_disposition.requires_delivery_gates() {
+        let skip_reason = if close_disposition == TaskCloseDisposition::Decision {
+            VerificationSkipReason::SupervisorDecision
+        } else if !close_disposition.requires_delivery_gates() {
             VerificationSkipReason::SupervisorNegativeResult
         } else if verification_enabled && is_supervisor_from_env() {
             if task.task_type == TaskType::Epic && task.epic_verification_owner.is_some() {

--- a/cas-cli/src/mcp/tools/core/task/query.rs
+++ b/cas-cli/src/mcp/tools/core/task/query.rs
@@ -152,7 +152,35 @@ impl CasCore {
         ));
 
         if let Some(closed) = task.closed_at {
-            output.push_str(&format!("\nClosed: {}", closed.format("%Y-%m-%d %H:%M")));
+            let label = if task.status == TaskStatus::Cancelled {
+                "Cancelled"
+            } else {
+                "Closed"
+            };
+            output.push_str(&format!("\n{label}: {}", closed.format("%Y-%m-%d %H:%M")));
+        }
+
+        if let Some(outcome) = task.effective_terminal_outcome() {
+            match outcome {
+                cas_types::TaskTerminalOutcome::Delivered => {
+                    output.push_str("\nOutcome: delivered");
+                }
+                cas_types::TaskTerminalOutcome::NegativeResult => {
+                    output.push_str("\nOutcome: measured negative result (no delivery)");
+                }
+                cas_types::TaskTerminalOutcome::Decision => {
+                    output.push_str("\nOutcome: recorded decision (no delivery)");
+                }
+                cas_types::TaskTerminalOutcome::Cancelled { superseded_by } => {
+                    output.push_str("\nOutcome: cancelled without delivery");
+                    if let Some(pointer) = superseded_by {
+                        output.push_str(&format!("\nSuperseded by: {pointer}"));
+                    }
+                }
+            }
+            if let Some(reason) = task.close_reason.as_deref() {
+                output.push_str(&format!("\nTerminal reason: {reason}"));
+            }
         }
 
         // Show deliverables for closed tasks
@@ -237,15 +265,19 @@ impl CasCore {
             if task.task_type == TaskType::Epic {
                 if let Ok(subtasks) = task_store.get_subtasks(&req.id) {
                     if !subtasks.is_empty() {
-                        let open_count = subtasks
+                        let terminal_count = subtasks.iter().filter(|t| t.is_terminal()).count();
+                        let delivered_count =
+                            subtasks.iter().filter(|t| t.counts_as_delivered()).count();
+                        let cancelled_count = subtasks
                             .iter()
-                            .filter(|t| t.status != TaskStatus::Closed)
+                            .filter(|t| t.status == TaskStatus::Cancelled)
                             .count();
-                        let closed_count = subtasks.len() - open_count;
                         output.push_str(&format!(
-                            "\n\nSubtasks ({}/{} complete):\n",
-                            closed_count,
-                            subtasks.len()
+                            "\n\nSubtasks ({}/{} terminal; {} delivered; {} cancelled):\n",
+                            terminal_count,
+                            subtasks.len(),
+                            delivered_count,
+                            cancelled_count
                         ));
                         for subtask in &subtasks {
                             let status_icon = match subtask.status {
@@ -253,6 +285,7 @@ impl CasCore {
                                 TaskStatus::InProgress => "●",
                                 TaskStatus::Blocked => "◉",
                                 TaskStatus::Closed => "✓",
+                                TaskStatus::Cancelled => "⊘",
                                 // cas-b51a: awaiting supervisor code-review
                                 TaskStatus::PendingSupervisorReview => "⏳",
                                 TaskStatus::AwaitingMerge => "⇄",
@@ -493,9 +526,20 @@ impl CasCore {
                 } else {
                     ""
                 };
+            let outcome_marker = if task.status == TaskStatus::Cancelled {
+                " [NO DELIVERY]"
+            } else {
+                ""
+            };
             output.push_str(&format!(
-                "- [{}] {:?}{} P{} {} - {}\n",
-                task.id, task.status, conflict_marker, task.priority.0, task.task_type, task.title
+                "- [{}] {:?}{}{} P{} {} - {}\n",
+                task.id,
+                task.status,
+                conflict_marker,
+                outcome_marker,
+                task.priority.0,
+                task.task_type,
+                task.title
             ));
         }
 

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -1379,6 +1379,7 @@ mod status_transition_tests {
 
         let mut task = Task::new("cas-anchor".into(), "Anchored closed task".into());
         task.status = TaskStatus::Closed;
+        task.terminal_outcome = Some(cas_types::TaskTerminalOutcome::Delivered);
         task.assignee = Some("worker".into());
         task.deliverables.factory_branch_anchor = Some(already_merged_anchor);
         task.deliverables.parked_branch = Some("factory/worker".into());
@@ -1396,6 +1397,10 @@ mod status_transition_tests {
         assert!(
             updated.deliverables.factory_branch_anchor.is_none(),
             "a Closed -> non-Closed transition must invalidate the prior close cycle's anchor"
+        );
+        assert_eq!(
+            updated.terminal_outcome, None,
+            "active work must not retain the prior terminal disposition"
         );
 
         git(repo, &["checkout", "-q", "factory/worker"]);

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -263,6 +263,32 @@ impl CasCore {
             data: None,
         })?;
         let original_updated_at = task.updated_at;
+        if req.status.as_deref().is_some_and(|status| {
+            status.eq_ignore_ascii_case("cancelled") || status.eq_ignore_ascii_case("canceled")
+        }) {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from(
+                    "TASK UPDATE REJECTED: status=cancelled cannot be set directly. Use task \
+                     action=cancel with a non-empty reason so supervisor authority and the \
+                     no-delivery audit outcome are recorded."
+                        .to_string(),
+                ),
+                data: None,
+            });
+        }
+        if task.status == TaskStatus::Cancelled && req.status.is_some() {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from(format!(
+                    "TASK UPDATE REJECTED: cancelled task {} may change status only through task \
+                     action=reopen so supervisor authority is checked and terminal outcome state \
+                     is cleared atomically.",
+                    task.id
+                )),
+                data: None,
+            });
+        }
         let reopening_closed = task.status == TaskStatus::Closed
             && req
                 .status

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -299,6 +299,22 @@ impl CasCore {
             .as_deref()
             .is_some_and(|status| status.eq_ignore_ascii_case("closed"))
             && task.status != TaskStatus::Closed
+            && task.task_type == TaskType::Gate
+        {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from(format!(
+                    "GATE UPDATE REJECTED: task {} may close only through task action=close so live supervisor authority and a non-empty recorded DECISION note are checked atomically.",
+                    task.id
+                )),
+                data: None,
+            });
+        }
+        if req
+            .status
+            .as_deref()
+            .is_some_and(|status| status.eq_ignore_ascii_case("closed"))
+            && task.status != TaskStatus::Closed
             && let Err(message) = self.guard_direct_update_close_delivery_state(&task)
         {
             return Err(McpError {

--- a/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
+++ b/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
@@ -264,7 +264,7 @@ fn reject_closed_epic_merge_target(
         .into_iter()
         .filter(|task| {
             task.task_type == cas_types::TaskType::Epic
-                && task.status == cas_types::TaskStatus::Closed
+                && task.is_terminal()
                 && task.branch.as_deref() == Some(target_branch)
         })
         .map(|task| task.id)
@@ -852,7 +852,7 @@ fn resolve_system_b_merge_target(
             data: None,
         })?;
         if let Some(epic) = epic {
-            if epic.status == cas_types::TaskStatus::Closed {
+            if epic.is_terminal() {
                 return Err(McpError {
                     code: ErrorCode::INVALID_PARAMS,
                     message: Cow::from(format!(
@@ -930,7 +930,7 @@ fn resolve_system_b_merge_target(
         // never silently fall through to trunk/focus (cas-0b32 review).
         match task_store.get_parent_epic(&task.id) {
             Ok(Some(epic)) => {
-                if epic.status == cas_types::TaskStatus::Closed {
+                if epic.is_terminal() {
                     closed_parent_epics.push((task.id.clone(), epic.id.clone()));
                     continue;
                 }

--- a/cas-cli/src/mcp/tools/service/core.rs
+++ b/cas-cli/src/mcp/tools/service/core.rs
@@ -356,6 +356,23 @@ impl CasService {
         self.inner.cas_task_reopen(Parameters(inner_req)).await
     }
 
+    pub(super) async fn task_cancel(&self, req: TaskRequest) -> Result<CallToolResult, McpError> {
+        use crate::mcp::tools::TaskCancelRequest;
+        let inner_req = TaskCancelRequest {
+            id: req
+                .id
+                .ok_or_else(|| Self::error(ErrorCode::INVALID_PARAMS, "id required for cancel"))?,
+            reason: req.reason.ok_or_else(|| {
+                Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    "reason required for cancel — explain why no delivery will be produced",
+                )
+            })?,
+            superseded_by: req.superseded_by,
+        };
+        self.inner.cas_task_cancel(Parameters(inner_req)).await
+    }
+
     pub(super) async fn task_request_changes(
         &self,
         req: TaskRequest,

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -2657,9 +2657,26 @@ impl CasService {
             })
             .collect();
 
-        if worker_events.is_empty() && transcript_activity.is_empty() && terminal_event_count == 0 {
+        // GH #255 round 2: hooks do not reliably observe Codex file edits, so
+        // the event/transcript view above must never make a dirty worker look
+        // idle. Snapshot each visible worktree at query time as a floor under
+        // those asynchronous signals. This deliberately reuses worker_status's
+        // resolver and collector rather than inventing a third git path.
+        let worktree_activity: Vec<_> = visible_workers
+            .iter()
+            .filter_map(|agent| {
+                collect_worker_activity_worktree_snapshot(&self.inner.cas_root, agent)
+            })
+            .collect();
+
+        if worker_activity_has_no_rows(
+            worker_events.len(),
+            transcript_activity.len(),
+            worktree_activity.len(),
+            terminal_event_count,
+        ) {
             return Ok(Self::success(
-                "No recent worker activity.\n\nworker_activity uses the same 10-minute event window as worker_status, plus resolved worker transcript/rollout freshness. Transcript activity is unavailable when a worker's transcript cannot be resolved.",
+                "No recent worker activity.\n\nworker_activity uses the same 10-minute event window as worker_status, plus resolved worker transcript/rollout freshness and a query-time dirty-worktree floor. Transcript activity is unavailable when a worker's transcript cannot be resolved.",
             ));
         }
 
@@ -2698,6 +2715,9 @@ impl CasService {
             output.push_str(&format!(
                 "• {worker_name} - {activity} ({age_secs}s ago; transcript-backed)\n"
             ));
+        }
+        for snapshot in &worktree_activity {
+            output.push_str(&format_worker_activity_worktree_snapshot(snapshot));
         }
 
         Ok(Self::success(output))
@@ -4514,6 +4534,32 @@ struct WorkerWorktreeStatus {
     git_info: String,
 }
 
+/// Query-time worktree evidence that floors `worker_activity` underneath the
+/// event and transcript feeds. A dirty snapshot is live evidence even when a
+/// harness did not emit a corresponding `WorkerFileEdited` event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkerActivityWorktreeSnapshot {
+    worker_name: String,
+    dirty_file_count: usize,
+    diffstat: String,
+    last_commit: String,
+}
+
+/// Whether `worker_activity` has no evidence to render at all. Kept pure so
+/// the zero-event worktree floor cannot accidentally be omitted from the
+/// early-empty branch during a future response refactor.
+fn worker_activity_has_no_rows(
+    worker_event_count: usize,
+    transcript_activity_count: usize,
+    worktree_activity_count: usize,
+    terminal_event_count: usize,
+) -> bool {
+    worker_event_count == 0
+        && transcript_activity_count == 0
+        && worktree_activity_count == 0
+        && terminal_event_count == 0
+}
+
 /// cas-f53c: shared resolution for worker clone/worktree path used by both
 /// `worker_status` and `sync_all_workers`.
 ///
@@ -4610,6 +4656,61 @@ fn collect_worker_worktree_status(
             }
         }
     }
+}
+
+/// Gather the live dirty-worktree floor for `worker_activity`.
+///
+/// This uses the same clone resolution and git-status collector as
+/// `worker_status`. It intentionally returns no row for a clean or unavailable
+/// worktree; absence is not manufactured into activity.
+fn collect_worker_activity_worktree_snapshot(
+    cas_root: &std::path::Path,
+    agent: &cas_types::Agent,
+) -> Option<WorkerActivityWorktreeSnapshot> {
+    let WorkerClonePathResolve::Ready(path) = resolve_worker_clone_path(cas_root, agent) else {
+        return None;
+    };
+    let git_status = collect_worker_git_status(&path);
+    if !git_status.dirty {
+        return None;
+    }
+
+    let dirty_file_count = worker_scope_paths(&path).ok()?.len();
+    if dirty_file_count == 0 {
+        return None;
+    }
+
+    let diffstat = run_git(&path, &["diff", "--stat", "HEAD"])
+        .ok()
+        .filter(|stat| !stat.is_empty())
+        .unwrap_or_else(|| "no tracked diffstat (untracked files may be present)".to_string());
+    let last_commit = run_git(&path, &["log", "-1", "--format=%h %s"])
+        .ok()
+        .filter(|commit| !commit.is_empty())
+        .unwrap_or_else(|| head_sha_for_display(&git_status.head_sha).to_string());
+
+    Some(WorkerActivityWorktreeSnapshot {
+        worker_name: agent.name.clone(),
+        dirty_file_count,
+        diffstat,
+        last_commit,
+    })
+}
+
+fn format_worker_activity_worktree_snapshot(snapshot: &WorkerActivityWorktreeSnapshot) -> String {
+    let diffstat = snapshot.diffstat.replace('\n', "\n    ");
+    format!(
+        "• {} - live worktree: {} dirty file{} (query-time snapshot; no event required)\n    diffstat: {}\n    last commit: {}\n",
+        snapshot.worker_name,
+        snapshot.dirty_file_count,
+        if snapshot.dirty_file_count == 1 {
+            ""
+        } else {
+            "s"
+        },
+        diffstat,
+        snapshot.last_commit,
+    )
 }
 
 /// Resolve a registered worker's concrete harness artifact using the same
@@ -11583,6 +11684,57 @@ effort = "high"
             }
             other => panic!("expected NotOnDisk, got {other:?}"),
         }
+    }
+
+    /// GH #255 round 2: a Codex edit can leave no WorkerFileEdited event at
+    /// all. The query-time snapshot is therefore an activity floor, not a
+    /// decoration for an already-live event row.
+    #[test]
+    fn worker_activity_dirty_worktree_floor_is_non_idle_without_events() {
+        let (_tmp, project) = setup_factory_project_with_worker_worktrees(&["codex-editor"]);
+        let cas_root = project.join(".cas");
+        let worktree = cas_root.join("worktrees/codex-editor");
+        std::fs::write(worktree.join("README"), "edited without an event\n").unwrap();
+
+        let agent = cas_types::Agent::new_with_role(
+            "codex-session".to_string(),
+            "codex-editor".to_string(),
+            AgentRole::Worker,
+        );
+        let worker_events: Vec<cas_types::Event> = Vec::new();
+        assert!(
+            worker_events.is_empty(),
+            "fixture intentionally has no events"
+        );
+
+        let snapshot = collect_worker_activity_worktree_snapshot(&cas_root, &agent)
+            .expect("dirty worktree must floor activity when there are no events");
+        let rendered = format_worker_activity_worktree_snapshot(&snapshot);
+
+        assert!(
+            !worker_activity_has_no_rows(0, 0, 1, 0),
+            "the live floor must bypass worker_activity's empty response"
+        );
+        assert!(
+            !rendered.contains("No recent worker activity"),
+            "a dirty zero-event worker must render as non-idle: {rendered}"
+        );
+        assert!(
+            rendered.contains("1 dirty file"),
+            "missing dirty count: {rendered}"
+        );
+        assert!(
+            rendered.contains("diffstat:"),
+            "missing diffstat: {rendered}"
+        );
+        assert!(
+            rendered.contains("README"),
+            "diffstat must name changed file: {rendered}"
+        );
+        assert!(
+            rendered.contains("last commit:"),
+            "missing last commit: {rendered}"
+        );
     }
 
     #[test]

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -572,6 +572,10 @@ fn format_assigned_task_info(
                 cas_types::TaskStatus::Open
                 | cas_types::TaskStatus::InProgress
                 | cas_types::TaskStatus::Closed => ("parked", "check the task"),
+                cas_types::TaskStatus::Cancelled => (
+                    "cancelled without delivery",
+                    "no delivery or merge action is pending",
+                ),
             };
             format!(
                 "\n    task: {id} ({label}) — {} → WAITING ON YOU: {action}",
@@ -4388,21 +4392,47 @@ fn scan_orphan_processes(
             })
             .map(|record| record.pgid)
             .collect();
-    crate::ui::factory::orphan_gc::scan(cas_root, &live_factory_sessions(), &protected_pgids, &deregistered_worker_worktrees(cas_root, live_workers))
+    crate::ui::factory::orphan_gc::scan(
+        cas_root,
+        &live_factory_sessions(),
+        &protected_pgids,
+        &deregistered_worker_worktrees(cas_root, live_workers),
+    )
 }
 
-fn deregistered_worker_worktrees(cas_root: &std::path::Path, live_workers: &LiveFactoryWorkers) -> std::collections::HashSet<std::path::PathBuf> {
+fn deregistered_worker_worktrees(
+    cas_root: &std::path::Path,
+    live_workers: &LiveFactoryWorkers,
+) -> std::collections::HashSet<std::path::PathBuf> {
     let repo_root = cas_root.parent().unwrap_or(cas_root);
     let config = crate::config::Config::load(cas_root).unwrap_or_default();
     let default_root = config.worktrees().resolve_base_path(repo_root);
-    crate::ui::factory::SessionManager::new().list_sessions().unwrap_or_default().into_iter().filter(|session| session.is_running).flat_map(|session| {
-        let session_name = session.name;
-        let worktree_root = default_root.clone();
-        session.metadata.workers.into_iter().filter_map(move |worker| {
-            let live = live_workers.contains(&(worker.name.clone(), Some(session_name.clone()))) || live_workers.contains(&(worker.name.clone(), None));
-            (!live).then(|| worker.worktree_path.map(std::path::PathBuf::from).unwrap_or_else(|| worktree_root.join(worker.name)))
+    crate::ui::factory::SessionManager::new()
+        .list_sessions()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|session| session.is_running)
+        .flat_map(|session| {
+            let session_name = session.name;
+            let worktree_root = default_root.clone();
+            session
+                .metadata
+                .workers
+                .into_iter()
+                .filter_map(move |worker| {
+                    let live = live_workers
+                        .contains(&(worker.name.clone(), Some(session_name.clone())))
+                        || live_workers.contains(&(worker.name.clone(), None));
+                    (!live).then(|| {
+                        worker
+                            .worktree_path
+                            .map(std::path::PathBuf::from)
+                            .unwrap_or_else(|| worktree_root.join(worker.name))
+                    })
+                })
         })
-    }).filter(|path| path.is_dir()).collect()
+        .filter(|path| path.is_dir())
+        .collect()
 }
 
 fn orphan_process_groups(
@@ -7215,9 +7245,12 @@ mod spawn_lifecycle_tests {
     /// read the absence of a message as "nothing needs me".
     #[test]
     fn an_undelivered_relay_is_named_in_worker_status() {
-        let out = format_undelivered_relay_section(&[lost_relay(
-            "task_awaiting_merge: cas-fe23 (2026-08-07T18:51:51Z)",
-        )], 0);
+        let out = format_undelivered_relay_section(
+            &[lost_relay(
+                "task_awaiting_merge: cas-fe23 (2026-08-07T18:51:51Z)",
+            )],
+            0,
+        );
         assert!(
             out.contains("UNDELIVERED SUPERVISOR RELAY"),
             "the banner must state the failure outright: {out}"

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -7503,6 +7503,74 @@ mod spawn_lifecycle_tests {
             out.len()
         );
     }
+
+    /// GH #257: spawning is another planning write moment. Its ordinary queue
+    /// receipt must carry a matching project memory, not require a separate
+    /// pull/search after the worker request was already made.
+    #[tokio::test]
+    async fn spawn_response_surfaces_related_recall_for_active_epic() {
+        use cas_types::{Entry, Task, TaskType};
+
+        let temp = tempfile::tempdir().expect("temp project");
+        let core = CasCore::with_daemon(temp.path().to_path_buf(), None, None);
+        let task_store = core.open_task_store().expect("open task store");
+        task_store.init().expect("init task store");
+
+        let mut epic = Task::new(
+            "cas-spawn-recall".to_string(),
+            "Deploy timeline work".to_string(),
+        );
+        epic.task_type = TaskType::Epic;
+        epic.description = "Coordinate the timeline deployment milestone.".to_string();
+        task_store.add(&epic).expect("add epic");
+        core.open_search_index()
+            .expect("open search index")
+            .index_task(&epic)
+            .expect("index epic");
+
+        let mut memory = Entry::new(
+            "m-spawn-recall".to_string(),
+            "Timeline deployment already has a verified rollout plan.".to_string(),
+        );
+        memory.title = Some("Reuse timeline rollout plan".to_string());
+        core.open_store()
+            .expect("open memory store")
+            .add(&memory)
+            .expect("add memory");
+        core.open_search_index()
+            .expect("open search index")
+            .index_entry(&memory)
+            .expect("index memory");
+
+        #[cfg(feature = "mcp-proxy")]
+        let service = CasService::new(core, None);
+        #[cfg(not(feature = "mcp-proxy"))]
+        let service = CasService::new(core);
+        let request: FactoryRequest = serde_json::from_value(serde_json::json!({
+            "action": "spawn_workers",
+            "count": 1,
+            "cli": "claude"
+        }))
+        .expect("valid spawn request");
+
+        let response = service
+            .factory_spawn_workers(request)
+            .await
+            .expect("queue worker spawn");
+        let text = response
+            .content
+            .into_iter()
+            .filter_map(|content| match content.raw {
+                rmcp::model::RawContent::Text(text) => Some(text.text),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(text.contains("Related prior context:"), "{text}");
+        assert!(text.contains("m-spawn-recall"), "{text}");
+        assert!(text.contains("Reuse timeline rollout plan"), "{text}");
+    }
 }
 
 #[cfg(test)]

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -1278,14 +1278,30 @@ impl CasService {
              to resolve request {request_id} to a worker and a state (registered / FAILED); \
              do not report dispatch complete until it shows registered."
         );
+        // Recall is response-only: use the active epic as the task-planning
+        // query and add nothing when the shared BM25 index has no useful
+        // project-local memory/epic result.
+        let related_context = task_store
+            .list(None)
+            .ok()
+            .and_then(|tasks| {
+                tasks.into_iter().find(|task| {
+                    task.task_type == TaskType::Epic && task.status != TaskStatus::Closed
+                })
+            })
+            .and_then(|epic| {
+                self.inner
+                    .related_recall(&format!("{} {}", epic.title, epic.description))
+            })
+            .unwrap_or_default();
 
         let msg = if worker_names.is_empty() {
             format!(
-                "Queued spawn request for {count} worker(s) (request ID: {request_id})\nWorker spec: {spec_summary}{spec_warning}{codex_fallback_notice}{config_dir_notice}{task_id_note}{liveness_note}"
+                "Queued spawn request for {count} worker(s) (request ID: {request_id})\nWorker spec: {spec_summary}{spec_warning}{codex_fallback_notice}{config_dir_notice}{task_id_note}{liveness_note}{related_context}"
             )
         } else {
             format!(
-                "Queued spawn request for worker(s): {} (request ID: {})\nWorker spec: {spec_summary}{spec_warning}{codex_fallback_notice}{config_dir_notice}{task_id_note}{liveness_note}",
+                "Queued spawn request for worker(s): {} (request ID: {})\nWorker spec: {spec_summary}{spec_warning}{codex_fallback_notice}{config_dir_notice}{task_id_note}{liveness_note}{related_context}",
                 worker_names.join(", "),
                 request_id
             )

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -196,7 +196,7 @@ fn shutdown_worker_snapshot(
             task.assignee
                 .as_deref()
                 .is_some_and(|assignee| assignee == worker.name || assignee == worker.id)
-                && task.status != cas_types::TaskStatus::Closed
+                && !task.is_terminal()
         })
         .collect();
     let has_in_progress_task = assigned
@@ -792,7 +792,7 @@ fn resolve_sync_all_workers_target(
     req: &FactoryRequest,
 ) -> std::result::Result<String, String> {
     use crate::store::open_task_store;
-    use cas_types::{TaskStatus, TaskType};
+    use cas_types::TaskType;
 
     fn epic_branch(
         task_store: &dyn crate::store::TaskStore,
@@ -808,7 +808,7 @@ fn resolve_sync_all_workers_target(
                 epic.task_type
             ));
         }
-        if epic.status == TaskStatus::Closed {
+        if epic.is_terminal() {
             return Err(format!(
                 "sync_all_workers: {source} epic {epic_id} is Closed"
             ));
@@ -998,11 +998,12 @@ impl CasService {
                     ),
                 )
             })?;
-            if task.status == TaskStatus::Closed {
+            if task.is_terminal() {
                 return Err(Self::error(
                     ErrorCode::INVALID_PARAMS,
                     format!(
-                        "task_id {task_id} is already closed — cannot pre-assign it to a spawned worker."
+                        "task_id {task_id} is terminal ({}) — cannot pre-assign it to a spawned worker.",
+                        task.status
                     ),
                 ));
             }
@@ -1136,7 +1137,7 @@ impl CasService {
                     )
                 })?
                 .into_iter()
-                .any(|t| t.task_type == TaskType::Epic && t.status != TaskStatus::Closed);
+                .any(|t| t.task_type == TaskType::Epic && !t.is_terminal());
 
             if !has_open_epic {
                 let why = match task_id_authorization {

--- a/cas-cli/src/mcp/tools/service/mod.rs
+++ b/cas-cli/src/mcp/tools/service/mod.rs
@@ -258,7 +258,7 @@ impl CasService {
     // ========================================================================
 
     #[tool(
-        description = "Task operations. Actions: create, show, update, start, close, reopen, request_changes, delete, list, ready (actionable), blocked, notes (add progress), dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine. Supervisors use request_changes as the sanctioned exit from AwaitingMerge whenever review fails — declined merge, amendment required after merge, or rejected work — reopening the task with its assignee preserved (use reset only for tasks orphaned by a dead session). Prefer `start` for normal worker execution; use `claim` for manual lease control/recovery; use `reset` to revive a task orphaned by a dead session (atomic: force-releases lease, clears assignee, forces status=open). IMPORTANT for 'close': verification must pass first. Workers should attempt close; if close returns verification-required guidance, follow the indicated verifier ownership workflow."
+        description = "Task operations. Actions: create, show, update, start, close, cancel, reopen, request_changes, delete, list, ready (actionable), blocked, notes (add progress), dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine. cancel is the supervisor-authorized, reason-required terminal path for work intentionally ended without delivery; it preserves history and accepts an optional superseded_by pointer. Supervisors use request_changes as the sanctioned exit from AwaitingMerge whenever review fails — declined merge, amendment required after merge, or rejected work — reopening the task with its assignee preserved (use reset only for tasks orphaned by a dead session). Prefer `start` for normal worker execution; use `claim` for manual lease control/recovery; use `reset` to revive a task orphaned by a dead session (atomic: force-releases lease, clears assignee, forces status=open). IMPORTANT for 'close': verification must pass first. Workers should attempt close; if close returns verification-required guidance, follow the indicated verifier ownership workflow."
     )]
     pub async fn task(
         &self,
@@ -274,6 +274,7 @@ impl CasService {
                     | "update"
                     | "start"
                     | "close"
+                    | "cancel"
                     | "reopen"
                     | "request_changes"
                     | "delete"
@@ -292,6 +293,7 @@ impl CasService {
                 "update" => this.task_update(req).await,
                 "start" => this.task_start(req).await,
                 "close" => this.task_close(req).await,
+                "cancel" => this.task_cancel(req).await,
                 "reopen" => this.task_reopen(req).await,
                 "request_changes" => this.task_request_changes(req).await,
                 "delete" => this.task_delete(req).await,
@@ -311,7 +313,7 @@ impl CasService {
                 _ => Err(Self::error(
                     ErrorCode::INVALID_PARAMS,
                     format!(
-                        "Unknown task action: {}. Valid: create, show, update, start, close, reopen, request_changes, delete, list, ready, blocked, notes, dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine",
+                        "Unknown task action: {}. Valid: create, show, update, start, close, cancel, reopen, request_changes, delete, list, ready, blocked, notes, dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine",
                         req.action
                     ),
                 )),
@@ -1251,8 +1253,8 @@ pub(crate) mod agent_liveness;
 mod agent_search_system;
 mod core;
 pub(crate) mod factory_ops;
-pub(crate) mod harness_observation;
 mod factory_remind;
+pub(crate) mod harness_observation;
 pub(crate) mod orphan_recovery;
 mod panic_catch;
 #[cfg(test)]

--- a/cas-cli/src/mcp/tools/service/orphan_recovery.rs
+++ b/cas-cli/src/mcp/tools/service/orphan_recovery.rs
@@ -47,6 +47,7 @@ fn is_protected_status(status: TaskStatus) -> bool {
     matches!(
         status,
         TaskStatus::Closed
+            | TaskStatus::Cancelled
             | TaskStatus::Open
             | TaskStatus::PendingSupervisorReview
             | TaskStatus::AwaitingMerge

--- a/cas-cli/src/mcp/tools/types/common.rs
+++ b/cas-cli/src/mcp/tools/types/common.rs
@@ -90,7 +90,7 @@ pub struct TaskListRequest {
 
     /// Task type filter
     #[schemars(
-        description = "Filter by task type: 'task', 'bug', 'feature', 'epic', 'chore', 'spike'"
+        description = "Filter by task type: 'task', 'bug', 'feature', 'epic', 'chore', 'spike', 'gate'"
     )]
     #[serde(default)]
     pub task_type: Option<String>,

--- a/cas-cli/src/mcp/tools/types/task.rs
+++ b/cas-cli/src/mcp/tools/types/task.rs
@@ -80,7 +80,9 @@ pub struct TaskCreateRequest {
     pub priority: u8,
 
     /// Task type
-    #[schemars(description = "Type: 'task' (default), 'bug', 'feature', 'epic', 'chore', 'spike'")]
+    #[schemars(
+        description = "Type: 'task' (default), 'bug', 'feature', 'epic', 'chore', 'spike', 'gate'"
+    )]
     #[serde(default = "default_task_type")]
     pub task_type: String,
 

--- a/cas-cli/src/mcp/tools/types/task.rs
+++ b/cas-cli/src/mcp/tools/types/task.rs
@@ -168,11 +168,9 @@ pub struct TaskCloseRequest {
     /// this flag get an explicit rejection. The override is logged as a
     /// decision note on the task so the audit trail captures who
     /// downgraded a P0 block and why.
-    #[schemars(
-        description = "Supervisor override for the code-review P0 gate. \
+    #[schemars(description = "Supervisor override for the code-review P0 gate. \
                        Only honored when the caller is a supervisor; other \
-                       roles are rejected. Logs a decision note on the task."
-    )]
+                       roles are rejected. Logs a decision note on the task.")]
     #[serde(default)]
     pub bypass_code_review: Option<bool>,
 
@@ -214,22 +212,19 @@ pub struct TaskCloseRequest {
                        Each Finding requires: title, severity, file, line, \
                        why_it_matters, autofix_class, owner, confidence, \
                        evidence, pre_existing (optional: suggested_fix, \
-                       requires_verification)."
-    )]
+                       requires_verification).")]
     #[serde(default)]
     pub code_review_findings: Option<String>,
 
     /// Search manifest for investigation-task (`Spike`) closes (cas-49f1).
     /// This is the per-action mirror of the unified `TaskRequest` field of
     /// the same name (`crates/cas-mcp/src/types.rs`).
-    #[schemars(
-        description = "Serialized JSON array of search steps run during an \
+    #[schemars(description = "Serialized JSON array of search steps run during an \
                        investigation (Spike) task, e.g. \
                        [{\"command\": \"grep -c foo file\", \"hits\": 3}]. \
                        Optional; when present on a Spike-type close, any \
                        entry with hits=0 is surfaced as a warning note \
-                       instead of a silent pass."
-    )]
+                       instead of a silent pass.")]
     #[serde(default)]
     pub search_manifest: Option<String>,
 
@@ -248,6 +243,17 @@ pub struct TaskCloseRequest {
 pub struct NegativeResultCloseRequest {
     pub artifact_path: Option<String>,
     pub reference: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TaskCancelRequest {
+    /// Task ID to cancel without delivery.
+    pub id: String,
+    /// Required explanation preserved in the task timeline.
+    pub reason: String,
+    /// Optional portable pointer to the task, commit, or PR that superseded it.
+    #[serde(default)]
+    pub superseded_by: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/cas-cli/src/migration/migrations/m233_tasks_add_terminal_outcome.rs
+++ b/cas-cli/src/migration/migrations/m233_tasks_add_terminal_outcome.rs
@@ -1,0 +1,57 @@
+//! Migration: persist typed terminal task outcomes without backfilling legacy rows.
+
+use crate::migration::{Migration, Subsystem};
+
+pub const MIGRATION: Migration = Migration {
+    id: 233,
+    name: "tasks_add_terminal_outcome",
+    subsystem: Subsystem::Tasks,
+    description: "Add nullable typed terminal outcome metadata to tasks (cas-5092)",
+    up: &["ALTER TABLE tasks ADD COLUMN terminal_outcome TEXT"],
+    detect: Some(
+        "SELECT CASE WHEN (SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='tasks') = 0 THEN 1 ELSE (SELECT COUNT(*) FROM pragma_table_info('tasks') WHERE name = 'terminal_outcome') END",
+    ),
+};
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    #[test]
+    fn migration_adds_nullable_column_without_backfilling_legacy_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE tasks (id TEXT PRIMARY KEY, status TEXT NOT NULL);
+             INSERT INTO tasks (id, status) VALUES
+               ('legacy-closed', 'closed'),
+               ('legacy-open', 'open');",
+        )
+        .unwrap();
+
+        assert_eq!(
+            conn.query_row(super::MIGRATION.detect.unwrap(), [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        for statement in super::MIGRATION.up {
+            conn.execute(statement, []).unwrap();
+        }
+        assert_eq!(
+            conn.query_row(super::MIGRATION.detect.unwrap(), [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM tasks WHERE terminal_outcome IS NOT NULL",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0,
+            "m233 must never backfill a guessed outcome"
+        );
+    }
+}

--- a/cas-cli/src/migration/migrations/mod.rs
+++ b/cas-cli/src/migration/migrations/mod.rs
@@ -208,6 +208,7 @@ mod m229_code_vector_state;
 mod m230_verification_repository_proof;
 mod m231_sync_conflicts_create_table;
 mod m232_worker_completion_receipts_add_artifact_path;
+mod m233_tasks_add_terminal_outcome;
 
 /// All migrations in order. IDs must be sequential and never reused.
 pub const MIGRATIONS: &[Migration] = &[
@@ -449,6 +450,7 @@ pub const MIGRATIONS: &[Migration] = &[
     m230_verification_repository_proof::MIGRATION,
     m231_sync_conflicts_create_table::MIGRATION,
     m232_worker_completion_receipts_add_artifact_path::MIGRATION,
+    m233_tasks_add_terminal_outcome::MIGRATION,
 ];
 
 #[cfg(test)]
@@ -487,7 +489,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Duplicate migration ID 1 registered by entries_add_session_id and synthetic_duplicate")]
+    #[should_panic(
+        expected = "Duplicate migration ID 1 registered by entries_add_session_id and synthetic_duplicate"
+    )]
     fn migration_registry_duplicate_id_names_both_migrations() {
         let first = MIGRATIONS[0].clone();
         let duplicate = Migration {

--- a/cas-cli/src/migration/mod.rs
+++ b/cas-cli/src/migration/mod.rs
@@ -736,8 +736,8 @@ pub fn run_migrations(cas_dir: &Path, dry_run: bool) -> Result<MigrationResult> 
                 }
                 Ok(false) => {
                     conn.execute("ROLLBACK", [])?;
-                    let reason = "schema was detected but its ledger row could not be recorded"
-                        .to_string();
+                    let reason =
+                        "schema was detected but its ledger row could not be recorded".to_string();
                     result
                         .errors
                         .push((migration.name.to_string(), reason.clone()));
@@ -930,7 +930,7 @@ mod tests {
 
     fn assert_repaired_v225_knowledge_gap(cas_dir: &Path, expected_m226_ledger: &str) {
         let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
-        for id in [225, 226, 227, 228, 229, 230, 231, 232] {
+        for id in [225, 226, 227, 228, 229, 230, 231, 232, 233] {
             assert_eq!(
                 conn.query_row(
                     "SELECT COUNT(*) FROM cas_migrations WHERE id = ?1",
@@ -997,7 +997,7 @@ mod tests {
         assert_eq!(pages[0].origin_project_id, None);
 
         let status = check_migrations(cas_dir).unwrap();
-        assert_eq!(status.current_version, 232);
+        assert_eq!(status.current_version, 233);
         assert!(status.pending.is_empty());
         let second = run_migrations(cas_dir, false).unwrap();
         assert_eq!(second.applied_count, 0, "repeated open must be idempotent");
@@ -1019,7 +1019,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 227, 228, 229, 230, 231, 232],
+                vec![225, 226, 227, 228, 229, 230, 231, 232, 233],
                 "recorded m225 and missing m226 must order all later work behind them"
             );
 
@@ -1038,10 +1038,7 @@ mod tests {
 
             let first = run_migrations(&cas_dir, false).unwrap();
             assert_eq!(first.applied_count, 1);
-            assert_eq!(
-                first.applied_names,
-                ["commit_links_link_method"]
-            );
+            assert_eq!(first.applied_names, ["commit_links_link_method"]);
 
             let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
             for id in [227, 228, 229] {
@@ -1106,15 +1103,12 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 230, 231, 232]
+                vec![225, 226, 230, 231, 232, 233]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();
             assert_eq!(first.applied_count, 1);
-            assert_eq!(
-                first.applied_names,
-                ["commit_links_link_method"]
-            );
+            assert_eq!(first.applied_names, ["commit_links_link_method"]);
             assert_repaired_v225_knowledge_gap(&cas_dir, "DETECTED");
         });
     }
@@ -1148,17 +1142,14 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 227, 228, 229, 230, 231, 232]
+                vec![225, 227, 228, 229, 230, 231, 232, 233]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();
             assert_eq!(first.applied_count, 2);
             assert_eq!(
                 first.applied_names,
-                [
-                    "commit_links_link_method",
-                    "knowledge_page_tombstones"
-                ]
+                ["commit_links_link_method", "knowledge_page_tombstones"]
             );
 
             let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
@@ -1422,7 +1413,10 @@ mod tests {
                     |row| row.get(0),
                 )
                 .unwrap();
-            assert_eq!(exists, 1, "expected table `{table}` to exist after bootstrap");
+            assert_eq!(
+                exists, 1,
+                "expected table `{table}` to exist after bootstrap"
+            );
         }
 
         // Negative invariant: migration-driven subsystems (Worktrees, Code,
@@ -1705,9 +1699,11 @@ mod tests {
 
         // Pre-existing data is untouched.
         let task_count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM tasks WHERE id = 'cas-old1'", [], |r| {
-                r.get(0)
-            })
+            .query_row(
+                "SELECT COUNT(*) FROM tasks WHERE id = 'cas-old1'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(task_count, 1);
     }
@@ -1740,8 +1736,7 @@ mod tests {
             }
 
             // Run migrations again — should not error, sentinel row must survive.
-            let result =
-                run_migrations(&cas_dir, false).expect("run_migrations should succeed");
+            let result = run_migrations(&cas_dir, false).expect("run_migrations should succeed");
             assert!(result.errors.is_empty());
 
             let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
@@ -1752,7 +1747,10 @@ mod tests {
                     |row| row.get(0),
                 )
                 .unwrap();
-            assert_eq!(sentinel_count, 1, "pre-existing data must survive bootstrap");
+            assert_eq!(
+                sentinel_count, 1,
+                "pre-existing data must survive bootstrap"
+            );
         });
     }
 

--- a/cas-cli/src/prompt_revalidation.rs
+++ b/cas-cli/src/prompt_revalidation.rs
@@ -441,6 +441,22 @@ pub(crate) fn attach_merge_request_envelope(
     format!("{message}\n\n{MERGE_ENVELOPE_OPEN}{encoded}{MERGE_ENVELOPE_CLOSE}")
 }
 
+/// Rewrite the opaque merge-request envelope with the target tip observed at
+/// delivery time.
+///
+/// The human body is the worker's original merge request and must remain
+/// byte-for-byte intact. Only the machine-readable receipt is refreshed: a
+/// queue delay can span several supervisor merges, so the tip captured when
+/// the worker enqueued the request is evidence about then, not now.
+pub(crate) fn refresh_merge_request_target_tip(prompt: &str, target_tip: &str) -> Option<String> {
+    let start = prompt.rfind(MERGE_ENVELOPE_OPEN)? + MERGE_ENVELOPE_OPEN.len();
+    let end = prompt[start..].find(MERGE_ENVELOPE_CLOSE)? + start;
+    let mut envelope: MergeRequestEnvelope = serde_json::from_str(&prompt[start..end]).ok()?;
+    envelope.target_branch_tip = target_tip.to_string();
+    let encoded = serde_json::to_string(&envelope).ok()?;
+    Some(format!("{}{}{}", &prompt[..start], encoded, &prompt[end..]))
+}
+
 pub(crate) fn merge_landed_guidance(
     task_id: &str,
     branch_tip: &str,
@@ -911,6 +927,68 @@ mod tests {
         assert_eq!(
             revalidate_merge_request(repo.path(), &worker_tip, "main"),
             MergeRequestDecision::Pending { target_tip }
+        );
+    }
+
+    /// cas-e3be (GH #260): a merge request can wait in the queue while the
+    /// target branch advances. The body sent at pop time must retain the
+    /// worker's request but name the tip resolved then, rather than the
+    /// enqueue-time snapshot.
+    #[test]
+    fn queued_merge_request_refreshes_target_tip_at_delivery() {
+        let repo = tempfile::tempdir().expect("temp repo");
+        git(repo.path(), &["init", "-b", "main"]);
+        git(
+            repo.path(),
+            &["config", "user.email", "cas-test@example.invalid"],
+        );
+        git(repo.path(), &["config", "user.name", "CAS Test"]);
+        std::fs::write(repo.path().join("base"), "base\n").expect("base file");
+        git(repo.path(), &["add", "base"]);
+        git(repo.path(), &["commit", "-m", "base"]);
+        let enqueue_target_tip = git(repo.path(), &["rev-parse", "main"]);
+
+        git(repo.path(), &["checkout", "-b", "factory/test-worker"]);
+        std::fs::write(repo.path().join("work"), "work\n").expect("work file");
+        git(repo.path(), &["add", "work"]);
+        git(repo.path(), &["commit", "-m", "work"]);
+        let worker_tip = git(repo.path(), &["rev-parse", "factory/test-worker"]);
+        let queued = attach_merge_request_envelope(
+            "Please merge my conflict fix.",
+            &MergeRequestEnvelope {
+                task_id: "cas-e3be".to_string(),
+                branch_tip: worker_tip.clone(),
+                target_branch: "main".to_string(),
+                target_branch_tip: enqueue_target_tip.clone(),
+            },
+        );
+
+        // The task is still awaiting merge, but unrelated work landed before
+        // this queue row reaches the supervisor.
+        git(repo.path(), &["checkout", "main"]);
+        std::fs::write(repo.path().join("later"), "later\n").expect("later file");
+        git(repo.path(), &["add", "later"]);
+        git(repo.path(), &["commit", "-m", "advance target"]);
+        let delivery_target_tip = git(repo.path(), &["rev-parse", "main"]);
+        assert_ne!(enqueue_target_tip, delivery_target_tip);
+
+        assert_eq!(
+            revalidate_merge_request(repo.path(), &worker_tip, "main"),
+            MergeRequestDecision::Pending {
+                target_tip: delivery_target_tip.clone(),
+            }
+        );
+        let injected = refresh_merge_request_target_tip(&queued, &delivery_target_tip)
+            .expect("structured queued merge request refreshes at pop");
+        assert!(injected.starts_with("Please merge my conflict fix."));
+        assert_eq!(
+            parse_merge_request_envelope(&injected),
+            Some(MergeRequestEnvelope {
+                task_id: "cas-e3be".to_string(),
+                branch_tip: worker_tip,
+                target_branch: "main".to_string(),
+                target_branch_tip: delivery_target_tip,
+            })
         );
     }
 

--- a/cas-cli/src/store/mock/task_store.rs
+++ b/cas-cli/src/store/mock/task_store.rs
@@ -155,7 +155,7 @@ impl TaskStore for MockTaskStore {
             .filter(|dependency| {
                 tasks
                     .get(&dependency.to_id)
-                    .map(|task| task.status != TaskStatus::Closed)
+                    .map(|task| !task.is_terminal())
                     .unwrap_or(false)
             })
             .map(|dependency| dependency.from_id.clone())
@@ -185,7 +185,7 @@ impl TaskStore for MockTaskStore {
 
         let mut result = Vec::new();
         for task in tasks.values() {
-            if task.status == TaskStatus::Closed {
+            if task.is_terminal() {
                 continue;
             }
 
@@ -197,7 +197,7 @@ impl TaskStore for MockTaskStore {
                 .filter_map(|dependency| {
                     tasks
                         .get(&dependency.to_id)
-                        .filter(|candidate| candidate.status != TaskStatus::Closed)
+                        .filter(|candidate| !candidate.is_terminal())
                         .cloned()
                 })
                 .collect();

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -1965,7 +1965,12 @@ fn non_closed_task_ids(data: &DirectorData) -> HashSet<&str> {
         .chain(
             data.epic_tasks
                 .iter()
-                .filter(|e| e.status != cas_types::TaskStatus::Closed),
+                .filter(|e| {
+                    !matches!(
+                        e.status,
+                        cas_types::TaskStatus::Closed | cas_types::TaskStatus::Cancelled
+                    )
+                }),
         )
         .map(|t| t.id.as_str())
         .collect()

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -644,7 +644,7 @@ fn worker_has_open_tasks(cas_dir: &std::path::Path, agent_id: &str) -> bool {
     match open_task_store(cas_dir) {
         Ok(store) => match store.list(None) {
             Ok(tasks) => tasks.iter().any(|t| {
-                t.assignee.as_deref() == Some(agent_id) && t.status != cas_types::TaskStatus::Closed
+                t.assignee.as_deref() == Some(agent_id) && !t.is_terminal()
             }),
             Err(e) => {
                 tracing::warn!(

--- a/cas-cli/src/ui/factory/app/render_and_ops/rendering/detail_views.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/rendering/detail_views.rs
@@ -53,6 +53,7 @@ impl FactoryApp {
                     cas_types::TaskStatus::Open => palette.task_open,
                     cas_types::TaskStatus::InProgress => palette.task_in_progress,
                     cas_types::TaskStatus::Closed => palette.task_closed,
+                    cas_types::TaskStatus::Cancelled => palette.task_closed,
                     cas_types::TaskStatus::Blocked => palette.task_blocked,
                     // cas-b51a: reuse warning color — task awaits supervisor review
                     cas_types::TaskStatus::PendingSupervisorReview => palette.task_blocked,

--- a/cas-cli/src/ui/factory/app/render_and_ops/rendering/dialogs.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/rendering/dialogs.rs
@@ -498,6 +498,7 @@ impl FactoryApp {
                     cas_types::TaskStatus::Open => palette.task_open,
                     cas_types::TaskStatus::InProgress => palette.task_in_progress,
                     cas_types::TaskStatus::Closed => palette.task_closed,
+                    cas_types::TaskStatus::Cancelled => palette.task_closed,
                     cas_types::TaskStatus::Blocked => palette.task_blocked,
                     // cas-b51a: reuse warning color — task awaits supervisor review
                     cas_types::TaskStatus::PendingSupervisorReview => palette.task_blocked,

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -2521,14 +2521,20 @@ impl FactoryDaemon {
             // still be retracted from the supervisor's inbox if the merge
             // lands after this delivery. `None` for every other message.
             let mut merge_request_task: Option<String> = None;
+            // cas-e3be (GH #260): the target branch can move while a merge
+            // request waits in the durable queue. Keep the worker's prose,
+            // but replace the envelope's enqueue-time target tip with the
+            // ref resolved at this pop/injection point.
+            let mut prompt_with_instructions = queued.prompt.clone();
 
             if let Some(envelope) =
                 crate::prompt_revalidation::parse_merge_request_envelope(&queued.prompt)
             {
                 use crate::mcp::tools::core::task::repo_context::resolve_repo_context;
                 use crate::prompt_revalidation::{
-                    MergeRequestDelivery, merge_landed_guidance, merge_request_delivery_decision,
-                    merge_request_moot_guidance, revalidate_merge_request,
+                    MergeRequestDecision, MergeRequestDelivery, merge_landed_guidance,
+                    merge_request_delivery_decision, merge_request_moot_guidance,
+                    revalidate_merge_request,
                 };
 
                 let task = crate::store::open_task_store_local(self.app.cas_dir())
@@ -2570,6 +2576,15 @@ impl FactoryDaemon {
                     &git,
                 ) {
                     MergeRequestDelivery::Deliver => {
+                        if let MergeRequestDecision::Pending { target_tip } = &git
+                            && let Some(refreshed) =
+                                crate::prompt_revalidation::refresh_merge_request_target_tip(
+                                    &queued.prompt,
+                                    target_tip,
+                                )
+                        {
+                            prompt_with_instructions = refreshed;
+                        }
                         merge_request_task = Some(envelope.task_id.clone());
                         (None, None, "")
                     }
@@ -2733,8 +2748,6 @@ impl FactoryDaemon {
                     }
                 }
             }
-
-            let prompt_with_instructions = queued.prompt.clone();
 
             // Resolve the queue source to a valid team member name for inbox writes.
             // The source must be a registered team member name for Claude Code to

--- a/cas-cli/src/ui/factory/director/prompts.rs
+++ b/cas-cli/src/ui/factory/director/prompts.rs
@@ -114,7 +114,7 @@ pub(crate) fn epic_completion_is_current(data: &DirectorData, epic_id: &str) -> 
     let Some(epic) = data.epic_tasks.iter().find(|epic| epic.id == epic_id) else {
         return true;
     };
-    if epic.status == TaskStatus::Closed {
+    if matches!(epic.status, TaskStatus::Closed | TaskStatus::Cancelled) {
         return false;
     }
 
@@ -123,7 +123,8 @@ pub(crate) fn epic_completion_is_current(data: &DirectorData, epic_id: &str) -> 
         .iter()
         .chain(data.in_progress_tasks.iter())
         .any(|task| {
-            task.epic.as_deref() == Some(epic_id) && task.status != TaskStatus::Closed
+            task.epic.as_deref() == Some(epic_id)
+                && !matches!(task.status, TaskStatus::Closed | TaskStatus::Cancelled)
         })
 }
 

--- a/cas-cli/src/ui/factory/director/tasks.rs
+++ b/cas-cli/src/ui/factory/director/tasks.rs
@@ -339,6 +339,7 @@ fn render_task_item(
         TaskStatus::Open => Icons::CIRCLE_EMPTY,
         TaskStatus::Blocked => Icons::CIRCLE_X,
         TaskStatus::Closed => Icons::CHECK,
+        TaskStatus::Cancelled => Icons::CIRCLE_X,
         // cas-b51a: awaiting supervisor code-review
         TaskStatus::PendingSupervisorReview => Icons::CLOCK,
         TaskStatus::AwaitingMerge => Icons::CLOCK,
@@ -348,6 +349,7 @@ fn render_task_item(
         TaskStatus::InProgress => palette.task_in_progress,
         TaskStatus::Blocked => palette.task_blocked,
         TaskStatus::Closed => palette.task_closed,
+        TaskStatus::Cancelled => palette.task_closed,
         TaskStatus::Open => palette.task_open,
         // cas-b51a: reuse warning color (same as blocked) — task is "waiting"
         TaskStatus::PendingSupervisorReview => palette.task_blocked,
@@ -471,9 +473,9 @@ mod tests {
             epic: epic.map(str::to_string),
             branch: None,
             updated_at: None,
-        epic_verification_owner: None,
+            epic_verification_owner: None,
         }
-        }
+    }
 
     fn data_for_scoping() -> DirectorData {
         DirectorData {

--- a/cas-cli/src/ui/widgets/tasks.rs
+++ b/cas-cli/src/ui/widgets/tasks.rs
@@ -161,6 +161,7 @@ pub fn build_task_item(
         TaskStatus::Open => Icons::CIRCLE_EMPTY,
         TaskStatus::Blocked => Icons::CIRCLE_X,
         TaskStatus::Closed => Icons::CHECK,
+        TaskStatus::Cancelled => Icons::CIRCLE_X,
         // cas-b51a: awaiting supervisor code-review
         TaskStatus::PendingSupervisorReview => Icons::CLOCK,
         TaskStatus::AwaitingMerge => Icons::CLOCK,
@@ -170,6 +171,7 @@ pub fn build_task_item(
         TaskStatus::InProgress => palette.task_in_progress,
         TaskStatus::Blocked => palette.task_blocked,
         TaskStatus::Closed => palette.task_closed,
+        TaskStatus::Cancelled => palette.task_closed,
         TaskStatus::Open => palette.task_open,
         // cas-b51a: reuse warning color — task is "waiting" for supervisor
         TaskStatus::PendingSupervisorReview => palette.task_blocked,

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -1288,8 +1288,8 @@ async fn test_spawn_workers_task_id_bypass_requires_a_valid_open_task() {
         .await
         .expect_err("a closed task must not authorize a spawn");
     assert!(
-        err.message.contains("already closed"),
-        "error should name the closed task: {}",
+        err.message.contains(&closed_id) && err.message.contains("terminal (closed)"),
+        "error should name the closed terminal task and status: {}",
         err.message
     );
 

--- a/cas-cli/tests/mcp_tools_test/task_tools/cancellation.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/cancellation.rs
@@ -1,0 +1,193 @@
+use crate::support::*;
+use cas::mcp::tools::{TaskCancelRequest, TaskListRequest, TaskReopenRequest, TaskShowRequest};
+use cas::store::{open_agent_store, open_task_store};
+use cas::types::{
+    AgentRole, Dependency, DependencyType, Task, TaskStatus, TaskTerminalOutcome, TaskType,
+};
+use rmcp::handler::server::wrapper::Parameters;
+
+fn promote_test_agent(cas_dir: &std::path::Path) {
+    let store = open_agent_store(cas_dir).unwrap();
+    let id = format!("test-session-{}", std::process::id());
+    let mut agent = store.get(&id).unwrap();
+    agent.role = AgentRole::Supervisor;
+    store.update(&agent).unwrap();
+}
+
+#[tokio::test]
+async fn cancel_without_commits_persists_pointer_and_lists_as_no_delivery() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    promote_test_agent(&cas_dir);
+    let store = open_task_store(&cas_dir).unwrap();
+    let task = Task::new("cas-cancel-pointer".into(), "superseded work".into());
+    store.add(&task).unwrap();
+
+    let result = extract_text(
+        core.cas_task_cancel(Parameters(TaskCancelRequest {
+            id: task.id.clone(),
+            reason: "requester delivered the same change".into(),
+            superseded_by: Some("https://github.com/example/repo/pull/258".into()),
+        }))
+        .await
+        .unwrap(),
+    );
+    assert!(
+        result.contains("Cancelled task without delivery"),
+        "{result}"
+    );
+
+    let persisted = store.get(&task.id).unwrap();
+    assert_eq!(persisted.status, TaskStatus::Cancelled);
+    assert!(!persisted.counts_as_delivered());
+    assert_eq!(
+        persisted.terminal_outcome,
+        Some(TaskTerminalOutcome::Cancelled {
+            superseded_by: Some("https://github.com/example/repo/pull/258".into()),
+        })
+    );
+
+    let listed = extract_text(
+        core.cas_task_list(Parameters(TaskListRequest {
+            limit: None,
+            scope: "all".into(),
+            status: Some("cancelled".into()),
+            task_type: None,
+            label: None,
+            assignee: None,
+            epic: None,
+            sort: None,
+            sort_order: None,
+        }))
+        .await
+        .unwrap(),
+    );
+    assert!(listed.contains("Cancelled [NO DELIVERY]"), "{listed}");
+
+    let shown = extract_text(
+        core.cas_task_show(Parameters(TaskShowRequest {
+            id: task.id,
+            with_deps: false,
+        }))
+        .await
+        .unwrap(),
+    );
+    assert!(
+        shown.contains("Outcome: cancelled without delivery"),
+        "{shown}"
+    );
+    assert!(shown.contains("Superseded by: https://github.com/example/repo/pull/258"));
+}
+
+#[tokio::test]
+async fn cancel_refuses_blank_reason_without_mutation() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    promote_test_agent(&cas_dir);
+    let store = open_task_store(&cas_dir).unwrap();
+    let task = Task::new(
+        "cas-cancel-blank".into(),
+        "must explain cancellation".into(),
+    );
+    store.add(&task).unwrap();
+
+    let error = core
+        .cas_task_cancel(Parameters(TaskCancelRequest {
+            id: task.id.clone(),
+            reason: "   ".into(),
+            superseded_by: None,
+        }))
+        .await
+        .expect_err("blank cancellation reason must be rejected");
+    assert!(error.message.contains("reason is required"));
+    assert_eq!(store.get(&task.id).unwrap().status, TaskStatus::Open);
+}
+
+#[tokio::test]
+async fn epic_cancel_requires_terminal_children_then_cancels_without_delivery() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    promote_test_agent(&cas_dir);
+    let store = open_task_store(&cas_dir).unwrap();
+    let mut epic = Task::new("cas-cancel-epic".into(), "superseded epic".into());
+    epic.task_type = TaskType::Epic;
+    let child = Task::new("cas-cancel-child".into(), "superseded child".into());
+    store.add(&epic).unwrap();
+    store.add(&child).unwrap();
+    store
+        .add_dependency(&Dependency {
+            from_id: child.id.clone(),
+            to_id: epic.id.clone(),
+            dep_type: DependencyType::ParentChild,
+            created_at: chrono::Utc::now(),
+            created_by: None,
+        })
+        .unwrap();
+
+    let blocked = core
+        .cas_task_cancel(Parameters(TaskCancelRequest {
+            id: epic.id.clone(),
+            reason: "replacement epic landed".into(),
+            superseded_by: Some("cas-replacement".into()),
+        }))
+        .await
+        .expect_err("non-terminal child must block epic cancellation");
+    assert!(blocked.message.contains(&child.id));
+
+    core.cas_task_cancel(Parameters(TaskCancelRequest {
+        id: child.id.clone(),
+        reason: "covered by replacement".into(),
+        superseded_by: Some("cas-replacement".into()),
+    }))
+    .await
+    .unwrap();
+    core.cas_task_cancel(Parameters(TaskCancelRequest {
+        id: epic.id.clone(),
+        reason: "replacement epic landed".into(),
+        superseded_by: Some("cas-replacement".into()),
+    }))
+    .await
+    .unwrap();
+
+    let persisted = store.get(&epic.id).unwrap();
+    assert_eq!(persisted.status, TaskStatus::Cancelled);
+    assert!(!persisted.has_delivery_to_integrate());
+}
+
+#[tokio::test]
+async fn registered_supervisor_can_reopen_cancelled_task_and_clear_outcome() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    promote_test_agent(&cas_dir);
+    let store = open_task_store(&cas_dir).unwrap();
+    let task = Task::new("cas-cancel-reopen".into(), "mistaken cancellation".into());
+    store.add(&task).unwrap();
+    core.cas_task_cancel(Parameters(TaskCancelRequest {
+        id: task.id.clone(),
+        reason: "thought replacement landed".into(),
+        superseded_by: Some("cas-replacement".into()),
+    }))
+    .await
+    .unwrap();
+
+    core.cas_task_reopen(Parameters(TaskReopenRequest {
+        id: task.id.clone(),
+        reason: Some("replacement was reverted".into()),
+    }))
+    .await
+    .unwrap();
+
+    let reopened = store.get(&task.id).unwrap();
+    assert_eq!(reopened.status, TaskStatus::Open);
+    assert_eq!(reopened.terminal_outcome, None);
+    assert_eq!(reopened.closed_at, None);
+    assert!(
+        reopened
+            .notes
+            .contains("Reopened: replacement was reverted")
+    );
+}

--- a/cas-cli/tests/mcp_tools_test/task_tools/cancellation.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/cancellation.rs
@@ -1,5 +1,9 @@
 use crate::support::*;
-use cas::mcp::tools::{TaskCancelRequest, TaskListRequest, TaskReopenRequest, TaskShowRequest};
+use cas::mcp::CasService;
+use cas::mcp::tools::{
+    IdRequest, LimitRequest, TaskCancelRequest, TaskListRequest, TaskReopenRequest,
+    TaskShowRequest, TaskUpdateRequest,
+};
 use cas::store::{open_agent_store, open_task_store};
 use cas::types::{
     AgentRole, Dependency, DependencyType, Task, TaskStatus, TaskTerminalOutcome, TaskType,
@@ -21,18 +25,19 @@ async fn cancel_without_commits_persists_pointer_and_lists_as_no_delivery() {
     let cas_dir = temp.path().join(".cas");
     promote_test_agent(&cas_dir);
     let store = open_task_store(&cas_dir).unwrap();
-    let task = Task::new("cas-cancel-pointer".into(), "superseded work".into());
+    let mut task = Task::new("cas-cancel-pointer".into(), "superseded work".into());
+    task.assignee = Some("test-agent".into());
     store.add(&task).unwrap();
 
-    let result = extract_text(
-        core.cas_task_cancel(Parameters(TaskCancelRequest {
-            id: task.id.clone(),
-            reason: "requester delivered the same change".into(),
-            superseded_by: Some("https://github.com/example/repo/pull/258".into()),
-        }))
-        .await
-        .unwrap(),
-    );
+    let service = CasService::new(core.clone(), None);
+    let request: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
+        "action": "cancel",
+        "id": task.id.clone(),
+        "reason": "requester delivered the same change",
+        "superseded_by": "https://github.com/example/repo/pull/258"
+    }))
+    .unwrap();
+    let result = extract_text(service.task(Parameters(request)).await.unwrap());
     assert!(
         result.contains("Cancelled task without delivery"),
         "{result}"
@@ -67,7 +72,7 @@ async fn cancel_without_commits_persists_pointer_and_lists_as_no_delivery() {
 
     let shown = extract_text(
         core.cas_task_show(Parameters(TaskShowRequest {
-            id: task.id,
+            id: task.id.clone(),
             with_deps: false,
         }))
         .await
@@ -78,6 +83,34 @@ async fn cancel_without_commits_persists_pointer_and_lists_as_no_delivery() {
         "{shown}"
     );
     assert!(shown.contains("Superseded by: https://github.com/example/repo/pull/258"));
+
+    assert!(
+        !store
+            .list_ready()
+            .unwrap()
+            .iter()
+            .any(|ready| ready.id == task.id),
+        "cancelled work must not re-enter the ready queue"
+    );
+
+    let mine_request: LimitRequest = serde_json::from_value(serde_json::json!({})).unwrap();
+    let mine = extract_text(core.cas_tasks_mine(Parameters(mine_request)).await.unwrap());
+    assert!(
+        !mine.contains(&task.id),
+        "cancelled work leaked into mine: {mine}"
+    );
+
+    let start_error = core
+        .cas_task_start(Parameters(IdRequest {
+            id: task.id.clone(),
+        }))
+        .await
+        .expect_err("cancelled work must not be startable");
+    assert!(
+        start_error.message.contains("terminal task"),
+        "{}",
+        start_error.message
+    );
 }
 
 #[tokio::test]
@@ -103,6 +136,56 @@ async fn cancel_refuses_blank_reason_without_mutation() {
         .expect_err("blank cancellation reason must be rejected");
     assert!(error.message.contains("reason is required"));
     assert_eq!(store.get(&task.id).unwrap().status, TaskStatus::Open);
+}
+
+#[tokio::test]
+async fn direct_status_updates_cannot_cancel_or_reopen_cancelled_work() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    promote_test_agent(&cas_dir);
+    let store = open_task_store(&cas_dir).unwrap();
+    let task = Task::new(
+        "cas-cancel-update-bypass".into(),
+        "guard cancellation verb".into(),
+    );
+    store.add(&task).unwrap();
+
+    let direct_cancel: TaskUpdateRequest = serde_json::from_value(serde_json::json!({
+        "id": task.id,
+        "status": "cancelled"
+    }))
+    .unwrap();
+    let error = core
+        .cas_task_update(Parameters(direct_cancel))
+        .await
+        .expect_err("direct cancellation must not bypass supervisor authority and reason");
+    assert!(error.message.contains("action=cancel"), "{}", error.message);
+    assert_eq!(store.get(&task.id).unwrap().status, TaskStatus::Open);
+
+    core.cas_task_cancel(Parameters(TaskCancelRequest {
+        id: task.id.clone(),
+        reason: "replacement landed".into(),
+        superseded_by: Some("cas-replacement".into()),
+    }))
+    .await
+    .unwrap();
+    let direct_reopen: TaskUpdateRequest = serde_json::from_value(serde_json::json!({
+        "id": task.id,
+        "status": "open"
+    }))
+    .unwrap();
+    let error = core
+        .cas_task_update(Parameters(direct_reopen))
+        .await
+        .expect_err("direct reopen must not bypass supervisor-authorized reopen");
+    assert!(error.message.contains("action=reopen"), "{}", error.message);
+    let persisted = store.get(&task.id).unwrap();
+    assert_eq!(persisted.status, TaskStatus::Cancelled);
+    assert!(matches!(
+        persisted.terminal_outcome,
+        Some(TaskTerminalOutcome::Cancelled { .. })
+    ));
 }
 
 #[tokio::test]

--- a/cas-cli/tests/mcp_tools_test/task_tools/gate.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/gate.rs
@@ -1,0 +1,212 @@
+use crate::support::*;
+use cas::mcp::CasService;
+use cas::mcp::tools::{IdRequest, TaskUpdateRequest};
+use cas::store::{open_agent_store, open_task_store};
+use cas::types::{AgentRole, TaskStatus, TaskTerminalOutcome, TaskType};
+use rmcp::handler::server::wrapper::Parameters;
+
+fn set_test_agent_role(cas_dir: &std::path::Path, role: AgentRole) {
+    let store = open_agent_store(cas_dir).unwrap();
+    let id = format!("test-session-{}", std::process::id());
+    let mut agent = store.get(&id).unwrap();
+    agent.role = role;
+    store.update(&agent).unwrap();
+}
+
+async fn unified_task(service: &CasService, request: serde_json::Value) -> String {
+    let request: cas_mcp::TaskRequest = serde_json::from_value(request).unwrap();
+    extract_text(service.task(Parameters(request)).await.unwrap())
+}
+
+#[tokio::test]
+async fn supervisor_gate_closes_on_decision_and_unblocks_dependent_without_commit() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    set_test_agent_role(&cas_dir, AgentRole::Supervisor);
+    let service = CasService::new(core.clone(), None);
+
+    let created = unified_task(
+        &service,
+        serde_json::json!({
+            "action": "create",
+            "title": "Approve rollout",
+            "task_type": "gate"
+        }),
+    )
+    .await;
+    let gate_id = extract_task_id(&created).unwrap().to_string();
+
+    let dependent = unified_task(
+        &service,
+        serde_json::json!({
+            "action": "create",
+            "title": "Begin rollout",
+            "task_type": "task",
+            "blocked_by": gate_id
+        }),
+    )
+    .await;
+    let dependent_id = extract_task_id(&dependent).unwrap().to_string();
+    let store = open_task_store(&cas_dir).unwrap();
+    assert_eq!(store.get(&gate_id).unwrap().task_type, TaskType::Gate);
+    assert!(
+        !store
+            .list_ready()
+            .unwrap()
+            .iter()
+            .any(|task| task.id == dependent_id),
+        "an open Gate must remain a normal dependency blocker"
+    );
+
+    let started = unified_task(
+        &service,
+        serde_json::json!({"action": "start", "id": gate_id, "brief": true}),
+    )
+    .await;
+    assert!(started.contains("Started task"), "{started}");
+    assert_eq!(store.get(&gate_id).unwrap().status, TaskStatus::InProgress);
+
+    // A structured but empty decision note is not a decision.
+    unified_task(
+        &service,
+        serde_json::json!({
+            "action": "notes",
+            "id": gate_id,
+            "note_type": "decision",
+            "notes": "   "
+        }),
+    )
+    .await;
+    let refused = unified_task(
+        &service,
+        serde_json::json!({
+            "action": "close",
+            "id": gate_id,
+            "reason": "promotion approved"
+        }),
+    )
+    .await;
+    assert!(refused.contains("no non-empty recorded DECISION note"), "{refused}");
+    let unchanged = store.get(&gate_id).unwrap();
+    assert_eq!(unchanged.status, TaskStatus::InProgress);
+    assert_eq!(unchanged.terminal_outcome, None);
+
+    unified_task(
+        &service,
+        serde_json::json!({
+            "action": "notes",
+            "id": gate_id,
+            "note_type": "decision",
+            "notes": "Approve the staged rollout after the error-budget review."
+        }),
+    )
+    .await;
+    let closed = unified_task(
+        &service,
+        serde_json::json!({
+            "action": "close",
+            "id": gate_id,
+            "reason": "promotion approved"
+        }),
+    )
+    .await;
+    assert!(closed.contains("Closed task"), "{closed}");
+
+    let persisted = store.get(&gate_id).unwrap();
+    assert_eq!(persisted.status, TaskStatus::Closed);
+    assert_eq!(
+        persisted.terminal_outcome,
+        Some(TaskTerminalOutcome::Decision)
+    );
+    assert!(!persisted.counts_as_delivered());
+    assert!(persisted.deliverables.merge_commit.is_none());
+    assert!(
+        store
+            .list_ready()
+            .unwrap()
+            .iter()
+            .any(|task| task.id == dependent_id),
+        "Decision-close must satisfy the Gate dependency"
+    );
+}
+
+#[tokio::test]
+async fn gate_start_is_supervisor_only_without_weakening_ordinary_start_protection() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    let store = open_task_store(&cas_dir).unwrap();
+    let service = CasService::new(core.clone(), None);
+
+    let mut gate = cas::types::Task::new("cas-gate-worker-start".into(), "Gate".into());
+    gate.task_type = TaskType::Gate;
+    store.add(&gate).unwrap();
+    let worker_error = core
+        .cas_task_start(Parameters(IdRequest {
+            id: gate.id.clone(),
+        }))
+        .await
+        .expect_err("a worker must not start a supervisor-owned Gate");
+    assert!(
+        worker_error.message.contains("only a live registered supervisor"),
+        "{}",
+        worker_error.message
+    );
+    assert_eq!(store.get(&gate.id).unwrap().status, TaskStatus::Open);
+
+    unified_task(
+        &service,
+        serde_json::json!({
+            "action": "notes",
+            "id": gate.id.clone(),
+            "note_type": "decision",
+            "notes": "Approve the rollout."
+        }),
+    )
+    .await;
+    let worker_close = unified_task(
+        &service,
+        serde_json::json!({"action": "close", "id": gate.id.clone()}),
+    )
+    .await;
+    assert!(
+        worker_close.contains("only a live registered supervisor"),
+        "{worker_close}"
+    );
+    assert_eq!(store.get(&gate.id).unwrap().status, TaskStatus::Open);
+
+    set_test_agent_role(&cas_dir, AgentRole::Supervisor);
+    let direct_close: TaskUpdateRequest = serde_json::from_value(serde_json::json!({
+        "id": gate.id.clone(),
+        "status": "closed"
+    }))
+    .unwrap();
+    let direct_close_error = core
+        .cas_task_update(Parameters(direct_close))
+        .await
+        .expect_err("direct status update must not bypass the Gate decision classifier");
+    assert!(
+        direct_close_error.message.contains("GATE UPDATE REJECTED"),
+        "{}",
+        direct_close_error.message
+    );
+    assert_eq!(store.get(&gate.id).unwrap().status, TaskStatus::Open);
+
+    let ordinary = cas::types::Task::new("cas-ordinary-supervisor-start".into(), "Work".into());
+    store.add(&ordinary).unwrap();
+    let supervisor_error = core
+        .cas_task_start(Parameters(IdRequest {
+            id: ordinary.id.clone(),
+        }))
+        .await
+        .expect_err("supervisors must still delegate ordinary work");
+    assert!(
+        supervisor_error
+            .message
+            .contains("Supervisors cannot start non-epic tasks"),
+        "{}",
+        supervisor_error.message
+    );
+    assert_eq!(store.get(&ordinary.id).unwrap().status, TaskStatus::Open);
+}

--- a/cas-cli/tests/mcp_tools_test/task_tools/mod.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/mod.rs
@@ -4,6 +4,7 @@ mod dependencies;
 mod depth_e2e;
 mod depth_light_close;
 mod double_close;
+mod gate;
 mod operations;
 mod reopen_atomicity;
 mod supervisor_review_flow;

--- a/cas-cli/tests/mcp_tools_test/task_tools/mod.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/mod.rs
@@ -1,3 +1,4 @@
+mod cancellation;
 mod create_and_epic;
 mod dependencies;
 mod depth_e2e;

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -7,7 +7,7 @@ cas doctor
 ──────────────────────────────────────────────────
 [OK] cas directory: Found at [TEMP_PATH]
 [OK] database: SQLite database found
-[OK] schema: v232 (up to date)
+[OK] schema: v233 (up to date)
 [OK] supervisor relay: no undelivered lifecycle relays
 [OK] delivery retries: no pending message has spent 3+ attempts
 [OK] tables: [N] tables, 716 columns, 195 rows total

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -10,7 +10,7 @@ cas doctor
 [OK] schema: v233 (up to date)
 [OK] supervisor relay: no undelivered lifecycle relays
 [OK] delivery retries: no pending message has spent 3+ attempts
-[OK] tables: [N] tables, 716 columns, 195 rows total
+[OK] tables: [N] tables, 717 columns, 196 rows total
 [OK] entry store: [N] entries accessible
 [WARN] search index: Index not found. Will be created on first search.
 [WARN] symbol index: nothing indexed for this project (0 symbol(s) in the store across all repositories); the code search index is missing. The daemon only indexes while idle — run `cas index code` to catch up now.

--- a/crates/cas-core/src/hooks/context/plan_mode.rs
+++ b/crates/cas-core/src/hooks/context/plan_mode.rs
@@ -86,6 +86,9 @@ pub fn build_plan_context_with_stores(
             if let Ok(closed) = ts.list(Some(TaskStatus::Closed)) {
                 all_tasks.extend(closed.into_iter().take(5));
             }
+            if let Ok(cancelled) = ts.list(Some(TaskStatus::Cancelled)) {
+                all_tasks.extend(cancelled.into_iter().take(5));
+            }
         }
 
         all_tasks.sort_by(|a, b| {
@@ -94,6 +97,7 @@ pub fn build_plan_context_with_stores(
                 TaskStatus::Blocked => 1,
                 TaskStatus::Open => 2,
                 TaskStatus::Closed => 3,
+                TaskStatus::Cancelled => 3,
                 // cas-b51a: tasks awaiting supervisor review sort after
                 // closed tasks — they are logically "done" from the worker's
                 // perspective, just not yet approved by the supervisor.

--- a/crates/cas-factory/src/director.rs
+++ b/crates/cas-factory/src/director.rs
@@ -304,9 +304,15 @@ impl DirectorData {
                         in_progress_tasks.push(to_summary(task));
                     }
                     TaskStatus::Closed => {
-                        if let Some(epic_id) = child_to_epic.get(&task.id) {
+                        if task.counts_as_delivered()
+                            && let Some(epic_id) = child_to_epic.get(&task.id)
+                        {
                             *epic_closed_counts.entry(epic_id.clone()).or_insert(0) += 1;
                         }
+                    }
+                    TaskStatus::Cancelled => {
+                        // Terminal but intentionally not delivered. Keep it out
+                        // of both active queues and delivered child counts.
                     }
                     // cas-b51a: show tasks awaiting supervisor review as a
                     // separate in-progress bucket so the TUI surfaces them
@@ -487,8 +493,7 @@ impl DirectorData {
                 let pending_messages = pending_counts.get(&a.name).copied().unwrap_or(0);
                 let pending_supervisor_messages =
                     pending_supervisor_counts.get(&a.name).copied().unwrap_or(0);
-                let latest_supervisor_message_at =
-                    latest_supervisor_messages.get(&a.name).copied();
+                let latest_supervisor_message_at = latest_supervisor_messages.get(&a.name).copied();
                 let effort = a
                     .metadata
                     .get("worker_effort")
@@ -532,13 +537,12 @@ impl DirectorData {
                     });
                 // Surface process-alive Stale rows as Active so icons/counts
                 // match worker_status dual-signal (cas-e98e).
-                let display_status = if a.status == AgentStatus::Stale
-                    && agent_pid_looks_alive(a.pid)
-                {
-                    AgentStatus::Active
-                } else {
-                    a.status
-                };
+                let display_status =
+                    if a.status == AgentStatus::Stale && agent_pid_looks_alive(a.pid) {
+                        AgentStatus::Active
+                    } else {
+                        a.status
+                    };
                 AgentSummary {
                     id: a.id,
                     name: a.name,

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -140,7 +140,7 @@ pub struct MemoryRequest {
 pub struct TaskRequest {
     /// Action to perform
     #[schemars(
-        description = "Action: 'create', 'show', 'update', 'start', 'close', 'reopen', 'delete', 'list', 'ready', 'blocked', 'notes', 'dep_add', 'dep_remove', 'dep_list', 'claim', 'release', 'transfer', 'available', 'mine'"
+        description = "Action: 'create', 'show', 'update', 'start', 'close', 'cancel', 'reopen', 'delete', 'list', 'ready', 'blocked', 'notes', 'dep_add', 'dep_remove', 'dep_list', 'claim', 'release', 'transfer', 'available', 'mine'"
     )]
     pub action: String,
 
@@ -206,17 +206,23 @@ pub struct TaskRequest {
     #[serde(default)]
     pub reason: Option<String>,
 
+    /// Portable task/commit/PR pointer for `action=cancel` when another result
+    /// superseded this task.
+    #[schemars(
+        description = "Optional portable task, commit, or PR pointer that superseded cancelled work"
+    )]
+    #[serde(default)]
+    pub superseded_by: Option<String>,
+
     /// Supervisor override for the cas-code-review P0 close gate (cas-b39f, Unit 9).
     ///
     /// When `true`, the close path skips the multi-persona code-review
     /// gate that would otherwise hard-block on P0 findings. Only honored
     /// when the caller runs under a supervisor role; other callers get
     /// an explicit rejection. Logs a decision note on the task.
-    #[schemars(
-        description = "Supervisor override for the code-review P0 gate. \
+    #[schemars(description = "Supervisor override for the code-review P0 gate. \
                        Only honored when the caller is a supervisor; other \
-                       roles are rejected. Logs a decision note on the task."
-    )]
+                       roles are rejected. Logs a decision note on the task.")]
     #[serde(default, deserialize_with = "deser::option_bool")]
     pub bypass_code_review: Option<bool>,
 
@@ -275,8 +281,7 @@ pub struct TaskRequest {
                        Each Finding requires: title, severity, file, line, \
                        why_it_matters, autofix_class, owner, confidence, \
                        evidence, pre_existing (optional: suggested_fix, \
-                       requires_verification)."
-    )]
+                       requires_verification).")]
     #[serde(default)]
     pub code_review_findings: Option<String>,
 
@@ -288,14 +293,12 @@ pub struct TaskRequest {
     /// entry reports `hits == 0`, a warning note is appended rather than
     /// letting the close proceed silently. Ordinary code tasks and tasks
     /// that omit this field are entirely unaffected.
-    #[schemars(
-        description = "Serialized JSON array of search steps run during an \
+    #[schemars(description = "Serialized JSON array of search steps run during an \
                        investigation (Spike) task, e.g. \
                        [{\"command\": \"grep -c foo file\", \"hits\": 3}]. \
                        Optional; when present on a Spike-type close, any \
                        entry with hits=0 is surfaced as a warning note \
-                       instead of a silent pass."
-    )]
+                       instead of a silent pass.")]
     #[serde(default)]
     pub search_manifest: Option<String>,
 
@@ -445,7 +448,9 @@ pub struct TaskRequest {
     pub depth: Option<String>,
 
     /// Explicit repository containing this task's code changes.
-    #[schemars(description = "Repository path containing this task's code changes (create/update).")]
+    #[schemars(
+        description = "Repository path containing this task's code changes (create/update)."
+    )]
     #[serde(default)]
     pub target_repo: Option<String>,
 
@@ -629,7 +634,9 @@ pub struct SkillRequest {
     pub allowed_tools: Option<String>,
 
     /// Disallowed tools (comma-separated) — harness-enforced bans (Claude Code 2.1.152+)
-    #[schemars(description = "Disallowed tools (comma-separated). Harness-enforced at runtime (Claude Code 2.1.152+).")]
+    #[schemars(
+        description = "Disallowed tools (comma-separated). Harness-enforced at runtime (Claude Code 2.1.152+)."
+    )]
     #[serde(default)]
     pub disallowed_tools: Option<String>,
 

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -177,8 +177,10 @@ pub struct TaskRequest {
     #[serde(default, deserialize_with = "deser::option_priority")]
     pub priority: Option<u8>,
 
-    /// Task type (for create): task, bug, feature, epic, chore
-    #[schemars(description = "Task type: 'task', 'bug', 'feature', 'epic', 'chore'")]
+    /// Task type (for create): task, bug, feature, epic, chore, spike, gate
+    #[schemars(
+        description = "Task type: 'task', 'bug', 'feature', 'epic', 'chore', 'spike', 'gate'"
+    )]
     #[serde(default)]
     pub task_type: Option<String>,
 

--- a/crates/cas-store/src/lib.rs
+++ b/crates/cas-store/src/lib.rs
@@ -161,8 +161,9 @@ pub use verification_store::{
     invalidate_verification_dispatch_for_repository_drift, issue_server_verifier_handoff,
     issue_server_verifier_handoff_with_secret, issue_verifier_capability,
     pend_task_for_supervisor_review_with_dispatch, reopen_closed_task_atomic,
-    request_changes_for_parked_delivery, resolve_verification_dispatch_with_conn,
-    save_verification_issues_with_conn, timeout_verification_dispatch, update_system_verification,
+    reopen_terminal_task_atomic, request_changes_for_parked_delivery,
+    resolve_verification_dispatch_with_conn, save_verification_issues_with_conn,
+    timeout_verification_dispatch, update_system_verification,
 };
 
 // Worktree store for git worktree tracking
@@ -200,8 +201,7 @@ pub use prompt_queue_store::{
 pub use reminder_store::{
     Reminder, ReminderExpiryOutcome, ReminderStatus, ReminderStore, ReminderTriggerType,
     SqliteReminderStore, expire_stale_bounded, format_cross_session_reminder_delivery,
-    format_reminder_delivery,
-    parse_reminder_delivery_id,
+    format_reminder_delivery, parse_reminder_delivery_id,
 };
 
 // Retrieval provenance and explicit outcome feedback

--- a/crates/cas-store/src/task_store.rs
+++ b/crates/cas-store/src/task_store.rs
@@ -613,6 +613,7 @@ impl TaskStore for SqliteTaskStore {
                 )
                 .optional()?;
             let mut persisted_deliverables = task.deliverables.clone();
+            let mut persisted_terminal_outcome = task.terminal_outcome.clone();
             let reopening_terminal = matches!(prev_status.as_deref(), Some("closed" | "cancelled"))
                 && !task.is_terminal();
             let resuming_merge_conflict = prev_status.as_deref() == Some("awaiting_merge")
@@ -627,6 +628,7 @@ impl TaskStore for SqliteTaskStore {
                 persisted_deliverables.factory_branch_anchor = None;
                 if reopening_terminal {
                     persisted_deliverables.negative_result = None;
+                    persisted_terminal_outcome = None;
                 }
             }
             if resuming_merge_conflict {
@@ -674,7 +676,7 @@ impl TaskStore for SqliteTaskStore {
                 task.execution_note,
                 task.share.as_ref().map(|s| s.to_string()),
                 task.depth.to_string(),
-                Self::terminal_outcome_to_string(&task.terminal_outcome),
+                Self::terminal_outcome_to_string(&persisted_terminal_outcome),
                 task.id,
             ],
         )?;

--- a/crates/cas-store/src/task_store.rs
+++ b/crates/cas-store/src/task_store.rs
@@ -11,7 +11,7 @@ use crate::recording_store::capture_task_event;
 use crate::{Result, TaskStore};
 use cas_types::{
     Dependency, DependencyType, Event, EventEntityType, EventType, Priority, RecordingEventType,
-    Scope, Task, TaskDeliverables, TaskStatus, TaskType,
+    Scope, Task, TaskDeliverables, TaskStatus, TaskTerminalOutcome, TaskType,
 };
 
 /// SQLite DDL for the `tasks` and `dependencies` tables.
@@ -63,7 +63,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- existing one, so they are gone. Old DBs that happen to carry them are
     -- unaffected: nothing selects them and they all have defaults.
     share TEXT,
-    depth TEXT
+    depth TEXT,
+    terminal_outcome TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
@@ -134,6 +135,16 @@ impl SqliteTaskStore {
         serde_json::to_string(deliverables).unwrap_or_else(|_| "{}".to_string())
     }
 
+    fn parse_terminal_outcome(value: Option<String>) -> Option<TaskTerminalOutcome> {
+        value.and_then(|value| serde_json::from_str(&value).ok())
+    }
+
+    fn terminal_outcome_to_string(outcome: &Option<TaskTerminalOutcome>) -> Option<String> {
+        outcome
+            .as_ref()
+            .and_then(|outcome| serde_json::to_string(outcome).ok())
+    }
+
     /// Compare-and-swap reopen: rewrite the row only if it still carries
     /// `expected_status` / `expected_updated_at`.
     ///
@@ -159,8 +170,9 @@ impl SqliteTaskStore {
              branch = ?16, worktree_id = ?17,
              pending_verification = ?18, pending_worktree_merge = ?19,
              epic_verification_owner = ?20, team_id = ?21, deliverables = ?22,
-             demo_statement = ?23, execution_note = ?24, share = ?25, depth = ?26
-             WHERE id = ?27 AND status = ?28 AND updated_at = ?29",
+             demo_statement = ?23, execution_note = ?24, share = ?25, depth = ?26,
+             terminal_outcome = ?27
+             WHERE id = ?28 AND status = ?29 AND updated_at = ?30",
             params![
                 task.title,
                 task.description,
@@ -188,6 +200,7 @@ impl SqliteTaskStore {
                 task.execution_note,
                 task.share.as_ref().map(|s| s.to_string()),
                 task.depth.to_string(),
+                Self::terminal_outcome_to_string(&task.terminal_outcome),
                 task.id,
                 expected_status.to_string(),
                 expected_updated_at.to_rfc3339(),
@@ -273,6 +286,7 @@ impl SqliteTaskStore {
                 .as_deref()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or_default(),
+            terminal_outcome: Self::parse_terminal_outcome(row.get(28)?),
         })
     }
 
@@ -308,8 +322,8 @@ impl SqliteTaskStore {
             "INSERT INTO tasks (id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28)",
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29)",
             params![
                 task.id,
                 task.title,
@@ -339,6 +353,7 @@ impl SqliteTaskStore {
                 task.execution_note,
                 task.share.as_ref().map(|s| s.to_string()),
                 task.depth.to_string(),
+                Self::terminal_outcome_to_string(&task.terminal_outcome),
             ],
         )?;
 
@@ -420,7 +435,7 @@ impl SqliteTaskStore {
                 "SELECT id, title, description, design, acceptance_criteria, notes,
                  status, priority, task_type, assignee, labels, created_at, updated_at,
                  closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
+                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
                  FROM tasks ORDER BY priority, created_at DESC",
             )?;
             stmt.query_map([], Self::task_from_row)?
@@ -566,7 +581,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
              FROM tasks WHERE id = ?",
             params![id],
             Self::task_from_row,
@@ -598,11 +613,11 @@ impl TaskStore for SqliteTaskStore {
                 )
                 .optional()?;
             let mut persisted_deliverables = task.deliverables.clone();
-            let reopening_closed =
-                prev_status.as_deref() == Some("closed") && task.status != TaskStatus::Closed;
+            let reopening_terminal = matches!(prev_status.as_deref(), Some("closed" | "cancelled"))
+                && !task.is_terminal();
             let resuming_merge_conflict = prev_status.as_deref() == Some("awaiting_merge")
                 && task.status == TaskStatus::InProgress;
-            if reopening_closed || resuming_merge_conflict {
+            if reopening_terminal || resuming_merge_conflict {
                 // cas-ed9a: a close-cycle anchor is evidence for that completed
                 // cycle only. Enforce invalidation at the persistence choke point
                 // so every Closed -> non-Closed path (MCP update, reopen, UI,
@@ -610,7 +625,7 @@ impl TaskStore for SqliteTaskStore {
                 // cas-5054 extends that invariant to conflict rework: the parked
                 // anchor must not satisfy or false-reject the eventual re-close.
                 persisted_deliverables.factory_branch_anchor = None;
-                if reopening_closed {
+                if reopening_terminal {
                     persisted_deliverables.negative_result = None;
                 }
             }
@@ -629,8 +644,9 @@ impl TaskStore for SqliteTaskStore {
              closed_at = ?12, close_reason = ?13, external_ref = ?14, content_hash = ?15,
              branch = ?16, worktree_id = ?17,
              pending_verification = ?18, pending_worktree_merge = ?19, epic_verification_owner = ?20, team_id = ?21,
-             deliverables = ?22, demo_statement = ?23, execution_note = ?24, share = ?25, depth = ?26
-             WHERE id = ?27",
+             deliverables = ?22, demo_statement = ?23, execution_note = ?24, share = ?25, depth = ?26,
+             terminal_outcome = ?27
+             WHERE id = ?28",
             params![
                 task.title,
                 task.description,
@@ -658,6 +674,7 @@ impl TaskStore for SqliteTaskStore {
                 task.execution_note,
                 task.share.as_ref().map(|s| s.to_string()),
                 task.depth.to_string(),
+                Self::terminal_outcome_to_string(&task.terminal_outcome),
                 task.id,
             ],
         )?;
@@ -680,6 +697,11 @@ impl TaskStore for SqliteTaskStore {
                             EventType::TaskCompleted,
                             format!("Task completed: {}", task.title),
                             RecordingEventType::TaskCompleted,
+                        ),
+                        TaskStatus::Cancelled => (
+                            EventType::TaskBlocked,
+                            format!("Task cancelled without delivery: {}", task.title),
+                            RecordingEventType::TaskBlocked,
                         ),
                         TaskStatus::Blocked => (
                             EventType::TaskBlocked,
@@ -769,7 +791,7 @@ impl TaskStore for SqliteTaskStore {
                 "SELECT id, title, description, design, acceptance_criteria, notes,
                  status, priority, task_type, assignee, labels, created_at, updated_at,
                  closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
+                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
                  FROM tasks WHERE status = ? ORDER BY priority, created_at DESC",
                 vec![s.to_string()],
             ),
@@ -777,7 +799,7 @@ impl TaskStore for SqliteTaskStore {
                 "SELECT id, title, description, design, acceptance_criteria, notes,
                  status, priority, task_type, assignee, labels, created_at, updated_at,
                  closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
+                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
                  FROM tasks ORDER BY priority, created_at DESC",
                 vec![],
             ),
@@ -803,7 +825,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
              FROM tasks t
              WHERE t.status = 'open'
              AND NOT EXISTS (
@@ -811,7 +833,7 @@ impl TaskStore for SqliteTaskStore {
                  JOIN tasks blocker ON d.to_id = blocker.id
                  WHERE d.from_id = t.id
                  AND d.dep_type = 'blocks'
-                 AND blocker.status != 'closed'
+                 AND blocker.status NOT IN ('closed', 'cancelled')
              )
              ORDER BY t.priority, t.created_at DESC",
         )?;
@@ -831,13 +853,13 @@ impl TaskStore for SqliteTaskStore {
             "SELECT DISTINCT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
              FROM tasks t
              JOIN dependencies d ON d.from_id = t.id
              JOIN tasks blocker ON d.to_id = blocker.id
-             WHERE t.status != 'closed'
+             WHERE t.status NOT IN ('closed', 'cancelled')
              AND d.dep_type = 'blocks'
-             AND blocker.status != 'closed'
+             AND blocker.status NOT IN ('closed', 'cancelled')
              ORDER BY t.priority, t.created_at DESC",
         )?;
 
@@ -857,12 +879,12 @@ impl TaskStore for SqliteTaskStore {
              t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
              FROM dependencies d
              JOIN tasks t ON d.to_id = t.id
              WHERE d.from_id IN ({placeholders})
              AND d.dep_type = 'blocks'
-             AND t.status != 'closed'"
+             AND t.status NOT IN ('closed', 'cancelled')"
         );
 
         let mut blocker_stmt = conn.prepare(&sql)?;
@@ -914,6 +936,7 @@ impl TaskStore for SqliteTaskStore {
                     .as_deref()
                     .and_then(|s| s.parse().ok())
                     .unwrap_or_default(),
+                terminal_outcome: Self::parse_terminal_outcome(row.get(29)?),
             };
             Ok((from_id, task))
         })?;
@@ -943,7 +966,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
              FROM tasks WHERE pending_verification = 1",
         )?;
         let tasks = stmt
@@ -958,7 +981,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
              FROM tasks WHERE pending_worktree_merge = 1",
         )?;
         let tasks = stmt
@@ -1036,10 +1059,10 @@ impl TaskStore for SqliteTaskStore {
             "SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
              FROM tasks t
              JOIN dependencies d ON d.to_id = t.id
-             WHERE d.from_id = ? AND d.dep_type = 'blocks' AND t.status != 'closed'",
+             WHERE d.from_id = ? AND d.dep_type = 'blocks' AND t.status NOT IN ('closed', 'cancelled')",
         )?;
 
         let tasks = stmt
@@ -1111,7 +1134,7 @@ impl TaskStore for SqliteTaskStore {
              SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
              FROM tasks t
              JOIN subtree s ON t.id = s.task_id",
         )?;
@@ -1164,7 +1187,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
              FROM tasks t
              JOIN dependencies d ON d.to_id = t.id
              WHERE d.from_id = ? AND d.dep_type = 'parent-child' AND t.task_type = 'epic'

--- a/crates/cas-store/src/task_store_tests/tests.rs
+++ b/crates/cas-store/src/task_store_tests/tests.rs
@@ -503,3 +503,54 @@ fn reopen_exact_rejects_a_mismatched_expected_updated_at() {
          it is an optimistic-concurrency key, not a general write path"
     );
 }
+
+#[test]
+fn cancelled_reopen_is_atomic_and_clears_terminal_outcome() {
+    let temp = TempDir::new().unwrap();
+    let store = SqliteTaskStore::open(temp.path()).unwrap();
+    store.init().unwrap();
+
+    let id = store.generate_id().unwrap();
+    let mut task = Task::new(id.clone(), "Cancelled optimistic lock".to_string());
+    store.add(&task).unwrap();
+    task.status = TaskStatus::Cancelled;
+    task.closed_at = Some(chrono::Utc::now());
+    task.terminal_outcome = Some(cas_types::TaskTerminalOutcome::Cancelled {
+        superseded_by: Some("cas-replacement".to_string()),
+    });
+    let cancelled_at = store.update(&task).unwrap();
+
+    let mut reopened = task.clone();
+    reopened.status = TaskStatus::Open;
+    reopened.closed_at = None;
+    reopened.terminal_outcome = None;
+    reopened.updated_at = chrono::Utc::now();
+
+    let stale = crate::reopen_terminal_task_atomic(
+        temp.path(),
+        &reopened,
+        TaskStatus::Cancelled,
+        cancelled_at - chrono::Duration::seconds(1),
+        crate::ParentDependencyUpdate::Unchanged,
+        None,
+    );
+    assert!(stale.is_err(), "a stale cancelled reopen must be refused");
+    let unchanged = store.get(&id).unwrap();
+    assert_eq!(unchanged.status, TaskStatus::Cancelled);
+    assert!(unchanged.terminal_outcome.is_some());
+
+    crate::reopen_terminal_task_atomic(
+        temp.path(),
+        &reopened,
+        TaskStatus::Cancelled,
+        cancelled_at,
+        crate::ParentDependencyUpdate::Unchanged,
+        None,
+    )
+    .expect("matching cancelled outcome should reopen atomically");
+
+    let after = store.get(&id).unwrap();
+    assert_eq!(after.status, TaskStatus::Open);
+    assert_eq!(after.terminal_outcome, None);
+    assert_eq!(after.updated_at, reopened.updated_at);
+}

--- a/crates/cas-store/src/verification_store.rs
+++ b/crates/cas-store/src/verification_store.rs
@@ -1424,9 +1424,37 @@ pub fn reopen_closed_task_atomic(
     parent_dependency: ParentDependencyUpdate,
     lifecycle_outbox: Option<&TaskReopenLifecycleOutbox>,
 ) -> Result<Option<VerificationDispatch>> {
+    reopen_terminal_task_atomic(
+        cas_dir,
+        task,
+        TaskStatus::Closed,
+        expected_updated_at,
+        parent_dependency,
+        lifecycle_outbox,
+    )
+}
+
+/// Reopen a closed or cancelled task as one optimistic durable mutation.
+///
+/// `expected_status` keeps the compare-and-swap explicit: callers cannot use
+/// this as a generic status rewrite, and a concurrent terminal-state mutation
+/// leaves the original row and lifecycle outbox untouched.
+pub fn reopen_terminal_task_atomic(
+    cas_dir: &Path,
+    task: &Task,
+    expected_status: TaskStatus,
+    expected_updated_at: DateTime<Utc>,
+    parent_dependency: ParentDependencyUpdate,
+    lifecycle_outbox: Option<&TaskReopenLifecycleOutbox>,
+) -> Result<Option<VerificationDispatch>> {
+    if !matches!(expected_status, TaskStatus::Closed | TaskStatus::Cancelled) {
+        return Err(StoreError::Parse(
+            "atomic terminal-task reopen requires closed or cancelled expected status".to_string(),
+        ));
+    }
     if task.status != TaskStatus::Open || task.closed_at.is_some() {
         return Err(StoreError::Parse(
-            "atomic closed-task reopen requires the complete proposed Open task".to_string(),
+            "atomic terminal-task reopen requires the complete proposed Open task".to_string(),
         ));
     }
 
@@ -1454,7 +1482,7 @@ pub fn reopen_closed_task_atomic(
         _ => None,
     };
 
-    SqliteTaskStore::reopen_exact_with_conn(&tx, task, TaskStatus::Closed, expected_updated_at)?;
+    SqliteTaskStore::reopen_exact_with_conn(&tx, task, expected_status, expected_updated_at)?;
 
     if let ParentDependencyUpdate::Replace(replacement) = parent_dependency {
         if let Some(dep) = replacement.as_ref() {

--- a/crates/cas-types/src/lib.rs
+++ b/crates/cas-types/src/lib.rs
@@ -65,9 +65,8 @@ pub use agent::{
 pub use code_review::{
     AutofixClass, FINDING_OPTIONAL_FIELDS, FINDING_REQUIRED_FIELDS, Finding,
     FindingValidationError, MAX_TITLE_LEN, Owner, ReviewExecution, ReviewExecutionStatus,
-    ReviewOutcome, ReviewOutcomeParseError,
-    ReviewerOutput, Severity as FindingSeverity, parse_review_outcome, parse_reviewer_output,
-    review_outcome_shape_hint,
+    ReviewOutcome, ReviewOutcomeParseError, ReviewerOutput, Severity as FindingSeverity,
+    parse_review_outcome, parse_reviewer_output, review_outcome_shape_hint,
 };
 pub use commit_link::{CommitLink, LINK_METHOD_HOOK_OBSERVED};
 pub use delivery::{
@@ -104,12 +103,13 @@ pub use sort::{
 pub use spec::{Spec, SpecStatus, SpecType};
 pub use task::{
     NegativeResultEvidence, PreCloseHookEvidence, Priority, Task, TaskDeliverables, TaskDepth,
-    TaskStatus, TaskType, WorkTarget,
+    TaskStatus, TaskTerminalOutcome, TaskType, WorkTarget,
 };
 pub use verification::{
-    IssueSeverity, Verification, VerificationDispatch, VerificationDispatchState,
-    RepositoryProofBoundary, VerificationIssue, VerificationProofBoundary, VerificationProvenance,
-    VerificationRecoveryAction, VerificationStatus, VerificationType, VerifierCapability,
+    IssueSeverity, RepositoryProofBoundary, Verification, VerificationDispatch,
+    VerificationDispatchState, VerificationIssue, VerificationProofBoundary,
+    VerificationProvenance, VerificationRecoveryAction, VerificationStatus, VerificationType,
+    VerifierCapability,
 };
 pub use worktree::{GitContext, Worktree, WorktreeStatus};
 

--- a/crates/cas-types/src/task.rs
+++ b/crates/cas-types/src/task.rs
@@ -595,9 +595,18 @@ impl Task {
     }
 
     /// Whether parent-epic branch accounting must find integrated delivery for
-    /// this task. Non-delivery outcomes never contribute a branch.
+    /// this task. Active work and Delivered terminal work both retain branch
+    /// reachability obligations; only an explicit terminal non-delivery
+    /// outcome removes the child from integration accounting.
     pub fn has_delivery_to_integrate(&self) -> bool {
-        self.counts_as_delivered()
+        !matches!(
+            self.effective_terminal_outcome(),
+            Some(
+                TaskTerminalOutcome::NegativeResult
+                    | TaskTerminalOutcome::Decision
+                    | TaskTerminalOutcome::Cancelled { .. }
+            )
+        )
     }
 
     /// Check if the task is ready to work on. Waiting states like

--- a/crates/cas-types/src/task.rs
+++ b/crates/cas-types/src/task.rs
@@ -25,6 +25,10 @@ pub enum TaskStatus {
     Blocked,
     /// Completed
     Closed,
+    /// Ended without a delivered result. The task record and audit history are
+    /// preserved; `terminal_outcome` records whether this was a cancellation
+    /// or a supersession and carries the optional superseding pointer.
+    Cancelled,
     /// Worker close ran the lightweight gate successfully; awaiting
     /// supervisor code-review dispatch. Only reachable when
     /// `[code_review] owner = "supervisor"` is set (cas-b51a).
@@ -59,6 +63,7 @@ impl fmt::Display for TaskStatus {
             TaskStatus::InProgress => write!(f, "in_progress"),
             TaskStatus::Blocked => write!(f, "blocked"),
             TaskStatus::Closed => write!(f, "closed"),
+            TaskStatus::Cancelled => write!(f, "cancelled"),
             TaskStatus::PendingSupervisorReview => write!(f, "pending_supervisor_review"),
             TaskStatus::AwaitingMerge => write!(f, "awaiting_merge"),
         }
@@ -80,6 +85,8 @@ impl FromStr for TaskStatus {
             Ok(TaskStatus::Blocked)
         } else if s.eq_ignore_ascii_case("closed") {
             Ok(TaskStatus::Closed)
+        } else if s.eq_ignore_ascii_case("cancelled") || s.eq_ignore_ascii_case("canceled") {
+            Ok(TaskStatus::Cancelled)
         } else if s.eq_ignore_ascii_case("pending_supervisor_review")
             || s.eq_ignore_ascii_case("pending-supervisor-review")
         {
@@ -92,6 +99,31 @@ impl FromStr for TaskStatus {
             Err(TypeError::InvalidTaskStatus(s.to_string()))
         }
     }
+}
+
+/// Why a task reached a terminal state.
+///
+/// This is deliberately separate from [`TaskStatus`]: `Closed` answers
+/// whether the lifecycle completed, while this value answers whether there is
+/// a delivery to count or integrate. The nullable database column preserves
+/// legacy rows; [`Task::effective_terminal_outcome`] derives their meaning at
+/// read time without backfilling them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TaskTerminalOutcome {
+    /// Ordinary work delivered through the commit/review/merge close gates.
+    Delivered,
+    /// A measured experiment completed negatively and was intentionally not
+    /// merged under the structured supervisor receipt.
+    NegativeResult,
+    /// A human/supervisor decision completed the task without code delivery.
+    Decision,
+    /// Planned work ended without delivery. `superseded_by` may identify the
+    /// PR, commit, or task that made this work unnecessary.
+    Cancelled {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        superseded_by: Option<String>,
+    },
 }
 
 /// Type of task
@@ -414,6 +446,11 @@ pub struct Task {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub close_reason: Option<String>,
 
+    /// Typed terminal disposition. Legacy rows remain NULL and are interpreted
+    /// read-side by `effective_terminal_outcome`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_outcome: Option<TaskTerminalOutcome>,
+
     /// Link to external tracker (GitHub, JIRA, etc.)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_ref: Option<String>,
@@ -499,6 +536,7 @@ impl Task {
             updated_at: now,
             closed_at: None,
             close_reason: None,
+            terminal_outcome: None,
             external_ref: None,
             content_hash: None,
             branch: None,
@@ -522,9 +560,44 @@ impl Task {
         task
     }
 
-    /// Check if the task is open (not closed)
+    /// Check if the task is open (not terminal)
     pub fn is_open(&self) -> bool {
-        self.status != TaskStatus::Closed
+        !self.is_terminal()
+    }
+
+    /// Whether no further work is expected for this lifecycle record.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self.status, TaskStatus::Closed | TaskStatus::Cancelled)
+    }
+
+    /// Effective terminal outcome, including read-side interpretation of
+    /// legacy NULL rows. This never mutates or backfills persistence.
+    pub fn effective_terminal_outcome(&self) -> Option<TaskTerminalOutcome> {
+        self.terminal_outcome.clone().or_else(|| match self.status {
+            TaskStatus::Closed if self.deliverables.negative_result.is_some() => {
+                Some(TaskTerminalOutcome::NegativeResult)
+            }
+            TaskStatus::Closed => Some(TaskTerminalOutcome::Delivered),
+            TaskStatus::Cancelled => Some(TaskTerminalOutcome::Cancelled {
+                superseded_by: None,
+            }),
+            _ => None,
+        })
+    }
+
+    /// Whether this terminal row represents delivered work.
+    pub fn counts_as_delivered(&self) -> bool {
+        self.is_terminal()
+            && matches!(
+                self.effective_terminal_outcome(),
+                Some(TaskTerminalOutcome::Delivered)
+            )
+    }
+
+    /// Whether parent-epic branch accounting must find integrated delivery for
+    /// this task. Non-delivery outcomes never contribute a branch.
+    pub fn has_delivery_to_integrate(&self) -> bool {
+        self.counts_as_delivered()
     }
 
     /// Check if the task is ready to work on. Waiting states like
@@ -566,6 +639,7 @@ impl Default for Task {
             updated_at: DateTime::<Utc>::default(),
             closed_at: None,
             close_reason: None,
+            terminal_outcome: None,
             external_ref: None,
             content_hash: None,
             branch: None,

--- a/crates/cas-types/src/task.rs
+++ b/crates/cas-types/src/task.rs
@@ -143,6 +143,8 @@ pub enum TaskType {
     Chore,
     /// Investigation or research (produces understanding, not code)
     Spike,
+    /// Supervisor-owned promotion, rollout, or sign-off decision
+    Gate,
 }
 
 impl fmt::Display for TaskType {
@@ -154,6 +156,7 @@ impl fmt::Display for TaskType {
             TaskType::Epic => write!(f, "epic"),
             TaskType::Chore => write!(f, "chore"),
             TaskType::Spike => write!(f, "spike"),
+            TaskType::Gate => write!(f, "gate"),
         }
     }
 }
@@ -174,6 +177,8 @@ impl FromStr for TaskType {
             Ok(TaskType::Chore)
         } else if s.eq_ignore_ascii_case("spike") {
             Ok(TaskType::Spike)
+        } else if s.eq_ignore_ascii_case("gate") {
+            Ok(TaskType::Gate)
         } else {
             Err(TypeError::Parse(format!("invalid task type: {s}")))
         }
@@ -755,6 +760,7 @@ mod tests {
         assert_eq!(TaskType::from_str("epic").unwrap(), TaskType::Epic);
         assert_eq!(TaskType::from_str("chore").unwrap(), TaskType::Chore);
         assert_eq!(TaskType::from_str("spike").unwrap(), TaskType::Spike);
+        assert_eq!(TaskType::from_str("gate").unwrap(), TaskType::Gate);
     }
 
     #[test]
@@ -766,6 +772,13 @@ mod tests {
         // Verify round-trip
         let s = spike.to_string();
         assert_eq!(TaskType::from_str(&s).unwrap(), TaskType::Spike);
+    }
+
+    #[test]
+    fn test_gate_task_type() {
+        let gate = TaskType::Gate;
+        assert_eq!(gate.to_string(), "gate");
+        assert_eq!(TaskType::from_str(&gate.to_string()).unwrap(), gate);
     }
 
     #[test]


### PR DESCRIPTION
Lands GitHub issue burn-down v14 (epic cas-7020): decision-time signals. Six subtasks, all individually reviewed and merged; full 4452-test Scoped Validation green on content byte-identical to this branch tip.

## Decision-time knowledge
- Epic-create and spawn_workers responses surface up to 3 related memories/past epics (bounded ~1.2k chars, silent on no-match, recall-before-index so an epic never matches itself)
- commit_receipt resolution best-effort-fetches the task's target branch before rejecting a remote-only SHA, and the refusal message gains the git-fetch remedy

## Signal freshness
- Queued merge-request relays refresh the target-branch tip at delivery time; stale lifecycle relays continue to be dropped/annotated (v13 machinery)
- worker_activity floors on query-time worktree truth: dirty file count, diffstat, last commit per worker — a mid-edit Codex worker can no longer read as idle with zero file-edit events

## Honest terminal states
- New typed TaskTerminalOutcome family (Delivered / NegativeResult / Decision / Cancelled) with additive m233 and read-side-only legacy interpretation
- action=cancel: supervisor-authorized, reason required, optional superseded_by pointer, history preserved, cancelled children satisfy epic close gates; reopen-from-cancelled supported; delete returns to being for mistakes
- TaskType::Gate: supervisor-startable decision tasks that close on a recorded DECISION note instead of commit evidence and work as dependency blockers; ordinary worker-task protections unchanged
- Epic close gate accounting hardened fail-closed after a mid-epic regression was caught by branch CI: active/Delivered children always owe branch reachability; bypass_code_review still never skips the merge gate

Also carries the regenerated .claude/CODEMAP.md (hub subsystem, cli/sync, limits, m232→m233).

Fixes #255
Fixes #257
Fixes #258
Fixes #259
Fixes #260
Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
