### PR TITLE
Record v2.64.0 Slack publication receipts

### DIFF
--- a/docs/release-notes/2026-08-12-v2.64.0-slack.md
+++ b/docs/release-notes/2026-08-12-v2.64.0-slack.md
@@ -2,7 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** Draft — post only after the release tag and artifacts are complete.
+**Status:** POSTED 2026-08-12 19:40 UTC to `#cas-internal` (`C0B44GUKDK2`). Verified against the live channel: exactly two v2.64.0 top-level posts, each with exactly one threaded reply.
 
 ## User thread
 
@@ -28,4 +28,9 @@ Live on production — **Dev** — v2.64.0 adds decision-time related-memory rec
 
 ## POSTED
 
-Pending release tag, artifacts, and Slack publication.
+UTC timestamp: 2026-08-12 19:40 UTC
+
+- User top-level: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786563606768909
+- User reply: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786563635827859?thread_ts=1786563606.768909&cid=C0B44GUKDK2
+- Dev top-level: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786563607754939
+- Dev reply: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786563636322849?thread_ts=1786563607.754939&cid=C0B44GUKDK2


### PR DESCRIPTION
Records the posted #cas-internal user and developer release threads, including all four permalinks and the structural verification receipt.