### PR TITLE
docs: v2.65.0 Slack posting receipts

### DIFF
--- a/docs/release-notes/2026-08-13-v2.65.0-slack.md
+++ b/docs/release-notes/2026-08-13-v2.65.0-slack.md
@@ -2,7 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** Draft — post only after the release tag and artifacts are complete.
+**Status:** Posted 2026-08-13 (see `## POSTED` receipt below).
 
 ## User thread
 
@@ -30,4 +30,14 @@ Live on production — **Dev** — v2.65.0 hardens queue delivery, process liven
 
 ## POSTED
 
-Pending release tag, artifacts, and Slack publication.
+Channel: #cas-internal (C0B44GUKDK2)
+Release: v2.65.0 — main d025463b, tag v2.65.0, assets published 2026-08-13T04:07:21Z
+
+| Post | UTC | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-13T04:11:43Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786594303785009 |
+| User reply (Was → Now) | 2026-08-13T04:11:49Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786594309670059?thread_ts=1786594303.785009&cid=C0B44GUKDK2 |
+| Dev top-level | 2026-08-13T04:11:53Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786594313379319 |
+| Dev reply (Was → Now) | 2026-08-13T04:12:01Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786594321463619?thread_ts=1786594313.379319&cid=C0B44GUKDK2 |
+
+Runtime release only — no harness-diary update in this merge, so no diary thread was published.


### PR DESCRIPTION
Records the posted Slack receipts (channel, UTC timestamps, four permalinks) into docs/release-notes/2026-08-13-v2.65.0-slack.md after the v2.65.0 announcement threads went out (User + Dev top-levels, each with one Was→Now reply, verified in-channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)