### PR TITLE
release: v2.66.0 — Commander, cross-project proposals, and factory isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.66.0] - 2026-08-13
+
+### Added
+- **Commander can now begin machine pairing from the page.** A short-lived code lets the target machine authorize the requesting Commander session, with strict controller, relay, and loopback origin boundaries throughout the exchange.
+- **Cross-project work can be proposed and followed without losing ownership.** Proposals carry explicit source and target projects, support auditable acceptance or rejection, and keep local dependent tasks blocked until the external work is resolved.
+
+### Changed
+- **Proposal synchronization now converges across retries, pagination, and reopen cycles.** Creation is idempotent, replayed feed rows are deduplicated, provenance remains authoritative, and external dependency state follows resolution transitions without duplicating local work.
+
+### Fixed
+- **Factory workers now fail closed before starting in the wrong checkout.** Spawn preparation proves the worker's exact worktree and branch, pre-harness validation rejects drift, commit guards deny sibling branches, and binding diagnostics inspect the assigned checkout.
+- **Commander pairing handles cancellation, replacement, and cleanup races safely.** Aborted or failed exchanges roll back only their own state, replacement rotates live credentials, stale cleanup cannot erase a newer pairing, and incomplete browser fragments are scrubbed before startup.
+- **Coordination and operator surfaces retain truthful state under edge cases.** Supervisor roles survive registration, stale reminders stay quarantined, long code snippets truncate on UTF-8 boundaries, stale-skill warnings render cleanly, and tag CI handles an all-zero base SHA.
+
 ## [2.65.0] - 2026-08-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.65.0"
+version = "2.66.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.65.0"
+version = "2.66.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.65.0"
+version = "2.66.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.65.0"
+version = "2.66.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.65.0"
+version = "2.66.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.65.0"
+version = "2.66.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.65.0"
+version = "2.66.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.65.0"
+version = "2.66.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.65.0"
+version = "2.66.0"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.65.0"
+version = "2.66.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.65.0"
+version = "2.66.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.65.0"
+version = "2.66.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-13-v2.66.0-slack.md
+++ b/docs/release-notes/2026-08-13-v2.66.0-slack.md
@@ -1,0 +1,29 @@
+# Slack draft — v2.66.0 runtime release, 2026-08-13
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Post only after the protected-main merge, annotated v2.66.0 tag, release assets, and required checks are verified.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — CAS v2.66.0 is out: adding machines and handing work across projects now happen through guided, trackable flows instead of loose links and manual follow-up.
+
+**Reply (Was → Now):**
+- Was: adding a machine began on the target and required moving its invitation link to Commander. Now: Commander creates a short-lived code from the page for the target to authorize, safely handles cancellation or credential replacement, and explains when browser cleanup needs attention.
+- Was: work owned by another project had to be copied or handed over manually, so its destination and outcome were easy to lose. Now: CAS sends one proposal to the intended project, shows whether it was accepted or declined, and keeps dependent work honestly blocked until the external task is finished.
+- Was: an isolated session could start in a stale or sibling checkout and accidentally act on the wrong branch. Now: startup proves the assigned checkout and branch before execution begins, rejects a mismatch, and reports the binding it actually inspected.
+- Install: use `cas update` for an existing installation, or download the v2.66.0 archive for Linux x86_64 or Apple Silicon from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v2.66.0 ships reverse pairing, cross-project proposal reconciliation, and fail-closed checkout isolation as explicit end-to-end contracts.
+
+**Reply (Was → Now):**
+- Was: Commander exposed only the command-led pairing path, with lifecycle and relay boundaries spread across the flow. Now: page-initiated create/poll/ack pairing uses strict controller, relay, and literal-loopback origin validation; cancellation and failed installation roll back identity-safely; replacement rotates authentication; and stale cleanup cannot erase a newer credential.
+- Was: tasks and dependencies were local to one project, while remote handoffs lacked durable provenance and reconciliation. Now: proposal creation is idempotent and explicitly source/target scoped, triage is auditable, paginated feed replay is deduplicated, and external dependencies follow resolve, reopen, and re-resolve transitions.
+- Was: spawn and commit checks could accept a path or branch that belonged to a different isolated session. Now: provisioning verifies the exact checkout root and assigned branch before launch, commit hooks reject sibling branches, and context diagnostics resolve Git state inside the assigned checkout.
+- Validation: the annotated v2.66.0 tag must point to the protected-main release commit; release preflight and required CI must be green; and the GitHub Release must publish verified Linux x86_64 and macOS ARM64 archives.
+
+Runtime release only. The Commander, task-proposal, and harness-diary merge announcements were published separately; this draft does not duplicate their publication receipts or require a new diary thread.


### PR DESCRIPTION
## Summary
- bump the six shared CAS crates and lockfile to 2.66.0
- add the audited v2.65.0..main changelog for Commander reverse pairing, cross-project proposals, and fail-closed factory isolation
- stage the separate runtime-release Slack announcement for publication only after tagged artifacts are live

## Verification
- release-preflight self-test: PASS
- migration release guard: component_output_test 13/13
- cargo metadata --locked --offline: PASS
- cargo check -p cas --lib --tests --locked: PASS
- diff check and clean remote-equality receipts: PASS

The supervisor will merge through protected main, create the annotated v2.66.0 tag, and verify both release artifacts before Slack publication.