### PR TITLE
fix(cas-9415): bind in-place factory merges to their resolved target branch

### DIFF
--- a/cas-cli/src/worktree/git.rs
+++ b/cas-cli/src/worktree/git.rs
@@ -70,6 +70,19 @@ pub enum GitError {
     #[error("The shared target checkout has pre-existing tracked changes and was not touched: {0}")]
     MergeCheckoutDirty(String),
 
+    /// cas-9415: an in-place merge must name and validate its destination.
+    /// Without this guard, `git merge <source>` commits to implicit HEAD, so
+    /// another process switching the shared checkout after venue selection
+    /// can contaminate an unrelated branch.
+    #[error(
+        "Refusing merge in {checkout}: checkout is on branch '{actual}', but the resolved merge target is '{expected}'"
+    )]
+    MergeTargetMismatch {
+        checkout: PathBuf,
+        expected: String,
+        actual: String,
+    },
+
     /// cas-4702: the ephemeral-worktree merge completed, but the target
     /// branch had moved since it was read, so the compare-and-swap that would
     /// have published the merge declined. A concurrent writer is never
@@ -1046,10 +1059,43 @@ impl GitOperations {
         Ok(paths)
     }
 
-    /// Merge a branch into the current branch of the main checkout.
-    pub fn merge_branch(&self, branch: &str, no_ff: bool) -> Result<Option<String>> {
+    /// Merge `source_branch` into `target_branch` in the main checkout.
+    ///
+    /// Git's merge command always writes implicit HEAD. Validate the live
+    /// symbolic HEAD at the last helper boundary before invoking it, rather
+    /// than trusting an earlier venue decision that another checkout process
+    /// can invalidate (cas-9415).
+    pub fn merge_branch(
+        &self,
+        target_branch: &str,
+        source_branch: &str,
+        no_ff: bool,
+    ) -> Result<Option<String>> {
         let repo_root = self.repo_root.clone();
-        self.merge_branch_in_dir(&repo_root, branch, no_ff)
+        self.merge_branch_in_dir(&repo_root, Some(target_branch), source_branch, no_ff)
+    }
+
+    /// Refuse an in-place merge unless `dir`'s symbolic HEAD is exactly the
+    /// resolved target branch. Detached HEAD is reported as a mismatch too.
+    fn ensure_merge_target_checked_out(&self, dir: &Path, expected: &str) -> Result<()> {
+        let output = Command::new("git")
+            .args(["symbolic-ref", "--quiet", "--short", "HEAD"])
+            .current_dir(dir)
+            .output()?;
+        let actual = if output.status.success() {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        } else {
+            "<detached HEAD>".to_string()
+        };
+
+        if actual != expected {
+            return Err(GitError::MergeTargetMismatch {
+                checkout: dir.to_path_buf(),
+                expected: expected.to_string(),
+                actual,
+            });
+        }
+        Ok(())
     }
 
     /// Merge `branch` into whatever `dir`'s HEAD points at.
@@ -1058,7 +1104,13 @@ impl GitOperations {
     /// detached worktree for [`Self::merge_branch_via_temp_worktree`]
     /// (cas-4702 / GH #68) — the merge mechanics, conflict detection and
     /// abort-on-failure guarantees are identical either way.
-    fn merge_branch_in_dir(&self, dir: &Path, branch: &str, no_ff: bool) -> Result<Option<String>> {
+    fn merge_branch_in_dir(
+        &self,
+        dir: &Path,
+        expected_target: Option<&str>,
+        branch: &str,
+        no_ff: bool,
+    ) -> Result<Option<String>> {
         // cas-e18f: a merge left over from a previous, un-aborted failure
         // must be reported distinctly, not surfaced as an opaque failure of
         // *this* (unrelated) merge attempt.
@@ -1069,6 +1121,13 @@ impl GitOperations {
         // Fix symlinked submodules before merge to avoid:
         // "error: expected submodule path 'vendor/...' not to be a symbolic link"
         self.fix_symlinked_submodules(dir)?;
+
+        // This is intentionally the final operation before `git merge`.
+        // Shared-checkout callers must revalidate live symbolic HEAD here;
+        // dedicated detached merge worktrees pass no branch expectation.
+        if let Some(target) = expected_target {
+            self.ensure_merge_target_checked_out(dir, target)?;
+        }
 
         let mut args = vec!["merge"];
         if no_ff {
@@ -1180,7 +1239,7 @@ impl GitOperations {
             .ok_or_else(|| GitError::BranchNotFound(target_branch.to_string()))?;
 
         let guard = self.add_temp_worktree(&old_tip)?;
-        let merged = self.merge_branch_in_dir(guard.path(), source_branch, no_ff)?;
+        let merged = self.merge_branch_in_dir(guard.path(), None, source_branch, no_ff)?;
 
         let new_tip = match merged {
             Some(ref tip) if *tip != old_tip => tip.clone(),

--- a/cas-cli/src/worktree/git_tests/tests.rs
+++ b/cas-cli/src/worktree/git_tests/tests.rs
@@ -67,6 +67,64 @@ fn test_current_branch() {
     assert!(branch == "main" || branch == "master");
 }
 
+/// cas-9415: `git merge` commits to implicit HEAD. If another supervisor
+/// parks the shared checkout on a foreign branch after the target was
+/// resolved, the merge helper must refuse before changing any ref or file.
+#[test]
+fn merge_refuses_when_checkout_head_differs_from_resolved_target_cas_9415() {
+    let (_temp, repo_path) = create_test_repo();
+    let git = GitOperations::new(repo_path.clone());
+    let trunk = git.current_branch().unwrap();
+
+    Command::new("git")
+        .args(["branch", "epic/assembly"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["checkout", "-q", "-b", "factory/worker"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    std::fs::write(repo_path.join("worker.txt"), "worker change\n").unwrap();
+    Command::new("git")
+        .args(["add", "worker.txt"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-q", "-m", "worker change"])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["checkout", "-q", "-b", "scratch/foreign", &trunk])
+        .current_dir(&repo_path)
+        .output()
+        .unwrap();
+
+    let epic_before = git.ref_sha("epic/assembly").unwrap();
+    let scratch_before = git.ref_sha("scratch/foreign").unwrap();
+    let error = git
+        .merge_branch("epic/assembly", "factory/worker", true)
+        .expect_err("a foreign checkout branch must abort the merge");
+
+    match error {
+        GitError::MergeTargetMismatch {
+            expected, actual, ..
+        } => {
+            assert_eq!(expected, "epic/assembly");
+            assert_eq!(actual, "scratch/foreign");
+        }
+        other => panic!("expected target mismatch, got {other:?}"),
+    }
+    assert_eq!(git.current_branch().unwrap(), "scratch/foreign");
+    assert_eq!(git.ref_sha("epic/assembly").unwrap(), epic_before);
+    assert_eq!(git.ref_sha("scratch/foreign").unwrap(), scratch_before);
+    assert!(!repo_path.join("worker.txt").exists());
+    assert!(!git.merge_in_progress());
+}
+
 #[test]
 fn test_detect_default_branch_ignores_current_feature_head() {
     let (_temp, repo_path) = create_test_repo();

--- a/cas-cli/src/worktree/manager/epic_ops.rs
+++ b/cas-cli/src/worktree/manager/epic_ops.rs
@@ -111,7 +111,9 @@ impl WorktreeManager {
             }
 
             let merge_result = match venue {
-                MergeVenue::SharedCheckout => self.git.merge_branch(worker_branch, true),
+                MergeVenue::SharedCheckout => {
+                    self.git.merge_branch(epic_branch, worker_branch, true)
+                }
                 MergeVenue::TempWorktree => {
                     self.git
                         .merge_branch_via_temp_worktree(epic_branch, worker_branch, true)

--- a/cas-cli/src/worktree/manager/mod.rs
+++ b/cas-cli/src/worktree/manager/mod.rs
@@ -518,7 +518,10 @@ impl WorktreeManager {
             // the branch ref is advanced by compare-and-swap, so the
             // supervisor's next commit still lands where they were.
             let merge_result = match self.merge_venue(&worktree.parent_branch) {
-                MergeVenue::SharedCheckout => self.git.merge_branch(&worktree.branch, true),
+                MergeVenue::SharedCheckout => {
+                    self.git
+                        .merge_branch(&worktree.parent_branch, &worktree.branch, true)
+                }
                 MergeVenue::TempWorktree => self.git.merge_branch_via_temp_worktree(
                     &worktree.parent_branch,
                     &worktree.branch,


### PR DESCRIPTION
Epic-assembly merge ran `git merge` against the shared main checkout's implicit HEAD. On 2026-08-13 that landed a v18 epic merge on `chore/housekeeping-sync-drift-receipts` — a foreign branch another supervisor had just checked out there — and pushed it, so an unrelated docs PR started carrying an awaiting_merge lane and failed CI on a test it never contained.

`merge_branch` now takes an explicit target and validates the live `git symbolic-ref HEAD` immediately before invoking `git merge`, refusing with `MergeTargetMismatch` when the checkout is parked anywhere else (detached HEAD included). The check is deliberately the last operation before the merge, so an earlier venue decision another process invalidated cannot be trusted. Dedicated detached merge worktrees pass no expectation and are unaffected.

## Verification

- New regression `merge_refuses_when_checkout_head_differs_from_resolved_target_cas_9415`: parks the checkout on a foreign branch, attempts the merge, and asserts the refusal plus that neither branch moved, no merge is left in progress, and the source file never appeared.
- Scoped: 233/233 `--lib merge` pass (supervisor-run, worker worktree).
- Branch CI green on 29cd4da4.


🤖 Generated with [Claude Code](https://claude.com/claude-code)