### PR TITLE
chore(cas-f2d4): prepare v2.67.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.67.0] - 2026-08-14
+
+### Added
+- **Task artifacts are now searchable with their work attached.** Bounded Markdown, text, and JSON deliverables enter the shared search index at close and during reindex, while oversized or unsupported files remain safely excluded.
+- **Factory worktrees now surface branch-local prerequisites before work begins.** New checkouts provision the pinned Zig toolchain when available and give lockfile-aware Node installation guidance without sharing path-sensitive dependencies.
+
+### Changed
+- **Factory delivery follows the task's declared target branch end to end.** Epic bases, freshness checks, merge relays, and landing status now resolve against the real destination instead of assuming `main` or counting unrelated commits.
+- **Task-focused recall and core maintenance contracts are more precise.** Relevant saved guidance remains competitive across search fallbacks, workspace dependency and lint policy is centralized, CLI backends share one typed interface, and lifecycle gate failures retain structured meaning internally.
+
+### Fixed
+- **No-code and supervisor-verified work can finish without close-gate deadlocks.** Portable evidence survives parked states, valid updates are no longer discarded alongside one rejected field, stale anchors can be cleared safely, and missing verification dispatches have a bounded recovery path.
+- **Lifecycle notifications now identify and acknowledge the event they actually represent.** Wake relays reach the acknowledgement bridge, supervisor-owned gates do not masquerade as worker events, stale completion prompts are revalidated, and instructions use the receiving harness's live tool namespace.
+- **Search, startup, and delivery edge cases fail safely instead of losing context.** Unknown colon-bearing terms search literally, custom-profile and Grok supervisors receive startup context, spawn-time corrections arrive before assigned work starts, and squash-landed or non-main-target work is reconciled by content.
+- **Harness and checkout setup reports its real capabilities.** Codex context reset names the supported restart path, supervisor launch parity is guarded across harnesses, and worker binding checks reject stale or sibling checkouts before execution.
+
 ## [2.66.0] - 2026-08-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.66.0"
+version = "2.67.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.66.0"
+version = "2.67.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.66.0"
+version = "2.67.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.66.0"
+version = "2.67.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.66.0"
+version = "2.67.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.66.0"
+version = "2.67.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.66.0"
+version = "2.67.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.66.0"
+version = "2.67.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.66.0"
+version = "2.67.0"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.66.0"
+version = "2.67.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.66.0"
+version = "2.67.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.66.0"
+version = "2.67.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-14-v2.67.0-slack.md
+++ b/docs/release-notes/2026-08-14-v2.67.0-slack.md
@@ -1,0 +1,42 @@
+# Slack draft — v2.67.0 runtime release, 2026-08-14
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Post only after the protected-main merge, annotated v2.67.0 tag, release assets, and required checks are verified.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — CAS v2.67.0 is out: work that used to stall at handoffs or start without the right setup now follows the real destination, carries its prerequisites, and finishes cleanly.
+
+**Reply (Was → Now):**
+- Was: non-code work could be complete and documented yet remain trapped behind a code-shaped close check. Now: portable evidence, parked-task updates, and authorized verification have explicit recovery paths that preserve honest task history.
+- Was: a task aimed at a staging or other non-main branch could still be judged or routed as though `main` were its destination. Now: checkout freshness, delivery prompts, merge relays, and landing status follow the branch the work actually declares.
+- Was: lifecycle notices could repeat, arrive with the wrong instructions, or describe an owned review gate as someone else's activity. Now: notices identify the event they need acknowledged, recheck current state before delivery, and speak the receiving tool's language.
+- Was: a fresh checkout could discover missing Zig or Node setup only after a build failed. Now: the pinned Zig toolchain is provisioned when present, and Node projects receive the branch-correct install command without sharing unsafe dependencies.
+- Was: search could reject everyday colon-bearing text and overlook useful task deliverables. Now: unknown colon text is searched literally, while bounded text artifacts stay searchable with their originating task.
+- Install: use `cas update` for an existing installation, or download the v2.67.0 archive for Linux x86_64 or Apple Silicon from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v2.67.0 turns close recovery, lifecycle delivery, target-branch resolution, and multi-CLI startup into explicit, tested contracts.
+
+**Reply (Was → Now):**
+- Was: no-code anchors, parked updates, and authorized verification could form circular close requirements. Now: execution posture is honored past the anchor, valid multi-field updates commit independently, stale anchors have an authorized clear path, and dispatch recovery is limited to the exact missing-dispatch review state.
+- Was: lifecycle relay text and acknowledgement routing could disagree, queued templates could outlive their state, and static tool prefixes could leak across harnesses. Now: relays carry their authoritative IDs through the ack bridge, delivery revalidates terminal and recipient state, and templates resolve capabilities from the live backend.
+- Was: delivery bases and merge instructions inferred `main` or measured commit counts unrelated to content. Now: declared work targets drive base selection, tree-based staleness, merge-required relays, and integrated-status reconciliation.
+- Was: Grok startup context, Codex reset behavior, and checkout prerequisites depended on CLI-specific assumptions. Now: Grok's real launch seam carries ambient recall and its required skills, Codex refuses unsupported context reset with the supported recovery path, and parity tests pin every CLI's intended behavior.
+- Was: fallback recall scoring and internal error contracts were scattered and weakly typed. Now: task matches remain stable across ranking paths, shared dependency/lint policy prevents drift, backend adapters implement one interface, and lifecycle gates return structured errors. These code-health changes are intentionally kept to the Dev thread because they are user-invisible maintenance rather than a new user workflow.
+- Validation: the annotated v2.67.0 tag must point to the protected-main release commit; release preflight and required tag/main CI must be green; and independently downloaded Linux x86_64 and macOS ARM64 archives must match the published sizes and SHA-256 digests.
+
+The earlier v17 and Code health v1 landing threads already announced their changes. This runtime release's two threads primarily carry the previously unannounced v18 landing, so no separate same-hour v18 thread is duplicated.
+
+## Posting sequence
+
+1. Read recent #cas-internal messages and confirm these exact bodies have not already been posted.
+2. Post the User top-level as a new message and capture its timestamp.
+3. Post the User reply as the only reply to that top-level.
+4. Post the Dev top-level as a new message and capture its timestamp.
+5. Post the Dev reply as the only reply to that top-level.
+6. Append `## POSTED` with UTC timestamps and all four permalinks, then verify both threads.


### PR DESCRIPTION
Release inputs for v2.67.0, covering v2.66.0..main — the v17 burn-down (PR #319), Code health v1 (PR #295), and the v18 burn-down (PR #327).

- Version bumped to 2.67.0 across all six shared release-train crates plus `Cargo.lock`
- Dated Keep-a-Changelog 2.67.0 section, audited against the commit range rather than PR titles
- Runtime release Slack draft at `docs/release-notes/2026-08-14-v2.67.0-slack.md`, gated on the merge, tag, assets and checks being verified before posting

Release inputs only; no runtime behavior changes. Scoped Validation green at f39b76e9 (run 31766303887).

🤖 Generated with [Claude Code](https://claude.com/claude-code)