### PR TITLE
Release v2.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.64.0] - 2026-08-12
+
+### Added
+- **Supervisors can make decisions with the context that matters.** Creating work now surfaces related prior recall, and explicit decision gates make consequential choices visible before work proceeds.
+
+### Changed
+- **Release-only changes validate faster.** Workspace version bumps can take the focused required-check path while preserving the heavier validation tier for product changes.
+- **Task handoffs now stay current through delivery.** Merge relays refresh the target tip and fetch remote receipts before reporting an outcome.
+
+### Fixed
+- **Expired memory and session reminders now respect their intended boundaries.** Valid context survives recall, expired entries stay out, and reminder lifecycle actions remain scoped to the session that created them.
+- **Terminal work states and activity reporting are more trustworthy.** Cancelled and superseded work follows a fail-closed lifecycle, and dirty worktrees still report their real activity floor.
+- **Automation recovery is clearer and safer.** Negative-result closures retain their evidence, CI red-run receipts are preserved, socket ownership elects one daemon safely, and session end snapshots the current state.
+
 ## [2.63.0] - 2026-08-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.63.0"
+version = "2.64.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.63.0"
+version = "2.64.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.63.0"
+version = "2.64.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.63.0"
+version = "2.64.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.63.0"
+version = "2.64.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.63.0"
+version = "2.64.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.63.0"
+version = "2.64.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.63.0"
+version = "2.64.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.63.0"
+version = "2.64.0"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.63.0"
+version = "2.64.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.63.0"
+version = "2.64.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.63.0"
+version = "2.64.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-12-v2.64.0-slack.md
+++ b/docs/release-notes/2026-08-12-v2.64.0-slack.md
@@ -1,0 +1,31 @@
+# Slack draft — v2.64.0 release, 2026-08-12
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft — post only after the release tag and artifacts are complete.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — CAS v2.64.0 is out: the system now remembers the right context at decision time, keeps session reminders private to their creator, and gives clearer, more reliable results when work finishes or changes course.
+
+**Reply (Was → Now):**
+- Was: helpful context could arrive too late to inform a new piece of work, expired information could linger, and a reminder action could affect more than the session that created it. Now: related recall appears when work is created, expired entries stay out of context, and reminder controls stay with their originating session.
+- Was: a cancelled or superseded task could leave an uncertain outcome, while activity in a changed worktree could look quieter than it was. Now: terminal task states complete through a fail-closed path and activity reporting keeps an honest floor.
+- Was: a delivery could report against stale information, automated evidence could disappear after a failed CI run, and competing daemon starts could contend for the same socket. Now: deliveries refresh their target, red-run evidence is retained, and socket ownership is elected safely.
+- Install: grab v2.64.0 from the GitHub releases page — `cas update` on an existing install, or the tarball for your platform.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v2.64.0 adds decision-time related-memory recall and explicit decision gates, hardens cancel/supersede lifecycle transitions and delivery receipt freshness, and classifies release-train version bumps for the focused required-check lane.
+
+**Reply (Was → Now):**
+- Was: work creation had no related-memory signal and operator decisions could remain implicit. Now: task creation returns related recall and supervisor decision gates make the required choices explicit.
+- Was: cancellation/supersession and merge delivery could expose stale or incomplete state. Now: terminal transitions are fail-closed, delivery refreshes the target tip, and remote receipts are fetched before a rejection is reported.
+- Was: expiry, session-scoped reminders, CI red-run evidence, worker activity, and daemon socket contention each had edge cases that could obscure the real state. Now: expiry is enforced end to end, reminder lifecycle is creator-session scoped, red-run receipts persist, dirty-worktree activity has an honest floor, and the socket election is lease-owned.
+- Validation: the release PR's observed required-check classification and the archive checksums will be recorded with the release receipt.
+
+## POSTED
+
+Pending release tag, artifacts, and Slack publication.


### PR DESCRIPTION
Cuts v2.64.0 from the main lineage containing the v13 and v14 landings. Includes the coordinated six-crate version bump, regenerated Cargo.lock, changelog, and pre-publication Slack draft.