### PR TITLE
feat(cas-3413): Codex supervisors receive ambient recall through the queued launch intro

### DIFF
--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -2291,6 +2291,12 @@ pub fn extract_body(content: &str) -> &str {
     content[body_start..].trim_start()
 }
 
+/// Claude Code harness truncation point for inline supervisor guidance.
+pub(crate) const SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES: usize = 8_192;
+
+/// Early-warning margin that preserves room for launch wrappers and banners.
+pub(crate) const SUPERVISOR_GUIDANCE_SOFT_CAP_BYTES: usize = 8_000;
+
 /// Get the supervisor guidance injected at factory SessionStart.
 ///
 /// Returns only the trimmed supervisor SKILL.md body. The checklist
@@ -2556,23 +2562,21 @@ This is the body content."#;
     /// See memory `project_session_start_truncation.md`.
     #[test]
     fn test_supervisor_guidance_under_8kb() {
-        const HARD_CEILING: usize = 8_192; // Claude Code harness truncation point.
-        const SOFT_CAP: usize = 8_000; // early-warning margin below the ceiling.
         let guide = supervisor_guidance();
         assert!(
-            guide.len() < HARD_CEILING,
-            "supervisor_guidance is {} bytes — over the {HARD_CEILING}B SessionStart ceiling. \
+            guide.len() < SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES,
+            "supervisor_guidance is {} bytes — over the {SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES}B SessionStart ceiling. \
              Move content into cas-supervisor/references/ instead of \
              inlining it in cas-supervisor.md.",
             guide.len()
         );
         assert!(
-            guide.len() <= SOFT_CAP,
-            "supervisor_guidance is {} bytes — over the {SOFT_CAP}B soft cap (only \
-             {}B from the {HARD_CEILING}B hard ceiling). Trim body prose or move it \
+            guide.len() <= SUPERVISOR_GUIDANCE_SOFT_CAP_BYTES,
+            "supervisor_guidance is {} bytes — over the {SUPERVISOR_GUIDANCE_SOFT_CAP_BYTES}B soft cap (only \
+             {}B from the {SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES}B hard ceiling). Trim body prose or move it \
              into cas-supervisor/references/ to keep CI headroom.",
             guide.len(),
-            HARD_CEILING - guide.len()
+            SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES - guide.len()
         );
     }
 

--- a/cas-cli/src/cli/factory/parity.rs
+++ b/cas-cli/src/cli/factory/parity.rs
@@ -400,8 +400,9 @@ mod tests {
     use super::*;
 
     /// The harness-specific ambient-recall delivery contract for a supervisor
-    /// launch. This is deliberately separate from the skill contract: Codex
-    /// has the same supervisor skills, but no SessionStart delivery channel.
+    /// launch. This is deliberately separate from the skill contract because
+    /// Claude receives its packet through SessionStart while Codex and Grok
+    /// receive it through their queued launch intros.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum AmbientRecallDelivery {
         /// Claude reads its SessionStart hook's stdout.
@@ -409,10 +410,6 @@ mod tests {
         /// Grok ignores SessionStart stdout, so the factory's queued launch
         /// intro is its delivery channel.
         QueuedSupervisorIntro,
-        /// cas-3413: Codex has no hooks and currently has no ambient-recall
-        /// launch delivery. Its queued intro is a viable future seam; remove
-        /// this exception when cas-3413 wires that packet through it.
-        NoHooksCodexUntilCas3413,
     }
 
     #[derive(Debug, Clone, Copy)]
@@ -437,7 +434,7 @@ mod tests {
                 // twin. It is still the universal supervisor-checklist
                 // capability, but its shipped skill name is harness-specific.
                 supervisor_skills: ["cas-supervisor", "cas-codex-supervisor-checklist"],
-                ambient_recall: AmbientRecallDelivery::NoHooksCodexUntilCas3413,
+                ambient_recall: AmbientRecallDelivery::QueuedSupervisorIntro,
             },
             SupervisorCli::Grok => SupervisorHarnessRequirement {
                 supervisor_skills: ["cas-supervisor", "cas-supervisor-checklist"],
@@ -446,13 +443,14 @@ mod tests {
         }
     }
 
-    /// Capture the concrete supervisor instruction launch payload. Claude and
-    /// Grok consume the queued factory intro; Codex consumes its CLI config.
+    /// Capture the concrete queued supervisor launch payload. The queued intro
+    /// is the ambient-recall delivery seam for Codex and Grok; Claude's own
+    /// ambient packet is delivered by SessionStart below.
     /// This is a second exhaustive match so a new backend cannot be quietly
     /// covered by a generic fallback.
     fn supervisor_skill_payload(cas_dir: &std::path::Path, harness: SupervisorCli) -> String {
         match harness {
-            SupervisorCli::Claude | SupervisorCli::Grok => {
+            SupervisorCli::Claude | SupervisorCli::Codex | SupervisorCli::Grok => {
                 use crate::store::detect::open_prompt_queue_store;
                 use crate::ui::factory::queue_supervisor_intro_prompt;
 
@@ -478,8 +476,6 @@ mod tests {
                 );
                 rows[0].prompt.clone()
             }
-            SupervisorCli::Codex => launch_instruction_text(harness, ContractRole::Supervisor)
-                .expect("Codex supervisor must have developer_instructions"),
         }
     }
 
@@ -572,12 +568,6 @@ mod tests {
                     assert!(
                         skill_payload.contains("grok-supervisor-ambient"),
                         "{harness:?} queued supervisor intro omitted the ambient recall sentinel: {skill_payload}"
-                    );
-                }
-                AmbientRecallDelivery::NoHooksCodexUntilCas3413 => {
-                    assert!(
-                        !harness.backend().capabilities().supports_hooks,
-                        "Codex's cas-3413 exception is valid only while it has no hooks; remove the exception and require ambient recall once that changes"
                     );
                 }
             }

--- a/cas-cli/src/hooks/handlers/session_budget.rs
+++ b/cas-cli/src/hooks/handlers/session_budget.rs
@@ -156,9 +156,8 @@ impl SessionContextAssembler {
         assembler
     }
 
-    /// Override the byte budget (tests; production uses
-    /// [`SESSION_START_BUDGET_BYTES`]).
-    #[cfg(test)]
+    /// Override the byte budget for another bounded delivery surface.
+    /// Production SessionStart uses [`SESSION_START_BUDGET_BYTES`].
     pub(crate) fn with_budget(mut self, budget: usize) -> Self {
         self.budget = Some(budget);
         self

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -2113,21 +2113,45 @@ pub(crate) fn queue_supervisor_intro_prompt(
         }
     }
 
-    // cas-91df / GH #296, #297: unlike Claude, Grok discards SessionStart
-    // stdout. Its queued launch intro is the actual delivery seam. Include the
-    // normal context and independently bounded ambient-recall packet here,
-    // supplying the child identity explicitly because the parent env is not
-    // the supervisor's env yet.
-    if supervisor_cli == cas_mux::SupervisorCli::Grok {
-        if let Some(context) = grok_supervisor_session_start_bundle(
+    // cas-3413 / cas-91df: Codex has no SessionStart hooks and Grok discards
+    // SessionStart stdout. Their queued launch intro is therefore the real
+    // delivery seam. Reuse one bundle so both receive the normal context and
+    // independently bounded ambient-recall packet, with explicit child
+    // identity because the parent env is not the supervisor's env yet.
+    if matches!(
+        supervisor_cli,
+        cas_mux::SupervisorCli::Codex | cas_mux::SupervisorCli::Grok
+    ) {
+        if let Some(bundle) = queued_supervisor_session_start_bundle(
             cas_dir,
             supervisor_name,
             session_id.unwrap_or(supervisor_name),
             factory_session.unwrap_or(supervisor_name),
         ) {
-            prompt.push_str("\n\n<cas-grok-session-start>\n");
-            prompt.push_str(&context);
-            prompt.push_str("\n</cas-grok-session-start>");
+            // Reuse the established supervisor-guidance ceiling for queued
+            // delivery. Ambient recall stays protected because it is the
+            // purpose of this fallback; ordinary SessionStart context can
+            // compact to its retrieval command rather than being truncated.
+            use crate::hooks::handlers::session_budget::SessionContextAssembler;
+
+            let mut assembler = SessionContextAssembler::new(format!(
+                "{prompt}\n\n<cas-queued-session-start>"
+            ))
+            .with_budget(crate::builtins::SUPERVISOR_GUIDANCE_SOFT_CAP_BYTES);
+            if let Some(context) = bundle.context {
+                let tool_prefix = supervisor_cli.backend().capabilities().tool_prefix;
+                assembler.append_degradable(
+                    context,
+                    format!(
+                        "[session-start context omitted to fit the queued launch payload — run `{tool_prefix}search action=context`]"
+                    ),
+                );
+            }
+            if let Some(packet) = bundle.ambient_recall {
+                assembler.append_protected(packet.full);
+            }
+            assembler.append_protected("</cas-queued-session-start>".to_string());
+            prompt = assembler.render();
         }
     }
 
@@ -2167,12 +2191,17 @@ fn claude_custom_config_context_fallback(
         .filter(|context| !context.trim().is_empty())
 }
 
-fn grok_supervisor_session_start_bundle(
+struct QueuedSupervisorSessionStartBundle {
+    context: Option<String>,
+    ambient_recall: Option<crate::ambient_recall::RecallPacket>,
+}
+
+fn queued_supervisor_session_start_bundle(
     cas_dir: &std::path::Path,
     supervisor_name: &str,
     session_id: &str,
     factory_session: &str,
-) -> Option<String> {
+) -> Option<QueuedSupervisorSessionStartBundle> {
     let input = cas_core::hooks::HookInput {
         session_id: session_id.to_string(),
         cwd: cas_dir.parent()?.to_string_lossy().into_owned(),
@@ -2181,22 +2210,20 @@ fn grok_supervisor_session_start_bundle(
         agent_role: Some("supervisor".to_string()),
         ..Default::default()
     };
-    let mut sections = Vec::new();
-    if let Ok(context) = crate::hooks::build_context(&input, 5, cas_dir)
-        && !context.trim().is_empty()
-    {
-        sections.push(context);
-    }
-    if let Some(packet) = crate::ambient_recall::build_ambient_recall_context_for_factory_launch(
+    let context = crate::hooks::build_context(&input, 5, cas_dir)
+        .ok()
+        .filter(|context| !context.trim().is_empty());
+    let ambient_recall = crate::ambient_recall::build_ambient_recall_context_for_factory_launch(
         &input,
         cas_dir,
         None,
         supervisor_name,
         factory_session,
-    ) {
-        sections.push(packet.full);
-    }
-    (!sections.is_empty()).then(|| sections.join("\n\n"))
+    );
+    (context.is_some() || ambient_recall.is_some()).then_some(QueuedSupervisorSessionStartBundle {
+        context,
+        ambient_recall,
+    })
 }
 
 pub(crate) fn queue_codex_worker_intro_prompt(
@@ -2696,6 +2723,62 @@ mod tests {
                 .contains("custom profile ambient memory sentinel"),
             "custom-config supervisor launch must receive ambient context even when Claude skips SessionStart: {}",
             rows[0].prompt
+        );
+    }
+
+    /// Codex has no SessionStart hook, so its queued startup intro is the
+    /// delivery path for both explicit supervisor skills and a real
+    /// ambient-recall packet.
+    #[test]
+    fn codex_supervisor_intro_carries_ambient_recall_and_supervisor_skills() {
+        use crate::store::{detect::open_prompt_queue_store, init_cas_dir, open_store};
+
+        let project = tempfile::tempdir().unwrap();
+        let cas_dir = init_cas_dir(project.path()).unwrap();
+        let _env =
+            TestEnvGuard::with_optional_vars(&[(crate::internal_llm::INTERNAL_LLM_ENV, None)]);
+        let mut entry = Entry::new(
+            "codex-supervisor-ambient".to_string(),
+            "Codex supervisor session start ambient recall sentinel".to_string(),
+        );
+        entry.title = Some("Codex supervisor launch recall".to_string());
+        entry.tags = vec!["codex".to_string(), "supervisor".to_string()];
+        entry.importance = 0.95;
+        open_store(&cas_dir).unwrap().add(&entry).unwrap();
+
+        queue_supervisor_intro_prompt(
+            &cas_dir,
+            "codex-sup",
+            cas_mux::SupervisorCli::Codex,
+            &[],
+            Some("codex-session-start"),
+            Some("codex-factory-session"),
+        );
+
+        let queue = open_prompt_queue_store(&cas_dir).unwrap();
+        let rows = queue
+            .peek_for_targets(&["codex-sup"], Some("codex-factory-session"), 10)
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        let prompt = &rows[0].prompt;
+        assert!(
+            prompt.contains("[ambient recall v1 role=supervisor"),
+            "Codex's queued startup intro must carry a non-empty ambient packet: {prompt}"
+        );
+        assert!(
+            prompt.contains("codex-supervisor-ambient"),
+            "ambient packet must surface the matched high-importance Codex supervisor memory: {prompt}"
+        );
+        for skill in ["cas-supervisor", "cas-codex-supervisor-checklist"] {
+            assert!(
+                prompt.contains(skill),
+                "Codex's queued startup payload must load {skill}: {prompt}"
+            );
+        }
+        assert!(
+            prompt.len() <= 8_000,
+            "Codex's measured queued supervisor payload is {} bytes, over the 8KB supervisor-guidance soft ceiling",
+            prompt.len()
         );
     }
 


### PR DESCRIPTION
Lands the v18 epic branch's outstanding child so the epic base and main stop diverging.

Codex has no SessionStart hook at all, and unlike Grok that absence was never a regression — it is a documented harness limitation. But the queued launch intro is a delivery seam that exists independently of hooks, which is exactly how Grok receives its packet, and Codex is the default worker CLI for this fleet. The most-used harness was the one flying without recall.

- The Grok-only `grok_supervisor_session_start_bundle` becomes the shared `queued_supervisor_session_start_bundle`, used by both Codex and Grok rather than adding a third bespoke path.
- Payload is bounded by the existing 8KB supervisor-guidance ceiling: ambient recall is `append_protected` because it is the entire purpose of the fallback, while ordinary SessionStart context degrades to its retrieval command instead of being truncated. Measured fixture payload: 950B.
- The `NoHooksCodexUntilCas3413` parity exception is deleted outright, so the harness-parity guard now requires Codex to carry the ambient sentinel like every other supervisor harness.

## Verification

- `codex_supervisor_intro_carries_ambient_recall_and_supervisor_skills` asserts the queued intro carries a non-empty ambient packet, surfaces the matched memory, loads both supervisor skills, and stays under the ceiling.
- Scoped: 1/1 focused Codex intro test, 38/38 parity-scoped — supervisor-run in the worker worktree.
- Branch CI green on 2e42d3ef.

🤖 Generated with [Claude Code](https://claude.com/claude-code)