### PR TITLE
fix: bind spawned workers to their own worktrees

### DIFF
--- a/cas-cli/src/factory_isolation.rs
+++ b/cas-cli/src/factory_isolation.rs
@@ -1,0 +1,476 @@
+//! Canonical worktree binding for factory workers (cas-30c6).
+//!
+//! A spawned worker owns exactly one branch — `factory/<its own name>` — and
+//! exactly one directory, the worktree checked out on that branch. Every
+//! surface that answers "which repository am I bound to?" must resolve that
+//! same canonical binding from the worker's *registered identity*, never from
+//! whatever directory the ambient process happens to be sitting in:
+//!
+//! - provisioning ([`crate::ui::factory::app::WorkerSpawnPrep::run`]) proves
+//!   the binding before any harness process is started, and fails the spawn
+//!   closed otherwise;
+//! - the PreToolUse commit guard denies writes made from another worker's
+//!   branch;
+//! - `coordination my_context` reports the binding it actually resolved, so a
+//!   misbinding is visible instead of silent.
+//!
+//! Two incidents motivated this module. In the first, a worker's harness stayed
+//! bound to the dirty shared checkout because a stale plain directory sat where
+//! its worktree belonged: git climbs out of a non-worktree directory into the
+//! enclosing checkout, so a branch-only comparison matched. In the second, a
+//! respawned worker was bound to a *sibling* worker's worktree, which every
+//! existing check accepted because `factory/*` is a permitted branch prefix.
+
+use std::path::Path;
+
+/// The one branch a factory worker of this name owns.
+///
+/// Mirrors `WorktreeManager::branch_name_for_worker`, which is what
+/// provisioning actually creates.
+pub fn expected_worker_branch(worker_name: &str) -> String {
+    format!("factory/{}", worker_name.trim())
+}
+
+/// The worker named by a `factory/<name>` branch, if it is one.
+pub fn factory_branch_owner(branch: &str) -> Option<&str> {
+    branch
+        .trim()
+        .strip_prefix("factory/")
+        .filter(|owner| !owner.is_empty())
+}
+
+/// Where an agent's ambient git state sits relative to the branch its
+/// registered identity owns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkerBinding {
+    /// HEAD is the worker's own `factory/<name>` branch — correctly bound.
+    Own,
+    /// HEAD is another worker's factory branch.
+    Sibling { owner: String },
+    /// HEAD is a shared trunk branch, or unresolvable (detached / not a repo).
+    /// The shared checkout is where every agent's `main` lives, so this is
+    /// never a worker's own workspace.
+    SharedTrunk,
+    /// Some other named branch (`feature/*`, `epic/*`, ...). Legitimate for
+    /// workers spawned without isolation; not evidence of misbinding.
+    Other,
+}
+
+/// Classify `branch` against the branch `worker_name` owns.
+///
+/// `branch` is the resolved HEAD at the directory the worker is bound to;
+/// `None` means git could not name a branch there (detached HEAD, missing
+/// directory, or not a repository).
+pub fn classify_worker_binding(worker_name: &str, branch: Option<&str>) -> WorkerBinding {
+    let worker_name = worker_name.trim();
+    let branch = branch.map(str::trim).unwrap_or("");
+    if branch.is_empty() {
+        return WorkerBinding::SharedTrunk;
+    }
+    match factory_branch_owner(branch) {
+        Some(owner) if owner == worker_name => WorkerBinding::Own,
+        Some(owner) => WorkerBinding::Sibling {
+            owner: owner.to_string(),
+        },
+        None if matches!(branch, "main" | "master" | "staging") => WorkerBinding::SharedTrunk,
+        None => WorkerBinding::Other,
+    }
+}
+
+/// Resolve HEAD at `path` as a branch name.
+///
+/// Returns `None` for a detached HEAD, a missing directory, or a path that is
+/// not inside a git repository. Note that for a plain directory *inside* a
+/// repository git answers with the enclosing checkout's HEAD — which is
+/// exactly the misbinding [`worktree_root_at`] exists to catch.
+pub fn branch_at(path: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!branch.is_empty()).then_some(branch)
+}
+
+/// The working-tree root that git resolves for `path`.
+///
+/// For a real worktree this is the worktree itself. For a stale plain
+/// directory it is the *enclosing* checkout — the signal that the directory is
+/// not a workspace of its own.
+pub fn worktree_root_at(path: &Path) -> Option<std::path::PathBuf> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!root.is_empty()).then(|| std::path::PathBuf::from(root))
+}
+
+/// Compare two paths after resolving symlinks, falling back to a literal
+/// comparison when a path cannot be canonicalized.
+fn same_path(left: &Path, right: &Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
+/// Fail-closed proof that `path` is the worktree `worker_name` owns.
+///
+/// Verifies both halves of the binding, because either alone is forgeable:
+/// the working-tree root must *be* `path` (a stale plain directory resolves to
+/// the enclosing shared checkout instead), and HEAD there must be the worker's
+/// own `factory/<name>` branch (a real worktree can still belong to a sibling).
+///
+/// `expected_branch` is the branch provisioning intends to bind, defaulting to
+/// [`expected_worker_branch`] when the caller has none to hand.
+///
+/// Callers must treat an error as a spawn failure: a worker that cannot be
+/// proven to own its directory must never be handed to a harness.
+pub fn verify_worker_worktree_binding(
+    worker_name: &str,
+    path: &Path,
+    expected_branch: Option<&str>,
+) -> anyhow::Result<()> {
+    let expected_branch = expected_branch
+        .map(str::to_string)
+        .unwrap_or_else(|| expected_worker_branch(worker_name));
+
+    let Some(root) = worktree_root_at(path) else {
+        anyhow::bail!(
+            "Worker '{worker_name}': {} is not inside a git repository, so it cannot be that \
+             worker's worktree on '{expected_branch}'. Remove the path and retry the spawn.",
+            path.display(),
+        );
+    };
+    if !same_path(&root, path) {
+        anyhow::bail!(
+            "ISOLATION BUG: worker '{worker_name}' would be bound to {}, which is not a git \
+             worktree root — git resolves it to the shared checkout at {}. Every commit made \
+             there would land in that shared checkout, not on '{expected_branch}'. Remove {} and \
+             retry the spawn.",
+            path.display(),
+            root.display(),
+            path.display(),
+        );
+    }
+
+    let branch = branch_at(path);
+    if branch.as_deref().map(str::trim) == Some(expected_branch.as_str()) {
+        return Ok(());
+    }
+    match classify_worker_binding(worker_name, branch.as_deref()) {
+        // Reachable only when the caller's expected branch disagrees with the
+        // worker's canonical one; refuse rather than pick a winner.
+        WorkerBinding::Own => anyhow::bail!(
+            "ISOLATION BUG: worker '{worker_name}' would be bound to {}, checked out on '{}', but \
+             provisioning intended '{expected_branch}'.",
+            path.display(),
+            branch.as_deref().unwrap_or("<unknown>"),
+        ),
+        WorkerBinding::Sibling { owner } => anyhow::bail!(
+            "ISOLATION BUG: worker '{worker_name}' would be bound to {}, which is checked out on \
+             '{}' — that worktree belongs to worker '{owner}', not to '{worker_name}'. \
+             '{worker_name}' owns '{expected_branch}'.",
+            path.display(),
+            branch.as_deref().unwrap_or("<unknown>"),
+        ),
+        WorkerBinding::SharedTrunk | WorkerBinding::Other => anyhow::bail!(
+            "ISOLATION BUG: worker '{worker_name}' would be bound to {}, which is checked out on \
+             '{}' instead of its own '{expected_branch}'.",
+            path.display(),
+            branch.as_deref().unwrap_or("<detached HEAD>"),
+        ),
+    }
+}
+
+/// The refusal shown when a worker acts from a sibling worker's branch.
+///
+/// Shared by the PreToolUse commit guard and `my_context` so both name the
+/// same canonical binding.
+pub fn sibling_misbinding_message(worker_name: &str, owner: &str, cwd: &str) -> String {
+    let expected_branch = expected_worker_branch(worker_name);
+    format!(
+        "🚫 WORKER ISOLATION MISBINDING: you are '{worker_name}', but {cwd} is checked out on \
+         'factory/{owner}' — that is worker '{owner}''s worktree.\n\n\
+         Committing here would put your work on another worker's branch, where its owner and the \
+         supervisor's merge sequence will not expect it.\n\n\
+         You own '{expected_branch}'. Move to your own worktree before committing:\n  \
+         cd \"$CAS_CLONE_PATH\"   # your assigned worktree\n  \
+         git rev-parse --abbrev-ref HEAD   # must print {expected_branch}\n\n\
+         If your assigned worktree is not on {expected_branch}, stop and report the misbinding to \
+         your supervisor — do not commit from another worker's tree.\n\n\
+         Note: --no-verify does NOT bypass this guard (it only skips git hooks, not the Claude \
+         Code PreToolUse harness)."
+    )
+}
+
+/// Render the worktree-binding section of `coordination my_context`.
+///
+/// `clone_path` is the directory the harness was launched in
+/// (`CAS_CLONE_PATH`); `branch` is HEAD resolved *at that directory* rather
+/// than wherever the MCP server process happens to be running. A worker whose
+/// binding does not match its registered identity gets an explicit misbinding
+/// block instead of a branch line that looks fine.
+pub fn render_worker_binding(
+    worker_name: &str,
+    is_worker: bool,
+    clone_path: Option<&str>,
+    branch: Option<&str>,
+) -> String {
+    let mut output = String::new();
+    if let Some(path) = clone_path {
+        output.push_str(&format!("**Clone Path**: {path}\n"));
+    }
+    if let Some(branch) = branch {
+        output.push_str(&format!("**Git Branch**: {branch}\n"));
+    } else {
+        output.push_str("**Git Branch**: (unresolved — detached HEAD or not a git repository)\n");
+    }
+    if !is_worker {
+        return output;
+    }
+
+    let expected_branch = expected_worker_branch(worker_name);
+    let location = clone_path.unwrap_or("this session's working directory");
+    match classify_worker_binding(worker_name, branch) {
+        WorkerBinding::Own => {
+            output.push_str(&format!(
+                "**Worktree Binding**: OK — own branch {expected_branch}\n"
+            ));
+        }
+        WorkerBinding::Sibling { owner } => {
+            output.push_str(&format!(
+                "\n🚫 **ISOLATION MISBINDING**: {location} is checked out on 'factory/{owner}', \
+                 which belongs to worker '{owner}', not to you ('{worker_name}'). You own \
+                 '{expected_branch}'. Do not commit from here — report this to your supervisor \
+                 and have your worker respawned onto its own worktree.\n"
+            ));
+        }
+        WorkerBinding::SharedTrunk => {
+            output.push_str(&format!(
+                "\n🚫 **ISOLATION MISBINDING**: {location} resolves to a shared trunk checkout \
+                 ({}), not to your own worktree on '{expected_branch}'. Work done here lands in \
+                 the checkout every other agent shares. Report this to your supervisor and have \
+                 your worker respawned onto its own worktree.\n",
+                branch.unwrap_or("detached HEAD"),
+            ));
+        }
+        WorkerBinding::Other => {
+            output.push_str(&format!(
+                "**Worktree Binding**: not isolated — on '{}' rather than '{expected_branch}'\n",
+                branch.unwrap_or("<unknown>"),
+            ));
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn init_repo(dir: &Path) {
+        for args in [
+            vec!["init", "-b", "main"],
+            vec!["config", "user.email", "test@cas.test"],
+            vec!["config", "user.name", "CAS Test"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(dir)
+                .output()
+                .expect("git setup");
+        }
+        std::fs::write(dir.join("README.md"), "# test").unwrap();
+        for args in [vec!["add", "."], vec!["commit", "-m", "init"]] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(dir)
+                .output()
+                .expect("git commit");
+        }
+    }
+
+    #[test]
+    fn own_factory_branch_is_the_only_correct_binding() {
+        assert_eq!(
+            classify_worker_binding("fair-pelican-51", Some("factory/fair-pelican-51")),
+            WorkerBinding::Own
+        );
+        assert_eq!(
+            classify_worker_binding("fair-pelican-51", Some("factory/bright-dolphin-92")),
+            WorkerBinding::Sibling {
+                owner: "bright-dolphin-92".to_string()
+            }
+        );
+        for trunk in ["main", "master", "staging"] {
+            assert_eq!(
+                classify_worker_binding("fair-pelican-51", Some(trunk)),
+                WorkerBinding::SharedTrunk,
+                "{trunk} is a shared checkout, never a worker's own workspace"
+            );
+        }
+        // Detached / unresolvable HEAD is treated as shared, not as "fine".
+        assert_eq!(
+            classify_worker_binding("fair-pelican-51", None),
+            WorkerBinding::SharedTrunk
+        );
+        // Non-trunk named branches remain legitimate for non-isolated workers.
+        assert_eq!(
+            classify_worker_binding("fair-pelican-51", Some("epic/cas-1276")),
+            WorkerBinding::Other
+        );
+    }
+
+    #[test]
+    fn factory_branch_owner_ignores_non_factory_refs() {
+        assert_eq!(
+            factory_branch_owner("factory/zen-bear-56"),
+            Some("zen-bear-56")
+        );
+        assert_eq!(
+            factory_branch_owner("  factory/zen-bear-56 "),
+            Some("zen-bear-56")
+        );
+        assert_eq!(factory_branch_owner("factory/"), None);
+        assert_eq!(factory_branch_owner("epic/cas-1276"), None);
+        assert_eq!(factory_branch_owner("main"), None);
+    }
+
+    /// The stale-directory shape: git answers the enclosing checkout's HEAD,
+    /// so only the working-tree root distinguishes it from a real worktree.
+    #[test]
+    fn stale_directory_inside_the_shared_checkout_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        init_repo(&repo);
+        Command::new("git")
+            .args(["switch", "-c", "factory/zen-bear-56"])
+            .current_dir(&repo)
+            .output()
+            .expect("park shared HEAD on the worker's branch");
+
+        let stale = repo.join(".cas").join("worktrees").join("zen-bear-56");
+        std::fs::create_dir_all(&stale).unwrap();
+
+        // The branch alone looks correct — that is the trap.
+        assert_eq!(
+            branch_at(&stale).as_deref(),
+            Some("factory/zen-bear-56"),
+            "git climbs out of a plain directory into the enclosing checkout"
+        );
+        let error = verify_worker_worktree_binding("zen-bear-56", &stale, None)
+            .expect_err("a plain directory is not a worktree")
+            .to_string();
+        assert!(error.contains("not a git worktree root"), "{error}");
+        assert!(error.contains(&repo.display().to_string()), "{error}");
+    }
+
+    #[test]
+    fn sibling_worktree_is_rejected_and_names_its_owner() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        init_repo(&repo);
+
+        let sibling = tmp.path().join("bright-dolphin-92");
+        Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "factory/bright-dolphin-92",
+                sibling.to_str().unwrap(),
+                "main",
+            ])
+            .current_dir(&repo)
+            .output()
+            .expect("git worktree add");
+
+        let error = verify_worker_worktree_binding("fair-pelican-51", &sibling, None)
+            .expect_err("a sibling's worktree is not this worker's binding")
+            .to_string();
+        assert!(error.contains("bright-dolphin-92"), "{error}");
+        assert!(error.contains("fair-pelican-51"), "{error}");
+    }
+
+    #[test]
+    fn own_worktree_verifies() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        init_repo(&repo);
+
+        let own = tmp.path().join("own-worker");
+        Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "factory/own-worker",
+                own.to_str().unwrap(),
+                "main",
+            ])
+            .current_dir(&repo)
+            .output()
+            .expect("git worktree add");
+
+        verify_worker_worktree_binding("own-worker", &own, Some("factory/own-worker"))
+            .expect("own worktree must verify");
+    }
+
+    #[test]
+    fn my_context_reports_a_sibling_binding_as_a_misbinding() {
+        let rendered = render_worker_binding(
+            "fair-pelican-51",
+            true,
+            Some("/repo/.cas/worktrees/bright-dolphin-92"),
+            Some("factory/bright-dolphin-92"),
+        );
+        assert!(rendered.contains("ISOLATION MISBINDING"), "{rendered}");
+        assert!(rendered.contains("bright-dolphin-92"), "{rendered}");
+        assert!(rendered.contains("factory/fair-pelican-51"), "{rendered}");
+    }
+
+    #[test]
+    fn my_context_reports_a_shared_trunk_binding_as_a_misbinding() {
+        let rendered = render_worker_binding("zen-bear-56", true, Some("/repo"), Some("main"));
+        assert!(rendered.contains("ISOLATION MISBINDING"), "{rendered}");
+        assert!(rendered.contains("shared trunk"), "{rendered}");
+        assert!(rendered.contains("factory/zen-bear-56"), "{rendered}");
+    }
+
+    #[test]
+    fn my_context_confirms_a_correct_binding_without_alarm() {
+        let rendered = render_worker_binding(
+            "own-worker",
+            true,
+            Some("/repo/.cas/worktrees/own-worker"),
+            Some("factory/own-worker"),
+        );
+        assert!(rendered.contains("**Worktree Binding**: OK"), "{rendered}");
+        assert!(!rendered.contains("MISBINDING"), "{rendered}");
+    }
+
+    /// Supervisors legitimately sit on trunk in the shared checkout; the
+    /// worker-identity check must not fire for them.
+    #[test]
+    fn non_workers_get_the_plain_branch_line() {
+        let rendered = render_worker_binding("wise-viper-85", false, Some("/repo"), Some("main"));
+        assert!(rendered.contains("**Git Branch**: main"), "{rendered}");
+        assert!(!rendered.contains("MISBINDING"), "{rendered}");
+    }
+}

--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -2018,6 +2018,68 @@ mod worker_commit_guard_tests {
 
     // ── check_worker_git_commit_scope tests ──────────────────────────────
 
+    // ── cas-30c6 regression: sibling-worktree misbinding ─────────────────
+
+    /// Respawn 1034 class: the harness was bound to a SIBLING worker's
+    /// factory worktree. `factory/*` is allowlisted by the cas-7e7b denylist
+    /// and the cwd is inside CAS_CLONE_PATH, so both existing checks passed
+    /// and the worker was free to commit onto another worker's branch.
+    ///
+    /// The guard must compare the branch against the worker's own registered
+    /// identity, not just against the protected-trunk denylist.
+    #[test]
+    fn sibling_factory_branch_commit_is_denied() {
+        let tmp = make_git_repo();
+        let p = tmp.path().to_string_lossy().to_string();
+        std::process::Command::new("git")
+            .args(["switch", "-c", "factory/bright-dolphin-92"])
+            .current_dir(tmp.path())
+            .output()
+            .expect("switch to the sibling's branch");
+
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_CLONE_PATH", Some(&p)),
+            ("CAS_AGENT_NAME", Some("fair-pelican-51")),
+        ]);
+
+        let msg = check_worker_git_commit_scope(&p)
+            .expect("a worker bound to a sibling's factory branch must be denied");
+        assert!(
+            msg.contains("bright-dolphin-92"),
+            "the refusal must name the sibling that owns the branch: {msg}"
+        );
+        assert!(
+            msg.contains("fair-pelican-51"),
+            "the refusal must name the worker's own identity: {msg}"
+        );
+        assert!(
+            msg.contains("factory/fair-pelican-51"),
+            "the refusal must name the branch this worker actually owns: {msg}"
+        );
+    }
+
+    /// A worker on its OWN factory branch is untouched by the sibling check.
+    #[test]
+    fn own_factory_branch_commit_is_still_allowed() {
+        let tmp = make_git_repo();
+        let p = tmp.path().to_string_lossy().to_string();
+        std::process::Command::new("git")
+            .args(["switch", "-c", "factory/fair-pelican-51"])
+            .current_dir(tmp.path())
+            .output()
+            .expect("switch to the worker's own branch");
+
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_CLONE_PATH", Some(&p)),
+            ("CAS_AGENT_NAME", Some("fair-pelican-51")),
+        ]);
+
+        assert!(
+            check_worker_git_commit_scope(&p).is_none(),
+            "a worker committing on its own factory branch must still be allowed"
+        );
+    }
+
     // ── cas-ba04 regression: non-isolated worker protection ──────────────
 
     #[test]

--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -1149,6 +1149,38 @@ pub(crate) fn check_worker_git_commit_scope(cwd: &str) -> Option<String> {
     // without CAS_CLONE_PATH running in the shared checkout must not commit to main.
     let worker_name =
         std::env::var("CAS_AGENT_NAME").unwrap_or_else(|_| "<worker-name>".to_string());
+
+    // DENY: the branch here belongs to a DIFFERENT worker (cas-30c6).
+    //
+    // The denylist above only protects the trunk, and `factory/*` is an
+    // allowed prefix (cas-7e7b), so a worker whose harness was bound to a
+    // sibling's worktree passed every check and could commit onto that
+    // sibling's branch — respawn 1034. Resolve the canonical binding from the
+    // worker's own registered identity instead; `my_context` reports the same
+    // classification from the same module, so the two never disagree.
+    //
+    // Only fires when the worker's identity is actually known: without
+    // CAS_AGENT_NAME there is no canonical branch to compare against, and
+    // guessing would deny every legitimate `factory/*` commit.
+    if let Some(registered_name) = std::env::var("CAS_AGENT_NAME")
+        .ok()
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+    {
+        if let crate::factory_isolation::WorkerBinding::Sibling { owner } =
+            crate::factory_isolation::classify_worker_binding(
+                &registered_name,
+                get_branch_at_cwd(cwd).as_deref(),
+            )
+        {
+            return Some(crate::factory_isolation::sibling_misbinding_message(
+                &registered_name,
+                &owner,
+                cwd,
+            ));
+        }
+    }
+
     match get_branch_at_cwd(cwd) {
         None => {
             return Some(format!(
@@ -2058,6 +2090,30 @@ mod worker_commit_guard_tests {
         );
     }
 
+    /// Without a registered identity there is no canonical branch to compare
+    /// against, so the sibling check must stand down rather than guess and
+    /// deny every `factory/*` commit.
+    #[test]
+    fn unknown_identity_does_not_trigger_the_sibling_check() {
+        let tmp = make_git_repo();
+        let p = tmp.path().to_string_lossy().to_string();
+        std::process::Command::new("git")
+            .args(["switch", "-c", "factory/some-other-worker"])
+            .current_dir(tmp.path())
+            .output()
+            .expect("switch branch");
+
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_CLONE_PATH", Some(&p)),
+            ("CAS_AGENT_NAME", None),
+        ]);
+
+        assert!(
+            check_worker_git_commit_scope(&p).is_none(),
+            "an unidentified worker must not be denied by the identity comparison"
+        );
+    }
+
     /// A worker on its OWN factory branch is untouched by the sibling check.
     #[test]
     fn own_factory_branch_commit_is_still_allowed() {
@@ -2189,7 +2245,12 @@ mod worker_commit_guard_tests {
             .output()
             .unwrap();
         let ps = p.to_string_lossy().to_string();
-        let _env = TestEnvGuard::with_optional_vars(&[("CAS_CLONE_PATH", None)]);
+        // cas-30c6: the branch must belong to THIS worker. Pinning the identity
+        // also makes the case hermetic against an inherited CAS_AGENT_NAME.
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_CLONE_PATH", None),
+            ("CAS_AGENT_NAME", Some("test-worker")),
+        ]);
 
         let result = check_worker_git_commit_scope(&ps);
         assert!(
@@ -2319,7 +2380,11 @@ mod worker_commit_guard_tests {
             .unwrap();
 
         let ps = p.to_string_lossy().to_string();
-        let _env = TestEnvGuard::with_optional_vars(&[("CAS_CLONE_PATH", Some(&ps))]);
+        // cas-30c6: factory/worker1 is allowed because this IS worker1.
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_CLONE_PATH", Some(&ps)),
+            ("CAS_AGENT_NAME", Some("worker1")),
+        ]);
 
         let result = check_worker_git_commit_scope(&ps);
         assert!(
@@ -2447,10 +2512,14 @@ mod worker_commit_guard_tests {
             .unwrap();
 
         let ps = p.to_string_lossy().to_string();
+        // cas-30c6: factory/guards is this worker's own branch — name it so the
+        // canonical binding check has an identity to compare against instead of
+        // whatever CAS_AGENT_NAME the test process inherited.
         let _env = TestEnvGuard::with_optional_vars(&[
             ("CAS_AGENT_ROLE", Some("worker")),
             ("CAS_FACTORY_MODE", Some("1")),
             ("CAS_CLONE_PATH", Some(&ps)),
+            ("CAS_AGENT_NAME", Some("guards")),
         ]);
 
         let mut input = crate::hooks::handlers::HookInput::default();

--- a/cas-cli/src/lib.rs
+++ b/cas-cli/src/lib.rs
@@ -37,6 +37,7 @@ pub mod duplicate_check;
 pub mod error;
 pub mod extraction;
 pub mod factory_context_reset;
+pub mod factory_isolation;
 pub mod factory_preflight;
 pub mod factory_target_cache;
 pub mod fs_space;

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -3156,12 +3156,31 @@ impl CasService {
         output.push_str(&format!("**Role**: {role_str}\n"));
         output.push_str(&format!("**ID**: {}\n\n", agent.id));
 
-        // Clone path (from environment)
-        if let Ok(cwd) = std::env::var("CAS_CLONE_PATH") {
-            output.push_str(&format!("**Clone Path**: {cwd}\n"));
-        } else if let Ok(cwd) = std::env::current_dir() {
-            output.push_str(&format!("**Working Directory**: {}\n", cwd.display()));
-        }
+        // Worktree binding (cas-30c6).
+        //
+        // The branch must be resolved AT the directory this session is bound to
+        // — previously it came from wherever the MCP server process happened to
+        // be running, so my_context and the PreToolUse commit guard could report
+        // different repositories. Both now classify the same canonical binding
+        // through `factory_isolation`, and a worker bound to a sibling's
+        // worktree or to the shared checkout is told so explicitly instead of
+        // being shown a branch line that looks fine.
+        let bound_path = std::env::var("CAS_CLONE_PATH")
+            .ok()
+            .map(std::path::PathBuf::from)
+            .or_else(|| std::env::current_dir().ok());
+        let branch = bound_path
+            .as_deref()
+            .and_then(crate::factory_isolation::branch_at);
+        output.push_str(&crate::factory_isolation::render_worker_binding(
+            &agent.name,
+            agent.role == AgentRole::Worker,
+            bound_path
+                .as_deref()
+                .map(|path| path.display().to_string())
+                .as_deref(),
+            branch.as_deref(),
+        ));
 
         // Current task(s)
         let leases = agent_store.list_agent_leases(&agent_id).unwrap_or_default();
@@ -3181,19 +3200,6 @@ impl CasService {
                 for lease in &leases {
                     output.push_str(&format!("  - {}\n", lease.task_id));
                 }
-            }
-        }
-
-        // Git branch info
-        if let Ok(branch_output) = std::process::Command::new("git")
-            .args(["rev-parse", "--abbrev-ref", "HEAD"])
-            .output()
-        {
-            if branch_output.status.success() {
-                let branch = String::from_utf8_lossy(&branch_output.stdout)
-                    .trim()
-                    .to_string();
-                output.push_str(&format!("\n**Git Branch**: {branch}\n"));
             }
         }
 

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -5065,6 +5065,174 @@ mod spawn_isolation_tests {
     }
 
     // -----------------------------------------------------------------
+    // cas-30c6: provisioning must bind the worker's OWN worktree, or fail
+    // closed before any harness is started.
+    // -----------------------------------------------------------------
+
+    /// Spawn request 1031 class: the worker's harness stayed bound to the
+    /// dirty SHARED checkout even though a factory worktree existed.
+    ///
+    /// The reuse validation compares branches by running git *inside* the
+    /// worktree path. A stale plain directory is not a worktree, so git
+    /// climbs out of it into the enclosing checkout — and when that shared
+    /// checkout is itself parked on `factory/<name>` (the GH #120 /
+    /// cas-5bef shape), the branch comparison *matches* and provisioning
+    /// hands back a cwd whose every git operation resolves to shared main.
+    ///
+    /// Only the worktree toplevel can distinguish the two, so provisioning
+    /// must prove the path is its own worktree root and fail closed
+    /// otherwise.
+    #[test]
+    fn stale_directory_resolving_to_shared_checkout_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        init_repo(&repo);
+
+        // The shared checkout was left parked on the worker's own branch.
+        Command::new("git")
+            .args(["switch", "-c", "factory/reuse-worker"])
+            .current_dir(&repo)
+            .output()
+            .expect("park shared HEAD on the worker branch");
+
+        // A stale plain directory sits where the worktree belongs.
+        let cas_dir = repo.join(".cas");
+        let worktree_path = cas_dir.join("worktrees").join("reuse-worker");
+        std::fs::create_dir_all(&worktree_path).unwrap();
+
+        let prep = WorkerSpawnPrep {
+            worker_name: "reuse-worker".to_string(),
+            worktree_info: Some(WorktreePrep {
+                worktree_path: worktree_path.clone(),
+                branch_name: "factory/reuse-worker".to_string(),
+                parent_branch: "main".to_string(),
+                base_ref: None,
+                repo_root: repo.clone(),
+                cas_dir,
+            }),
+            warnings: Vec::new(),
+            base_provenance: None,
+        };
+
+        let error = match prep.run() {
+            Ok(result) => panic!(
+                "a directory that is not the worker's own worktree must fail the spawn, \
+                 but provisioning returned cwd {:?}",
+                result.cwd
+            ),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("reuse-worker"),
+            "the refusal must name the worker whose spawn failed: {error}"
+        );
+        assert!(
+            error.contains(&repo.display().to_string()),
+            "the refusal must name the shared checkout the path really resolves to: {error}"
+        );
+    }
+
+    /// Respawn 1034 class: the path exists as a real worktree but belongs to
+    /// a SIBLING worker. Provisioning must refuse rather than hand a worker
+    /// another worker's branch.
+    #[test]
+    fn sibling_owned_worktree_is_rejected_for_a_different_worker() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        init_repo(&repo);
+
+        let cas_dir = repo.join(".cas");
+        let sibling_path = cas_dir.join("worktrees").join("bright-dolphin-92");
+        std::fs::create_dir_all(sibling_path.parent().unwrap()).unwrap();
+        Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "factory/bright-dolphin-92",
+                sibling_path.to_str().unwrap(),
+                "main",
+            ])
+            .current_dir(&repo)
+            .output()
+            .expect("git worktree add");
+
+        // fair-pelican-51 is handed the sibling's directory.
+        let prep = WorkerSpawnPrep {
+            worker_name: "fair-pelican-51".to_string(),
+            worktree_info: Some(WorktreePrep {
+                worktree_path: sibling_path,
+                branch_name: "factory/fair-pelican-51".to_string(),
+                parent_branch: "main".to_string(),
+                base_ref: None,
+                repo_root: repo,
+                cas_dir,
+            }),
+            warnings: Vec::new(),
+            base_provenance: None,
+        };
+
+        let error = match prep.run() {
+            Ok(result) => panic!(
+                "a sibling's worktree must never be bound to another worker, \
+                 but provisioning returned cwd {:?}",
+                result.cwd
+            ),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("fair-pelican-51") && error.contains("bright-dolphin-92"),
+            "the refusal must name both the spawning worker and the real owner: {error}"
+        );
+    }
+
+    /// The ordinary reuse path is unchanged: a real worktree on the worker's
+    /// own branch still provisions.
+    #[test]
+    fn own_worktree_is_still_reused() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        init_repo(&repo);
+
+        let cas_dir = repo.join(".cas");
+        let worktree_path = cas_dir.join("worktrees").join("own-worker");
+        std::fs::create_dir_all(worktree_path.parent().unwrap()).unwrap();
+        Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                "-b",
+                "factory/own-worker",
+                worktree_path.to_str().unwrap(),
+                "main",
+            ])
+            .current_dir(&repo)
+            .output()
+            .expect("git worktree add");
+
+        let prep = WorkerSpawnPrep {
+            worker_name: "own-worker".to_string(),
+            worktree_info: Some(WorktreePrep {
+                worktree_path: worktree_path.clone(),
+                branch_name: "factory/own-worker".to_string(),
+                parent_branch: "main".to_string(),
+                base_ref: None,
+                repo_root: repo,
+                cas_dir,
+            }),
+            warnings: Vec::new(),
+            base_provenance: None,
+        };
+
+        let result = prep.run().expect("own worktree must still be reusable");
+        assert_eq!(result.cwd, worktree_path);
+        assert!(!result.worktree_created, "the existing worktree is reused");
+    }
+
+    // -----------------------------------------------------------------
     // verify_isolated_worker_branch tests
     // -----------------------------------------------------------------
 

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -296,6 +296,19 @@ impl WorkerSpawnPrep {
                 // directory itself (not in wt.repo_root).  In a valid worktree the
                 // answer is the worktree's branch; in a plain directory git climbs to
                 // the nearest ancestor repo and reports its HEAD instead.
+                //
+                // cas-30c6: the branch answer alone is forgeable. When the shared
+                // checkout is itself parked on `factory/<name>` (the GH #120 /
+                // cas-5bef shape), a stale plain directory *matches* the expected
+                // branch while every git operation in it resolves to that shared
+                // checkout — the exact misbinding of spawn request 1031. Prove the
+                // full canonical binding (working-tree root AND branch) first and
+                // fail the spawn closed, so no harness is ever started on it.
+                crate::factory_isolation::verify_worker_worktree_binding(
+                    &self.worker_name,
+                    &wt.worktree_path,
+                    Some(&wt.branch_name),
+                )?;
                 let wt_git = GitOperations::new(wt.worktree_path.clone());
                 match wt_git.current_branch() {
                     Ok(ref actual_branch) if actual_branch == &wt.branch_name => {

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -1340,10 +1340,38 @@ impl FactoryApp {
         let cas_root = result.cas_root;
 
         // STEP 3 (cas-5232): Capture expected branch before worktree is consumed.
-        // `verify_isolated_worker_branch` runs AFTER the PTY is up, so we log errors
-        // rather than returning them (the worker process is already running at that
-        // point and terminating finish_worker_spawn would orphan it).
         let expected_branch: Option<String> = result.worktree.as_ref().map(|wt| wt.branch.clone());
+
+        // cas-30c6: PRE-harness binding gate — fail closed.
+        //
+        // The post-spawn assertion below used to be the only check, and it runs
+        // after `mux.add_worker` has already started the PTY, so it can do
+        // nothing but log: by then the harness is live on the wrong repository
+        // and will accept a task there (spawn request 1031). Prove the binding
+        // BEFORE the process exists so a misbound spawn simply fails; the
+        // daemon's existing failure path releases the early task pre-assign and
+        // reports the refusal to the supervisor.
+        if let Some(ref expected) = expected_branch {
+            if let Err(e) = crate::factory_isolation::verify_worker_worktree_binding(
+                &worker_name,
+                &cwd,
+                Some(expected),
+            ) {
+                crate::telemetry::track(
+                    "factory_worker_spawn_result",
+                    vec![("success", "false"), ("reason", "worktree_binding_failed")],
+                );
+                tracing::error!(
+                    worker = %worker_name,
+                    cwd = %cwd.display(),
+                    expected_branch = %expected,
+                    error = %e,
+                    "ISOLATION BUG pre-spawn: refusing to start a harness that is not bound \
+                     to its own worktree"
+                );
+                return Err(e);
+            }
+        }
 
         // Register the worktree with the manager if applicable
         if let (Some(manager), Some(wt)) = (&mut self.worktree_manager, result.worktree) {
@@ -1372,12 +1400,12 @@ impl FactoryApp {
         }
         self.track_worker_process_group(&worker_name);
 
-        // STEP 3 (cas-5232): Post-spawn branch assertion.
-        // PTY is now running. Verify the worker's cwd resolves to the expected
-        // branch. STEP 2 makes this nearly impossible to trigger for the stale-
-        // directory case, but this catch covers any gap (e.g. concurrent FS changes,
-        // git state drift between prep and finish, or non-isolated workers that
-        // somehow inherit the wrong cwd).
+        // STEP 3 (cas-5232): Post-spawn branch assertion — now the SECOND belt.
+        // The cas-30c6 gate above already refused a misbound spawn before the
+        // PTY existed; this remains to catch drift between that gate and the
+        // running process (concurrent FS changes, git state drift). It still
+        // only logs: the process is live by this point, and unwinding here
+        // would orphan it.
         if let Some(ref expected) = expected_branch {
             if let Err(e) =
                 crate::ui::factory::app::verify_isolated_worker_branch(&worker_name, &cwd, expected)

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -4423,6 +4423,12 @@ impl FactoryDaemon {
                     if let Some(ref tc) = teams_config {
                         crate::ui::theme::register_agent_color(&tc.agent_name, &tc.agent_color);
                     }
+                    // cas-30c6: the Teams member entry must carry the cwd the
+                    // harness was actually bound to. Re-deriving it from the
+                    // worktree manager below named a worktree path even for
+                    // non-isolated spawns, so the roster could disagree with the
+                    // live process about which directory the worker is in.
+                    let bound_cwd = result.cwd.clone();
                     let task_id_for_finish = pending_task_id.clone();
                     match self.app.finish_worker_spawn(
                         result,
@@ -4463,12 +4469,7 @@ impl FactoryDaemon {
                             self.dead_workers.remove(&name);
                             // Register new worker with native Agent Teams
                             if let Some(ref teams) = self.teams {
-                                let worker_cwd = self
-                                    .app
-                                    .worktree_manager()
-                                    .map(|mgr| mgr.worktree_path_for_worker(&name))
-                                    .unwrap_or_else(|| self.app.project_path().to_path_buf());
-                                if let Err(e) = teams.add_member(&name, &worker_cwd, color_idx) {
+                                if let Err(e) = teams.add_member(&name, &bound_cwd, color_idx) {
                                     tracing::error!(
                                         "Failed to add worker '{}' to teams: {}",
                                         name,


### PR DESCRIPTION
Promotes the reviewed cas-30c6 isolation fix from the V17 epic onto current main. It fails worker spawn before starting a harness when the resolved worktree/root/branch is wrong, makes the commit guard identity-aware, and makes my_context report the canonical registered worktree. This directly resolves the live misbinding that blocked both current release lanes. Original scoped proof: factory_isolation 9/9, spawn isolation 9/9, commit guard 39/39, factory MCP ops 141/141, worktree surface 55/55, cargo check.