### PR TITLE
chore: cut v2.65.0 release inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.65.0] - 2026-08-13
+
+### Added
+- **Silent coordination failures now become visible, recoverable outcomes.** Aged unread messages return a one-shot notice to their sender, stalled sessions escalate durable attention signals, and status output includes recent progress timestamps.
+- **Concurrent planning now warns before work is duplicated.** Session startup surfaces simultaneous planning activity, sibling titles are checked without collapsing meaningful distinctions, and duplicate plans are identified early.
+
+### Changed
+- **Startup and launch checks fail earlier with actionable context.** Configuration directories are validated before launch, registration failures preserve the relevant terminal tail and reap abandoned processes, and MCP startup applies pending schema migrations only after arming its parent-death watchdog.
+- **Close verification handles real delivery shapes without weakening proof.** No-code work can close with portable evidence, target-branch and squash receipts retain a non-empty lint range, merge receipts receive useful correction hints, and merged delivery facts remain immutable.
+
+### Fixed
+- **Dead or stale sessions no longer leave work looking active.** Held work is returned to a recoverable state with an audit trail, and epic status marks stale ownership instead of presenting it as live progress.
+- **Claude session progress and interrupts are now observable.** Transcript turn watermarks feed stall detection, explicit interrupts report confirmed delivery or a clear failure, and status reports distinguish recent output from recent file changes.
+- **Delivery-stall thresholds and bounce eligibility are fail-safe.** Oversized thresholds return a clean error instead of panicking or wrapping, while broadcasts, synthetic traffic, stale rows, cross-session senders, and prior watchdog notices cannot create false bounces.
+
 ## [2.64.0] - 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.64.0"
+version = "2.65.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.64.0"
+version = "2.65.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.64.0"
+version = "2.65.0"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.64.0"
+version = "2.65.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.64.0"
+version = "2.65.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.64.0"
+version = "2.65.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-13-v2.65.0-slack.md
+++ b/docs/release-notes/2026-08-13-v2.65.0-slack.md
@@ -1,0 +1,33 @@
+# Slack draft — v2.65.0 release, 2026-08-13
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft — post only after the release tag and artifacts are complete.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — CAS v2.65.0 is out: silent stalls now turn into visible recovery, interrupted sessions confirm whether they heard you, and crashes no longer leave work pretending to be active.
+
+**Reply (Was → Now):**
+- Was: an unread message or stalled session could sit quietly until someone noticed. Now: overdue direct messages return a one-time notice to their sender, and persistent stalls surface an attention signal without manual checking.
+- Was: a crashed or stale session could leave work looking owned and active. Now: abandoned work returns to a recoverable state with a clear audit trail, while stale ownership is marked instead of mistaken for progress.
+- Was: an interrupt could be sent without proving it reached the session, and recent activity was hard to interpret. Now: interrupts confirm delivery or explain the failure, and status distinguishes recent output from recent file changes.
+- Was: launch, planning, and close failures often appeared late with little recovery guidance. Now: launch configuration is checked up front, concurrent or duplicate plans are flagged early, and delivery evidence works across target-branch and squash commits while still being linted.
+- Install: grab v2.65.0 from the GitHub releases page — use `cas update` for an existing install, or download the tarball for your platform.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v2.65.0 hardens queue delivery, process liveness, schema startup, planning concurrency, and close verification as one end-to-end reliability pass.
+
+**Reply (Was → Now):**
+- Was: unread direct-message aging had no sender feedback and broad queue sweeps could misclassify broadcasts, synthetic traffic, stale rows, or cross-session sources. Now: priority-tiered one-shot bounces require an eligible same-session registered sender, cancel on read or acknowledgement, and reject structural watchdog rows; oversized thresholds fail cleanly without wrap or mutex poisoning.
+- Was: process death, registration timeout, and parent loss could leave tasks, PTYs, or database handles behind. Now: held work is parked with audit evidence, preflight names invalid configuration before spawn, timed-out launches preserve a pane tail and are reaped, and the parent watchdog is armed before automatic schema migration.
+- Was: Claude progress relied on weak activity signals and interrupt injection lacked an explicit outcome. Now: transcript turn watermarks feed stall classification, interrupt delivery is confirmed or rejected, and status exposes last outbound progress and last file write separately.
+- Was: concurrent planning could duplicate work, and close proof could lose its lint range across target-only or squash delivery shapes. Now: planning races and duplicate titles are detected without erasing token distinctions, target receipts lint real changes, no-code proof is portable, squash failures suggest the usable receipt, and merged delivery records cannot be rewritten as stale.
+- Validation: the release PR must pass required checks and release preflight before the annotated tag is pushed; artifact workflow results and archive checksums should accompany the publication receipt.
+
+## POSTED
+
+Pending release tag, artifacts, and Slack publication.


### PR DESCRIPTION
## Summary
- bump the six enforced release-train crates to 2.65.0 and refresh Cargo.lock
- add the v2.65.0 changelog entry
- draft the required User and Dev Slack release posts without publishing them

## Validation
- cargo metadata --locked --format-version 1 --no-deps
- cargo check -p cas --lib --tests --locked
- scripts/check-release-migration-snapshots.sh

Task: cas-2143