### PR TITLE
GitHub issue burn-down v16: overnight P1 field bugs + harness diary catch-up

### DIFF
--- a/.github/actions/classify-required-diff/action.yml
+++ b/.github/actions/classify-required-diff/action.yml
@@ -21,8 +21,9 @@ runs:
       run: |
         # checkout fetch-depth: 0 makes this a true merge-base comparison,
         # including an ancestry-only merge with no content changes.
-        if [[ -z "$BASE_SHA" ]]; then
-          # Schedules and manual dispatches do not have a comparison event.
+        if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+          # Schedules, manual dispatches, and tag pushes without a predecessor
+          # do not have a comparison event.
           # They are intentionally never eligible to fast-pass.
           class=full
         else

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -10,7 +10,9 @@ use crate::migration::{
     detector::{SchemaSummary, get_schema_summary},
     run_migrations,
 };
-use crate::store::{StoreType, detect_store_type, open_rule_store, open_store, open_task_store};
+use crate::store::{
+    StoreType, detect_store_type, open_agent_store, open_rule_store, open_store, open_task_store,
+};
 use crate::types::RuleStatus;
 use crate::ui::components::Formatter;
 use crate::ui::theme::ActiveTheme;
@@ -100,6 +102,54 @@ fn schema_tables_check(summary: &SchemaSummary) -> Check {
             ),
         }
     }
+}
+
+/// Report the routable supervisor population for every factory session that
+/// still has at least one live registered agent. Stale historical supervisor
+/// rows do not make an active session ambiguous.
+fn factory_supervisor_checks(agents: &[crate::types::Agent]) -> Vec<Check> {
+    use crate::types::AgentRole;
+
+    let mut sessions: BTreeMap<&str, Vec<&crate::types::Agent>> = BTreeMap::new();
+    for agent in agents.iter().filter(|agent| agent.is_alive()) {
+        if let Some(session) = agent.factory_session.as_deref() {
+            sessions.entry(session).or_default().push(agent);
+        }
+    }
+
+    sessions
+        .into_iter()
+        .map(|(session, members)| {
+            let supervisors: Vec<_> = members
+                .into_iter()
+                .filter(|agent| agent.role == AgentRole::Supervisor)
+                .collect();
+            let count = supervisors.len();
+            let status = if count == 1 {
+                CheckStatus::Ok
+            } else {
+                CheckStatus::Warning
+            };
+            let detail = match count {
+                0 => "expected exactly 1; `target=supervisor` cannot resolve in this session"
+                    .to_string(),
+                1 => format!("{} ({})", supervisors[0].name, supervisors[0].id),
+                _ => format!(
+                    "expected exactly 1; found {}",
+                    supervisors
+                        .iter()
+                        .map(|agent| format!("{} ({})", agent.name, agent.id))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            };
+            Check {
+                name: format!("factory session {session}"),
+                status,
+                message: format!("supervisors: {count}; {detail}"),
+            }
+        })
+        .collect()
 }
 
 pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow::Result<()> {
@@ -308,6 +358,21 @@ pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
                 message: format!("cannot check undelivered lifecycle relays: {e}"),
             }),
         }
+    }
+
+    // Every active factory session needs exactly one live durable supervisor
+    // row. Otherwise logical handoffs and verification recovery have nowhere
+    // to route even while the supervisor pane itself exists.
+    match open_agent_store(&cas_root)
+        .and_then(|store| Ok(store.list(None)?))
+        .map(|agents| factory_supervisor_checks(&agents))
+    {
+        Ok(session_checks) => checks.extend(session_checks),
+        Err(error) => checks.push(Check {
+            name: "factory supervisors".to_string(),
+            status: CheckStatus::Warning,
+            message: format!("cannot inspect registered factory supervisors: {error}"),
+        }),
     }
 
     // Check 3a-ii: messages the factory keeps failing to hand over
@@ -1737,6 +1802,81 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    fn factory_agent(
+        id: &str,
+        name: &str,
+        session: &str,
+        role: crate::types::AgentRole,
+    ) -> crate::types::Agent {
+        let mut agent = crate::types::Agent::new(id.to_string(), name.to_string());
+        agent.factory_session = Some(session.to_string());
+        agent.role = role;
+        agent
+    }
+
+    #[test]
+    fn factory_supervisor_check_reports_one_per_active_session() {
+        use crate::types::AgentRole;
+        let agents = vec![
+            factory_agent("sup-a", "supervisor-a", "factory-a", AgentRole::Supervisor),
+            factory_agent("worker-a", "worker-a", "factory-a", AgentRole::Worker),
+        ];
+        let checks = factory_supervisor_checks(&agents);
+        assert_eq!(checks.len(), 1);
+        assert!(matches!(checks[0].status, CheckStatus::Ok));
+        assert_eq!(checks[0].name, "factory session factory-a");
+        assert!(checks[0].message.contains("supervisors: 1"));
+        assert!(checks[0].message.contains("supervisor-a"));
+    }
+
+    #[test]
+    fn factory_supervisor_check_flags_zero_and_multiple() {
+        use crate::types::AgentRole;
+        let agents = vec![
+            factory_agent("worker-a", "worker-a", "factory-zero", AgentRole::Worker),
+            factory_agent(
+                "sup-b1",
+                "supervisor-b1",
+                "factory-many",
+                AgentRole::Supervisor,
+            ),
+            factory_agent(
+                "sup-b2",
+                "supervisor-b2",
+                "factory-many",
+                AgentRole::Supervisor,
+            ),
+        ];
+        let checks = factory_supervisor_checks(&agents);
+        assert_eq!(checks.len(), 2);
+        assert!(matches!(checks[0].status, CheckStatus::Warning));
+        assert!(checks[0].message.contains("supervisors: 2"));
+        assert!(matches!(checks[1].status, CheckStatus::Warning));
+        assert!(checks[1].message.contains("supervisors: 0"));
+    }
+
+    #[test]
+    fn factory_supervisor_check_ignores_stale_historical_rows() {
+        use crate::types::{AgentRole, AgentStatus};
+        let current = factory_agent(
+            "sup-current",
+            "supervisor-current",
+            "factory-restarted",
+            AgentRole::Supervisor,
+        );
+        let mut predecessor = factory_agent(
+            "sup-old",
+            "supervisor-old",
+            "factory-restarted",
+            AgentRole::Supervisor,
+        );
+        predecessor.status = AgentStatus::Stale;
+        let checks = factory_supervisor_checks(&[current, predecessor]);
+        assert_eq!(checks.len(), 1);
+        assert!(matches!(checks[0].status, CheckStatus::Ok));
+        assert!(checks[0].message.contains("supervisors: 1"));
+    }
 
     // ── cas-f699 / GH #134: canonical-id doctor rows ─────────────────────
 

--- a/cas-cli/src/hooks/handlers/handlers_session.rs
+++ b/cas-cli/src/hooks/handlers/handlers_session.rs
@@ -1084,6 +1084,7 @@ mod session_end_reminder_tests {
                     Some("factory-a"),
                     Some("session-ending"),
                     cross_session,
+                    None,
                 )
                 .unwrap();
         }

--- a/cas-cli/src/hooks/handlers/handlers_session.rs
+++ b/cas-cli/src/hooks/handlers/handlers_session.rs
@@ -1,6 +1,18 @@
 use crate::hooks::handlers::*;
 use crate::hooks::handlers::session_budget::SessionContextAssembler;
 
+fn registered_role_mismatch_banner(
+    configured_role: Option<AgentRole>,
+    registered_role: Option<AgentRole>,
+) -> Option<String> {
+    let (configured, registered) = configured_role.zip(registered_role)?;
+    (configured != registered).then(|| {
+        format!(
+            "\u{26a0}\u{fe0f} CAS AGENT ROLE MISMATCH: `CAS_AGENT_ROLE={configured}` but the durable agent row was registered as `{registered}` at session start. CAS attempted to repair the row; run `mcp__cs__coordination action=whoami` and `cas doctor` before assigning or closing factory work."
+        )
+    })
+}
+
 pub fn handle_session_start(
     input: &HookInput,
     cas_root: Option<&Path>,
@@ -10,6 +22,7 @@ pub fn handle_session_start(
     // Computed inside the inner `cas_root` block and applied to the output
     // after context building (cas-ae09). None for non-factory sessions.
     let mut factory_session_title: Option<String> = None;
+    let mut registration_role_warning: Option<String> = None;
 
     // Record session start for analytics and register agent
     if let Some(cas_root) = cas_root {
@@ -37,6 +50,16 @@ pub fn handle_session_start(
         let agent_name = std::env::var("CAS_AGENT_NAME").ok();
         let agent_role = std::env::var("CAS_AGENT_ROLE").ok();
         let clone_path = std::env::var("CAS_CLONE_PATH").ok();
+
+        // Capture disagreement before re-registration repairs it so a
+        // supervisor does not begin factory work with a silently broken row.
+        let configured_role = crate::mcp::daemon::parse_agent_role_hint(agent_role.as_deref());
+        let registered_role = stores
+            .agents()
+            .and_then(|store| store.get(&input.session_id).ok())
+            .map(|agent| agent.role);
+        registration_role_warning =
+            registered_role_mismatch_banner(configured_role, registered_role);
 
         // Helper to register agent directly in database
         let register_directly = |stores: &mut HookStores| {
@@ -176,6 +199,10 @@ pub fn handle_session_start(
     // being silently truncated by the harness at ~10KB. The base context
     // (role guidance + CAS header + memories/tasks) is protected.
     let mut assembler = SessionContextAssembler::new(context);
+
+    if let Some(warning) = registration_role_warning {
+        assembler.append_protected(warning);
+    }
 
     // Planning is a shared write surface: two live supervisors can otherwise
     // decompose the same epic before either sees the other's task set. Put
@@ -532,6 +559,34 @@ mod large_artifact_staging_tests {
         assert!(context.contains(
             "Stage large artifacts (>1GB) in /mnt/datacube/staging — /tmp is tmpfs on this host."
         ));
+    }
+
+    #[test]
+    fn supervisor_session_start_warns_and_repairs_registered_role_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agent_store = crate::store::open_agent_store(tmp.path()).unwrap();
+        agent_store.init().unwrap();
+        let standard = Agent::new(
+            "staging-session".to_string(),
+            "supervisor-before-repair".to_string(),
+        );
+        agent_store.register(&standard).unwrap();
+
+        let mut env = staging_env("supervisor");
+        env.set("CAS_AGENT_NAME", "supervisor-after-repair");
+        env.set("CAS_FACTORY_SESSION", "factory-role-warning");
+        let input = session_input(tmp.path().to_str().unwrap());
+        let context = additional_context(handle_session_start(&input, Some(tmp.path())).unwrap());
+
+        assert!(
+            context.contains("CAS AGENT ROLE MISMATCH"),
+            "session start must expose the env/row disagreement: {context}"
+        );
+        assert!(context.contains("CAS_AGENT_ROLE=supervisor"));
+        assert!(context.contains("registered as `standard`"));
+        let repaired = agent_store.get("staging-session").unwrap();
+        assert_eq!(repaired.role, AgentRole::Supervisor);
+        assert_eq!(repaired.agent_type, crate::types::AgentType::Primary);
     }
 
     #[test]

--- a/cas-cli/src/mcp/daemon.rs
+++ b/cas-cli/src/mcp/daemon.rs
@@ -90,6 +90,48 @@ pub(crate) fn apply_factory_worker_metadata(agent: &mut Agent, clone_path: Optio
     }
 }
 
+/// Parse the harness-provided durable role hint used by every registration
+/// entrypoint. Verification authority is still bound independently to the
+/// in-process [`AgentIdentitySource`](crate::mcp::server::AgentIdentitySource);
+/// this helper only keeps the registered row aligned with the factory launch
+/// contract so routing and session ownership can resolve it.
+pub(crate) fn parse_agent_role_hint(role: Option<&str>) -> Option<AgentRole> {
+    role.and_then(|value| value.trim().parse().ok())
+}
+
+fn apply_agent_role(agent: &mut Agent, role: AgentRole) {
+    agent.role = role;
+    match role {
+        AgentRole::Worker => agent.agent_type = AgentType::Worker,
+        AgentRole::Supervisor | AgentRole::Director => agent.agent_type = AgentType::Primary,
+        AgentRole::Standard => {}
+    }
+}
+
+/// Register while preserving the store's general anti-forgery contract, then
+/// explicitly reconcile a role that came from the harness environment or a
+/// typed server-internal caller. `AgentStore::register` deliberately preserves
+/// role on conflict, so this narrow second step is required to repair rows
+/// created as `standard` by an earlier registration path.
+pub(crate) fn register_with_role_reconciliation(
+    store: &dyn crate::store::AgentStore,
+    agent: &Agent,
+    configured_role: Option<AgentRole>,
+) -> crate::store::Result<Agent> {
+    store.register(agent)?;
+    let mut persisted = store.get(&agent.id)?;
+    if let Some(role) = configured_role
+        && (persisted.role != role
+            || (role == AgentRole::Worker && persisted.agent_type != AgentType::Worker)
+            || (matches!(role, AgentRole::Supervisor | AgentRole::Director)
+                && persisted.agent_type != AgentType::Primary))
+    {
+        apply_agent_role(&mut persisted, role);
+        store.update(&persisted)?;
+    }
+    Ok(persisted)
+}
+
 /// Queue the factory daemon's proven teardown for a worker maintenance just declared dead.
 pub(crate) fn queue_stale_factory_worker_shutdown(
     cas_root: &std::path::Path,
@@ -142,7 +184,8 @@ pub(crate) fn register_session_start_agent(
     cc_pid: u32,
     clone_path: Option<&str>,
 ) -> crate::store::Result<(Agent, bool)> {
-    let requested_worker = agent_role.is_some_and(|role| role.eq_ignore_ascii_case("worker"));
+    let configured_role = parse_agent_role_hint(agent_role);
+    let requested_worker = configured_role == Some(AgentRole::Worker);
     let reusable = if requested_worker {
         agent_name.and_then(|name| {
             [
@@ -188,14 +231,13 @@ pub(crate) fn register_session_start_agent(
     stamp_pid_fingerprint(&mut agent, cc_pid);
     agent.machine_id = Some(Agent::get_or_generate_machine_id());
 
-    if requested_worker {
-        agent.role = AgentRole::Worker;
-        agent.agent_type = AgentType::Worker;
+    if let Some(role) = configured_role {
+        apply_agent_role(&mut agent, role);
     }
     apply_factory_worker_metadata(&mut agent, clone_path);
 
-    store.register(&agent)?;
-    Ok((agent, reused))
+    let persisted = register_with_role_reconciliation(store, &agent, configured_role)?;
+    Ok((persisted, reused))
 }
 
 /// Extension trait for EmbeddedDaemonConfig to convert to DaemonConfig

--- a/cas-cli/src/mcp/daemon_tests/tests.rs
+++ b/cas-cli/src/mcp/daemon_tests/tests.rs
@@ -117,6 +117,46 @@ fn repeated_factory_worker_session_start_reuses_live_pid_identity() {
     assert_eq!(same_worker_rows, 1, "worker identity must remain singular");
 }
 
+#[test]
+fn supervisor_hook_registration_persists_role_and_resolves_owner() {
+    let _env = TestEnvGuard::with_optional_vars(&[
+        ("CAS_AGENT_ROLE", Some("supervisor")),
+        (
+            "CAS_FACTORY_SESSION",
+            Some("factory-supervisor-registration"),
+        ),
+    ]);
+    let temp = TempDir::new().expect("temp project");
+    let cas_root = init_cas_dir(temp.path()).expect("init cas dir");
+    let agent_store = crate::store::open_agent_store(&cas_root).expect("open agent store");
+
+    let (supervisor, reused) = register_session_start_agent(
+        agent_store.as_ref(),
+        "supervisor-hook-session",
+        Some("lively-supervisor-11"),
+        Some("supervisor"),
+        std::process::id(),
+        None,
+    )
+    .expect("register supervisor from SessionStart hook");
+
+    assert!(!reused);
+    assert_eq!(supervisor.role, AgentRole::Supervisor);
+    assert_eq!(supervisor.agent_type, cas_types::AgentType::Primary);
+    assert_eq!(
+        supervisor.factory_session.as_deref(),
+        Some("factory-supervisor-registration")
+    );
+    let owner =
+        crate::mcp::tools::core::task::lifecycle::supervisor_push::resolve_owning_supervisor(
+            agent_store.as_ref(),
+            Some("factory-supervisor-registration"),
+        )
+        .expect("registered supervisor resolves as factory owner");
+    assert_eq!(owner.agent_id, "supervisor-hook-session");
+    assert_eq!(owner.name, "lively-supervisor-11");
+}
+
 /// cas-921f (P1 fix-round): the real env→register→resolve chain for a
 /// worker's harness, end to end — from a REAL `CAS_FACTORY_WORKER_CLI` env
 /// var (not injected `Agent.metadata` directly, which is what the earlier

--- a/cas-cli/src/mcp/server/mod.rs
+++ b/cas-cli/src/mcp/server/mod.rs
@@ -111,7 +111,9 @@ impl CasCore {
             matches!(
                 agent.role,
                 crate::types::AgentRole::Supervisor | crate::types::AgentRole::Director
-            )
+            ) && crate::mcp::daemon::parse_agent_role_hint(
+                std::env::var("CAS_AGENT_ROLE").ok().as_deref(),
+            ) != Some(agent.role)
         }) && !self.has_server_internal_identity(agent_id)
         {
             return Err(McpError {
@@ -595,21 +597,28 @@ impl CasCore {
                 }
                 agent.machine_id = Some(crate::types::Agent::get_or_generate_machine_id());
 
-                // Environment is a worker bootstrap hint, never a source of
-                // Supervisor/Director authority.
-                if std::env::var("CAS_AGENT_ROLE")
-                    .ok()
-                    .is_some_and(|role| role.eq_ignore_ascii_case("worker"))
-                {
-                    agent.role = crate::types::AgentRole::Worker;
-                }
-                if agent.role == crate::types::AgentRole::Worker {
-                    agent.agent_type = crate::types::AgentType::Worker;
+                let configured_role = crate::mcp::daemon::parse_agent_role_hint(
+                    std::env::var("CAS_AGENT_ROLE").ok().as_deref(),
+                );
+                if let Some(role) = configured_role {
+                    agent.role = role;
+                    agent.agent_type = match role {
+                        crate::types::AgentRole::Worker => crate::types::AgentType::Worker,
+                        crate::types::AgentRole::Supervisor | crate::types::AgentRole::Director => {
+                            crate::types::AgentType::Primary
+                        }
+                        crate::types::AgentRole::Standard => agent.agent_type,
+                    };
                 }
 
                 crate::mcp::daemon::apply_factory_worker_metadata(&mut agent, None);
 
-                agent_store.register(&agent).map_err(|e| McpError {
+                crate::mcp::daemon::register_with_role_reconciliation(
+                    agent_store.as_ref(),
+                    &agent,
+                    configured_role,
+                )
+                .map_err(|e| McpError {
                     code: ErrorCode::INTERNAL_ERROR,
                     message: Cow::from(format!("Failed to re-register agent: {e}")),
                     data: None,
@@ -687,19 +696,23 @@ impl CasCore {
         }
         agent.machine_id = Some(crate::types::Agent::get_or_generate_machine_id());
 
-        // Only a typed server-internal call may carry a privileged role.
-        // Public/env registration can establish Standard or Worker only.
-        if source == AgentIdentitySource::ServerInternal {
-            if let Some(role) = role_hint {
-                agent.role = role;
-            } else if std::env::var("CAS_AGENT_ROLE")
-                .ok()
-                .is_some_and(|role| role.eq_ignore_ascii_case("worker"))
-            {
-                agent.role = crate::types::AgentRole::Worker;
-            }
-        }
-        if agent.agent_type == crate::types::AgentType::Worker {
+        let environment_role = crate::mcp::daemon::parse_agent_role_hint(
+            std::env::var("CAS_AGENT_ROLE").ok().as_deref(),
+        );
+        let configured_role = match source {
+            AgentIdentitySource::ServerInternal => role_hint.or(environment_role),
+            AgentIdentitySource::PublicRegistration => environment_role.or(role_hint),
+        };
+        if let Some(role) = configured_role {
+            agent.role = role;
+            agent.agent_type = match role {
+                crate::types::AgentRole::Worker => crate::types::AgentType::Worker,
+                crate::types::AgentRole::Supervisor | crate::types::AgentRole::Director => {
+                    crate::types::AgentType::Primary
+                }
+                crate::types::AgentRole::Standard => agent.agent_type,
+            };
+        } else if agent.agent_type == crate::types::AgentType::Worker {
             agent.role = crate::types::AgentRole::Worker;
         }
 
@@ -717,7 +730,12 @@ impl CasCore {
 
         crate::mcp::daemon::apply_factory_worker_metadata(&mut agent, None);
 
-        agent_store.register(&agent).map_err(|e| McpError {
+        crate::mcp::daemon::register_with_role_reconciliation(
+            agent_store.as_ref(),
+            &agent,
+            configured_role,
+        )
+        .map_err(|e| McpError {
             code: ErrorCode::INTERNAL_ERROR,
             message: Cow::from(format!("Failed to register agent: {e}")),
             data: None,
@@ -879,3 +897,67 @@ pub use runtime::{
     write_proxy_catalog_cache, write_proxy_health_cache, write_proxy_snapshot_cache,
     write_proxy_snapshot_cache_for_config, write_unavailable_proxy_snapshot_cache,
 };
+
+#[cfg(test)]
+mod role_registration_tests {
+    use super::*;
+    use crate::store::{init_cas_dir, open_agent_store};
+    use crate::test_support::TestEnvGuard;
+    use crate::types::{AgentRole, AgentType};
+
+    #[test]
+    fn eager_environment_registration_persists_supervisor_role() {
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_AGENT_ROLE", Some("supervisor")),
+            ("CAS_FACTORY_SESSION", Some("factory-eager-supervisor")),
+        ]);
+        let temp = tempfile::tempdir().unwrap();
+        let cas_root = init_cas_dir(temp.path()).unwrap();
+        let core = CasCore::with_daemon(cas_root.clone(), None, None);
+
+        core.register_agent(
+            "eager-supervisor-session".to_string(),
+            "eager-supervisor".to_string(),
+            None,
+        )
+        .unwrap();
+
+        let agent = open_agent_store(&cas_root)
+            .unwrap()
+            .get("eager-supervisor-session")
+            .unwrap();
+        assert_eq!(agent.role, AgentRole::Supervisor);
+        assert_eq!(agent.agent_type, AgentType::Primary);
+        assert_eq!(
+            agent.factory_session.as_deref(),
+            Some("factory-eager-supervisor")
+        );
+    }
+
+    #[test]
+    fn missing_cached_agent_reregisters_as_supervisor() {
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_AGENT_ROLE", Some("supervisor")),
+            ("CAS_FACTORY_SESSION", Some("factory-reregister-supervisor")),
+        ]);
+        let temp = tempfile::tempdir().unwrap();
+        let cas_root = init_cas_dir(temp.path()).unwrap();
+        let core = CasCore::with_daemon(cas_root.clone(), None, None);
+        core.register_agent(
+            "cached-supervisor-session".to_string(),
+            "original-supervisor".to_string(),
+            None,
+        )
+        .unwrap();
+        let store = open_agent_store(&cas_root).unwrap();
+        store.unregister("cached-supervisor-session").unwrap();
+
+        core.ensure_agent_active("cached-supervisor-session")
+            .unwrap();
+
+        let agent = store.get("cached-supervisor-session").unwrap();
+        assert_eq!(agent.name, "Primary (re-registered)");
+        assert_eq!(agent.role, AgentRole::Supervisor);
+        assert_eq!(agent.agent_type, AgentType::Primary);
+    }
+}

--- a/cas-cli/src/mcp/tools/core/agent_coordination/agent_session.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/agent_session.rs
@@ -10,10 +10,13 @@ fn public_registration_hints(
     McpError,
 > {
     let requested_role = agent_type.and_then(|value| value.parse().ok());
+    let environment_role =
+        crate::mcp::daemon::parse_agent_role_hint(std::env::var("CAS_AGENT_ROLE").ok().as_deref());
     if matches!(
         requested_role,
         Some(crate::types::AgentRole::Supervisor | crate::types::AgentRole::Director)
-    ) {
+    ) && requested_role != environment_role
+    {
         return Err(McpError {
             code: ErrorCode::INVALID_PARAMS,
             message: Cow::from(
@@ -23,8 +26,10 @@ fn public_registration_hints(
         });
     }
     let requested_type = agent_type.and_then(|value| value.parse().ok());
-    let safe_role = (requested_type == Some(crate::types::AgentType::Worker))
-        .then_some(crate::types::AgentRole::Worker);
+    let safe_role = environment_role.or_else(|| {
+        (requested_type == Some(crate::types::AgentType::Worker))
+            .then_some(crate::types::AgentRole::Worker)
+    });
     Ok((requested_type, safe_role))
 }
 

--- a/cas-cli/src/mcp/tools/core/skills.rs
+++ b/cas-cli/src/mcp/tools/core/skills.rs
@@ -46,13 +46,13 @@ impl CasCore {
         let skill_store = self.open_skill_store()?;
 
         // Try database first
-        let skill = match skill_store.get(&req.id) {
-            Ok(s) => s,
+        let (skill, served_from_project_file) = match skill_store.get(&req.id) {
+            Ok(s) => (s, false),
             Err(_) => {
                 // Try to find in .claude/skills/ by name
                 let project_root = self.cas_root.parent().unwrap_or(&self.cas_root);
                 match read_skill_from_file(project_root, &req.id) {
-                    Ok(Some(s)) => s,
+                    Ok(Some(s)) => (s, true),
                     Ok(None) => {
                         return Err(McpError {
                             code: ErrorCode::INVALID_PARAMS,
@@ -71,13 +71,19 @@ impl CasCore {
             }
         };
 
-        let source = if skill.id.starts_with("file-") {
+        let source = if served_from_project_file {
             "file (.claude/skills/)"
         } else {
             "database"
         };
+        let project_root = self.cas_root.parent().unwrap_or(&self.cas_root);
+        let staleness_banner = served_from_project_file
+            .then(|| project_skill_staleness_banner(project_root))
+            .flatten()
+            .unwrap_or_default();
         let output = format!(
-            "Skill: {} ({})\n{}\n\nSource: {}\nType: {:?}\nStatus: {:?}\nUsage count: {}\nTags: {}\nCreated: {}\n\nDescription:\n{}\n\nInvocation:\n{}",
+            "{}Skill: {} ({})\n{}\n\nSource: {}\nType: {:?}\nStatus: {:?}\nUsage count: {}\nTags: {}\nCreated: {}\n\nDescription:\n{}\n\nInvocation:\n{}",
+            staleness_banner,
             skill.name,
             skill.id,
             "=".repeat(skill.name.len() + skill.id.len() + 4),
@@ -563,4 +569,29 @@ impl CasCore {
 
         Ok(Self::success(output))
     }
+}
+
+/// A project SKILL.md is served directly from the checkout, so readers need a
+/// signal when that checkout lacks commits already present on its sync target.
+/// Keep this read-only: an MCP read must not fetch or otherwise mutate state.
+fn project_skill_staleness_banner(project_root: &std::path::Path) -> Option<String> {
+    let (behind, sync_ref) =
+        crate::mcp::tools::check_worktree_staleness_cached(project_root.to_str()?, None)?;
+    if behind == 0 {
+        return None;
+    }
+
+    let served_ref = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(project_root)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|branch| !branch.is_empty())
+        .unwrap_or_else(|| "HEAD".to_string());
+
+    Some(format!(
+        "WARNING: STALE PROJECT SKILL\nServed from checkout ref `{served_ref}`, which is {behind} commit(s) behind `{sync_ref}`. \\\n+         The file may omit newer project guidance; run `cas factory sync` before relying on it.\n\n"
+    ))
 }

--- a/cas-cli/src/mcp/tools/core/skills.rs
+++ b/cas-cli/src/mcp/tools/core/skills.rs
@@ -592,6 +592,6 @@ fn project_skill_staleness_banner(project_root: &std::path::Path) -> Option<Stri
         .unwrap_or_else(|| "HEAD".to_string());
 
     Some(format!(
-        "WARNING: STALE PROJECT SKILL\nServed from checkout ref `{served_ref}`, which is {behind} commit(s) behind `{sync_ref}`. \\\n+         The file may omit newer project guidance; run `cas factory sync` before relying on it.\n\n"
+        "WARNING: STALE PROJECT SKILL\nServed from checkout ref `{served_ref}`, which is {behind} commit(s) behind `{sync_ref}`. The file may omit newer project guidance; run `cas factory sync` before relying on it.\n\n"
     ))
 }

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -4087,6 +4087,32 @@ impl CasCore {
             data: None,
         })?;
 
+        // GH #276: reminders armed while working a task carry frozen context.
+        // Once the task closes, default reminders must not wake a successor
+        // with obsolete draft IDs or decisions. `cross_session` is the explicit
+        // opt-in to retain a reminder across this boundary; retained deliveries
+        // are stamped at fire time with this task's current status and age.
+        match crate::store::open_reminder_store(&self.cas_root) {
+            Ok(store) => match store.cancel_pending_for_task(&req.id) {
+                Ok(cancelled) if cancelled > 0 => tracing::info!(
+                    task_id = %req.id,
+                    cancelled,
+                    "quarantined task-scoped reminders on task close"
+                ),
+                Ok(_) => {}
+                Err(error) => tracing::error!(
+                    task_id = %req.id,
+                    error = %error,
+                    "task closed but reminder quarantine failed"
+                ),
+            },
+            Err(error) => tracing::error!(
+                task_id = %req.id,
+                error = %error,
+                "task closed but reminder store could not open for quarantine"
+            ),
+        }
+
         // cas-062d / cas-17e4: durable Closed outbox push after successful close.
         {
             let actor = self

--- a/cas-cli/src/mcp/tools/mod.rs
+++ b/cas-cli/src/mcp/tools/mod.rs
@@ -279,9 +279,30 @@ pub(crate) fn resolve_staleness_sync_ref(
 /// When set, it always wins so multi-epic factories compare against the correct epic.
 ///
 /// Returns (commits_behind, sync_ref) or None if check fails (missing path / git error).
-fn check_worktree_staleness(
+pub(crate) fn check_worktree_staleness(
     clone_path: &str,
     preferred_sync_ref: Option<&str>,
+) -> Option<(u32, String)> {
+    check_worktree_staleness_with_fetch(clone_path, preferred_sync_ref, true)
+}
+
+/// Read-only variant of [`check_worktree_staleness`] for request paths that
+/// must not turn a display operation into an unbounded network fetch.
+///
+/// It deliberately uses the already-available local refs. A stale cached ref
+/// can only suppress a warning, never invent one; SessionStart and factory
+/// synchronization remain responsible for refreshing remotes.
+pub(crate) fn check_worktree_staleness_cached(
+    clone_path: &str,
+    preferred_sync_ref: Option<&str>,
+) -> Option<(u32, String)> {
+    check_worktree_staleness_with_fetch(clone_path, preferred_sync_ref, false)
+}
+
+fn check_worktree_staleness_with_fetch(
+    clone_path: &str,
+    preferred_sync_ref: Option<&str>,
+    fetch: bool,
 ) -> Option<(u32, String)> {
     use crate::worktree::GitOperations;
     use std::path::Path;
@@ -321,7 +342,7 @@ fn check_worktree_staleness(
     );
 
     // Fetch latest refs when sync target is a remote-tracking ref.
-    if let Some(remote) = remote_for_ref(path, &sync_ref) {
+    if fetch && let Some(remote) = remote_for_ref(path, &sync_ref) {
         let _ = Command::new("git")
             .args(["fetch", &remote])
             .current_dir(path)

--- a/cas-cli/src/mcp/tools/service/factory_remind.rs
+++ b/cas-cli/src/mcp/tools/service/factory_remind.rs
@@ -96,13 +96,13 @@ impl CasService {
 
         let ttl_secs = req.remind_ttl_secs.unwrap_or(3600);
         let cross_session = req.cross_session.unwrap_or(false);
-        let task_id = req
+        let explicit_task_id = req
             .task_id
             .as_deref()
             .map(str::trim)
             .filter(|id| !id.is_empty());
 
-        if let Some(task_id) = task_id {
+        let task_id = if let Some(task_id) = explicit_task_id {
             let task_store = self.inner.open_task_store().map_err(|e| {
                 Self::error(
                     ErrorCode::INTERNAL_ERROR,
@@ -115,7 +115,42 @@ impl CasService {
                     format!("Cannot bind reminder to task {task_id}: {e}"),
                 )
             })?;
-        }
+            Some(task_id.to_string())
+        } else {
+            // GH #276: callers historically had no task_id parameter. Bind a
+            // reminder to the issuer's one unambiguous active task so closing
+            // that task quarantines stale follow-up context by default.
+            let task_store = self.inner.open_task_store().map_err(|e| {
+                Self::error(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Cannot open task store for reminder context: {e}"),
+                )
+            })?;
+            let agent_name = crate::store::open_agent_store(&self.inner.cas_root)
+                .ok()
+                .and_then(|store| store.get(&owner_id).ok())
+                .map(|agent| agent.name);
+            let active: Vec<_> = task_store
+                .list(None)
+                .map_err(|e| {
+                    Self::error(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Cannot list tasks for reminder context: {e}"),
+                    )
+                })?
+                .into_iter()
+                .filter(|task| {
+                    task.status == cas_types::TaskStatus::InProgress
+                        && task.assignee.as_deref().is_some_and(|assignee| {
+                            assignee.eq_ignore_ascii_case(&owner_id)
+                                || agent_name
+                                    .as_deref()
+                                    .is_some_and(|name| assignee.eq_ignore_ascii_case(name))
+                        })
+                })
+                .collect();
+            (active.len() == 1).then(|| active[0].id.clone())
+        };
 
         // cas-fcd4: bind event-based (and all) reminds to the registering factory
         // session so concurrent factories sharing cas.db do not cross-fire.
@@ -156,7 +191,7 @@ impl CasService {
                     session_id.as_deref(),
                     Some(&origin_session_id),
                     cross_session,
-                    task_id,
+                    task_id.as_deref(),
                 )
                 .map_err(|e| {
                     Self::error(
@@ -188,6 +223,7 @@ impl CasService {
                 ", session-scoped; cancelled when this session ends".to_string()
             };
             let task_desc = task_id
+                .as_deref()
                 .map(|id| format!(", task: {id}"))
                 .unwrap_or_default();
             Ok(Self::success(format!(
@@ -248,7 +284,7 @@ impl CasService {
                     session_id.as_deref(),
                     Some(&origin_session_id),
                     cross_session,
-                    task_id,
+                    task_id.as_deref(),
                 )
                 .map_err(|e| {
                     Self::error(
@@ -283,6 +319,7 @@ impl CasService {
                 (None, false) => ", session-scoped; cancelled when this session ends".to_string(),
             };
             let task_desc = task_id
+                .as_deref()
                 .map(|id| format!(", task: {id}"))
                 .unwrap_or_default();
 

--- a/cas-cli/src/mcp/tools/service/factory_remind.rs
+++ b/cas-cli/src/mcp/tools/service/factory_remind.rs
@@ -96,6 +96,26 @@ impl CasService {
 
         let ttl_secs = req.remind_ttl_secs.unwrap_or(3600);
         let cross_session = req.cross_session.unwrap_or(false);
+        let task_id = req
+            .task_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty());
+
+        if let Some(task_id) = task_id {
+            let task_store = self.inner.open_task_store().map_err(|e| {
+                Self::error(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Cannot open task store for reminder context: {e}"),
+                )
+            })?;
+            task_store.get(task_id).map_err(|e| {
+                Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    format!("Cannot bind reminder to task {task_id}: {e}"),
+                )
+            })?;
+        }
 
         // cas-fcd4: bind event-based (and all) reminds to the registering factory
         // session so concurrent factories sharing cas.db do not cross-fire.
@@ -136,6 +156,7 @@ impl CasService {
                     session_id.as_deref(),
                     Some(&origin_session_id),
                     cross_session,
+                    task_id,
                 )
                 .map_err(|e| {
                     Self::error(
@@ -160,12 +181,17 @@ impl CasService {
             };
 
             let scope_desc = if cross_session {
-                format!(", cross-session opt-in; origin session: {origin_session_id}")
+                format!(
+                    ", explicit keep across session/task close; origin session: {origin_session_id}"
+                )
             } else {
                 ", session-scoped; cancelled when this session ends".to_string()
             };
+            let task_desc = task_id
+                .map(|id| format!(", task: {id}"))
+                .unwrap_or_default();
             Ok(Self::success(format!(
-                "Reminder #{id} set (time-based, fires in {time_desc}{target_desc}{scope_desc})\nMessage: {message}"
+                "Reminder #{id} set (time-based, fires in {time_desc}{target_desc}{task_desc}{scope_desc})\nMessage: {message}"
             )))
         } else {
             let event_type = req.remind_event.unwrap();
@@ -222,6 +248,7 @@ impl CasService {
                     session_id.as_deref(),
                     Some(&origin_session_id),
                     cross_session,
+                    task_id,
                 )
                 .map_err(|e| {
                     Self::error(
@@ -243,19 +270,24 @@ impl CasService {
 
             let session_desc = match (&session_id, cross_session) {
                 (Some(s), true) => format!(
-                    ", factory session: {s}, cross-session opt-in; origin session: {origin_session_id}"
+                    ", factory session: {s}, explicit keep across session/task close; origin session: {origin_session_id}"
                 ),
                 (Some(s), false) => format!(
                     ", factory session: {s}, session-scoped; cancelled when this session ends"
                 ),
                 (None, true) => {
-                    format!(", cross-session opt-in; origin session: {origin_session_id}")
+                    format!(
+                        ", explicit keep across session/task close; origin session: {origin_session_id}"
+                    )
                 }
                 (None, false) => ", session-scoped; cancelled when this session ends".to_string(),
             };
+            let task_desc = task_id
+                .map(|id| format!(", task: {id}"))
+                .unwrap_or_default();
 
             Ok(Self::success(format!(
-                "Reminder #{id} set (event-based, fires on {event_type}{filter_desc}{target_desc}{session_desc})\nMessage: {message}"
+                "Reminder #{id} set (event-based, fires on {event_type}{filter_desc}{target_desc}{task_desc}{session_desc})\nMessage: {message}"
             )))
         }
     }

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -5112,6 +5112,7 @@ impl FactoryDaemon {
                 &self.session_name,
                 agent_id_to_name,
                 None,
+                self.app.cas_dir(),
             );
         }
 
@@ -5142,6 +5143,7 @@ impl FactoryDaemon {
                         &self.session_name,
                         agent_id_to_name,
                         Some(event),
+                        self.app.cas_dir(),
                     );
                 }
             }
@@ -5271,6 +5273,7 @@ fn fire_reminder(
     session_name: &str,
     agent_id_to_name: &std::collections::HashMap<String, String>,
     triggering_event: Option<&crate::ui::factory::director::DirectorEvent>,
+    cas_dir: &std::path::Path,
 ) {
     // Build event JSON for persistence
     let event_json = triggering_event.map(|e| {
@@ -5329,13 +5332,23 @@ fn fire_reminder(
         // mail to avoid accusing a healthy waiting worker of being wedged,
         // parses exactly what is written here.
         let event_context = triggering_event.map(|event| event.description());
+        let task_status = reminder.task_id.as_deref().and_then(|task_id| {
+            crate::store::open_task_store(cas_dir)
+                .ok()
+                .and_then(|store| store.get(task_id).ok())
+                .map(|task| task.status.to_string())
+        });
         let prompt = if reminder.cross_session {
-            cas_store::format_cross_session_reminder_delivery(reminder, event_context.as_deref())
-        } else {
-            cas_store::format_reminder_delivery(
-                reminder.id,
-                &reminder.message,
+            cas_store::format_cross_session_reminder_delivery(
+                reminder,
                 event_context.as_deref(),
+                task_status.as_deref(),
+            )
+        } else {
+            cas_store::format_reminder_delivery_with_provenance(
+                reminder,
+                event_context.as_deref(),
+                task_status.as_deref(),
             )
         };
 
@@ -8343,6 +8356,7 @@ mod tests {
             session_id: Some("session-a".into()),
             origin_session_id: Some("creator-session".into()),
             cross_session: false,
+            task_id: None,
         };
         let match_event = DirectorEvent::TaskCompleted {
             task_id: "cas-keep".into(),

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -19,11 +19,12 @@ use std::sync::Arc;
 use cas::mcp::{CasCore, CasService};
 use cas::store::{
     AgentStore, EventStore, PromptQueueStore, SpawnQueueStore, TaskStore, init_cas_dir,
-    open_agent_store, open_event_store, open_prompt_queue_store, open_spawn_queue_store,
-    open_task_store,
+    open_agent_store, open_event_store, open_prompt_queue_store, open_reminder_store,
+    open_spawn_queue_store, open_task_store,
 };
 use cas::types::{
-    Agent, AgentStatus, Event, EventEntityType, EventType, Task, TaskStatus, TaskType, WorkTarget,
+    Agent, AgentStatus, Event, EventEntityType, EventType, Task, TaskDepth, TaskStatus, TaskType,
+    WorkTarget,
 };
 use cas_mcp::types::{CoordinationRequest, FactoryRequest};
 use cas_mux::{Mux, MuxConfig, SupervisorCli};
@@ -535,6 +536,48 @@ fn coord_req(action: &str) -> CoordinationRequest {
         port: None,
         shared: None,
     }
+}
+
+/// GH #276: existing callers did not supply task_id. With exactly one active
+/// issuer task, remind must infer that context so close quarantines it.
+#[tokio::test]
+async fn remind_auto_binds_issuer_single_in_progress_task_and_close_quarantines_it() {
+    let env = FactoryTestEnv::new();
+    env.register_worker_with_id("test-agent-id", "reminder-worker", None);
+
+    let task_store = env.task_store();
+    let task_id = task_store.generate_id().unwrap();
+    let mut task = Task::new(task_id.clone(), "reminder context".to_string());
+    task.assignee = Some("test-agent-id".to_string());
+    task.status = TaskStatus::InProgress;
+    task.depth = TaskDepth::Light;
+    task_store.add(&task).unwrap();
+
+    let mut remind = factory_req("remind");
+    remind.remind_message = Some("follow up on discarded draft".to_string());
+    remind.remind_delay_secs = Some(300);
+    env.service
+        .factory(Parameters(remind))
+        .await
+        .expect("remind should infer the issuer task");
+
+    let reminders = open_reminder_store(&env.cas_root).unwrap();
+    let pending = reminders.list_pending("test-agent-id").unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].task_id.as_deref(), Some(task_id.as_str()));
+
+    let close: cas_mcp::types::TaskRequest = serde_json::from_value(serde_json::json!({
+        "action": "close", "id": task_id, "reason": "done"
+    }))
+    .unwrap();
+    env.service
+        .task(Parameters(close))
+        .await
+        .expect("light task close should succeed");
+    assert!(
+        reminders.list_pending("test-agent-id").unwrap().is_empty(),
+        "task close must quarantine the inferred reminder"
+    );
 }
 
 fn get_text(result: &rmcp::model::CallToolResult) -> String {

--- a/cas-cli/tests/mcp_tools_test/skill_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/skill_tools.rs
@@ -141,9 +141,12 @@ async fn project_skill_show_marks_a_checkout_behind_its_sync_ref() {
         .expect("file-backed skill should be served");
     let text = extract_text(result);
 
-    assert!(text.starts_with("WARNING: STALE PROJECT SKILL"), "{text}");
-    assert!(text.contains("factory/stale-skill"), "{text}");
-    assert!(text.contains("1 commit(s) behind `main`"), "{text}");
+    assert!(
+        text.starts_with(
+            "WARNING: STALE PROJECT SKILL\nServed from checkout ref `factory/stale-skill`, which is 1 commit(s) behind `main`. The file may omit newer project guidance; run `cas factory sync` before relying on it.\n\n"
+        ),
+        "{text}"
+    );
 }
 
 #[tokio::test]

--- a/cas-cli/tests/mcp_tools_test/skill_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/skill_tools.rs
@@ -1,6 +1,37 @@
 use crate::support::*;
 use cas::mcp::tools::*;
 use rmcp::handler::server::wrapper::Parameters;
+use std::process::Command;
+
+fn git(root: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("git should run");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit(root: &std::path::Path, message: &str) {
+    git(root, &["add", "."]);
+    git(
+        root,
+        &[
+            "-c",
+            "user.name=CAS Test",
+            "-c",
+            "user.email=cas-test@example.invalid",
+            "commit",
+            "-m",
+            message,
+        ],
+    );
+}
 
 #[tokio::test]
 async fn test_skill_create() {
@@ -81,6 +112,63 @@ async fn test_skill_show() {
 
     let text = extract_text(result);
     assert!(text.contains("Show Skill") || text.contains("show-skill"));
+}
+
+#[tokio::test]
+async fn project_skill_show_marks_a_checkout_behind_its_sync_ref() {
+    let (temp, service) = setup_cas();
+    let root = temp.path();
+    git(root, &["init", "--initial-branch=main"]);
+    std::fs::create_dir_all(root.join(".claude/skills/stale-skill")).unwrap();
+    std::fs::write(
+        root.join(".claude/skills/stale-skill/SKILL.md"),
+        "---\nname: stale-skill\ndescription: stale test\n---\n\nOld guidance\n",
+    )
+    .unwrap();
+    commit(root, "add project skill");
+
+    git(root, &["checkout", "-b", "factory/stale-skill"]);
+    git(root, &["checkout", "main"]);
+    std::fs::write(root.join("new-guidance.md"), "new guidance\n").unwrap();
+    commit(root, "new project guidance");
+    git(root, &["checkout", "factory/stale-skill"]);
+
+    let result = service
+        .cas_skill_show(Parameters(IdRequest {
+            id: "stale-skill".to_string(),
+        }))
+        .await
+        .expect("file-backed skill should be served");
+    let text = extract_text(result);
+
+    assert!(text.starts_with("WARNING: STALE PROJECT SKILL"), "{text}");
+    assert!(text.contains("factory/stale-skill"), "{text}");
+    assert!(text.contains("1 commit(s) behind `main`"), "{text}");
+}
+
+#[tokio::test]
+async fn project_skill_show_is_quiet_when_checkout_is_current() {
+    let (temp, service) = setup_cas();
+    let root = temp.path();
+    git(root, &["init", "--initial-branch=main"]);
+    std::fs::create_dir_all(root.join(".claude/skills/current-skill")).unwrap();
+    std::fs::write(
+        root.join(".claude/skills/current-skill/SKILL.md"),
+        "---\nname: current-skill\ndescription: current test\n---\n\nCurrent guidance\n",
+    )
+    .unwrap();
+    commit(root, "add current project skill");
+
+    let result = service
+        .cas_skill_show(Parameters(IdRequest {
+            id: "current-skill".to_string(),
+        }))
+        .await
+        .expect("file-backed skill should be served");
+    let text = extract_text(result);
+
+    assert!(!text.contains("STALE PROJECT SKILL"), "{text}");
+    assert!(text.starts_with("Skill: current-skill"), "{text}");
 }
 
 #[tokio::test]

--- a/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
@@ -11,7 +11,7 @@
 use crate::support::*;
 use cas::mcp::tools::*;
 use cas::mcp::{CasCore, CasService};
-use cas::store::open_task_store;
+use cas::store::{ReminderTriggerType, open_reminder_store, open_task_store};
 use cas::types::TaskStatus;
 use rmcp::handler::server::wrapper::Parameters;
 use std::process::Command;
@@ -177,6 +177,65 @@ async fn test_light_depth_solo_close_skips_verification_jail() {
          gates: {}",
         task.notes
     );
+}
+
+/// GH #276: a task close must quarantine its default reminders while retaining
+/// only the explicit cross-session/task-close opt-in.
+#[tokio::test]
+async fn task_close_quarantines_linked_reminders_unless_explicitly_kept() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+
+    let created = core
+        .cas_task_create(Parameters(create_req(
+            "reminder context task",
+            Some("light"),
+        )))
+        .await
+        .expect("task_create should succeed");
+    let id = extract_task_id(&extract_text(created))
+        .expect("should have task ID")
+        .to_string();
+    core.cas_task_start(Parameters(IdRequest { id: id.clone() }))
+        .await
+        .expect("task_start should succeed");
+
+    let reminders = open_reminder_store(&cas_dir).unwrap();
+    for keep in [false, true] {
+        reminders
+            .create_with_scope(
+                "worker-1",
+                None,
+                "follow up on transient draft",
+                ReminderTriggerType::Time,
+                Some(chrono::Utc::now() + chrono::Duration::minutes(5)),
+                None,
+                None,
+                3600,
+                None,
+                None,
+                keep,
+                Some(&id),
+            )
+            .unwrap();
+    }
+
+    core.cas_task_close(Parameters(TaskCloseRequest {
+        id: id.clone(),
+        reason: Some("The task is complete.".to_string()),
+        bypass_code_review: None,
+        code_review_findings: None,
+        search_manifest: None,
+        commit_receipt: None,
+    }))
+    .await
+    .expect("task close should succeed");
+
+    let remaining = reminders.list_pending("worker-1").unwrap();
+    assert_eq!(remaining.len(), 1, "only explicit keep may survive close");
+    assert!(remaining[0].cross_session);
+    assert_eq!(remaining[0].task_id.as_deref(), Some(id.as_str()));
 }
 
 /// Regression guard: a `depth=deep` (explicit) task still arms the jail.

--- a/cas-cli/tests/worktree_surface_test.rs
+++ b/cas-cli/tests/worktree_surface_test.rs
@@ -4383,9 +4383,10 @@ async fn public_registration_cannot_mint_or_capture_supervisor_verification_auth
     )
     .expect("exact dispatch");
 
-    // A public caller controls request fields, display name, and its process
-    // environment. Registration may establish an ordinary session, but those
-    // hints must carry zero supervisor_direct authority.
+    // The MCP server's launch environment is the factory's durable role
+    // contract, so registration must persist it for routing. Identity-source
+    // provenance remains separate: a public call still carries zero
+    // supervisor_direct verification authority.
     let public = CasCore::with_daemon(cas_root.clone(), None, None);
     {
         let _role = VarGuard::set(&env, "CAS_AGENT_ROLE", "supervisor");
@@ -4404,8 +4405,8 @@ async fn public_registration_cannot_mint_or_capture_supervisor_verification_auth
             .get("public-env-supervisor")
             .expect("registered public agent")
             .role,
-        AgentRole::Standard,
-        "environment and display-name hints cannot mint a supervisor row"
+        AgentRole::Supervisor,
+        "register must persist the harness-provided supervisor role"
     );
 
     let before_denial = durable_close_snapshot(&cas_root);
@@ -4470,8 +4471,8 @@ async fn public_registration_cannot_mint_or_capture_supervisor_verification_auth
             .get("public-session-env-supervisor")
             .expect("public session agent")
             .role,
-        AgentRole::Standard,
-        "session_start environment/name hints cannot mint supervisor"
+        AgentRole::Supervisor,
+        "session_start must persist the harness-provided supervisor role"
     );
     let before_session_denial = durable_close_snapshot(&cas_root);
     public_session
@@ -4495,8 +4496,9 @@ async fn public_registration_cannot_mint_or_capture_supervisor_verification_auth
         "denied session_start spoof must not mutate proof state"
     );
 
-    // An existing Worker row also cannot be elevated by ON CONFLICT
-    // re-registration, even with a privileged environment claim.
+    // Re-registration must repair a stale role even though the generic store
+    // ON CONFLICT contract preserves authority by default. Public provenance
+    // still prevents the repaired row from submitting verification directly.
     register_delivery_agent(
         &cas_root,
         "existing-worker-registration",
@@ -4519,9 +4521,9 @@ async fn public_registration_cannot_mint_or_capture_supervisor_verification_auth
     }
     let worker = agent_store
         .get("existing-worker-registration")
-        .expect("worker remains registered");
-    assert_eq!(worker.role, AgentRole::Worker);
-    assert_eq!(worker.agent_type, AgentType::Worker);
+        .expect("re-registered supervisor");
+    assert_eq!(worker.role, AgentRole::Supervisor);
+    assert_eq!(worker.agent_type, AgentType::Primary);
     let mut worker_task = Task::new(
         "cas-worker-reregister-proof".to_string(),
         "Worker re-registration cannot mint proof authority".to_string(),

--- a/crates/cas-mcp/src/types/ops_secondary.rs
+++ b/crates/cas-mcp/src/types/ops_secondary.rs
@@ -724,9 +724,11 @@ pub struct CoordinationRequest {
     #[serde(default)]
     pub id: Option<String>,
 
-    /// Task ID (for loop_start, worktree_create, spawn_workers)
+    /// Task ID (for loop_start, worktree_create, spawn_workers, or remind).
+    /// A reminder linked to this task is quarantined when it closes unless
+    /// `cross_session=true` explicitly keeps it.
     #[schemars(
-        description = "Task ID. For loop_start/worktree_create: the task the loop/worktree is scoped to. For spawn_workers: pre-assign this task to the spawned worker (single-worker requests only) — see spawn_workers-specific docs. An open task_id also authorizes the spawn on its own, so a standalone follow-up needs no active EPIC."
+        description = "Task ID. For loop_start/worktree_create: the task the loop/worktree is scoped to. For spawn_workers: pre-assign this task to the spawned worker (single-worker requests only). For remind: bind stale-context cleanup to this task; close quarantines it unless cross_session=true explicitly keeps it. An open task_id also authorizes the spawn on its own, so a standalone follow-up needs no active EPIC."
     )]
     #[serde(default)]
     pub task_id: Option<String>,
@@ -973,10 +975,11 @@ pub struct CoordinationRequest {
     #[serde(default, deserialize_with = "deser::option_i64")]
     pub remind_ttl_secs: Option<i64>,
 
-    /// Allow a reminder to survive its creator's session end. This is an
-    /// explicit opt-in; delivery includes origin and creation-time context.
+    /// Explicitly keep a reminder across its creator's session end and a
+    /// linked task close. Delivery includes origin, creation-time, and task
+    /// status context.
     #[schemars(
-        description = "Opt in to a reminder surviving its creator session (default false). Cross-session deliveries include origin-session and created-at context."
+        description = "Explicitly keep a reminder across creator session end and linked task close (default false). Deliveries include origin-session, created-at, and linked-task status context."
     )]
     #[serde(default)]
     pub cross_session: Option<bool>,

--- a/crates/cas-mcp/src/types_tests/tests.rs
+++ b/crates/cas-mcp/src/types_tests/tests.rs
@@ -324,10 +324,16 @@ fn test_factory_remind_fields_as_string() {
 #[test]
 fn cross_session_reminder_opt_in_survives_coordination_mapping() {
     let req: CoordinationRequest =
-        serde_json::from_str(r#"{"action":"remind","remind_delay_secs":120,"cross_session":true}"#)
+        serde_json::from_str(
+            r#"{"action":"remind","task_id":"cas-issue-276","remind_delay_secs":120,"cross_session":true}"#,
+        )
             .unwrap();
     assert_eq!(req.cross_session, Some(true));
     assert_eq!(req.to_factory_request().cross_session, Some(true));
+    assert_eq!(
+        req.to_factory_request().task_id.as_deref(),
+        Some("cas-issue-276")
+    );
 }
 
 // ===== option_u32 tests =====

--- a/crates/cas-store/src/lib.rs
+++ b/crates/cas-store/src/lib.rs
@@ -202,7 +202,7 @@ pub use prompt_queue_store::{
 pub use reminder_store::{
     Reminder, ReminderExpiryOutcome, ReminderStatus, ReminderStore, ReminderTriggerType,
     SqliteReminderStore, expire_stale_bounded, format_cross_session_reminder_delivery,
-    format_reminder_delivery, parse_reminder_delivery_id,
+    format_reminder_delivery, format_reminder_delivery_with_provenance, parse_reminder_delivery_id,
 };
 
 // Retrieval provenance and explicit outcome feedback

--- a/crates/cas-store/src/reminder_store.rs
+++ b/crates/cas-store/src/reminder_store.rs
@@ -137,9 +137,15 @@ pub struct Reminder {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin_session_id: Option<String>,
     /// Explicit opt-in for a reminder to survive its creator's SessionEnd.
-    /// Such deliveries carry origin and age context for stale-context triage.
+    /// It also keeps a task-linked reminder alive when that task closes. Such
+    /// deliveries carry origin and age context for stale-context triage.
     #[serde(default)]
     pub cross_session: bool,
+    /// Task context active when this reminder was issued, if supplied by the
+    /// caller. Task closure cancels linked reminders unless `cross_session` is
+    /// explicitly set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
 }
 
 /// Wire prefix that marks a prompt-queue row as a fired-reminder delivery.
@@ -166,13 +172,36 @@ pub fn format_reminder_delivery(id: i64, message: &str, event_context: Option<&s
     }
 }
 
+/// Add issue-time and task-state provenance to every fired reminder. This is
+/// deliberately rendered at fire time: a reminder that was valid when armed
+/// may no longer be actionable after its task changes state.
+pub fn format_reminder_delivery_with_provenance(
+    reminder: &Reminder,
+    event_context: Option<&str>,
+    task_status: Option<&str>,
+) -> String {
+    let mut delivery = format_reminder_delivery(reminder.id, &reminder.message, event_context);
+    let age_minutes = (Utc::now() - reminder.created_at).num_minutes().max(0);
+    let task_context = match (reminder.task_id.as_deref(), task_status) {
+        (Some(task_id), Some(status)) => format!("task {task_id} ({status})"),
+        (Some(task_id), None) => format!("task {task_id} (missing)"),
+        (None, _) => "no task context".to_string(),
+    };
+    delivery.push_str(&format!(
+        "\n\nProvenance: issued {age_minutes} min ago under {task_context}."
+    ));
+    delivery
+}
+
 /// Render an explicitly cross-session delivery without losing the durable
 /// `Reminder #<id>:` prefix that downstream status logic parses.
 pub fn format_cross_session_reminder_delivery(
     reminder: &Reminder,
     event_context: Option<&str>,
+    task_status: Option<&str>,
 ) -> String {
-    let mut delivery = format_reminder_delivery(reminder.id, &reminder.message, event_context);
+    let mut delivery =
+        format_reminder_delivery_with_provenance(reminder, event_context, task_status);
     let origin = reminder
         .origin_session_id
         .as_deref()
@@ -234,6 +263,8 @@ const MIGRATION_SESSION_ID: &str = "ALTER TABLE reminders ADD COLUMN session_id 
 const MIGRATION_ORIGIN_SESSION_ID: &str = "ALTER TABLE reminders ADD COLUMN origin_session_id TEXT";
 const MIGRATION_CROSS_SESSION: &str =
     "ALTER TABLE reminders ADD COLUMN cross_session INTEGER NOT NULL DEFAULT 0";
+/// Migration: task context lets task-close quarantine stale reminders.
+const MIGRATION_TASK_ID: &str = "ALTER TABLE reminders ADD COLUMN task_id TEXT";
 
 /// Trait for reminder storage operations
 #[allow(clippy::too_many_arguments)]
@@ -275,6 +306,7 @@ pub trait ReminderStore: Send + Sync {
         session_id: Option<&str>,
         origin_session_id: Option<&str>,
         cross_session: bool,
+        task_id: Option<&str>,
     ) -> Result<i64>;
 
     /// List pending reminders owned by a specific agent
@@ -311,6 +343,11 @@ pub trait ReminderStore: Send + Sync {
     /// Cancel pending default-scoped reminders created by a completed session.
     /// Explicit cross-session reminders are deliberately retained.
     fn cancel_pending_for_origin_session(&self, origin_session_id: &str) -> Result<usize>;
+
+    /// Cancel pending reminders issued under a task that has just closed.
+    /// Explicit cross-session opt-in keeps a reminder alive across this
+    /// boundary, but its delivery is stamped with task status and age.
+    fn cancel_pending_for_task(&self, task_id: &str) -> Result<usize>;
 
     /// Expire reminders past their TTL, returns count expired
     fn expire_stale(&self) -> Result<usize>;
@@ -398,6 +435,7 @@ impl SqliteReminderStore {
             }
         });
         let cross_session: bool = row.get::<_, i64>(16)? != 0;
+        let task_id: Option<String> = row.get(17)?;
 
         Ok(Reminder {
             id: row.get(0)?,
@@ -417,6 +455,7 @@ impl SqliteReminderStore {
             session_id,
             origin_session_id,
             cross_session,
+            task_id,
         })
     }
 
@@ -457,10 +496,17 @@ impl SqliteReminderStore {
             conn.execute_batch(MIGRATION_CROSS_SESSION)?;
         }
 
+        if conn
+            .prepare_cached("SELECT task_id FROM reminders LIMIT 0")
+            .is_err()
+        {
+            conn.execute_batch(MIGRATION_TASK_ID)?;
+        }
+
         Ok(())
     }
 
-    const SELECT_COLUMNS: &str = "id, supervisor_id, message, trigger_type, trigger_at, trigger_event, trigger_filter, status, ttl_secs, created_at, fired_at, cancelled_at, target_id, fired_event, session_id, origin_session_id, cross_session";
+    const SELECT_COLUMNS: &str = "id, supervisor_id, message, trigger_type, trigger_at, trigger_event, trigger_filter, status, ttl_secs, created_at, fired_at, cancelled_at, target_id, fired_event, session_id, origin_session_id, cross_session, task_id";
 }
 
 fn expire_stale_with_conn(conn: &Connection) -> Result<usize> {
@@ -540,6 +586,7 @@ impl ReminderStore for SqliteReminderStore {
             session_id,
             None,
             false,
+            None,
         )
     }
 
@@ -556,6 +603,7 @@ impl ReminderStore for SqliteReminderStore {
         session_id: Option<&str>,
         origin_session_id: Option<&str>,
         cross_session: bool,
+        task_id: Option<&str>,
     ) -> Result<i64> {
         let conn = self.conn.lock().unwrap();
         let now = Utc::now().to_rfc3339();
@@ -570,10 +618,14 @@ impl ReminderStore for SqliteReminderStore {
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string);
+        let task_id = task_id
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
 
         conn.execute(
-            "INSERT INTO reminders (supervisor_id, message, trigger_type, trigger_at, trigger_event, trigger_filter, ttl_secs, created_at, target_id, session_id, origin_session_id, cross_session)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO reminders (supervisor_id, message, trigger_type, trigger_at, trigger_event, trigger_filter, ttl_secs, created_at, target_id, session_id, origin_session_id, cross_session, task_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params![
                 owner_id,
                 message,
@@ -587,6 +639,7 @@ impl ReminderStore for SqliteReminderStore {
                 session_id,
                 origin_session_id,
                 cross_session,
+                task_id,
             ],
         )?;
 
@@ -745,6 +798,18 @@ impl ReminderStore for SqliteReminderStore {
         Ok(rows)
     }
 
+    fn cancel_pending_for_task(&self, task_id: &str) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let now = Utc::now().to_rfc3339();
+        let rows = conn.execute(
+            "UPDATE reminders SET status = 'cancelled', cancelled_at = ?1 \
+             WHERE status = 'pending' AND task_id = ?2 \
+             AND COALESCE(cross_session, 0) = 0",
+            params![now, task_id],
+        )?;
+        Ok(rows)
+    }
+
     fn expire_stale(&self) -> Result<usize> {
         let conn = self.conn.lock().unwrap();
         expire_stale_with_conn(&conn)
@@ -844,11 +909,12 @@ mod tests {
                 Some("factory-a"),
                 Some("origin-session"),
                 true,
+                None,
             )
             .unwrap();
         let reminder = store.list_pending("supervisor-1").unwrap().pop().unwrap();
         assert_eq!(reminder.id, id);
-        let delivery = format_cross_session_reminder_delivery(&reminder, None);
+        let delivery = format_cross_session_reminder_delivery(&reminder, None, None);
         assert!(delivery.contains("Cross-session reminder"));
         assert!(delivery.contains("Origin session: origin-session"));
         assert!(delivery.contains("Created at:"));
@@ -872,6 +938,7 @@ mod tests {
                     Some("factory-a"),
                     Some("origin-session"),
                     cross_session,
+                    None,
                 )
                 .unwrap();
         }
@@ -888,6 +955,41 @@ mod tests {
         assert_eq!(
             pending[0].origin_session_id.as_deref(),
             Some("origin-session")
+        );
+    }
+
+    #[test]
+    fn closing_task_quarantines_default_reminders_but_keeps_explicit_opt_in() {
+        let (_temp, store) = create_test_store();
+        for cross_session in [false, true] {
+            store
+                .create_with_scope(
+                    "worker-1",
+                    None,
+                    "recheck discarded draft",
+                    ReminderTriggerType::Time,
+                    Some(Utc::now() + chrono::Duration::minutes(5)),
+                    None,
+                    None,
+                    3600,
+                    Some("factory-a"),
+                    Some("worker-session"),
+                    cross_session,
+                    Some("cas-issue-276"),
+                )
+                .unwrap();
+        }
+
+        assert_eq!(store.cancel_pending_for_task("cas-issue-276").unwrap(), 1);
+        let pending = store.list_pending("worker-1").unwrap();
+        assert_eq!(pending.len(), 1);
+        assert!(pending[0].cross_session);
+        assert_eq!(pending[0].task_id.as_deref(), Some("cas-issue-276"));
+
+        let delivery = format_reminder_delivery_with_provenance(&pending[0], None, Some("closed"));
+        assert!(
+            delivery.contains("issued 0 min ago under task cas-issue-276 (closed)"),
+            "delivery must make closed task staleness visible: {delivery}"
         );
     }
 

--- a/docs/notes/claude-code-changelog-diary.md
+++ b/docs/notes/claude-code-changelog-diary.md
@@ -44,6 +44,17 @@ When a new Claude Code version ships:
 
 | CC version | Headline | CAS verdict | Pointer |
 |------------|----------|-------------|---------|
+| 2.1.231 | MCP OAuth redirect-URI repair | ✅ no action | this doc |
+| 2.1.230 | No section in Anthropic's official changelog | ⏭ source gap | this doc |
+| 2.1.229 | Self-hosted hook/MCP startup fixes · workflow fan-out · sandbox hardening | 👀 / 🟢 | this doc |
+| 2.1.228 | Worktree/session cleanup · skill shadowing hardening · deferred-tool correctness | 🟢 direct wins | this doc |
+| 2.1.227 | Generic reliability and UI rollup | ✅ no action | this doc |
+| 2.1.226 | Generic bug-fix and reliability rollup | ⏭ source-limited | this doc |
+| 2.1.225 | Headless message delivery · agent workspace trust · MCP OAuth recovery | 👀 / 🟢 | this doc |
+| 2.1.224 | Cross-session message controls · worktree/session isolation · MCP discovery | 👀 / 🟢 | this doc |
+| 2.1.223 | Permission/workflow sandbox hardening · bounded context and review behavior | 🟢 direct wins | this doc |
+| 2.1.222 | Worktree and background-hook isolation · MCP error visibility | 🟢 direct wins | this doc |
+| 2.1.221 | Print-mode MCP startup · background commits/worktrees · permission hardening | 👀 / 🟢 | this doc |
 | 2.1.220 | Generic bug-fix and reliability rollup; no component detail in the official note | ⏭ source-limited | this doc |
 | 2.1.219 | **Opus 5 default** · bounded dynamic/nested agent changes · MCP startup/connection diagnostics | 👀 config watch / 🟢 / ✅ | this doc |
 | 2.1.218 | Built-in `/code-review` backgrounds · **tool/transcript evidence-loss fixes** | ✅ no action / 🟢 win | this doc |
@@ -95,6 +106,34 @@ When a new Claude Code version ships:
 ---
 
 ## Entries
+
+### 2.1.231–2.1.221 — MCP, worktree, hook, and lifecycle reliability sweep
+
+Reviewed 2026-08-13. Host on **2.1.231**. Source: [Anthropic's official
+changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md),
+covering 2.1.221–2.1.229 and 2.1.231; the official changelog has no 2.1.230
+section.
+
+- **2.1.231 repairs an MCP OAuth redirect-URI mismatch; 2.1.229 fixes strict OAuth redirects,
+  remote-session startup with managed MCP, and adds server-supplied hooks for self-hosted runners.**
+  → ✅ / 👀 **no direct CAS change; retain MCP startup watch.** CAS's local `cs` stdio server has no
+  OAuth, but the new behavior remains relevant when a workspace also configures remote MCP servers.
+  CAS's SessionStart/PreToolUse contracts remain configuration-owned; do not treat runner-provided
+  hooks as a substitute for them.
+- **2.1.229 fixes CPU-limited dynamic-workflow fan-out; 2.1.225–2.1.224 improve headless and
+  cross-session message delivery; 2.1.221 makes background sessions commit/push and gives forked
+  sessions their own worktree.** → 🟢 **lifecycle and isolation wins.** CAS keeps task ownership,
+  its explicit factory concurrency limit, and worktree records as the authority. The host changes
+  reduce stalled or misplaced work without changing that contract.
+- **2.1.228 hardens cloud-synced skills against shadowing local commands/MCP prompts and fixes
+  deferred-tool duplication; 2.1.229 refreshes command-source plugins per session.** → 👀 **watch
+  skill precedence.** On a Claude upgrade, verify the CAS-synced skill/agent mirror still wins
+  predictably in a worktree and that required worker instructions are not silently displaced.
+- **2.1.224–2.1.221 close destructive-git/worktree, permission-check, background-hook, print-mode
+  MCP-startup, and MCP-error-visibility gaps.** → 🟢 **direct safety and evidence wins.** CAS's
+  own clone-path, hook, and verifier boundaries remain defense in depth; no runtime change follows.
+- **2.1.227 is UI/reliability-only and 2.1.226 is a generic rollup.** → ✅ / ⏭ **no action.**
+  **Source gap:** 2.1.230 has no official section, so no behavior or verdict is inferred for it.
 
 ### 2.1.220 — generic bug-fix and reliability rollup
 

--- a/docs/notes/codex-changelog-diary.md
+++ b/docs/notes/codex-changelog-diary.md
@@ -32,10 +32,12 @@ verify on upgrade) · 🔧 fix shipped · 🏗 EPIC · ⏭ n/a
   matrix passed on 2026-07-30 after `cas-8c80` projected `mcp__cs` as a direct-only code-mode
   namespace and pinned Codex's restricted MCP subprocess to the pane's `CAS_ROOT`. The typed
   receipt is `crates/cas-pty/conformance/codex-cli-0.146.0-2026-07-30.json`.
-- **Locally installed:** **0.146.0** (`codex-cli 0.146.0`, checked 2026-07-30).
-- **Latest stable:** **0.146.0** (2026-07-29). **0.147.0** remains prerelease-only (alpha.2 as of
-  2026-07-30) — untracked under this diary's stable-only policy.
-- **Gap:** none: the validated pin, local installation, and latest stable are all 0.146.0.
+- **Locally installed:** **0.147.0** (`codex-cli 0.147.0`, checked 2026-08-13).
+- **Latest stable:** **0.147.0** (2026-08-07). 0.148.0 remains prerelease-only and is untracked
+  under this diary's stable-only policy.
+- **Gap:** the validated pin remains 0.146.0 while the local installation and latest stable are
+  0.147.0. This review found no documented launch-contract rename, but a fresh `PtyConfig::codex`
+  matrix remains required before calling 0.147.0 validated.
   The older entries below are a *triage pass* against the touchpoints, not a per-item code audit —
   upgrade-time re-verification is the trigger for promoting any 👀 to a task. (Contrast the Claude
   Code diary's .166/.162 entries, which were deep-verified for specific user questions.) The
@@ -73,7 +75,9 @@ The load-bearing surface, all in `crates/cas-pty/src/pty.rs::PtyConfig::codex` u
 
 | Codex version | Headline | CAS verdict | Pointer |
 |---------------|----------|-------------|---------|
-| 0.147.0-alpha | (pre-release; alpha.2 as of 2026-07-30 — untracked until stable) | — | — |
+| 0.148.0-alpha | Pre-release as of 2026-08-13 — untracked under stable-only policy | — | — |
+| 0.147.0 | MCP 2026-07-28 discovery/non-blocking startup · Agent Plugins · trust/approval hardening | 👀 upgrade validation | this doc |
+| 0.146.1 | Safer cyber-model auto-review defaults | ✅ no action | this doc |
 | 0.146.0 | **Live MCP refresh/reconnect** · executor skills and Agent Plugins · approval-state preservation | 🔧 validated/fix shipped | receipt + cas-8c80 |
 | 0.145.0 | **Multi-agent V2 stable** · broader `/import` · MCP startup hardening · concurrent skill discovery · approval tightening | 👀 watch | this doc |
 | 0.144.1–.4 | Installer/code-mode reliability · Guardian auto-review prompt revert · two empty patch releases | ✅ no action | this doc |
@@ -92,6 +96,38 @@ The load-bearing surface, all in `crates/cas-pty/src/pty.rs::PtyConfig::codex` u
 ---
 
 ## Entries
+
+### 0.147.0 — MCP 2026-07-28, portable plugins, and approval/trust boundaries
+
+Reviewed 2026-08-13. Triage pass vs touchpoints. Source: official
+[`rust-v0.147.0` release](https://github.com/openai/codex/releases/tag/rust-v0.147.0)
+(published 2026-08-07).
+
+- **Codex supports the opt-in MCP 2026-07-28 protocol, paginated discovery, multi-round requests,
+  cached tools before optional server startup, and non-blocking startup.** → 👀 **touchpoint: MCP
+  (`cs`).** These are direct client-runtime changes. Upgrade validation must prove that the local
+  stdio `cs` server is discovered under `mcp__cs__*`, is ready before required lifecycle calls, and
+  never leaves a stale or partially paginated tool catalog.
+- **Portable Agent Plugins and imported Cursor skills expand the plugin/skill sources, while host
+  skill budgets and isolation were hardened.** → 👀 **touchpoint: `.codex/skills/`,
+  `.codex/agents/`, and `AGENTS.md`.** CAS does not use plugins as its authority path; confirm its
+  synced mirror remains discoverable and cannot be shadowed by an imported or plugin-provided skill.
+- **`--approve-for-me`, explicit trust for unfamiliar projects, managed-auth enforcement, and
+  fail-closed network/plugin policy behavior change approval and sandbox boundaries.** → 👀
+  **touchpoint: `--yolo`, `CAS_AGENT_ROLE`, and `CAS_FACTORY_MODE`.** No documented removal or
+  rename affects CAS, but a factory resume and fresh-worktree smoke is required before promotion.
+- **Thread organization, rendering, remote compaction, and installer/package changes** are
+  ⏭ **n/a** to the CAS PTY launch contract. **Source gaps:** none for the stable release.
+
+### 0.146.1 — safer automatic-review defaults
+
+Reviewed 2026-08-13. Source: official
+[`rust-v0.146.1` release](https://github.com/openai/codex/releases/tag/rust-v0.146.1)
+(published 2026-08-05).
+
+- **Cyber-capable model automatic-review defaults and terminal permission explanation were made
+  safer.** → ✅ **no action.** CAS starts factory workers with the explicit `--yolo` contract;
+  no CLI spelling or MCP/skill/instruction behavior changed. **Source gaps:** none.
 
 ### 0.146.0 — live MCP refresh/reconnect · executor skills and Agent Plugins · approval continuity
 

--- a/docs/notes/grok-changelog-diary.md
+++ b/docs/notes/grok-changelog-diary.md
@@ -38,25 +38,16 @@ dependency, verify on upgrade) · 🔧 fix shipped · 🏗 EPIC · ⏭ n/a
   (`grok 0.2.114 (0c78503879) [stable]`), verified live 2026-07-30 through the
   complete isolated `PtyConfig::grok` worker matrix and recorded in the typed
   `grok-build-0.2.114-2026-07-30` conformance receipt.
-- **Current default symlink:** **0.2.117**
-  (`grok 0.2.117 (f1c0609308) [stable]`, checked 2026-07-30). The validated
-  retained 0.2.114 executable remains installed separately. The typed receipt
-  records this mismatch so unified preflight can surface it as stale/warn rather
-  than silently treating 0.2.117 as validated.
-- **Latest versioned local changelog evidence:** **0.2.114** (2026-07-29). The
-  current `~/.grok/CHANGELOG.md` contains **0.2.113–0.2.114** sections. The current
-  `~/.grok/CHANGELOG.json` is a flat item list with no version or date fields; its
-  items are therefore only **current-install evidence**, not grounds to assign
-  history to 0.2.115–0.2.117 or another guessed release. Earlier host snapshots
-  captured the evidence-backed **0.2.100–0.2.101** and **0.2.104–0.2.106** entries
-  retained below. Versions **0.2.102–0.2.103**, **0.2.107–0.2.111**, and
-  **0.2.115–0.2.117** have no attributable notes on the available local surfaces
-  and remain explicit source gaps. **0.2.100** remains the diary's evidence-backed
-  **seed floor**.
-- **Gap:** the validated binary is **three patches behind** the current default
-  symlink (0.2.114 vs 0.2.117), and versioned changelog evidence also ends at
-  0.2.114. The 0.2.114 touchpoint checklist is a completed live validation;
-  0.2.115–0.2.117 remain unvalidated source gaps.
+- **Locally installed and latest stable:** **1.0.3** (`grok 1.0.3 (1a29d5bc12)
+  [stable]`, checked 2026-08-13). The former 0.2.117 default has been superseded.
+- **Latest release-note evidence:** xAI's official [Grok Build
+  changelog](https://x.ai/build/changelog) covers **0.2.115–0.2.119** and
+  **1.0.0–1.0.3**. The local `~/.grok/CHANGELOG.md` retains the 0.2.115–0.2.117
+  sections; the official page supplies the later release attribution.
+- **Gap:** the validated pin remains 0.2.114 while the current release is 1.0.3.
+  The new notes expose permission, subagent, MCP, worktree, hook, and transcript
+  surfaces, so a fresh complete `PtyConfig::grok` matrix is required before
+  treating 1.0.3 as validated. There are no source gaps in 0.2.115–1.0.3.
 
 ## CAS ↔ Grok touchpoints (what a release can break)
 
@@ -128,6 +119,15 @@ At minimum, `PtyConfig::grok` sets:
 
 | Grok version | Headline | CAS verdict | Pointer |
 |--------------|----------|-------------|---------|
+| 1.0.3 | Faster subagent spawning · session-info and high-refresh TUI polish | 🟢 / ⏭ | this doc |
+| 1.0.2 | Startup diagnostics · worktree fetch safety · hook/tool presentation | 🟢 / 👀 | this doc |
+| 1.0.1 | Bounded subagents · read-only tool metadata · MCP/headless lifecycle | 👀 / 🟢 | this doc |
+| 1.0.0 | MCP image reliability · permission visibility · session/task lifecycle | 👀 / 🟢 | this doc |
+| 0.2.119 | Bash allow-list, plan/task, auth, and startup reliability | 👀 / ✅ | this doc |
+| 0.2.118 | Session controls · doctor/compact · background-task correctness | ✅ / ⏭ | this doc |
+| 0.2.117 | TLS roots · background-subagent stop · ACP task reliability | 👀 / 🟢 | this doc |
+| 0.2.116 | Headless streaming JSON · undo · token-refresh reliability | 👀 / ✅ | this doc |
+| 0.2.115 | Tool-result history correctness · prompt-cache reliability | 🟢 direct win | this doc |
 | 0.2.114 | Session deletion · no-free-thread startup crash fix · full CAS factory matrix | ✅ | this doc |
 | 0.2.113 | MCP enable/disable · SessionEnd · auth/process/session reliability · instant cold start | 👀 / ✅ / ⏭ | this doc |
 | 0.2.112 | Version policy · env/provider config · session/resume/transcripts · MCP/subagents · hooks/workflows/background lifecycle | 👀 / ✅ / ⏭ | this doc |
@@ -148,6 +148,34 @@ At minimum, `PtyConfig::grok` sets:
 ---
 
 ## Entries
+
+### 1.0.3–0.2.115 — current release sweep: factory lifecycle and integration boundaries
+
+Reviewed 2026-08-13. Host on **1.0.3**. Sources: the local versioned
+`~/.grok/CHANGELOG.md` for 0.2.115–0.2.117 and xAI's official [Grok Build
+changelog](https://x.ai/build/changelog) for 0.2.118–1.0.3.
+
+- **0.2.115 fixes duplicate/corrupt tool results; 0.2.116 adds headless streaming JSON; 0.2.117
+  stops all prior-turn background subagents and adds a custom TLS-root variable.** → 🟢 / 👀
+  **evidence and lifecycle wins; retain launch-environment watch.** More truthful tool history and
+  stopped background work improve CAS proof and cleanup, while `GROK_EXTRA_CA_BUNDLE` is a separate
+  transport input that must not hide the inherited CAS identity or persistent MCP configuration.
+- **0.2.118–0.2.119 fix background-task completion state, compaction cancellation, startup/doctor
+  behavior, auth recovery, and broad bash allow-list editing.** → ✅ / 👀 **operational wins; watch
+  approval semantics.** CAS continues to set explicit bypass mode and remains the authority for task
+  lifecycle; permissive allow-list changes do not replace the factory’s scope and tool guards.
+- **1.0.0 improves MCP image results and permission-prompt visibility; 1.0.1 bounds wide subagent
+  fan-out, exposes read-only tool metadata, waits for MCP in headless sessions, and stops subagents
+  before deleting sessions.** → 👀 / 🟢 **high-value compatibility gains.** Verify `cas__*`
+  discovery and `--rules`/environment priming on a fresh headless worker, and keep CAS’s own
+  concurrency and state authority; the host bounds are complementary.
+- **1.0.2 makes startup delays diagnosable, preserves worktree fetch safety, and presents hook
+  results with grouped tool calls; 1.0.3 speeds subagent spawning.** → 🟢 / 👀 **isolation and
+  observability wins.** Re-run the full PTY matrix before advancing the validated pin, particularly
+  for fresh session UUIDs, inherited identity, persistent MCP discovery, rules precedence,
+  transcript/liveness, and worktree containment.
+- **Source gaps:** none for 0.2.115–1.0.3; the official page and retained local changelog provide
+  attributable notes for every release in this reviewed range.
 
 ### 0.2.114 — session deletion and startup thread-exhaustion fix
 
@@ -435,14 +463,14 @@ changelog; no pre-0.2.100 entries inventable from this host.
 
 ## Backlog of opportunities (not required, tracked)
 
-- **0.2.115–0.2.117 validation:** the default symlink is newer than the retained,
-  validated 0.2.114 binary. Re-run the complete live checklist before advancing
-  the typed receipt or validated pin.
+- **1.0.3 validation:** the installed/latest release is materially newer than the
+  retained, validated 0.2.114 binary. Re-run the complete live checklist before
+  advancing the typed receipt or validated pin.
 - **Changelog history depth:** find an authoritative release surface for the missing
-  0.2.102–0.2.103, 0.2.107–0.2.111, and 0.2.115–0.2.117 notes, plus any
-  pre-0.2.100 history, before backfilling them. The companion JSON remains
-  unversioned; keep every gap and the 0.2.100 evidence-backed seed floor explicit
-  until attributable sources exist.
+  0.2.102–0.2.103 and 0.2.107–0.2.111 notes, plus any pre-0.2.100 history,
+  before backfilling them. The companion JSON remains unversioned; keep every gap
+  and the 0.2.100 evidence-backed seed floor explicit until attributable sources
+  exist.
 - **SessionStart stdout:** if a future Grok release starts delivering SessionStart
   stdout like Claude, re-evaluate whether `--rules` remains the sole context path or
   becomes defense-in-depth (would be a deliberate EPIC, not a silent drop of `--rules`).

--- a/docs/release-notes/2026-08-13-harness-diary-sweep-slack.md
+++ b/docs/release-notes/2026-08-13-harness-diary-sweep-slack.md
@@ -1,0 +1,46 @@
+# 2026-08-13 — Harness diary sweep — #cas-internal thread
+
+## Parent post
+
+🧭 The compatibility picture is current through Grok Build 1.0.3, Claude Code
+2.1.231, and Codex 0.147.0: upstream is improving worktree safety, MCP startup,
+tool evidence, and subagent cleanup, while the newest Codex and Grok versions
+remain upgrade-validation targets before their CAS pins move.
+
+CAS users should see a healthier harness baseline without a runtime behavior
+change. The diaries now distinguish direct reliability gains from integration
+surfaces that still need a fresh launch matrix.
+
+## Grok reply
+
+**Grok Build 0.2.115–1.0.3:** tool-result history, background-task cleanup,
+headless streaming, MCP image handling, bounded subagent fan-out, read-only tool
+metadata, headless MCP readiness, worktree fetch safety, and hook-result display
+all changed across this range.
+
+**Verdict/action:** 🟢 take the evidence, cleanup, isolation, and observability
+improvements; 👀 re-run the Grok compatibility matrix before advancing CAS’s validated
+0.2.114 pin, with emphasis on `cas__*` discovery, rules/environment priming,
+session/transcript identity, and permission bypass. **Source gaps:** none.
+
+## Claude reply
+
+**Claude Code 2.1.221–2.1.231:** print-mode and managed MCP startup, worktree and
+background-hook isolation, skill precedence, cross-session delivery, workflow
+fan-out, and OAuth recovery received safety and reliability fixes.
+
+**Verdict/action:** 🟢 take the worktree, hook, lifecycle, and evidence gains; 👀
+continue checking MCP startup and CAS-synced skill precedence on upgrade. **Source
+gaps:** 2.1.230 has no section in Anthropic’s official changelog; no behavior is
+attributed to it.
+
+## Codex reply
+
+**Codex stable 0.146.1–0.147.0:** the new stable adds MCP 2026-07-28 discovery
+and non-blocking startup, portable plugins and imported skills, explicit project
+trust, approval/network hardening, and safer automatic-review defaults.
+
+**Verdict/action:** 👀 run a fresh Codex compatibility matrix before moving the validated
+0.146.0 pin: prove `mcp__cs__*` readiness/catalog freshness, mirrored
+skill/agent precedence, and non-interactive approval continuity. **Source gaps:**
+none.

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -105,6 +105,7 @@ for job in fast-validation-preflight fast-validation-suite fast-validation-docs 
 done
 
 classifier="$repo_root/scripts/classify-ci-diff.sh"
+classify_action="$repo_root/.github/actions/classify-required-diff/action.yml"
 if [[ -x "$classifier" ]]; then
     # These committed fixtures pin both directions: the three explicitly safe
     # classes fast-pass, while a real mixed code/release change remains full.
@@ -118,6 +119,24 @@ else
     printf 'FAIL CI diff classifier is executable\n'
     fail=$((fail + 1))
 fi
+
+# GitHub provides an all-zero `before` SHA when a pushed tag has no predecessor.
+# Run the composite action body itself so this contract cannot regress into a
+# `git merge-base 000... HEAD` failure before the required test lanes start.
+tag_push_output="$(mktemp)"
+if BASE_SHA="0000000000000000000000000000000000000000" \
+    GITHUB_OUTPUT="$tag_push_output" \
+    bash < <(awk '
+        /^      run: \|$/ { in_run = 1; next }
+        in_run { sub(/^        /, ""); print }
+    ' "$classify_action"); then
+    require_text "$(<"$tag_push_output")" 'class=full' 'tag push with all-zero BASE_SHA falls back to full tier'
+    require_text "$(<"$tag_push_output")" 'fast-pass=false' 'tag push all-zero BASE_SHA never fast-passes'
+else
+    printf 'FAIL tag push all-zero BASE_SHA runs the shared classifier action\n'
+    fail=$((fail + 1))
+fi
+rm -f "$tag_push_output"
 
 for job in fast-validation-preflight fast-validation-suite fast-validation-docs fast-validation macos-check; do
     block="$(job_block "$job")"


### PR DESCRIPTION
## Summary

Four field bugs from overnight 2026-08-13 sessions plus the two-week harness diary catch-up.

- **Fixes #277** — `CAS_AGENT_ROLE=supervisor` now persists at every registration entrypoint (explicit register, session_start, hook auto-register, eager env registration, missing-row re-register). Verification authority stays bound to server-internal identity provenance. Adds a doctor per-factory-session supervisor cardinality check and a SessionStart env-vs-row mismatch warning with automatic row repair.
- **Fixes #276** — Reminders are now bound to their issuing task (explicit `task_id` or auto-bound to the issuer's single in-progress task). Task close quarantines pending reminders by default; `cross_session=true` is the explicit keep, and every fired reminder carries issue-time + task-status provenance.
- **Fixes #274** — Project skills served from a checkout behind its integration branch now open with a prominent stale-source banner (ref + behind-count), computed from local refs only (no fetch on the read path).
- **Fixes #280** — Tag pushes deliver an all-zero `BASE_SHA`; classify-required-diff now treats `^0+$` as absent and falls back to the full tier. The tier-policy test executes the composite action's real run block to pin this.
- **Harness diaries** — Claude (2.1.221–2.1.231), Codex (0.146.1–0.147.0), Grok (0.2.115–1.0.3) reviewed and appended; Slack thread draft at `docs/release-notes/2026-08-13-harness-diary-sweep-slack.md` (posting after this lands).

## Test plan

- Per-task scoped suites run by each worker (mcp_tools_test 317/317, factory_mcp_ops targeted, daemon + worktree_surface regressions, tier-policy script 128 checks).
- Required PR lanes (Fast Validation, macOS Check) gate this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)