### PR TITLE
docs: record v2.66.0 runtime release publication

### DIFF
--- a/docs/release-notes/2026-08-13-v2.66.0-slack.md
+++ b/docs/release-notes/2026-08-13-v2.66.0-slack.md
@@ -27,3 +27,14 @@ Live on production — **Dev** — v2.66.0 ships reverse pairing, cross-project 
 - Validation: the annotated v2.66.0 tag must point to the protected-main release commit; release preflight and required CI must be green; and the GitHub Release must publish verified Linux x86_64 and macOS ARM64 archives.
 
 Runtime release only. The Commander, task-proposal, and harness-diary merge announcements were published separately; this draft does not duplicate their publication receipts or require a new diary thread.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-13T21:42:31.375249000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786657351375249 |
+| User reply (Was → Now) | 2026-08-13T21:42:39.300449000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786657359300449?thread_ts=1786657351.375249&cid=C0B44GUKDK2 |
+| Dev top-level | 2026-08-13T21:42:43.272359000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786657363272359 |
+| Dev reply (Was → Now) | 2026-08-13T21:42:50.541949000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786657370541949?thread_ts=1786657363.272359&cid=C0B44GUKDK2 |


### PR DESCRIPTION
Receipt-only follow-up for the already-published v2.66.0 runtime release. Records the four verified #cas-internal Slack permalinks and UTC timestamps. No product, build, release, or message-body changes.\n\nVerified before handoff: Release run 31744874025 green; tag CI 31744874038 green; main CI 31744861617 green; Linux and macOS assets present with matching downloaded hashes; Slack readback has exactly one reply per User/Dev root.