### PR TITLE
docs(cas-f2d4): record v2.67.0 release receipts

### DIFF
--- a/docs/release-notes/2026-08-14-v2.67.0-slack.md
+++ b/docs/release-notes/2026-08-14-v2.67.0-slack.md
@@ -40,3 +40,14 @@ The earlier v17 and Code health v1 landing threads already announced their chang
 4. Post the Dev top-level as a new message and capture its timestamp.
 5. Post the Dev reply as the only reply to that top-level.
 6. Append `## POSTED` with UTC timestamps and all four permalinks, then verify both threads.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-14T03:55:54.753129000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786679754753129 |
+| User reply (Was → Now) | 2026-08-14T03:56:03.177149000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786679763177149?thread_ts=1786679754.753129&cid=C0B44GUKDK2 |
+| Dev top-level | 2026-08-14T03:56:07.010239000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786679767010239 |
+| Dev reply (Was → Now) | 2026-08-14T03:56:16.628309000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786679776628309?thread_ts=1786679767.010239&cid=C0B44GUKDK2 |


### PR DESCRIPTION
Slack posting receipts for the v2.67.0 runtime release (tag at e452dfa3).

Both #cas-internal threads are posted and verified — user top-level + one reply, dev top-level + one reply — per docs/RELEASE_SLACK_RUBRIC.md. These threads also satisfy the per-merge announcement obligation for PR #327 (v18 burn-down), which merged without its own post; v17 and Code health v1 already have their own posted threads.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)