### PR TITLE
feat: add cross-project task proposals

### DIFF
--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -28,6 +28,7 @@ pub mod code_embeddings;
 // anyone running `cas cloud sync`.
 pub mod embed_drain;
 pub(crate) mod me;
+pub mod task_proposals;
 mod sync_queue;
 mod syncer;
 

--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -43,6 +43,62 @@ fn deserialize_pulled_entity<T: DeserializeOwned>(
         .map_err(|error| format!("{entity_type} deserialize error (id={id}): {error}"))
 }
 
+/// Persist proposal provenance visibly in the ordinary local task record.
+/// The cloud proposal row remains authoritative; this rendering is explicitly
+/// labeled and is refreshed whenever the materialized task is pulled.
+fn render_task_proposal_provenance(raw: &mut serde_json::Value) {
+    const MARKER: &str = "Server-attested proposal provenance:";
+    let Some(raw_provenance) = raw.get("proposal_provenance").cloned() else {
+        return;
+    };
+    let Ok(provenance) =
+        serde_json::from_value::<crate::cloud::task_proposals::ProposalProvenance>(raw_provenance)
+    else {
+        return;
+    };
+    let server = &provenance.server_attested;
+    let client = &provenance.client_asserted;
+    let rendered = format!(
+        "{MARKER}\n  proposal_id: {}\n  target_task_id: {}\n  creator_user_id: {}\n  team_id: {}\n  origin_project_canonical_id: {}\n  target_project_canonical_id: {}\n  received_at: {}\n  client_request_id: {}\nClient-asserted proposal provenance:\n  origin_session_id: {}\n  origin_agent_id: {}\n  origin_agent_name: {}\n  origin_agent_role: {}\n  client_version: {}\n  client_build: {}",
+        server.proposal_id,
+        server.target_task_id,
+        server.creator_user_id,
+        server.team_id,
+        server.origin_project_canonical_id,
+        server.target_project_canonical_id,
+        server.received_at,
+        server.client_request_id,
+        client
+            .origin_session_id
+            .as_deref()
+            .unwrap_or("(not asserted)"),
+        client
+            .origin_agent_id
+            .as_deref()
+            .unwrap_or("(not asserted)"),
+        client
+            .origin_agent_name
+            .as_deref()
+            .unwrap_or("(not asserted)"),
+        client
+            .origin_agent_role
+            .as_deref()
+            .unwrap_or("(not asserted)"),
+        client.client_version.as_deref().unwrap_or("(not asserted)"),
+        client.client_build.as_deref().unwrap_or("(not asserted)"),
+    );
+    let notes = raw
+        .get("notes")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let prefix = notes.split(MARKER).next().unwrap_or_default().trim_end();
+    raw["notes"] = serde_json::Value::String(if prefix.is_empty() {
+        rendered
+    } else {
+        format!("{prefix}\n\n{rendered}")
+    });
+}
+
 /// Build a project-scoped `/api/sync/pull` URL, **failing closed** when the
 /// project scope cannot be resolved.
 ///
@@ -363,7 +419,7 @@ impl CloudSyncer {
         }
 
         // Process tasks
-        for raw_task in body.tasks.unwrap_or_default() {
+        for mut raw_task in body.tasks.unwrap_or_default() {
             if !entity_matches_project(&raw_task, &current_project_id, "task") {
                 continue;
             }
@@ -372,6 +428,7 @@ impl CloudSyncer {
             // close — apply it authoritatively rather than via the
             // timestamp-gated upsert.
             let web_close = is_web_close_tombstone(&raw_task);
+            render_task_proposal_provenance(&mut raw_task);
             let remote_task: Task = match deserialize_pulled_entity(raw_task, "task") {
                 Ok(t) => t,
                 Err(e) => {
@@ -1139,10 +1196,11 @@ impl CloudSyncer {
         }
 
         // Process tasks
-        for raw_task in body.tasks.unwrap_or_default() {
+        for mut raw_task in body.tasks.unwrap_or_default() {
             if !entity_matches_project(&raw_task, &current_project_id, "task") {
                 continue;
             }
+            render_task_proposal_provenance(&mut raw_task);
             let remote_task: Task = match deserialize_pulled_entity(raw_task, "task") {
                 Ok(t) => t,
                 Err(e) => {
@@ -1235,6 +1293,7 @@ impl CloudSyncer {
 mod tests {
     use super::{
         PULL_PATH, build_scoped_pull_url_with, deserialize_pulled_entity, entity_matches_project,
+        render_task_proposal_provenance,
     };
     use crate::types::Entry;
     use serde_json::json;
@@ -1254,6 +1313,40 @@ mod tests {
         assert!(error.contains("entry deserialize error"), "{error}");
         assert!(error.contains("id=p-malformed-created"), "{error}");
         assert!(error.contains("missing field `created`"), "{error}");
+    }
+
+    #[test]
+    fn materialized_task_renders_attested_and_asserted_provenance_visibly() {
+        let mut raw = json!({
+            "notes": "Receiver notes",
+            "proposal_provenance": {
+                "server_attested": {
+                    "proposal_id": "proposal-1",
+                    "target_task_id": "cas-0123456789abcdef",
+                    "creator_user_id": "user-1",
+                    "team_id": "team-1",
+                    "origin_project_canonical_id": "origin",
+                    "target_project_canonical_id": "target",
+                    "received_at": "2026-08-13T12:00:00Z",
+                    "client_request_id": "request-1"
+                },
+                "client_asserted": {
+                    "origin_session_id": "session-1",
+                    "origin_agent_id": "agent-1",
+                    "origin_agent_name": "supervisor",
+                    "origin_agent_role": "supervisor",
+                    "client_version": "2.65.0",
+                    "client_build": "deadbeef"
+                }
+            }
+        });
+        render_task_proposal_provenance(&mut raw);
+        let notes = raw["notes"].as_str().unwrap();
+        assert!(notes.contains("Server-attested proposal provenance:"));
+        assert!(notes.contains("creator_user_id: user-1"));
+        assert!(notes.contains("Client-asserted proposal provenance:"));
+        assert!(notes.contains("origin_agent_role: supervisor"));
+        assert!(notes.starts_with("Receiver notes"));
     }
 
     // cas-0be9: the pull URL builder must FAIL CLOSED when the project scope

--- a/cas-cli/src/cloud/task_proposals.rs
+++ b/cas-cli/src/cloud/task_proposals.rs
@@ -5,6 +5,7 @@
 //! JSON advisory, matching the contract in
 //! `docs/specs/2026-08-11-cross-project-task-proposals.md`.
 
+use std::collections::HashSet;
 use std::fmt;
 use std::time::Duration;
 
@@ -135,9 +136,7 @@ impl std::error::Error for TaskProposalError {}
 /// registered CAS agent store; environment strings alone are not authority.
 pub fn authorize_registered_role(role: Option<AgentRole>) -> Result<AgentRole, TaskProposalError> {
     match role {
-        Some(AgentRole::Supervisor | AgentRole::Director) => Err(TaskProposalError::Contract(
-            "red boundary: supervisor/director authorization is not implemented".to_string(),
-        )),
+        Some(role @ (AgentRole::Supervisor | AgentRole::Director)) => Ok(role),
         _ => Err(TaskProposalError::Authorization(
             ROLE_REQUIREMENT.to_string(),
         )),
@@ -173,54 +172,282 @@ impl TaskProposalClient {
 
     pub fn create(
         &self,
-        _request: &CreateTaskProposalRequest,
+        request: &CreateTaskProposalRequest,
     ) -> Result<CreateTaskProposalResponse, TaskProposalError> {
-        let _ = (&self.endpoint, &self.token, &self.team_id, self.timeout);
-        Err(TaskProposalError::Contract(
-            "red boundary: proposal create is not implemented".to_string(),
-        ))
+        let url = self.team_url("task-proposals");
+        self.post_json(&url, request)
     }
 
-    pub fn inbox_all(&self, _target_project: &str) -> Result<Vec<TaskProposal>, TaskProposalError> {
-        Err(TaskProposalError::Contract(
-            "red boundary: proposal inbox is not implemented".to_string(),
-        ))
+    pub fn inbox_all(&self, target_project: &str) -> Result<Vec<TaskProposal>, TaskProposalError> {
+        let target = required_explicit("target project", target_project)?;
+        let mut proposals = Vec::new();
+        let mut cursor: Option<String> = None;
+        let mut seen = HashSet::new();
+
+        loop {
+            let mut url = format!(
+                "{}?target_project_id={}&state=proposed",
+                self.team_url("task-proposals"),
+                urlencoding::encode(target)
+            );
+            if let Some(value) = cursor.as_deref() {
+                url.push_str("&cursor=");
+                url.push_str(&urlencoding::encode(value));
+            }
+            let page: ProposalPage = self.get_json(&url)?;
+            let continuation = page.continuation();
+            proposals.extend(page.proposals);
+            let Some(next) = continuation else {
+                break;
+            };
+            // Cursor contents are opaque. Equality is the only operation CAS
+            // performs, solely to prevent a stable/repeated token loop.
+            if next.is_empty()
+                || next == cursor.as_deref().unwrap_or_default()
+                || !seen.insert(next.clone())
+            {
+                break;
+            }
+            cursor = Some(next);
+        }
+        Ok(proposals)
     }
 
     pub fn accept(
         &self,
-        _proposal_id: &str,
-        _target_project: &str,
+        proposal_id: &str,
+        target_project: &str,
     ) -> Result<TaskProposal, TaskProposalError> {
-        Err(TaskProposalError::Contract(
-            "red boundary: proposal accept is not implemented".to_string(),
-        ))
+        self.decide(proposal_id, target_project, "accept", None)
     }
 
     pub fn reject(
         &self,
-        _proposal_id: &str,
-        _target_project: &str,
-        _reason: Option<&str>,
+        proposal_id: &str,
+        target_project: &str,
+        reason: Option<&str>,
     ) -> Result<TaskProposal, TaskProposalError> {
-        Err(TaskProposalError::Contract(
-            "red boundary: proposal reject is not implemented".to_string(),
-        ))
+        self.decide(proposal_id, target_project, "reject", reason)
     }
 
     pub fn dependency_feed_all(
         &self,
-        _origin_project: &str,
-        _since: Option<&str>,
+        origin_project: &str,
+        since: Option<&str>,
     ) -> Result<DependencyFeed, TaskProposalError> {
-        Err(TaskProposalError::Contract(
-            "red boundary: dependency feed is not implemented".to_string(),
-        ))
+        let origin = required_explicit("origin project", origin_project)?;
+        let mut dependencies = Vec::new();
+        let mut page_cursor: Option<String> = None;
+        let mut watermark = since.map(ToString::to_string);
+        let mut seen = HashSet::new();
+        if let Some(value) = since {
+            seen.insert(value.to_string());
+        }
+
+        loop {
+            let mut url = format!(
+                "{}?origin_project_id={}",
+                self.team_url("cross-project-task-dependencies"),
+                urlencoding::encode(origin)
+            );
+            if let Some(value) = page_cursor.as_deref() {
+                url.push_str("&cursor=");
+                url.push_str(&urlencoding::encode(value));
+            } else if let Some(value) = since {
+                // `since` is the current production high-watermark contract.
+                // It is passed through byte-for-byte and never parsed.
+                url.push_str("&since=");
+                url.push_str(&urlencoding::encode(value));
+            }
+
+            let page: DependencyPage = self.get_json(&url)?;
+            let continuation = page.continuation();
+            dependencies.extend(page.dependencies);
+            if page.cursor.is_some() {
+                watermark = page.cursor.clone();
+            }
+            let Some(next) = continuation else {
+                break;
+            };
+            if next.is_empty()
+                || next == page_cursor.as_deref().unwrap_or_default()
+                || !seen.insert(next.clone())
+            {
+                break;
+            }
+            page_cursor = Some(next);
+        }
+        Ok(DependencyFeed {
+            dependencies,
+            cursor: watermark,
+        })
+    }
+
+    fn decide(
+        &self,
+        proposal_id: &str,
+        target_project: &str,
+        decision: &str,
+        reason: Option<&str>,
+    ) -> Result<TaskProposal, TaskProposalError> {
+        let proposal = required_explicit("proposal id", proposal_id)?;
+        let target = required_explicit("target project", target_project)?;
+        let url = format!(
+            "{}/api/teams/{}/task-proposals/{}/{}",
+            self.endpoint,
+            urlencoding::encode(&self.team_id),
+            urlencoding::encode(proposal),
+            decision
+        );
+        let mut body = serde_json::json!({ "target_project_id": target });
+        if let Some(reason) = reason {
+            body["reason"] = serde_json::Value::String(reason.to_string());
+        }
+        self.post_json(&url, &body)
+    }
+
+    fn team_url(&self, resource: &str) -> String {
+        format!(
+            "{}/api/teams/{}/{}",
+            self.endpoint,
+            urlencoding::encode(&self.team_id),
+            resource
+        )
+    }
+
+    fn get_json<T: for<'de> Deserialize<'de>>(&self, url: &str) -> Result<T, TaskProposalError> {
+        let response = ureq::get(url)
+            .set("Authorization", &format!("Bearer {}", self.token))
+            .timeout(self.timeout)
+            .call();
+        decode_response(response)
+    }
+
+    fn post_json<T: for<'de> Deserialize<'de>>(
+        &self,
+        url: &str,
+        body: &impl Serialize,
+    ) -> Result<T, TaskProposalError> {
+        let response = ureq::post(url)
+            .set("Authorization", &format!("Bearer {}", self.token))
+            .timeout(self.timeout)
+            .send_json(body);
+        decode_response(response)
     }
 }
 
-pub fn render_proposal(_proposal: &TaskProposal) -> String {
-    String::new()
+#[derive(Debug, Deserialize)]
+struct ProposalPage {
+    #[serde(default)]
+    proposals: Vec<TaskProposal>,
+    #[serde(default)]
+    next_cursor: Option<String>,
+    #[serde(default)]
+    cursor: Option<String>,
+    #[serde(default)]
+    has_more: Option<bool>,
+}
+
+impl ProposalPage {
+    fn continuation(&self) -> Option<String> {
+        self.next_cursor.clone().or_else(|| {
+            self.has_more
+                .unwrap_or(false)
+                .then(|| self.cursor.clone())
+                .flatten()
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DependencyPage {
+    #[serde(default)]
+    dependencies: Vec<ExternalTaskDependency>,
+    #[serde(default)]
+    cursor: Option<String>,
+    #[serde(default)]
+    next_cursor: Option<String>,
+    #[serde(default)]
+    has_more: Option<bool>,
+}
+
+impl DependencyPage {
+    fn continuation(&self) -> Option<String> {
+        self.next_cursor.clone().or_else(|| {
+            self.has_more
+                .unwrap_or(false)
+                .then(|| self.cursor.clone())
+                .flatten()
+        })
+    }
+}
+
+fn required_explicit<'a>(field: &str, value: &'a str) -> Result<&'a str, TaskProposalError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(TaskProposalError::Contract(format!(
+            "Cross-project task proposals require an explicit {field}; nothing is inferred from cwd."
+        )));
+    }
+    Ok(value)
+}
+
+fn decode_response<T: for<'de> Deserialize<'de>>(
+    response: Result<ureq::Response, ureq::Error>,
+) -> Result<T, TaskProposalError> {
+    match response {
+        Ok(response) => response
+            .into_json::<T>()
+            .map_err(|error| TaskProposalError::Decode(format!("Invalid cloud response: {error}"))),
+        Err(ureq::Error::Status(status, response)) => {
+            let raw = response.into_string().unwrap_or_default();
+            let message = serde_json::from_str::<serde_json::Value>(&raw)
+                .ok()
+                .and_then(|body| {
+                    body.get("error")
+                        .and_then(serde_json::Value::as_str)
+                        .or_else(|| body.get("message").and_then(serde_json::Value::as_str))
+                        .map(ToString::to_string)
+                })
+                .filter(|message| !message.is_empty())
+                .unwrap_or(raw);
+            Err(TaskProposalError::Http { status, message })
+        }
+        Err(ureq::Error::Transport(error)) => Err(TaskProposalError::Transport(format!(
+            "Cloud request failed: {error}"
+        ))),
+    }
+}
+
+pub fn render_proposal(proposal: &TaskProposal) -> String {
+    let server = &proposal.provenance.server_attested;
+    let client = &proposal.provenance.client_asserted;
+    let mut output = format!(
+        "Proposal: {}\nTarget task: {}\nState: {}\n\nServer-attested provenance:\n  creator_user_id: {}\n  team_id: {}\n  origin_project_canonical_id: {}\n  target_project_canonical_id: {}\n  received_at: {}\n  client_request_id: {}\n\nClient-asserted provenance:\n",
+        proposal.proposal_id,
+        proposal.target_task_id,
+        proposal.state,
+        server.creator_user_id,
+        server.team_id,
+        server.origin_project_canonical_id,
+        server.target_project_canonical_id,
+        server.received_at,
+        server.client_request_id,
+    );
+    for (name, value) in [
+        ("origin_session_id", client.origin_session_id.as_deref()),
+        ("origin_agent_id", client.origin_agent_id.as_deref()),
+        ("origin_agent_name", client.origin_agent_name.as_deref()),
+        ("origin_agent_role", client.origin_agent_role.as_deref()),
+        ("client_version", client.client_version.as_deref()),
+        ("client_build", client.client_build.as_deref()),
+    ] {
+        output.push_str(&format!(
+            "  {name}: {}\n",
+            value.unwrap_or("(not asserted)")
+        ));
+    }
+    output
 }
 
 #[cfg(test)]

--- a/cas-cli/src/cloud/task_proposals.rs
+++ b/cas-cli/src/cloud/task_proposals.rs
@@ -95,6 +95,8 @@ pub struct CreateTaskProposalResponse {
 pub struct ExternalTaskDependency {
     pub origin_task_id: String,
     pub proposal_id: String,
+    #[serde(default)]
+    pub target_project_canonical_id: String,
     pub target_task_id: String,
     pub proposal_state: String,
     pub target_task_status: Option<String>,

--- a/cas-cli/src/cloud/task_proposals.rs
+++ b/cas-cli/src/cloud/task_proposals.rs
@@ -1,0 +1,472 @@
+//! Dedicated client boundary for cloud-owned cross-project task proposals.
+//!
+//! Pending proposals are deliberately separate from ordinary task sync.  This
+//! module models the proposal row as authoritative and keeps materialized task
+//! JSON advisory, matching the contract in
+//! `docs/specs/2026-08-11-cross-project-task-proposals.md`.
+
+use std::fmt;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::AgentRole;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+pub const ROLE_REQUIREMENT: &str =
+    "Cross-project task creation requires a registered supervisor or director session.";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CreateTaskProposalRequest {
+    pub client_request_id: String,
+    pub origin_project_canonical_id: String,
+    pub target_project_canonical_id: String,
+    pub origin_session_id: String,
+    pub origin_agent_id: String,
+    pub origin_agent_name: Option<String>,
+    pub origin_agent_role: String,
+    pub client_version: String,
+    pub client_build: String,
+    pub task: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocks_origin_task_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServerAttestedProvenance {
+    pub proposal_id: String,
+    pub target_task_id: String,
+    pub creator_user_id: String,
+    pub team_id: String,
+    pub origin_project_canonical_id: String,
+    pub target_project_canonical_id: String,
+    pub received_at: String,
+    pub client_request_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientAssertedProvenance {
+    pub origin_session_id: Option<String>,
+    pub origin_agent_id: Option<String>,
+    pub origin_agent_name: Option<String>,
+    pub origin_agent_role: Option<String>,
+    pub client_version: Option<String>,
+    pub client_build: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposalProvenance {
+    pub server_attested: ServerAttestedProvenance,
+    pub client_asserted: ClientAssertedProvenance,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TaskProposal {
+    pub proposal_id: String,
+    pub target_task_id: String,
+    pub state: String,
+    #[serde(default)]
+    pub origin_project_canonical_id: Option<String>,
+    #[serde(default)]
+    pub target_project_canonical_id: Option<String>,
+    #[serde(default)]
+    pub received_at: Option<String>,
+    #[serde(default)]
+    pub decided_by_user_id: Option<String>,
+    #[serde(default)]
+    pub decided_at: Option<String>,
+    #[serde(default)]
+    pub rejection_reason: Option<String>,
+    #[serde(default)]
+    pub task: Option<serde_json::Value>,
+    pub provenance: ProposalProvenance,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CreateTaskProposalResponse {
+    pub proposal_id: String,
+    pub target_task_id: String,
+    pub state: String,
+    pub provenance: ProposalProvenance,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExternalTaskDependency {
+    pub origin_task_id: String,
+    pub proposal_id: String,
+    pub target_task_id: String,
+    pub proposal_state: String,
+    pub target_task_status: Option<String>,
+    pub resolution_state: String,
+    pub resolved_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyFeed {
+    pub dependencies: Vec<ExternalTaskDependency>,
+    /// The last server-issued high-watermark. It is opaque to CAS.
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskProposalError {
+    Authorization(String),
+    Http { status: u16, message: String },
+    Transport(String),
+    Decode(String),
+    Contract(String),
+}
+
+impl fmt::Display for TaskProposalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Authorization(message)
+            | Self::Transport(message)
+            | Self::Decode(message)
+            | Self::Contract(message) => f.write_str(message),
+            Self::Http { status, message } => write!(f, "Cloud returned HTTP {status}: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for TaskProposalError {}
+
+/// Fail-closed local role gate. `None` means the caller was not found in the
+/// registered CAS agent store; environment strings alone are not authority.
+pub fn authorize_registered_role(role: Option<AgentRole>) -> Result<AgentRole, TaskProposalError> {
+    match role {
+        Some(AgentRole::Supervisor | AgentRole::Director) => Err(TaskProposalError::Contract(
+            "red boundary: supervisor/director authorization is not implemented".to_string(),
+        )),
+        _ => Err(TaskProposalError::Authorization(
+            ROLE_REQUIREMENT.to_string(),
+        )),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskProposalClient {
+    endpoint: String,
+    token: String,
+    team_id: String,
+    timeout: Duration,
+}
+
+impl TaskProposalClient {
+    pub fn new(
+        endpoint: impl Into<String>,
+        token: impl Into<String>,
+        team_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            endpoint: endpoint.into().trim_end_matches('/').to_string(),
+            token: token.into(),
+            team_id: team_id.into(),
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn create(
+        &self,
+        _request: &CreateTaskProposalRequest,
+    ) -> Result<CreateTaskProposalResponse, TaskProposalError> {
+        let _ = (&self.endpoint, &self.token, &self.team_id, self.timeout);
+        Err(TaskProposalError::Contract(
+            "red boundary: proposal create is not implemented".to_string(),
+        ))
+    }
+
+    pub fn inbox_all(&self, _target_project: &str) -> Result<Vec<TaskProposal>, TaskProposalError> {
+        Err(TaskProposalError::Contract(
+            "red boundary: proposal inbox is not implemented".to_string(),
+        ))
+    }
+
+    pub fn accept(
+        &self,
+        _proposal_id: &str,
+        _target_project: &str,
+    ) -> Result<TaskProposal, TaskProposalError> {
+        Err(TaskProposalError::Contract(
+            "red boundary: proposal accept is not implemented".to_string(),
+        ))
+    }
+
+    pub fn reject(
+        &self,
+        _proposal_id: &str,
+        _target_project: &str,
+        _reason: Option<&str>,
+    ) -> Result<TaskProposal, TaskProposalError> {
+        Err(TaskProposalError::Contract(
+            "red boundary: proposal reject is not implemented".to_string(),
+        ))
+    }
+
+    pub fn dependency_feed_all(
+        &self,
+        _origin_project: &str,
+        _since: Option<&str>,
+    ) -> Result<DependencyFeed, TaskProposalError> {
+        Err(TaskProposalError::Contract(
+            "red boundary: dependency feed is not implemented".to_string(),
+        ))
+    }
+}
+
+pub fn render_proposal(_proposal: &TaskProposal) -> String {
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{
+        body_json, header, method, path, query_param, query_param_is_missing,
+    };
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn provenance() -> serde_json::Value {
+        json!({
+            "server_attested": {
+                "proposal_id": "proposal-1",
+                "target_task_id": "cas-0123456789abcdef",
+                "creator_user_id": "user-1",
+                "team_id": "team-1",
+                "origin_project_canonical_id": "origin-project",
+                "target_project_canonical_id": "target-project",
+                "received_at": "2026-08-13T15:00:00.000Z",
+                "client_request_id": "request-1"
+            },
+            "client_asserted": {
+                "origin_session_id": "session-1",
+                "origin_agent_id": "agent-1",
+                "origin_agent_name": "supervisor-one",
+                "origin_agent_role": "supervisor",
+                "client_version": "2.48.0",
+                "client_build": "deadbeef"
+            }
+        })
+    }
+
+    fn proposal(state: &str) -> serde_json::Value {
+        json!({
+            "proposal_id": "proposal-1",
+            "target_task_id": "cas-0123456789abcdef",
+            "state": state,
+            "origin_project_canonical_id": "origin-project",
+            "target_project_canonical_id": "target-project",
+            "received_at": "2026-08-13T15:00:00.000Z",
+            "decided_by_user_id": null,
+            "decided_at": null,
+            "rejection_reason": null,
+            "task": {"title": "Cross-project work", "status": "open"},
+            "provenance": provenance()
+        })
+    }
+
+    fn create_request() -> CreateTaskProposalRequest {
+        CreateTaskProposalRequest {
+            client_request_id: "request-1".to_string(),
+            origin_project_canonical_id: "origin-project".to_string(),
+            target_project_canonical_id: "target-project".to_string(),
+            origin_session_id: "session-1".to_string(),
+            origin_agent_id: "agent-1".to_string(),
+            origin_agent_name: Some("supervisor-one".to_string()),
+            origin_agent_role: "supervisor".to_string(),
+            client_version: "2.48.0".to_string(),
+            client_build: "deadbeef".to_string(),
+            task: json!({"title": "Cross-project work", "priority": 1}),
+            blocks_origin_task_id: Some("cas-abcd".to_string()),
+        }
+    }
+
+    fn client(server: &MockServer) -> TaskProposalClient {
+        TaskProposalClient::new(server.uri(), "test-token", "team-1")
+    }
+
+    #[test]
+    fn role_gate_accepts_only_registered_supervisor_or_director() {
+        assert_eq!(
+            authorize_registered_role(Some(AgentRole::Supervisor)).unwrap(),
+            AgentRole::Supervisor
+        );
+        assert_eq!(
+            authorize_registered_role(Some(AgentRole::Director)).unwrap(),
+            AgentRole::Director
+        );
+        for role in [None, Some(AgentRole::Worker), Some(AgentRole::Standard)] {
+            let error = authorize_registered_role(role).unwrap_err();
+            assert_eq!(error.to_string(), ROLE_REQUIREMENT);
+        }
+    }
+
+    #[tokio::test]
+    async fn create_uses_dedicated_endpoint_and_exact_wire_body() {
+        let server = MockServer::start().await;
+        let request = create_request();
+        Mock::given(method("POST"))
+            .and(path("/api/teams/team-1/task-proposals"))
+            .and(header("Authorization", "Bearer test-token"))
+            .and(body_json(serde_json::to_value(&request).unwrap()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "proposal_id": "proposal-1",
+                "target_task_id": "cas-0123456789abcdef",
+                "state": "proposed",
+                "provenance": provenance()
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = tokio::task::spawn_blocking(move || client(&server).create(&request))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.target_task_id, "cas-0123456789abcdef");
+        assert_eq!(result.provenance.server_attested.creator_user_id, "user-1");
+    }
+
+    #[tokio::test]
+    async fn inbox_follows_opaque_cursor_to_exhaustion() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/teams/team-1/task-proposals"))
+            .and(query_param("target_project_id", "target-project"))
+            .and(query_param("state", "proposed"))
+            .and(query_param_is_missing("cursor"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "proposals": [proposal("proposed")],
+                "next_cursor": "opaque/one+two="
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/teams/team-1/task-proposals"))
+            .and(query_param("target_project_id", "target-project"))
+            .and(query_param("state", "proposed"))
+            .and(query_param("cursor", "opaque/one+two="))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "proposals": [],
+                "next_cursor": null
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let proposals =
+            tokio::task::spawn_blocking(move || client(&server).inbox_all("target-project"))
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(proposals.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn accept_and_reject_send_explicit_target_and_reason() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/teams/team-1/task-proposals/proposal-1/accept"))
+            .and(body_json(json!({"target_project_id": "target-project"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(proposal("accepted")))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/teams/team-1/task-proposals/proposal-2/reject"))
+            .and(body_json(
+                json!({"target_project_id": "target-project", "reason": "not owned here"}),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json({
+                let mut value = proposal("rejected");
+                value["proposal_id"] = json!("proposal-2");
+                value["rejection_reason"] = json!("not owned here");
+                value.as_object_mut().unwrap().remove("task");
+                value
+            }))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (accepted, rejected) = tokio::task::spawn_blocking(move || {
+            let client = client(&server);
+            (
+                client.accept("proposal-1", "target-project"),
+                client.reject("proposal-2", "target-project", Some("not owned here")),
+            )
+        })
+        .await
+        .unwrap();
+        assert_eq!(accepted.unwrap().state, "accepted");
+        assert_eq!(
+            rejected.unwrap().rejection_reason.as_deref(),
+            Some("not owned here")
+        );
+    }
+
+    #[tokio::test]
+    async fn dependency_feed_follows_opaque_cursor_and_stops_on_stable_loop() {
+        let server = MockServer::start().await;
+        let row = json!({
+            "origin_task_id": "cas-origin",
+            "proposal_id": "proposal-1",
+            "target_task_id": "cas-0123456789abcdef",
+            "proposal_state": "rejected",
+            "target_task_status": null,
+            "resolution_state": "handoff_rejected",
+            "resolved_at": null
+        });
+        Mock::given(method("GET"))
+            .and(path("/api/teams/team-1/cross-project-task-dependencies"))
+            .and(query_param("origin_project_id", "origin-project"))
+            .and(query_param("since", "opaque-start"))
+            .and(query_param_is_missing("cursor"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "dependencies": [row],
+                "cursor": "server-watermark",
+                "next_cursor": "opaque-next"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/teams/team-1/cross-project-task-dependencies"))
+            .and(query_param("origin_project_id", "origin-project"))
+            .and(query_param("cursor", "opaque-next"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "dependencies": [],
+                "cursor": "server-watermark",
+                "next_cursor": "opaque-next"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let feed = tokio::task::spawn_blocking(move || {
+            client(&server).dependency_feed_all("origin-project", Some("opaque-start"))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(feed.dependencies.len(), 1);
+        assert_eq!(feed.dependencies[0].resolution_state, "handoff_rejected");
+        assert_eq!(feed.cursor.as_deref(), Some("server-watermark"));
+    }
+
+    #[test]
+    fn provenance_rendering_keeps_attested_and_asserted_fields_visibly_separate() {
+        let parsed: TaskProposal = serde_json::from_value(proposal("proposed")).unwrap();
+        let rendered = render_proposal(&parsed);
+        assert!(rendered.contains("Server-attested provenance"));
+        assert!(rendered.contains("creator_user_id: user-1"));
+        assert!(rendered.contains("Client-asserted provenance"));
+        assert!(rendered.contains("origin_agent_role: supervisor"));
+    }
+}

--- a/cas-cli/src/cloud/task_proposals.rs
+++ b/cas-cli/src/cloud/task_proposals.rs
@@ -5,7 +5,7 @@
 //! JSON advisory, matching the contract in
 //! `docs/specs/2026-08-11-cross-project-task-proposals.md`.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::time::Duration;
 
@@ -16,6 +16,13 @@ use crate::types::AgentRole;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 pub const ROLE_REQUIREMENT: &str =
     "Cross-project task creation requires a registered supervisor or director session.";
+
+/// Cloud pagination is additive and opt-in: a request carrying neither `limit`
+/// nor `cursor` is answered in the legacy shape with no `next_cursor`, which
+/// would silently truncate a drain at the server default. CAS therefore always
+/// sends an explicit in-range `limit` (server accepts 1..=500) so every listing
+/// receives a `next_cursor` it can follow to exhaustion.
+const PAGE_LIMIT_PARAM: &str = "100";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CreateTaskProposalRequest {
@@ -188,7 +195,7 @@ impl TaskProposalClient {
 
         loop {
             let mut url = format!(
-                "{}?target_project_id={}&state=proposed",
+                "{}?target_project_id={}&state=proposed&limit={PAGE_LIMIT_PARAM}",
                 self.team_url("task-proposals"),
                 urlencoding::encode(target)
             );
@@ -248,7 +255,7 @@ impl TaskProposalClient {
 
         loop {
             let mut url = format!(
-                "{}?origin_project_id={}",
+                "{}?origin_project_id={}&limit={PAGE_LIMIT_PARAM}",
                 self.team_url("cross-project-task-dependencies"),
                 urlencoding::encode(origin)
             );
@@ -280,7 +287,7 @@ impl TaskProposalClient {
             page_cursor = Some(next);
         }
         Ok(DependencyFeed {
-            dependencies,
+            dependencies: dedupe_by_proposal_id(dependencies),
             cursor: watermark,
         })
     }
@@ -382,6 +389,28 @@ impl DependencyPage {
                 .flatten()
         })
     }
+}
+
+/// `since=` feed reads deliberately replay a 5-second safety window so a
+/// late-committing transaction cannot fall permanently behind an observed
+/// cursor. That makes duplicates an expected, contractual outcome rather than a
+/// server bug, so CAS collapses them by `proposal_id`. The most recently
+/// observed row wins (feed order is the server's, and later rows carry the
+/// newer resolution state), while first-seen ordering is preserved so the
+/// reconciler reports a stable, truthful edge count.
+fn dedupe_by_proposal_id(dependencies: Vec<ExternalTaskDependency>) -> Vec<ExternalTaskDependency> {
+    let mut position: HashMap<String, usize> = HashMap::new();
+    let mut deduped: Vec<ExternalTaskDependency> = Vec::with_capacity(dependencies.len());
+    for dependency in dependencies {
+        match position.get(&dependency.proposal_id) {
+            Some(&index) => deduped[index] = dependency,
+            None => {
+                position.insert(dependency.proposal_id.clone(), deduped.len());
+                deduped.push(dependency);
+            }
+        }
+    }
+    deduped
 }
 
 fn required_explicit<'a>(field: &str, value: &'a str) -> Result<&'a str, TaskProposalError> {
@@ -687,6 +716,143 @@ mod tests {
         assert_eq!(feed.dependencies.len(), 1);
         assert_eq!(feed.dependencies[0].resolution_state, "handoff_rejected");
         assert_eq!(feed.cursor.as_deref(), Some("server-watermark"));
+    }
+
+    /// Pagination is opt-in on production: a request carrying neither `limit`
+    /// nor `cursor` is answered in the legacy shape with no `next_cursor`, so a
+    /// client that never opts in cannot discover page 2 and silently truncates
+    /// at the server default. CAS must send an explicit in-range `limit`.
+    #[tokio::test]
+    async fn inbox_opts_into_pagination_so_later_pages_are_not_silently_dropped() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/teams/team-1/task-proposals"))
+            .and(query_param("target_project_id", "target-project"))
+            .and(query_param("limit", PAGE_LIMIT_PARAM))
+            .and(query_param_is_missing("cursor"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "proposals": [proposal("proposed")],
+                "next_cursor": "opaque-page-2"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/teams/team-1/task-proposals"))
+            .and(query_param("limit", PAGE_LIMIT_PARAM))
+            .and(query_param("cursor", "opaque-page-2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "proposals": [{
+                    "proposal_id": "proposal-2",
+                    "target_task_id": "cas-89abcdef01234567",
+                    "state": "proposed",
+                    "origin_project_canonical_id": "origin-project",
+                    "target_project_canonical_id": "target-project",
+                    "received_at": "2026-08-13T15:01:00.000Z",
+                    "decided_by_user_id": null,
+                    "decided_at": null,
+                    "rejection_reason": null,
+                    "task": null,
+                    "provenance": provenance()
+                }],
+                "next_cursor": null
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let proposals =
+            tokio::task::spawn_blocking(move || client(&server).inbox_all("target-project"))
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(proposals.len(), 2, "second page must not be dropped");
+        assert_eq!(proposals[1].proposal_id, "proposal-2");
+    }
+
+    /// `since` reads deliberately replay a 5-second safety window, so the feed
+    /// can return the same `proposal_id` more than once within a single drain.
+    /// The contract requires de-duplication by `proposal_id`, with the most
+    /// recently observed state winning.
+    #[tokio::test]
+    async fn dependency_feed_deduplicates_replayed_rows_by_proposal_id() {
+        let server = MockServer::start().await;
+        let unresolved = json!({
+            "origin_task_id": "cas-origin",
+            "proposal_id": "proposal-1",
+            "target_task_id": "cas-0123456789abcdef",
+            "proposal_state": "accepted",
+            "target_task_status": "open",
+            "resolution_state": "unresolved",
+            "resolved_at": null
+        });
+        let resolved = json!({
+            "origin_task_id": "cas-origin",
+            "proposal_id": "proposal-1",
+            "target_task_id": "cas-0123456789abcdef",
+            "proposal_state": "accepted",
+            "target_task_status": "closed",
+            "resolution_state": "resolved",
+            "resolved_at": "2026-08-13T16:00:00.000Z"
+        });
+        let other = json!({
+            "origin_task_id": "cas-origin-2",
+            "proposal_id": "proposal-2",
+            "target_task_id": "cas-89abcdef01234567",
+            "proposal_state": "accepted",
+            "target_task_status": "open",
+            "resolution_state": "unresolved",
+            "resolved_at": null
+        });
+        Mock::given(method("GET"))
+            .and(path("/api/teams/team-1/cross-project-task-dependencies"))
+            .and(query_param("origin_project_id", "origin-project"))
+            .and(query_param("limit", PAGE_LIMIT_PARAM))
+            .and(query_param_is_missing("cursor"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "dependencies": [unresolved, other],
+                "next_cursor": "opaque-page-2"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/teams/team-1/cross-project-task-dependencies"))
+            .and(query_param("limit", PAGE_LIMIT_PARAM))
+            .and(query_param("cursor", "opaque-page-2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "dependencies": [resolved],
+                "cursor": "server-watermark",
+                "next_cursor": null
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let feed = tokio::task::spawn_blocking(move || {
+            client(&server).dependency_feed_all("origin-project", None)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            feed.dependencies.len(),
+            2,
+            "replayed proposal_id must collapse to one edge"
+        );
+        let replayed = feed
+            .dependencies
+            .iter()
+            .find(|dependency| dependency.proposal_id == "proposal-1")
+            .expect("replayed edge retained");
+        assert_eq!(
+            replayed.resolution_state, "resolved",
+            "most recently observed state wins"
+        );
+        assert_eq!(
+            replayed.resolved_at.as_deref(),
+            Some("2026-08-13T16:00:00.000Z")
+        );
     }
 
     #[test]

--- a/cas-cli/src/hybrid_search/id_utils.rs
+++ b/cas-cli/src/hybrid_search/id_utils.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 pub fn extract_id_patterns(query: &str) -> (Vec<String>, String) {
     // Match CAS-style IDs: cas-XXXX, rule-XXX, cas-skXX, etc.
     // Pattern: word boundary + (cas|rule|skill) + hyphen + alphanumeric
-    let re = match Regex::new(r"(?i)\b(cas-[a-z0-9]{2,8}|rule-[a-z0-9]{2,6}|skill-[a-z0-9]{2,6})\b")
+    let re = match Regex::new(r"(?i)\b(cas-[a-z0-9]{2,16}|rule-[a-z0-9]{2,6}|skill-[a-z0-9]{2,6})\b")
     {
         Ok(regex) => regex,
         Err(_) => return (Vec::new(), query.trim().to_string()),

--- a/cas-cli/src/hybrid_search/mod.rs
+++ b/cas-cli/src/hybrid_search/mod.rs
@@ -381,6 +381,11 @@ mod tests {
         assert_eq!(ids.len(), 2);
         assert!(ids.contains(&"cas-abcd".to_string()));
         assert!(ids.contains(&"cas-1234".to_string()));
+
+        // Cloud-reserved proposal task IDs use exactly 16 lowercase hex digits.
+        let (ids, remaining) = extract_id_patterns("open cas-0123456789abcdef now");
+        assert_eq!(ids, vec!["cas-0123456789abcdef"]);
+        assert_eq!(remaining, "open now");
     }
 
     #[test]

--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -1262,8 +1262,15 @@ mod tests {
             .expect_err("a corrupt migration ledger must refuse MCP startup")
             .to_string();
         assert!(error.contains("binary"), "missing binary version: {error}");
+        // Derived from the migration ledger rather than hardcoded: the refusal
+        // names whichever schema version this binary requires, so adding a
+        // migration must not require editing this assertion.
+        let required = crate::migration::MIGRATIONS
+            .last()
+            .map(|migration| migration.id)
+            .expect("at least one migration");
         assert!(
-            error.contains("requires schema v233"),
+            error.contains(&format!("requires schema v{required}")),
             "missing schema requirement: {error}"
         );
         assert!(

--- a/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
@@ -25,6 +25,7 @@ impl CasCore {
         }
 
         super::super::task::ensure_no_open_blockers(task_store.as_ref(), &req.task_id, "claim")?;
+        super::super::task::ensure_no_external_blockers(&self.cas_root, &req.task_id, "claim")?;
 
         // Get or register the agent - this ensures the agent exists in the database
         // before we try to claim a task (required due to foreign key constraint)

--- a/cas-cli/src/mcp/tools/core/task.rs
+++ b/cas-cli/src/mcp/tools/core/task.rs
@@ -1,6 +1,7 @@
 mod dependencies;
 pub(crate) mod lifecycle;
 mod notes;
+mod proposals;
 mod query;
 pub(crate) mod repo_context;
 mod update;
@@ -42,6 +43,42 @@ pub(crate) fn ensure_no_open_blockers(
              Close those blocker tasks first, or remove an incorrect `blocks` dependency \
              with `task action=dep_remove id={task_id} to_id=<blocker-id> dep_type=blocks`.",
             blocker_ids.join(", ")
+        )),
+        data: None,
+    })
+}
+
+pub(crate) fn ensure_no_external_blockers(
+    cas_root: &std::path::Path,
+    task_id: &str,
+    action: &str,
+) -> Result<(), rmcp::ErrorData> {
+    let blockers = cas_store::ExternalTaskDependencyStore::open(cas_root)
+        .and_then(|store| store.list_blocking_for_task(task_id))
+        .map_err(|error| rmcp::ErrorData {
+            code: rmcp::model::ErrorCode::INTERNAL_ERROR,
+            message: std::borrow::Cow::from(format!(
+                "Failed to check external blocking dependencies for task {task_id}: {error}"
+            )),
+            data: None,
+        })?;
+    if blockers.is_empty() {
+        return Ok(());
+    }
+    let rendered = blockers
+        .iter()
+        .map(|blocker| {
+            format!(
+                "{} ({}, proposal {})",
+                blocker.target_task_id, blocker.resolution_state, blocker.proposal_id
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(rmcp::ErrorData {
+        code: rmcp::model::ErrorCode::INVALID_PARAMS,
+        message: std::borrow::Cow::from(format!(
+            "Cannot {action} task {task_id}: cross-project blockers are unresolved: {rendered}. Reconcile after the target closes; a rejected handoff remains blocking until an operator removes or replaces it."
         )),
         data: None,
     })

--- a/cas-cli/src/mcp/tools/core/task/dependencies.rs
+++ b/cas-cli/src/mcp/tools/core/task/dependencies.rs
@@ -100,6 +100,40 @@ impl CasCore {
             })?;
 
         if !found {
+            if dep_type == DependencyType::Blocks {
+                let external_store = cas_store::ExternalTaskDependencyStore::open(&self.cas_root)
+                    .map_err(|error| {
+                    Self::error(ErrorCode::INTERNAL_ERROR, error.to_string())
+                })?;
+                if external_store
+                    .remove(&req.from_id, &req.to_id)
+                    .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?
+                {
+                    let mut task = task_store.get(&req.from_id).map_err(|error| {
+                        Self::error(ErrorCode::INVALID_PARAMS, error.to_string())
+                    })?;
+                    if task.status == TaskStatus::Blocked
+                        && task_store
+                            .get_blockers(&req.from_id)
+                            .unwrap_or_default()
+                            .is_empty()
+                        && external_store
+                            .list_blocking_for_task(&req.from_id)
+                            .unwrap_or_default()
+                            .is_empty()
+                    {
+                        task.status = TaskStatus::Open;
+                        task.updated_at = chrono::Utc::now();
+                        task_store.update(&task).map_err(|error| {
+                            Self::error(ErrorCode::INTERNAL_ERROR, error.to_string())
+                        })?;
+                    }
+                    return Ok(Self::success(format!(
+                        "Removed external dependency: {} was blocked_by {}.",
+                        req.from_id, req.to_id
+                    )));
+                }
+            }
             return Err(McpError {
                 code: ErrorCode::INVALID_PARAMS,
                 message: Cow::from(format!(
@@ -172,10 +206,7 @@ mod describe_dependency_tests {
             DependencyType::Blocks,
         );
         let msg = describe_dependency(&dep);
-        assert!(
-            !msg.contains("->"),
-            "must not contain a bare arrow: {msg}"
-        );
+        assert!(!msg.contains("->"), "must not contain a bare arrow: {msg}");
         assert!(
             msg.contains("blocked_by"),
             "must state blocked_by in plain words: {msg}"
@@ -211,10 +242,16 @@ mod describe_dependency_tests {
 
     #[test]
     fn discovered_from_and_extracted_from_have_no_arrow() {
-        for dep_type in [DependencyType::DiscoveredFrom, DependencyType::ExtractedFrom] {
+        for dep_type in [
+            DependencyType::DiscoveredFrom,
+            DependencyType::ExtractedFrom,
+        ] {
             let dep = Dependency::new("cas-a".to_string(), "cas-b".to_string(), dep_type);
             let msg = describe_dependency(&dep);
-            assert!(!msg.contains("->"), "{dep_type:?}: must not contain arrow: {msg}");
+            assert!(
+                !msg.contains("->"),
+                "{dep_type:?}: must not contain arrow: {msg}"
+            );
         }
     }
 }

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -677,6 +677,7 @@ impl CasCore {
         }
 
         super::ensure_no_open_blockers(task_store.as_ref(), &req.id, "start")?;
+        super::ensure_no_external_blockers(&self.cas_root, &req.id, "start")?;
 
         if let Some(target) = task.deliverables.work_target.as_ref() {
             super::repo_context::resolve_repo_context(&self.cas_root, target).map_err(

--- a/cas-cli/src/mcp/tools/core/task/proposals.rs
+++ b/cas-cli/src/mcp/tools/core/task/proposals.rs
@@ -1,0 +1,491 @@
+use crate::mcp::tools::core::imports::*;
+
+use cas_store::{ExternalTaskDependencyProjection, ExternalTaskDependencyStore};
+
+use crate::cloud::task_proposals::{
+    CreateTaskProposalRequest, ProposalProvenance, TaskProposal, TaskProposalClient,
+    authorize_registered_role, render_proposal,
+};
+use crate::cloud::{CloudConfig, canonical_id_from_config_toml};
+
+const EXPLICIT_ORIGIN_REQUIRED: &str = "Cross-project task proposals require an explicit [project] canonical_id in .cas/config.toml; nothing is inferred from cwd, folder name, or git remote.";
+
+impl CasCore {
+    fn proposal_authority(&self) -> Result<cas_types::Agent, McpError> {
+        // This lookup and registered-store role check intentionally happen
+        // before CloudConfig loading or any network-capable client exists.
+        let agent_id = self.get_agent_id().map_err(|_| {
+            Self::error(
+                ErrorCode::INVALID_PARAMS,
+                crate::cloud::task_proposals::ROLE_REQUIREMENT,
+            )
+        })?;
+        let agent = self.open_agent_store()?.get(&agent_id).map_err(|_| {
+            Self::error(
+                ErrorCode::INVALID_PARAMS,
+                crate::cloud::task_proposals::ROLE_REQUIREMENT,
+            )
+        })?;
+        authorize_registered_role(Some(agent.role))
+            .map_err(|error| Self::error(ErrorCode::INVALID_PARAMS, error.to_string()))?;
+        Ok(agent)
+    }
+
+    fn proposal_client_after_authority(&self) -> Result<TaskProposalClient, McpError> {
+        let project_config = CloudConfig::load_from_cas_dir(&self.cas_root).map_err(|error| {
+            Self::error(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to load project cloud configuration: {error}"),
+            )
+        })?;
+        let user_config = CloudConfig::load_user().unwrap_or_default();
+        let token = project_config
+            .token
+            .clone()
+            .or(user_config.token.clone())
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    "Cross-project task proposals require an authenticated cloud bearer token.",
+                )
+            })?;
+        let team_id = project_config
+            .active_team_id_with_user_config(Some(&user_config))
+            .ok_or_else(|| {
+                Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    "Cross-project task creation requires membership in a team shared by the origin and target projects.",
+                )
+            })?;
+        let endpoint = if project_config.endpoint.trim().is_empty() {
+            user_config.endpoint
+        } else {
+            project_config.endpoint
+        };
+        Ok(TaskProposalClient::new(endpoint, token, team_id))
+    }
+
+    fn explicit_local_project(&self) -> Result<String, McpError> {
+        canonical_id_from_config_toml(&self.cas_root)
+            .ok_or_else(|| Self::error(ErrorCode::INVALID_PARAMS, EXPLICIT_ORIGIN_REQUIRED))
+    }
+
+    fn require_local_project(&self, requested: &str) -> Result<String, McpError> {
+        let requested = requested.trim();
+        if requested.is_empty() {
+            return Err(Self::error(
+                ErrorCode::INVALID_PARAMS,
+                "Cross-project task proposals require an explicit project; nothing is inferred from cwd.",
+            ));
+        }
+        let local = self.explicit_local_project()?;
+        if requested != local {
+            return Err(Self::error(
+                ErrorCode::INVALID_PARAMS,
+                format!(
+                    "Requested project `{requested}` does not match this CAS database's explicit canonical project `{local}`."
+                ),
+            ));
+        }
+        Ok(local)
+    }
+
+    pub(crate) async fn cas_task_proposal_create(
+        &self,
+        req: TaskCreateRequest,
+        target_project: &str,
+        blocks_origin_task_id: Option<&str>,
+    ) -> Result<CallToolResult, McpError> {
+        let agent = self.proposal_authority()?;
+        let origin_project = self.explicit_local_project()?;
+        let target_project = target_project.trim();
+        if target_project.is_empty() {
+            return Err(Self::error(
+                ErrorCode::INVALID_PARAMS,
+                "Cross-project task proposals require an explicit target project; nothing is inferred from cwd.",
+            ));
+        }
+        let client = self.proposal_client_after_authority()?;
+
+        if let Some(origin_task_id) = blocks_origin_task_id {
+            self.open_task_store()?
+                .get(origin_task_id)
+                .map_err(|error| {
+                    Self::error(
+                        ErrorCode::INVALID_PARAMS,
+                        format!("Origin blocker task not found: {error}"),
+                    )
+                })?;
+        }
+
+        let request = CreateTaskProposalRequest {
+            client_request_id: uuid::Uuid::new_v4().to_string(),
+            origin_project_canonical_id: origin_project,
+            target_project_canonical_id: target_project.to_string(),
+            origin_session_id: agent
+                .cc_session_id
+                .clone()
+                .unwrap_or_else(|| agent.id.clone()),
+            origin_agent_id: agent.id.clone(),
+            origin_agent_name: Some(agent.name.clone()),
+            origin_agent_role: agent.role.to_string(),
+            client_version: env!("CARGO_PKG_VERSION").to_string(),
+            client_build: option_env!("CAS_GIT_HASH").unwrap_or("unknown").to_string(),
+            task: serde_json::json!({
+                "title": req.title,
+                "description": req.description.unwrap_or_default(),
+                "priority": req.priority,
+                "task_type": req.task_type,
+                "labels": req.labels.as_deref().unwrap_or_default().split(',')
+                    .map(str::trim).filter(|label| !label.is_empty()).collect::<Vec<_>>(),
+                "design": req.design.unwrap_or_default(),
+                "acceptance_criteria": req.acceptance_criteria.unwrap_or_default(),
+                "external_ref": req.external_ref.unwrap_or_default(),
+            }),
+            blocks_origin_task_id: blocks_origin_task_id.map(ToString::to_string),
+        };
+        let response = tokio::task::spawn_blocking(move || client.create(&request))
+            .await
+            .map_err(|error| {
+                Self::error(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Cloud proposal request panicked: {error}"),
+                )
+            })?
+            .map_err(|error| Self::error(ErrorCode::INVALID_PARAMS, error.to_string()))?;
+
+        if let Some(origin_task_id) = blocks_origin_task_id {
+            let projection = ExternalTaskDependencyProjection {
+                origin_task_id: origin_task_id.to_string(),
+                proposal_id: response.proposal_id.clone(),
+                target_project_canonical_id: target_project.to_string(),
+                target_task_id: response.target_task_id.clone(),
+                proposal_state: response.state.clone(),
+                target_task_status: None,
+                resolution_state: "unresolved".to_string(),
+                resolved_at: None,
+            };
+            ExternalTaskDependencyStore::open(&self.cas_root)
+                .and_then(|store| store.upsert(&projection))
+                .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, format!("Proposal was created, but local external blocker projection failed: {error}")))?;
+            let task_store = self.open_task_store()?;
+            let mut origin = task_store
+                .get(origin_task_id)
+                .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?;
+            if origin.status == TaskStatus::Open {
+                origin.status = TaskStatus::Blocked;
+                origin.updated_at = chrono::Utc::now();
+                task_store.update(&origin).map_err(|error| {
+                    Self::error(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!(
+                            "Proposal was created, but marking origin task blocked failed: {error}"
+                        ),
+                    )
+                })?;
+            }
+        }
+
+        let proposal = proposal_from_create(response.provenance, response.state);
+        Ok(Self::success(format!(
+            "Created cross-project task proposal. No foreign task was inserted locally.\n\n{}",
+            render_proposal(&proposal)
+        )))
+    }
+
+    pub(crate) async fn cas_task_proposal_inbox(
+        &self,
+        target_project: &str,
+    ) -> Result<CallToolResult, McpError> {
+        self.proposal_authority()?;
+        let target_project = self.require_local_project(target_project)?;
+        let client = self.proposal_client_after_authority()?;
+        let proposals = tokio::task::spawn_blocking(move || client.inbox_all(&target_project))
+            .await
+            .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?
+            .map_err(|error| Self::error(ErrorCode::INVALID_PARAMS, error.to_string()))?;
+        if proposals.is_empty() {
+            return Ok(Self::success(
+                "No proposed cross-project tasks in this project inbox.",
+            ));
+        }
+        Ok(Self::success(
+            proposals
+                .iter()
+                .map(render_proposal)
+                .collect::<Vec<_>>()
+                .join("\n---\n"),
+        ))
+    }
+
+    pub(crate) async fn cas_task_proposal_accept(
+        &self,
+        proposal_id: &str,
+        target_project: &str,
+    ) -> Result<CallToolResult, McpError> {
+        self.proposal_authority()?;
+        let target_project = self.require_local_project(target_project)?;
+        let proposal_id = proposal_id.to_string();
+        let client = self.proposal_client_after_authority()?;
+        let proposal =
+            tokio::task::spawn_blocking(move || client.accept(&proposal_id, &target_project))
+                .await
+                .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?
+                .map_err(|error| Self::error(ErrorCode::INVALID_PARAMS, error.to_string()))?;
+        Ok(Self::success(format!(
+            "Accepted proposal atomically as one open target task.\n\n{}",
+            render_proposal(&proposal)
+        )))
+    }
+
+    pub(crate) async fn cas_task_proposal_reject(
+        &self,
+        proposal_id: &str,
+        target_project: &str,
+        reason: Option<&str>,
+    ) -> Result<CallToolResult, McpError> {
+        self.proposal_authority()?;
+        let target_project = self.require_local_project(target_project)?;
+        let proposal_id = proposal_id.to_string();
+        let reason = reason.map(ToString::to_string);
+        let client = self.proposal_client_after_authority()?;
+        let proposal = tokio::task::spawn_blocking(move || {
+            client.reject(&proposal_id, &target_project, reason.as_deref())
+        })
+        .await
+        .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?
+        .map_err(|error| Self::error(ErrorCode::INVALID_PARAMS, error.to_string()))?;
+        Ok(Self::success(format!(
+            "Rejected proposal; no task was materialized.\n\n{}",
+            render_proposal(&proposal)
+        )))
+    }
+
+    pub(crate) async fn cas_task_proposal_reconcile(
+        &self,
+        origin_project: &str,
+    ) -> Result<CallToolResult, McpError> {
+        self.proposal_authority()?;
+        let origin_project = self.require_local_project(origin_project)?;
+        let projection_store = ExternalTaskDependencyStore::open(&self.cas_root)
+            .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?;
+        let cursor = projection_store
+            .cursor(&origin_project)
+            .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?;
+        let client = self.proposal_client_after_authority()?;
+        let request_project = origin_project.clone();
+        let request_cursor = cursor.clone();
+        let feed = tokio::task::spawn_blocking(move || {
+            client.dependency_feed_all(&request_project, request_cursor.as_deref())
+        })
+        .await
+        .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?
+        .map_err(|error| Self::error(ErrorCode::INVALID_PARAMS, error.to_string()))?;
+
+        let task_store = self.open_task_store()?;
+        let mut touched = std::collections::BTreeSet::new();
+        for dependency in &feed.dependencies {
+            touched.insert(dependency.origin_task_id.clone());
+            projection_store
+                .upsert(&ExternalTaskDependencyProjection {
+                    origin_task_id: dependency.origin_task_id.clone(),
+                    proposal_id: dependency.proposal_id.clone(),
+                    target_project_canonical_id: dependency.target_project_canonical_id.clone(),
+                    target_task_id: dependency.target_task_id.clone(),
+                    proposal_state: dependency.proposal_state.clone(),
+                    target_task_status: dependency.target_task_status.clone(),
+                    resolution_state: dependency.resolution_state.clone(),
+                    resolved_at: dependency.resolved_at.clone(),
+                })
+                .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?;
+        }
+        projection_store
+            .set_cursor(&origin_project, feed.cursor.as_deref())
+            .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?;
+
+        let mut reopened = Vec::new();
+        let mut rejected = Vec::new();
+        for task_id in touched {
+            let blockers = projection_store
+                .list_blocking_for_task(&task_id)
+                .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?;
+            rejected.extend(
+                blockers
+                    .iter()
+                    .filter(|dependency| dependency.resolution_state == "handoff_rejected")
+                    .map(|_| task_id.clone()),
+            );
+            if !blockers.is_empty() {
+                if let Ok(mut task) = task_store.get(&task_id) {
+                    if task.status == TaskStatus::Open {
+                        task.status = TaskStatus::Blocked;
+                        task.updated_at = chrono::Utc::now();
+                        task_store.update(&task).map_err(|error| {
+                            Self::error(ErrorCode::INTERNAL_ERROR, error.to_string())
+                        })?;
+                    }
+                }
+                continue;
+            }
+            if blockers.is_empty()
+                && task_store
+                    .get_blockers(&task_id)
+                    .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?
+                    .is_empty()
+            {
+                if let Ok(mut task) = task_store.get(&task_id) {
+                    if task.status == TaskStatus::Blocked {
+                        task.status = TaskStatus::Open;
+                        task.updated_at = chrono::Utc::now();
+                        task_store.update(&task).map_err(|error| {
+                            Self::error(ErrorCode::INTERNAL_ERROR, error.to_string())
+                        })?;
+                        reopened.push(task_id);
+                    }
+                }
+            }
+        }
+        rejected.sort();
+        rejected.dedup();
+        Ok(Self::success(format!(
+            "Reconciled {} external dependency signal(s) for explicit project `{}`. Reopened: {}. Rejected handoffs still blocking: {}.",
+            feed.dependencies.len(),
+            origin_project,
+            if reopened.is_empty() {
+                "none".into()
+            } else {
+                reopened.join(", ")
+            },
+            if rejected.is_empty() {
+                "none".into()
+            } else {
+                rejected.join(", ")
+            },
+        )))
+    }
+}
+
+fn proposal_from_create(provenance: ProposalProvenance, state: String) -> TaskProposal {
+    let server = &provenance.server_attested;
+    TaskProposal {
+        proposal_id: server.proposal_id.clone(),
+        target_task_id: server.target_task_id.clone(),
+        state,
+        origin_project_canonical_id: Some(server.origin_project_canonical_id.clone()),
+        target_project_canonical_id: Some(server.target_project_canonical_id.clone()),
+        received_at: Some(server.received_at.clone()),
+        decided_by_user_id: None,
+        decided_at: None,
+        rejection_reason: None,
+        task: None,
+        provenance,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn request() -> TaskCreateRequest {
+        TaskCreateRequest {
+            title: "Foreign work".into(),
+            description: Some("Description".into()),
+            priority: 2,
+            task_type: "task".into(),
+            labels: None,
+            notes: None,
+            blocked_by: None,
+            design: None,
+            acceptance_criteria: None,
+            external_ref: None,
+            assignee: None,
+            demo_statement: None,
+            execution_note: None,
+            epic: None,
+            depth: None,
+        }
+    }
+
+    fn core_with_role(role: cas_types::AgentRole) -> (tempfile::TempDir, CasCore) {
+        let temp = tempfile::tempdir().unwrap();
+        let cas_root = crate::store::init_cas_dir(temp.path()).unwrap();
+        let store = crate::store::open_agent_store(&cas_root).unwrap();
+        let mut agent = cas_types::Agent::new("proposal-test-agent".into(), "proposal-test".into());
+        agent.role = role;
+        store.register(&agent).unwrap();
+        let core = CasCore::with_daemon(cas_root, None, None);
+        core.set_agent_id_for_testing(agent.id);
+        (temp, core)
+    }
+
+    #[tokio::test]
+    async fn worker_is_refused_before_cloud_config_is_loaded() {
+        let (_temp, core) = core_with_role(cas_types::AgentRole::Worker);
+        let error = core
+            .cas_task_proposal_create(request(), "target-project", None)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.message.as_ref(),
+            crate::cloud::task_proposals::ROLE_REQUIREMENT
+        );
+    }
+
+    #[tokio::test]
+    async fn supervisor_without_explicit_origin_never_falls_back_to_cwd_or_git() {
+        let (_temp, core) = core_with_role(cas_types::AgentRole::Supervisor);
+        let error = core
+            .cas_task_proposal_create(request(), "target-project", None)
+            .await
+            .unwrap_err();
+        assert_eq!(error.message.as_ref(), EXPLICIT_ORIGIN_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn task_list_scope_names_project_and_rejects_global() {
+        let (_temp, core) = core_with_role(cas_types::AgentRole::Supervisor);
+        let task_store = core.open_task_store().unwrap();
+        task_store
+            .add(&cas_types::Task::new(
+                "cas-scope".into(),
+                "Scope truth".into(),
+            ))
+            .unwrap();
+        let project = core
+            .cas_task_list(Parameters(TaskListRequest {
+                limit: None,
+                scope: "project".into(),
+                status: None,
+                task_type: None,
+                label: None,
+                assignee: None,
+                epic: None,
+                sort: None,
+                sort_order: None,
+            }))
+            .await
+            .unwrap();
+        let rmcp::model::RawContent::Text(project_text) = &project.content[0].raw else {
+            panic!("task list must return text")
+        };
+        let project_text = project_text.text.as_str();
+        assert!(project_text.contains("Scope: project `"));
+        assert!(project_text.contains("current CAS database"));
+
+        let global = core
+            .cas_task_list(Parameters(TaskListRequest {
+                limit: None,
+                scope: "global".into(),
+                status: None,
+                task_type: None,
+                label: None,
+                assignee: None,
+                epic: None,
+                sort: None,
+                sort_order: None,
+            }))
+            .await
+            .unwrap_err();
+        assert!(global.message.contains("Global task scope is unsupported"));
+    }
+}

--- a/cas-cli/src/mcp/tools/core/task/query.rs
+++ b/cas-cli/src/mcp/tools/core/task/query.rs
@@ -422,13 +422,26 @@ impl CasCore {
             crate::mcp::tools::truncated_list_header("Blocked tasks", total, shown, &sort_opts);
         for (task, blockers) in blocked.iter().take(limit) {
             let blocker_ids: Vec<_> = blockers.iter().map(|t| t.id.as_str()).collect();
+            let external = cas_store::ExternalTaskDependencyStore::open(&self.cas_root)
+                .and_then(|store| store.list_blocking_for_task(&task.id))
+                .unwrap_or_default();
+            let mut rendered_blockers = blocker_ids
+                .into_iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            rendered_blockers.extend(external.iter().map(|dependency| {
+                format!(
+                    "{} [external: {}]",
+                    dependency.target_task_id, dependency.resolution_state
+                )
+            }));
             output.push_str(&format!(
                 "- [{}] P{} {} - {}\n  Blocked by: {}\n",
                 task.id,
                 task.priority.0,
                 task.task_type,
                 task.title,
-                blocker_ids.join(", ")
+                rendered_blockers.join(", ")
             ));
         }
         output.push_str(&crate::mcp::tools::truncated_list_footer(total, shown));
@@ -442,6 +455,22 @@ impl CasCore {
         Parameters(req): Parameters<TaskListRequest>,
     ) -> Result<CallToolResult, McpError> {
         use cas_types::TaskSortOptions;
+
+        let scope = req.scope.trim().to_ascii_lowercase();
+        if scope == "global" {
+            return Err(Self::error(
+                ErrorCode::INVALID_PARAMS,
+                "Global task scope is unsupported. Tasks belong to the current CAS project database.",
+            ));
+        }
+        if !matches!(scope.as_str(), "project" | "all") {
+            return Err(Self::error(
+                ErrorCode::INVALID_PARAMS,
+                "Task scope must be `project` or `all`; global tasks are unsupported.",
+            ));
+        }
+        let project_id = crate::cloud::get_project_canonical_id()
+            .unwrap_or_else(|| "(unresolved current project)".to_string());
 
         let task_store = self.open_task_store()?;
 
@@ -507,15 +536,25 @@ impl CasCore {
             TaskSortOptions::from_params(req.sort.as_deref(), req.sort_order.as_deref());
         sort_tasks(&mut filtered, &sort_opts);
 
+        let scope_note = if scope == "all" {
+            format!(
+                "Scope: all (currently equivalent to the current project database `{project_id}`; no multi-project aggregator exists)"
+            )
+        } else {
+            format!("Scope: project `{project_id}` (current CAS database)")
+        };
         if filtered.is_empty() {
-            return Ok(Self::success("No tasks found matching filters"));
+            return Ok(Self::success(format!(
+                "No tasks found matching filters.\n{scope_note}."
+            )));
         }
 
         let limit = req.limit.unwrap_or(20);
         let mut output = format!(
-            "Tasks ({} total, showing {}):\n\n",
+            "Tasks ({} total, showing {})\n{}:\n\n",
             filtered.len(),
-            filtered.len().min(limit)
+            filtered.len().min(limit),
+            scope_note,
         );
         for task in filtered.iter().take(limit) {
             // cas-a844: flag a conflicted awaiting_merge distinctly from a

--- a/cas-cli/src/mcp/tools/service/core.rs
+++ b/cas-cli/src/mcp/tools/service/core.rs
@@ -227,6 +227,8 @@ impl CasService {
         use crate::mcp::tools::TaskCreateRequest;
         let target_repo = req.target_repo.clone();
         let target_branch = req.target_branch.clone();
+        let target_project = req.project.clone();
+        let blocks_origin_task_id = req.blocks_origin_task_id.clone();
         let inner_req = TaskCreateRequest {
             title: req.title.ok_or_else(|| {
                 Self::error(
@@ -250,6 +252,16 @@ impl CasService {
             epic: req.epic,
             depth: req.depth,
         };
+        if let Some(target_project) = target_project {
+            return self
+                .inner
+                .cas_task_proposal_create(
+                    inner_req,
+                    &target_project,
+                    blocks_origin_task_id.as_deref(),
+                )
+                .await;
+        }
         self.inner
             .cas_task_create_with_target(
                 inner_req,
@@ -257,6 +269,79 @@ impl CasService {
                 target_branch.as_deref(),
                 req.confirm_warning.unwrap_or(false),
             )
+            .await
+    }
+
+    pub(super) async fn task_proposal_inbox(
+        &self,
+        req: TaskRequest,
+    ) -> Result<CallToolResult, McpError> {
+        self.inner
+            .cas_task_proposal_inbox(req.project.as_deref().ok_or_else(|| {
+                Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    "project required for proposal_inbox",
+                )
+            })?)
+            .await
+    }
+
+    pub(super) async fn task_proposal_accept(
+        &self,
+        req: TaskRequest,
+    ) -> Result<CallToolResult, McpError> {
+        self.inner
+            .cas_task_proposal_accept(
+                req.proposal_id.as_deref().ok_or_else(|| {
+                    Self::error(
+                        ErrorCode::INVALID_PARAMS,
+                        "proposal_id required for proposal_accept",
+                    )
+                })?,
+                req.project.as_deref().ok_or_else(|| {
+                    Self::error(
+                        ErrorCode::INVALID_PARAMS,
+                        "project required for proposal_accept",
+                    )
+                })?,
+            )
+            .await
+    }
+
+    pub(super) async fn task_proposal_reject(
+        &self,
+        req: TaskRequest,
+    ) -> Result<CallToolResult, McpError> {
+        self.inner
+            .cas_task_proposal_reject(
+                req.proposal_id.as_deref().ok_or_else(|| {
+                    Self::error(
+                        ErrorCode::INVALID_PARAMS,
+                        "proposal_id required for proposal_reject",
+                    )
+                })?,
+                req.project.as_deref().ok_or_else(|| {
+                    Self::error(
+                        ErrorCode::INVALID_PARAMS,
+                        "project required for proposal_reject",
+                    )
+                })?,
+                req.reason.as_deref(),
+            )
+            .await
+    }
+
+    pub(super) async fn task_proposal_reconcile(
+        &self,
+        req: TaskRequest,
+    ) -> Result<CallToolResult, McpError> {
+        self.inner
+            .cas_task_proposal_reconcile(req.project.as_deref().ok_or_else(|| {
+                Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    "project required for proposal_reconcile",
+                )
+            })?)
             .await
     }
 

--- a/cas-cli/src/mcp/tools/service/mod.rs
+++ b/cas-cli/src/mcp/tools/service/mod.rs
@@ -258,7 +258,7 @@ impl CasService {
     // ========================================================================
 
     #[tool(
-        description = "Task operations. Actions: create, show, update, start, close, cancel, reopen, request_changes, delete, list, ready (actionable), blocked, notes (add progress), dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine. cancel is the supervisor-authorized, reason-required terminal path for work intentionally ended without delivery; it preserves history and accepts an optional superseded_by pointer. Supervisors use request_changes as the sanctioned exit from AwaitingMerge whenever review fails — declined merge, amendment required after merge, or rejected work — reopening the task with its assignee preserved (use reset only for tasks orphaned by a dead session). Prefer `start` for normal worker execution; use `claim` for manual lease control/recovery; use `reset` to revive a task orphaned by a dead session (atomic: force-releases lease, clears assignee, forces status=open). IMPORTANT for 'close': verification must pass first. Workers should attempt close; if close returns verification-required guidance, follow the indicated verifier ownership workflow."
+        description = "Task operations. Actions: create (local, or cross-project proposal with explicit project), proposal_inbox, proposal_accept, proposal_reject, proposal_reconcile, show, update, start, close, cancel, reopen, request_changes, delete, list, ready (actionable), blocked, notes (add progress), dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine. Pending proposals are a dedicated cloud inbox, never TaskStatus rows. cancel is the supervisor-authorized, reason-required terminal path for work intentionally ended without delivery; it preserves history and accepts an optional superseded_by pointer. Supervisors use request_changes as the sanctioned exit from AwaitingMerge whenever review fails — declined merge, amendment required after merge, or rejected work — reopening the task with its assignee preserved (use reset only for tasks orphaned by a dead session). Prefer `start` for normal worker execution; use `claim` for manual lease control/recovery; use `reset` to revive a task orphaned by a dead session (atomic: force-releases lease, clears assignee, forces status=open). IMPORTANT for 'close': verification must pass first. Workers should attempt close; if close returns verification-required guidance, follow the indicated verifier ownership workflow."
     )]
     pub async fn task(
         &self,
@@ -279,6 +279,9 @@ impl CasService {
                     | "request_changes"
                     | "delete"
                     | "notes"
+                    | "proposal_accept"
+                    | "proposal_reject"
+                    | "proposal_reconcile"
                     | "dep_add"
                     | "dep_remove"
                     | "claim"
@@ -289,6 +292,10 @@ impl CasService {
 
             let result = match req.action.as_str() {
                 "create" => this.task_create(req).await,
+                "proposal_inbox" => this.task_proposal_inbox(req).await,
+                "proposal_accept" => this.task_proposal_accept(req).await,
+                "proposal_reject" => this.task_proposal_reject(req).await,
+                "proposal_reconcile" => this.task_proposal_reconcile(req).await,
                 "show" => this.task_show(req).await,
                 "update" => this.task_update(req).await,
                 "start" => this.task_start(req).await,
@@ -313,7 +320,7 @@ impl CasService {
                 _ => Err(Self::error(
                     ErrorCode::INVALID_PARAMS,
                     format!(
-                        "Unknown task action: {}. Valid: create, show, update, start, close, cancel, reopen, request_changes, delete, list, ready, blocked, notes, dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine",
+                        "Unknown task action: {}. Valid: create, proposal_inbox, proposal_accept, proposal_reject, proposal_reconcile, show, update, start, close, cancel, reopen, request_changes, delete, list, ready, blocked, notes, dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine",
                         req.action
                     ),
                 )),

--- a/cas-cli/src/migration/migrations/m234_external_task_dependencies.rs
+++ b/cas-cli/src/migration/migrations/m234_external_task_dependencies.rs
@@ -1,0 +1,43 @@
+//! Migration: local projection for cloud-owned cross-project blockers (cas-e0c9).
+
+use crate::migration::{Migration, Subsystem};
+
+pub const MIGRATION: Migration = Migration {
+    id: 234,
+    name: "external_task_dependencies",
+    subsystem: Subsystem::Tasks,
+    description: "Project cloud-owned cross-project blockers without foreign task replicas (cas-e0c9)",
+    up: &[
+        "CREATE TABLE IF NOT EXISTS external_task_dependencies (origin_task_id TEXT NOT NULL, proposal_id TEXT NOT NULL, target_project_canonical_id TEXT NOT NULL DEFAULT '', target_task_id TEXT NOT NULL, proposal_state TEXT NOT NULL, target_task_status TEXT, resolution_state TEXT NOT NULL, resolved_at TEXT, updated_at TEXT NOT NULL, PRIMARY KEY (origin_task_id, proposal_id))",
+        "CREATE INDEX IF NOT EXISTS idx_external_task_dependencies_origin_state ON external_task_dependencies(origin_task_id, resolution_state)",
+        "CREATE TABLE IF NOT EXISTS external_task_dependency_sync_state (origin_project_canonical_id TEXT PRIMARY KEY, cursor TEXT, updated_at TEXT NOT NULL)",
+    ],
+    detect: Some(
+        "SELECT CASE WHEN (SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='external_task_dependencies') = 0 THEN 0 WHEN (SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='external_task_dependency_sync_state') = 0 THEN 0 ELSE 1 END",
+    ),
+};
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    #[test]
+    fn migration_creates_projection_and_cursor_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        assert_eq!(
+            conn.query_row(super::MIGRATION.detect.unwrap(), [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        for statement in super::MIGRATION.up {
+            conn.execute(statement, []).unwrap();
+        }
+        assert_eq!(
+            conn.query_row(super::MIGRATION.detect.unwrap(), [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+    }
+}

--- a/cas-cli/src/migration/migrations/mod.rs
+++ b/cas-cli/src/migration/migrations/mod.rs
@@ -209,6 +209,7 @@ mod m230_verification_repository_proof;
 mod m231_sync_conflicts_create_table;
 mod m232_worker_completion_receipts_add_artifact_path;
 mod m233_tasks_add_terminal_outcome;
+mod m234_external_task_dependencies;
 
 /// All migrations in order. IDs must be sequential and never reused.
 pub const MIGRATIONS: &[Migration] = &[
@@ -451,6 +452,7 @@ pub const MIGRATIONS: &[Migration] = &[
     m231_sync_conflicts_create_table::MIGRATION,
     m232_worker_completion_receipts_add_artifact_path::MIGRATION,
     m233_tasks_add_terminal_outcome::MIGRATION,
+    m234_external_task_dependencies::MIGRATION,
 ];
 
 #[cfg(test)]

--- a/cas-cli/src/migration/mod.rs
+++ b/cas-cli/src/migration/mod.rs
@@ -972,7 +972,7 @@ mod tests {
 
     fn assert_repaired_v225_knowledge_gap(cas_dir: &Path, expected_m226_ledger: &str) {
         let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
-        for id in [225, 226, 227, 228, 229, 230, 231, 232, 233] {
+        for id in [225, 226, 227, 228, 229, 230, 231, 232, 233, 234] {
             assert_eq!(
                 conn.query_row(
                     "SELECT COUNT(*) FROM cas_migrations WHERE id = ?1",
@@ -1039,7 +1039,7 @@ mod tests {
         assert_eq!(pages[0].origin_project_id, None);
 
         let status = check_migrations(cas_dir).unwrap();
-        assert_eq!(status.current_version, 233);
+        assert_eq!(status.current_version, 234);
         assert!(status.pending.is_empty());
         let second = run_migrations(cas_dir, false).unwrap();
         assert_eq!(second.applied_count, 0, "repeated open must be idempotent");
@@ -1061,7 +1061,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 227, 228, 229, 230, 231, 232, 233],
+                vec![225, 226, 227, 228, 229, 230, 231, 232, 233, 234],
                 "recorded m225 and missing m226 must order all later work behind them"
             );
 
@@ -1145,7 +1145,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 230, 231, 232, 233]
+                vec![225, 226, 230, 231, 232, 233, 234]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();
@@ -1184,7 +1184,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 227, 228, 229, 230, 231, 232, 233]
+                vec![225, 227, 228, 229, 230, 231, 232, 233, 234]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -7,7 +7,7 @@ cas doctor
 ──────────────────────────────────────────────────
 [OK] cas directory: Found at [TEMP_PATH]
 [OK] database: SQLite database found
-[OK] schema: v233 (up to date)
+[OK] schema: v234 (up to date)
 [OK] supervisor relay: no undelivered lifecycle relays
 [OK] delivery retries: no pending message has spent 3+ attempts
 [OK] tables: [N] tables, 718 columns, 196 rows total

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -10,7 +10,7 @@ cas doctor
 [OK] schema: v234 (up to date)
 [OK] supervisor relay: no undelivered lifecycle relays
 [OK] delivery retries: no pending message has spent 3+ attempts
-[OK] tables: [N] tables, 718 columns, 196 rows total
+[OK] tables: [N] tables, 730 columns, 197 rows total
 [OK] entry store: [N] entries accessible
 [WARN] search index: Index not found. Will be created on first search.
 [WARN] symbol index: nothing indexed for this project (0 symbol(s) in the store across all repositories); the code search index is missing. The daemon only indexes while idle — run `cas index code` to catch up now.

--- a/crates/cas-core/src/search/mod.rs
+++ b/crates/cas-core/src/search/mod.rs
@@ -72,7 +72,7 @@ use crate::error::CoreError;
 /// Returns (extracted_ids, remaining_query)
 /// Matches patterns like: cas-XXXX, cas-sk0a, rule-041, etc.
 pub fn extract_id_patterns(query: &str) -> (Vec<String>, String) {
-    let re = Regex::new(r"(?i)\b(cas-[a-z0-9]{2,8}|rule-[a-z0-9]{2,6}|skill-[a-z0-9]{2,6})\b")
+    let re = Regex::new(r"(?i)\b(cas-[a-z0-9]{2,16}|rule-[a-z0-9]{2,6}|skill-[a-z0-9]{2,6})\b")
         .unwrap_or_else(|_| Regex::new("$").expect("fallback regex"));
 
     let mut ids = Vec::new();

--- a/crates/cas-core/src/search/tests.rs
+++ b/crates/cas-core/src/search/tests.rs
@@ -119,6 +119,11 @@ fn test_extract_id_patterns() {
     assert_eq!(ids.len(), 2);
     assert!(ids.contains(&"cas-abcd".to_string()));
     assert!(ids.contains(&"cas-1234".to_string()));
+
+    // Cloud-reserved proposal task IDs use exactly 16 lowercase hex digits.
+    let (ids, remaining) = extract_id_patterns("open cas-0123456789abcdef now");
+    assert_eq!(ids, vec!["cas-0123456789abcdef"]);
+    assert_eq!(remaining, "open now");
 }
 
 #[test]

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -140,7 +140,7 @@ pub struct MemoryRequest {
 pub struct TaskRequest {
     /// Action to perform
     #[schemars(
-        description = "Action: 'create', 'show', 'update', 'start', 'close', 'cancel', 'reopen', 'delete', 'list', 'ready', 'blocked', 'notes', 'dep_add', 'dep_remove', 'dep_list', 'claim', 'release', 'transfer', 'available', 'mine'"
+        description = "Action: 'create', 'proposal_inbox', 'proposal_accept', 'proposal_reject', 'proposal_reconcile', 'show', 'update', 'start', 'close', 'cancel', 'reopen', 'delete', 'list', 'ready', 'blocked', 'notes', 'dep_add', 'dep_remove', 'dep_list', 'claim', 'release', 'transfer', 'available', 'mine'"
     )]
     pub action: String,
 
@@ -162,6 +162,25 @@ pub struct TaskRequest {
     #[schemars(description = "Task title for create")]
     #[serde(default)]
     pub title: Option<String>,
+
+    /// Explicit target canonical project ID for cross-project proposal actions.
+    #[schemars(
+        description = "Explicit canonical project ID. On create, presence selects the cross-project proposal path; never inferred from cwd."
+    )]
+    #[serde(default)]
+    pub project: Option<String>,
+
+    /// Cloud proposal ID for accept/reject.
+    #[schemars(description = "Cloud proposal ID for proposal_accept or proposal_reject")]
+    #[serde(default)]
+    pub proposal_id: Option<String>,
+
+    /// Optional local origin task blocked by the proposed target task.
+    #[schemars(
+        description = "For cross-project create: local origin task ID that remains blocked until the accepted target task closes"
+    )]
+    #[serde(default)]
+    pub blocks_origin_task_id: Option<String>,
 
     /// Description (for create)
     #[schemars(description = "Task description")]
@@ -457,7 +476,9 @@ pub struct TaskRequest {
     pub depth: Option<String>,
 
     /// Explicit acknowledgement of a planning-race or duplicate-task warning on create.
-    #[schemars(description = "For action=create, confirm creation after CAS reports a recent competing epic plan or a high-similarity open task.")]
+    #[schemars(
+        description = "For action=create, confirm creation after CAS reports a recent competing epic plan or a high-similarity open task."
+    )]
     #[serde(default, deserialize_with = "deser::option_bool")]
     pub confirm_warning: Option<bool>,
 

--- a/crates/cas-store/src/external_task_dependency_store.rs
+++ b/crates/cas-store/src/external_task_dependency_store.rs
@@ -240,6 +240,60 @@ mod tests {
         );
     }
 
+    /// Cloud contract: closing an accepted target task resolves the edge;
+    /// reopening it returns the edge to `unresolved` with a null `resolved_at`
+    /// (never contradictory fields), and a later close re-resolves with a fresh
+    /// timestamp. The local projection must track that round trip, including
+    /// clearing a previously stored `resolved_at`.
+    #[test]
+    fn reopened_target_returns_edge_to_unresolved_and_reclose_reresolves() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = ExternalTaskDependencyStore::open(temp.path()).unwrap();
+        let mut dependency = ExternalTaskDependencyProjection {
+            origin_task_id: "cas-origin".into(),
+            proposal_id: "proposal-1".into(),
+            target_project_canonical_id: "target".into(),
+            target_task_id: "cas-0123456789abcdef".into(),
+            proposal_state: "accepted".into(),
+            target_task_status: Some("closed".into()),
+            resolution_state: "resolved".into(),
+            resolved_at: Some("2026-08-13T12:00:00Z".into()),
+        };
+        store.upsert(&dependency).unwrap();
+        assert!(
+            store
+                .list_blocking_for_task("cas-origin")
+                .unwrap()
+                .is_empty(),
+            "resolved edge does not block"
+        );
+
+        // Target reopened: back to unresolved, resolved_at cleared.
+        dependency.target_task_status = Some("open".into());
+        dependency.resolution_state = "unresolved".into();
+        dependency.resolved_at = None;
+        store.upsert(&dependency).unwrap();
+        let blocking = store.list_blocking_for_task("cas-origin").unwrap();
+        assert_eq!(blocking, vec![dependency.clone()], "reopen re-blocks");
+        assert!(
+            blocking[0].resolved_at.is_none(),
+            "stale resolved_at must be cleared, not retained"
+        );
+
+        // Closed again: re-resolves with a fresh timestamp.
+        dependency.target_task_status = Some("closed".into());
+        dependency.resolution_state = "resolved".into();
+        dependency.resolved_at = Some("2026-08-13T18:30:00Z".into());
+        store.upsert(&dependency).unwrap();
+        assert!(
+            store
+                .list_blocking_for_task("cas-origin")
+                .unwrap()
+                .is_empty(),
+            "re-close resolves again"
+        );
+    }
+
     #[test]
     fn ready_and_blocked_queries_consider_external_projection() {
         let temp = tempfile::tempdir().unwrap();

--- a/crates/cas-store/src/external_task_dependency_store.rs
+++ b/crates/cas-store/src/external_task_dependency_store.rs
@@ -1,0 +1,273 @@
+//! Local projection of cloud-owned cross-project task dependencies.
+//!
+//! These rows are signals about foreign tasks, not replicas of those tasks.
+//! The cloud proposal/dependency row remains authoritative.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use chrono::Utc;
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::{Result, shared_db};
+
+pub const EXTERNAL_TASK_DEPENDENCY_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS external_task_dependencies (
+    origin_task_id TEXT NOT NULL,
+    proposal_id TEXT NOT NULL,
+    target_project_canonical_id TEXT NOT NULL DEFAULT '',
+    target_task_id TEXT NOT NULL,
+    proposal_state TEXT NOT NULL,
+    target_task_status TEXT,
+    resolution_state TEXT NOT NULL,
+    resolved_at TEXT,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (origin_task_id, proposal_id)
+);
+CREATE INDEX IF NOT EXISTS idx_external_task_dependencies_origin_state
+    ON external_task_dependencies(origin_task_id, resolution_state);
+CREATE TABLE IF NOT EXISTS external_task_dependency_sync_state (
+    origin_project_canonical_id TEXT PRIMARY KEY,
+    cursor TEXT,
+    updated_at TEXT NOT NULL
+);
+"#;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalTaskDependencyProjection {
+    pub origin_task_id: String,
+    pub proposal_id: String,
+    pub target_project_canonical_id: String,
+    pub target_task_id: String,
+    pub proposal_state: String,
+    pub target_task_status: Option<String>,
+    pub resolution_state: String,
+    pub resolved_at: Option<String>,
+}
+
+impl ExternalTaskDependencyProjection {
+    pub fn is_blocking(&self) -> bool {
+        self.resolution_state != "resolved"
+    }
+}
+
+pub struct ExternalTaskDependencyStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl ExternalTaskDependencyStore {
+    pub fn open(cas_dir: &Path) -> Result<Self> {
+        let conn = shared_db::shared_connection(&cas_dir.join("cas.db"))?;
+        let store = Self { conn };
+        store.init()?;
+        Ok(store)
+    }
+
+    pub fn init(&self) -> Result<()> {
+        self.conn
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .execute_batch(EXTERNAL_TASK_DEPENDENCY_SCHEMA)?;
+        Ok(())
+    }
+
+    pub fn upsert(&self, dependency: &ExternalTaskDependencyProjection) -> Result<()> {
+        self.conn
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .execute(
+                "INSERT INTO external_task_dependencies
+                 (origin_task_id, proposal_id, target_project_canonical_id, target_task_id,
+                  proposal_state, target_task_status, resolution_state, resolved_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                 ON CONFLICT(origin_task_id, proposal_id) DO UPDATE SET
+                   target_project_canonical_id = excluded.target_project_canonical_id,
+                   target_task_id = excluded.target_task_id,
+                   proposal_state = excluded.proposal_state,
+                   target_task_status = excluded.target_task_status,
+                   resolution_state = excluded.resolution_state,
+                   resolved_at = excluded.resolved_at,
+                   updated_at = excluded.updated_at",
+                params![
+                    dependency.origin_task_id,
+                    dependency.proposal_id,
+                    dependency.target_project_canonical_id,
+                    dependency.target_task_id,
+                    dependency.proposal_state,
+                    dependency.target_task_status,
+                    dependency.resolution_state,
+                    dependency.resolved_at,
+                    Utc::now().to_rfc3339(),
+                ],
+            )?;
+        Ok(())
+    }
+
+    pub fn list_blocking_for_task(
+        &self,
+        task_id: &str,
+    ) -> Result<Vec<ExternalTaskDependencyProjection>> {
+        let conn = self.conn.lock().unwrap_or_else(|error| error.into_inner());
+        let mut statement = conn.prepare(
+            "SELECT origin_task_id, proposal_id, target_project_canonical_id, target_task_id,
+                    proposal_state, target_task_status, resolution_state, resolved_at
+             FROM external_task_dependencies
+             WHERE origin_task_id = ?1 AND resolution_state != 'resolved'
+             ORDER BY proposal_id",
+        )?;
+        let rows = statement.query_map(params![task_id], |row| {
+            Ok(ExternalTaskDependencyProjection {
+                origin_task_id: row.get(0)?,
+                proposal_id: row.get(1)?,
+                target_project_canonical_id: row.get(2)?,
+                target_task_id: row.get(3)?,
+                proposal_state: row.get(4)?,
+                target_task_status: row.get(5)?,
+                resolution_state: row.get(6)?,
+                resolved_at: row.get(7)?,
+            })
+        })?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    pub fn remove(&self, origin_task_id: &str, target_task_id: &str) -> Result<bool> {
+        let deleted = self
+            .conn
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .execute(
+                "DELETE FROM external_task_dependencies
+                 WHERE origin_task_id = ?1 AND target_task_id = ?2",
+                params![origin_task_id, target_task_id],
+            )?;
+        Ok(deleted > 0)
+    }
+
+    pub fn cursor(&self, origin_project: &str) -> Result<Option<String>> {
+        Ok(self
+            .conn
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .query_row(
+                "SELECT cursor FROM external_task_dependency_sync_state
+                 WHERE origin_project_canonical_id = ?1",
+                params![origin_project],
+                |row| row.get(0),
+            )
+            .optional()?
+            .flatten())
+    }
+
+    pub fn set_cursor(&self, origin_project: &str, cursor: Option<&str>) -> Result<()> {
+        self.conn
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .execute(
+                "INSERT INTO external_task_dependency_sync_state
+                 (origin_project_canonical_id, cursor, updated_at) VALUES (?1, ?2, ?3)
+                 ON CONFLICT(origin_project_canonical_id) DO UPDATE SET
+                   cursor = excluded.cursor, updated_at = excluded.updated_at",
+                params![origin_project, cursor, Utc::now().to_rfc3339()],
+            )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SqliteTaskStore, TaskStore};
+
+    #[test]
+    fn rejected_handoff_remains_blocking_until_operator_removes_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = ExternalTaskDependencyStore::open(temp.path()).unwrap();
+        let mut dependency = ExternalTaskDependencyProjection {
+            origin_task_id: "cas-origin".into(),
+            proposal_id: "proposal-1".into(),
+            target_project_canonical_id: "target".into(),
+            target_task_id: "cas-0123456789abcdef".into(),
+            proposal_state: "proposed".into(),
+            target_task_status: None,
+            resolution_state: "unresolved".into(),
+            resolved_at: None,
+        };
+        store.upsert(&dependency).unwrap();
+        dependency.proposal_state = "rejected".into();
+        dependency.resolution_state = "handoff_rejected".into();
+        store.upsert(&dependency).unwrap();
+        assert_eq!(
+            store.list_blocking_for_task("cas-origin").unwrap(),
+            vec![dependency]
+        );
+        assert!(store.remove("cas-origin", "cas-0123456789abcdef").unwrap());
+        assert!(
+            store
+                .list_blocking_for_task("cas-origin")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn resolved_projection_stops_blocking_and_cursor_is_opaque() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = ExternalTaskDependencyStore::open(temp.path()).unwrap();
+        store
+            .upsert(&ExternalTaskDependencyProjection {
+                origin_task_id: "cas-origin".into(),
+                proposal_id: "proposal-1".into(),
+                target_project_canonical_id: "target".into(),
+                target_task_id: "cas-0123456789abcdef".into(),
+                proposal_state: "accepted".into(),
+                target_task_status: Some("closed".into()),
+                resolution_state: "resolved".into(),
+                resolved_at: Some("2026-08-13T12:00:00Z".into()),
+            })
+            .unwrap();
+        assert!(
+            store
+                .list_blocking_for_task("cas-origin")
+                .unwrap()
+                .is_empty()
+        );
+        store
+            .set_cursor("origin", Some("opaque:cursor/value"))
+            .unwrap();
+        assert_eq!(
+            store.cursor("origin").unwrap().as_deref(),
+            Some("opaque:cursor/value")
+        );
+    }
+
+    #[test]
+    fn ready_and_blocked_queries_consider_external_projection() {
+        let temp = tempfile::tempdir().unwrap();
+        let tasks = SqliteTaskStore::open(temp.path()).unwrap();
+        tasks.init().unwrap();
+        tasks
+            .add(&cas_types::Task::new(
+                "cas-origin".into(),
+                "Origin work".into(),
+            ))
+            .unwrap();
+        let external = ExternalTaskDependencyStore::open(temp.path()).unwrap();
+        external
+            .upsert(&ExternalTaskDependencyProjection {
+                origin_task_id: "cas-origin".into(),
+                proposal_id: "proposal-1".into(),
+                target_project_canonical_id: "target".into(),
+                target_task_id: "cas-0123456789abcdef".into(),
+                proposal_state: "accepted".into(),
+                target_task_status: Some("open".into()),
+                resolution_state: "unresolved".into(),
+                resolved_at: None,
+            })
+            .unwrap();
+        assert!(tasks.list_ready().unwrap().is_empty());
+        let blocked = tasks.list_blocked().unwrap();
+        assert_eq!(blocked.len(), 1);
+        assert_eq!(blocked[0].0.id, "cas-origin");
+        assert!(blocked[0].1.is_empty(), "foreign tasks are not replicas");
+    }
+}

--- a/crates/cas-store/src/lib.rs
+++ b/crates/cas-store/src/lib.rs
@@ -43,6 +43,7 @@ mod delivery_store;
 mod entity_store;
 pub mod error;
 mod event_store;
+mod external_task_dependency_store;
 mod file_change_store;
 mod fts_query;
 mod history_provenance;
@@ -104,6 +105,9 @@ pub use sqlite_code_store::{CODE_SCHEMA, SqliteCodeStore};
 
 // Entity store for knowledge graph feature
 pub use entity_store::{ENTITY_SCHEMA, SqliteEntityStore};
+pub use external_task_dependency_store::{
+    EXTERNAL_TASK_DEPENDENCY_SCHEMA, ExternalTaskDependencyProjection, ExternalTaskDependencyStore,
+};
 
 // Structural git-history index (EPIC cas-6212 / cas-7a21): commits, their
 // touched files, and the walker watermark.

--- a/crates/cas-store/src/task_store.rs
+++ b/crates/cas-store/src/task_store.rs
@@ -83,6 +83,26 @@ CREATE TABLE IF NOT EXISTS dependencies (
 CREATE INDEX IF NOT EXISTS idx_deps_from ON dependencies(from_id);
 CREATE INDEX IF NOT EXISTS idx_deps_to ON dependencies(to_id);
 CREATE INDEX IF NOT EXISTS idx_deps_type ON dependencies(dep_type);
+
+CREATE TABLE IF NOT EXISTS external_task_dependencies (
+    origin_task_id TEXT NOT NULL,
+    proposal_id TEXT NOT NULL,
+    target_project_canonical_id TEXT NOT NULL DEFAULT '',
+    target_task_id TEXT NOT NULL,
+    proposal_state TEXT NOT NULL,
+    target_task_status TEXT,
+    resolution_state TEXT NOT NULL,
+    resolved_at TEXT,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (origin_task_id, proposal_id)
+);
+CREATE INDEX IF NOT EXISTS idx_external_task_dependencies_origin_state
+    ON external_task_dependencies(origin_task_id, resolution_state);
+CREATE TABLE IF NOT EXISTS external_task_dependency_sync_state (
+    origin_project_canonical_id TEXT PRIMARY KEY,
+    cursor TEXT,
+    updated_at TEXT NOT NULL
+);
 "#;
 
 /// SQLite-based task store
@@ -837,6 +857,11 @@ impl TaskStore for SqliteTaskStore {
                  AND d.dep_type = 'blocks'
                  AND blocker.status NOT IN ('closed', 'cancelled')
              )
+             AND NOT EXISTS (
+                 SELECT 1 FROM external_task_dependencies external
+                 WHERE external.origin_task_id = t.id
+                 AND external.resolution_state != 'resolved'
+             )
              ORDER BY t.priority, t.created_at DESC",
         )?;
 
@@ -857,11 +882,20 @@ impl TaskStore for SqliteTaskStore {
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
              t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
              FROM tasks t
-             JOIN dependencies d ON d.from_id = t.id
-             JOIN tasks blocker ON d.to_id = blocker.id
              WHERE t.status NOT IN ('closed', 'cancelled')
-             AND d.dep_type = 'blocks'
-             AND blocker.status NOT IN ('closed', 'cancelled')
+             AND (
+                 EXISTS (
+                     SELECT 1 FROM dependencies d
+                     JOIN tasks blocker ON d.to_id = blocker.id
+                     WHERE d.from_id = t.id AND d.dep_type = 'blocks'
+                     AND blocker.status NOT IN ('closed', 'cancelled')
+                 )
+                 OR EXISTS (
+                     SELECT 1 FROM external_task_dependencies external
+                     WHERE external.origin_task_id = t.id
+                     AND external.resolution_state != 'resolved'
+                 )
+             )
              ORDER BY t.priority, t.created_at DESC",
         )?;
 

--- a/docs/requests/completed/FEATURE-cross-project-task-creation-for-supervisors.md
+++ b/docs/requests/completed/FEATURE-cross-project-task-creation-for-supervisors.md
@@ -5,13 +5,18 @@ date: 2026-08-07
 priority: P2
 ---
 
-> **Disposition (2026-08-11, cas-a0ba):** DESIGN COMPLETE — the authorization predicate,
-> proposal/triage flow, provenance schema, and cross-project dependency projection are decided in
+> **Disposition (2026-08-13, cas-e0c9):** IMPLEMENTED — the authorization predicate,
+> proposal/triage flow, provenance schema, and cross-project dependency projection are defined in
 > [`docs/specs/2026-08-11-cross-project-task-proposals.md`](../../specs/2026-08-11-cross-project-task-proposals.md).
-> The required cloud contract is filed as
+> The shipped CLI mechanism is `task action=create project=<target-canonical-id>` plus the dedicated
+> `proposal_inbox`, `proposal_accept`, `proposal_reject`, and `proposal_reconcile` actions. Pending
+> proposals never enter the local task table; optional origin blockers live in the
+> `external_task_dependencies` projection and unblock only after reconciliation reports the accepted
+> target task closed. The cloud contract is tracked at
 > [Richards-LLC/petra-stella-cloud#44](https://github.com/Richards-LLC/petra-stella-cloud/issues/44);
-> CLI implementation is intentionally split to a successor gated on that endpoint. Original CAS
-> issue: [#171](https://github.com/pippenz/cas/issues/171).
+> create/triage/dependency endpoints are live, while authoritative push-side preservation of the
+> materialized task's provenance copy remains a cloud hardening gate. Original CAS issue:
+> [#171](https://github.com/pippenz/cas/issues/171).
 
 # Feature Request: let supervisors create tasks in other projects, when appropriate and authorized
 

--- a/docs/requests/completed/FEATURE-cross-project-task-creation-for-supervisors.md
+++ b/docs/requests/completed/FEATURE-cross-project-task-creation-for-supervisors.md
@@ -14,8 +14,10 @@ priority: P2
 > `external_task_dependencies` projection and unblock only after reconciliation reports the accepted
 > target task closed. The cloud contract is tracked at
 > [Richards-LLC/petra-stella-cloud#44](https://github.com/Richards-LLC/petra-stella-cloud/issues/44);
-> create/triage/dependency endpoints are live, while authoritative push-side preservation of the
-> materialized task's provenance copy remains a cloud hardening gate. Original CAS issue:
+> the create/triage/dependency endpoints, authoritative push-side preservation of the materialized
+> task's provenance copy, and the final opt-in pagination shape are all live on production, so no
+> cloud gate remains open. Because `since=` feed reads deliberately replay a five-second safety
+> window, reconciliation de-duplicates repeated edges by `proposal_id`. Original CAS issue:
 > [#171](https://github.com/pippenz/cas/issues/171).
 
 # Feature Request: let supervisors create tasks in other projects, when appropriate and authorized

--- a/docs/specs/2026-08-11-cross-project-task-proposals.html
+++ b/docs/specs/2026-08-11-cross-project-task-proposals.html
@@ -68,7 +68,7 @@
     <div class="eyebrow">Design decision · 11 August 2026</div>
     <h1>Cross-project work should arrive as a proposal, not a foreign task replica.</h1>
     <p class="recommendation">Add a dedicated cloud proposal API and proposal store. Require an explicit target, gate the client to supervisors/directors, validate a shared-team grant in the cloud, stamp provenance there, and create an ordinary target task only after receiving-side acceptance.</p>
-    <div class="meta"><span>Status: design decided</span><span>Implementation: cloud-first successor</span><span>Audience: CAS CLI + Cloud maintainers</span><span>Source: cas-a0ba / cas#171</span><span>Cloud: <a href="https://github.com/Richards-LLC/petra-stella-cloud/issues/44">petra-stella-cloud#44</a></span></div>
+    <div class="meta"><span>Status: cloud + CLI implemented</span><span>Remaining gate: cloud push-side provenance preservation confirmation</span><span>Audience: CAS CLI + Cloud maintainers</span><span>Source: cas-a0ba / cas#171</span><span>Cloud: <a href="https://github.com/Richards-LLC/petra-stella-cloud/issues/44">petra-stella-cloud#44</a></span></div>
   </header>
 
   <main id="content">
@@ -209,7 +209,7 @@ GET  /api/teams/{team_id}/cross-project-task-dependencies?origin_project_id=...&
 
     <section aria-labelledby="boundary">
       <h2 id="boundary">Current versus planned boundary</h2>
-      <div class="boundary"><p><strong>Current:</strong> team membership validation, explicit project-scoped pulls, normal task sync, and task mutations. <strong>Planned:</strong> proposal/dependency tables and endpoints, CLI <code>project</code> parameter, triage actions, provenance rendering, and external dependency reconciliation. Cloud ships first.</p></div>
+      <div class="boundary"><p><strong>Implemented:</strong> <code>create project=&lt;target-canonical-id&gt;</code> selects the proposal path; <code>proposal_inbox</code>, <code>proposal_accept</code>, and <code>proposal_reject</code> keep triage separate; <code>proposal_reconcile project=&lt;current-canonical-id&gt;</code> projects dependency signals without foreign task replicas. The origin is accepted only from an explicit <code>.cas/config.toml</code> canonical ID, and registered supervisor/director authorization runs before cloud configuration or network setup. Project task listing names its current database boundary; all documents current-project equivalence; global is rejected.</p></div>
     </section>
 
     <section aria-labelledby="tests">

--- a/docs/specs/2026-08-11-cross-project-task-proposals.md
+++ b/docs/specs/2026-08-11-cross-project-task-proposals.md
@@ -2,7 +2,7 @@
 
 **Recommendation:** add a dedicated cloud proposal API and proposal store; do not route cross-project creation through generic task sync. The CLI must require an explicit `project=<canonical_id>`, gate the call to a registered supervisor/director, and let the cloud validate the shared-team grant, stamp authenticated provenance, hold the item in `proposed`, and materialize a normal `open` task only after a receiving supervisor accepts it.
 
-Status: design decided; implementation split at the cloud contract boundary
+Status: cloud contract and CLI client implemented; cloud push-side provenance preservation awaiting live confirmation
 
 Date: 2026-08-11
 
@@ -162,6 +162,15 @@ The local `tasks` table has no row-level `project_id`; its project boundary is t
 It must not pretend to row-filter on a column that does not exist.
 
 ## Current versus planned boundary
+
+The CLI half now exposes the selected design through the unified `task` MCP tool:
+
+- `create project=<target-canonical-id>` selects the proposal path; omitting `project` preserves local create.
+- `proposal_inbox`, `proposal_accept`, and `proposal_reject` keep receiving triage separate from ordinary task lists.
+- `proposal_reconcile project=<current-canonical-id>` projects cloud dependency signals locally; rejected handoffs remain blockers until an operator removes or replaces them.
+- `list scope=project` names the current canonical project database, `scope=all` documents its current-project equivalence, and `scope=global` is rejected.
+
+The origin canonical ID must be explicitly pinned in `.cas/config.toml`; the proposal path does not use the folder/git/cwd fallback chain. The registered supervisor/director check runs before cloud configuration is loaded or a network client is constructed.
 
 Current code already provides team membership validation, explicit project-scoped pulls, normal task sync, and receiving-side task mutations. The proposal API, proposal/dependency tables, CLI `project` parameter, triage actions, and external-dependency reconciliation are planned and must ship in the cloud-first order.
 


### PR DESCRIPTION
Adds explicit cross-project proposal create/triage, server-attested provenance rendering, external dependency reconciliation, truthful project scope, 16-hex task IDs, and the finalized opaque pagination/replay/reopen contract.\n\nValidation: factory scoped CI is green at c6148498 (run 31724698069).\n\nCloses #171.