### PR TITLE
fix(cas-56f8): wake the supervisor when a rejected verification reopens an assigned task

### DIFF
--- a/cas-cli/src/mcp/tools/core/mod.rs
+++ b/cas-cli/src/mcp/tools/core/mod.rs
@@ -10,6 +10,6 @@ mod skills;
 mod system;
 pub(crate) mod task;
 mod task_extensions;
-mod workflow;
+pub(crate) mod workflow;
 
 // truncate_str is defined in the parent module (tools/mod.rs) and re-exported via imports.rs

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -1,4 +1,5 @@
 use crate::mcp::tools::core::imports::*;
+use crate::mcp::tools::core::workflow::verification_tools::VERIFICATION_REJECTED_REOPEN_LABEL;
 use thiserror::Error;
 
 /// Typed failures from lifecycle gates. The MCP boundary renders these with
@@ -1231,7 +1232,7 @@ impl CasCore {
         // A worker has acted on the supervisor's recovery choice; remove the
         // structured rejection-reopen marker so a later unrelated Open state
         // cannot be rendered as waiting on the supervisor.
-        task.labels.retain(|label| label != "verification-rejected-reopen");
+        task.labels.retain(|label| label != VERIFICATION_REJECTED_REOPEN_LABEL);
         task.status = TaskStatus::InProgress;
         task.updated_at = chrono::Utc::now();
 

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -1228,6 +1228,10 @@ impl CasCore {
 
         // Capture old status before mutation for lifecycle push (cas-062d).
         let old_status = task.status;
+        // A worker has acted on the supervisor's recovery choice; remove the
+        // structured rejection-reopen marker so a later unrelated Open state
+        // cannot be rendered as waiting on the supervisor.
+        task.labels.retain(|label| label != "verification-rejected-reopen");
         task.status = TaskStatus::InProgress;
         task.updated_at = chrono::Utc::now();
 

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/supervisor_push.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/supervisor_push.rs
@@ -816,6 +816,7 @@ impl CasCore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::tools::core::workflow::verification_tools::VERIFICATION_REJECTED_REOPEN_RECOVERY;
     use crate::test_support::TestEnvGuard;
     use cas_store::{
         PromptQueueStore, SqliteAgentStore, SqlitePromptQueueStore, SqliteSupervisorQueueStore,
@@ -1039,7 +1040,7 @@ mod tests {
             &sq, Some(&pq as &dyn PromptQueueStore), &agents,
             "cas-56f8", "Rejected review recovery", TaskStatus::PendingSupervisorReview,
             TaskStatus::Open, "task-verifier",
-            Some("Verification rejected; worker remains assigned but inactive. Resume the existing worker or replace it."),
+            Some(VERIFICATION_REJECTED_REOPEN_RECOVERY),
             LifecycleTransition::VerificationRejectedReopened, "reject-occurrence",
         );
         let first = emit().expect("rejection reopen wake");
@@ -1047,7 +1048,7 @@ mod tests {
         let rows = pq.peek_all(10).unwrap();
         assert_eq!(rows.len(), 1);
         assert!(is_lifecycle_wake_source(&rows[0].source));
-        assert!(rows[0].prompt.contains("resume the existing worker or replace it"));
+        assert!(rows[0].prompt.contains(VERIFICATION_REJECTED_REOPEN_RECOVERY));
 
         // Message acknowledgement consumes the prompt; replaying its exact
         // occurrence must observe the completed durable outbox and add no wake.

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/supervisor_push.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/supervisor_push.rs
@@ -28,6 +28,7 @@ pub enum LifecycleTransition {
     Started,
     Blocked,
     ReadyReopened,
+    VerificationRejectedReopened,
     CloseRejected,
     AwaitingMerge,
     Closed,
@@ -39,6 +40,7 @@ impl LifecycleTransition {
             Self::Started => "task_started",
             Self::Blocked => "task_blocked",
             Self::ReadyReopened => "task_ready",
+            Self::VerificationRejectedReopened => "task_verification_rejected_reopened",
             Self::CloseRejected => "task_close_rejected",
             Self::AwaitingMerge => "task_awaiting_merge",
             Self::Closed => "task_closed",
@@ -47,7 +49,10 @@ impl LifecycleTransition {
 
     pub fn priority(self) -> NotificationPriority {
         match self {
-            Self::CloseRejected | Self::Blocked | Self::AwaitingMerge => NotificationPriority::High,
+            Self::CloseRejected
+            | Self::Blocked
+            | Self::AwaitingMerge
+            | Self::VerificationRejectedReopened => NotificationPriority::High,
             Self::Started | Self::ReadyReopened | Self::Closed => NotificationPriority::Normal,
         }
     }
@@ -70,7 +75,10 @@ impl LifecycleTransition {
     /// idle-nudge exclusion (cas-dab2) was added to stop.
     pub fn wakes_idle_supervisor(self) -> bool {
         match self {
-            Self::CloseRejected | Self::AwaitingMerge | Self::Blocked => true,
+            Self::CloseRejected
+            | Self::AwaitingMerge
+            | Self::Blocked
+            | Self::VerificationRejectedReopened => true,
             Self::Started | Self::ReadyReopened | Self::Closed => false,
         }
     }
@@ -906,6 +914,10 @@ mod tests {
             "task_ready"
         );
         assert_eq!(
+            LifecycleTransition::VerificationRejectedReopened.as_event_type(),
+            "task_verification_rejected_reopened"
+        );
+        assert_eq!(
             LifecycleTransition::CloseRejected.as_event_type(),
             "task_close_rejected"
         );
@@ -924,6 +936,7 @@ mod tests {
         assert!(LifecycleTransition::AwaitingMerge.wakes_idle_supervisor());
         assert!(LifecycleTransition::CloseRejected.wakes_idle_supervisor());
         assert!(LifecycleTransition::Blocked.wakes_idle_supervisor());
+        assert!(LifecycleTransition::VerificationRejectedReopened.wakes_idle_supervisor());
         assert!(!LifecycleTransition::Started.wakes_idle_supervisor());
         assert!(!LifecycleTransition::ReadyReopened.wakes_idle_supervisor());
         assert!(!LifecycleTransition::Closed.wakes_idle_supervisor());

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/supervisor_push.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/supervisor_push.rs
@@ -1017,6 +1017,46 @@ mod tests {
     }
 
     #[test]
+    fn verification_rejection_reopen_wakes_once_and_replay_after_ack_is_quiet() {
+        let _env = TestEnvGuard::with_vars(&[("CAS_FACTORY_SESSION", "sess-reject-wake")]);
+        let temp = TempDir::new().unwrap();
+        let agents = SqliteAgentStore::open(temp.path()).unwrap();
+        agents.init().unwrap();
+        agents
+            .register(&agent_in_session(
+                "sup-reject-wake",
+                "cosmic-bear-43",
+                AgentRole::Supervisor,
+                "sess-reject-wake",
+            ))
+            .unwrap();
+        let sq = SqliteSupervisorQueueStore::open(temp.path()).unwrap();
+        sq.init().unwrap();
+        let pq = SqlitePromptQueueStore::open(temp.path()).unwrap();
+        pq.init().unwrap();
+
+        let emit = || emit_task_lifecycle_transition(
+            &sq, Some(&pq as &dyn PromptQueueStore), &agents,
+            "cas-56f8", "Rejected review recovery", TaskStatus::PendingSupervisorReview,
+            TaskStatus::Open, "task-verifier",
+            Some("Verification rejected; worker remains assigned but inactive. Resume the existing worker or replace it."),
+            LifecycleTransition::VerificationRejectedReopened, "reject-occurrence",
+        );
+        let first = emit().expect("rejection reopen wake");
+        let notification_id = match first { LifecyclePushResult::Enqueued { notification_id } => notification_id, other => panic!("unexpected first result: {other:?}") };
+        let rows = pq.peek_all(10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(is_lifecycle_wake_source(&rows[0].source));
+        assert!(rows[0].prompt.contains("resume the existing worker or replace it"));
+
+        // Message acknowledgement consumes the prompt; replaying its exact
+        // occurrence must observe the completed durable outbox and add no wake.
+        sq.mark_prompt_delivered(notification_id).unwrap();
+        assert!(matches!(emit().unwrap(), LifecyclePushResult::AlreadyComplete { .. }));
+        assert_eq!(pq.peek_all(10).unwrap().len(), 1, "no duplicate wake storm after ack");
+    }
+
+    #[test]
     fn failure_message_never_claims_task_op_retry_is_safe() {
         let msg = lifecycle_push_failure_message(
             "cas-x",

--- a/cas-cli/src/mcp/tools/core/workflow.rs
+++ b/cas-cli/src/mcp/tools/core/workflow.rs
@@ -1,3 +1,3 @@
 mod loop_tools;
-mod verification_tools;
+pub(crate) mod verification_tools;
 mod worktree_ops;

--- a/cas-cli/src/mcp/tools/core/workflow/verification_tools.rs
+++ b/cas-cli/src/mcp/tools/core/workflow/verification_tools.rs
@@ -509,6 +509,7 @@ impl CasCore {
             }
         }
 
+        let mut rejection_reopened_at = None;
         // Atomically persist the verdict, resolve any active exact-task
         // dispatch, and clear that task's pending transition. If any step
         // fails, all authority and lifecycle writes roll back.
@@ -698,12 +699,13 @@ impl CasCore {
                 } else {
                     format!("{}\n\n{}", task.notes.trim_end(), decision)
                 };
+                let reopened_at = chrono::Utc::now();
                 let changed = tx
                     .execute(
                         "UPDATE tasks
                          SET status = 'open', pending_verification = 0, notes = ?2, updated_at = ?3
                          WHERE id = ?1 AND status = 'pending_supervisor_review'",
-                        rusqlite::params![req.task_id, notes, chrono::Utc::now().to_rfc3339(),],
+                        rusqlite::params![req.task_id, notes, reopened_at.to_rfc3339(),],
                     )
                     .map_err(|e| McpError {
                         code: ErrorCode::INTERNAL_ERROR,
@@ -721,6 +723,7 @@ impl CasCore {
                         data: None,
                     });
                 }
+                rejection_reopened_at = Some(reopened_at);
             } else if delivery_transitioned {
                 tx.execute(
                     "UPDATE tasks
@@ -758,6 +761,46 @@ impl CasCore {
             tx.commit().map_err(|e| McpError {
                 code: ErrorCode::INTERNAL_ERROR,
                 message: Cow::from(format!("Failed to commit verification transaction: {e}")),
+                data: None,
+            })?;
+        }
+
+        // Reopening after a rejected supervisor review leaves the prior worker
+        // assigned but without an active lease. This is not ordinary ready work:
+        // a supervisor must explicitly resume that worker or replace it. Route
+        // the transition through the durable lifecycle outbox so an idle
+        // supervisor receives one wake-eligible, acknowledgeable recovery cue.
+        if let Some(reopened_at) = rejection_reopened_at {
+            use crate::mcp::tools::core::task::lifecycle::supervisor_push::{
+                emit_task_lifecycle_transition, occurrence_from_updated_at, LifecycleTransition,
+            };
+            let supervisor_queue = crate::store::open_supervisor_queue_store(&self.cas_root)
+                .map_err(|e| McpError {
+                    code: ErrorCode::INTERNAL_ERROR,
+                    message: Cow::from(format!("Failed to open supervisor queue for rejection wake: {e}")),
+                    data: None,
+                })?;
+            let prompt_queue = crate::store::open_prompt_queue_store(&self.cas_root).map_err(|e| McpError {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(format!("Failed to open prompt queue for rejection wake: {e}")),
+                data: None,
+            })?;
+            emit_task_lifecycle_transition(
+                supervisor_queue.as_ref(),
+                Some(prompt_queue.as_ref()),
+                agent_store.as_ref(),
+                &req.task_id,
+                &task.title,
+                TaskStatus::PendingSupervisorReview,
+                TaskStatus::Open,
+                &caller_id,
+                Some("Verification rejected; worker remains assigned but inactive. Resume the existing worker or replace it."),
+                LifecycleTransition::VerificationRejectedReopened,
+                &occurrence_from_updated_at(reopened_at),
+            )
+            .map_err(|e| McpError {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(format!("Verification rejection reopened task but supervisor recovery wake failed: {e}")),
                 data: None,
             })?;
         }

--- a/cas-cli/src/mcp/tools/core/workflow/verification_tools.rs
+++ b/cas-cli/src/mcp/tools/core/workflow/verification_tools.rs
@@ -7,6 +7,8 @@ const SUPERVISOR_DIRECT_RECOVERY_DISPATCH_TIMEOUT_SECS: i64 = 600;
 /// Structured task label marking an Open task that was reopened by a rejected
 /// supervisor review and therefore needs a supervisor recovery decision.
 pub const VERIFICATION_REJECTED_REOPEN_LABEL: &str = "verification-rejected-reopen";
+pub const VERIFICATION_REJECTED_REOPEN_RECOVERY: &str =
+    "Verification rejected; worker remains assigned but inactive. Resume the existing worker or replace it.";
 
 impl CasCore {
     pub async fn cas_verification_add(
@@ -806,7 +808,7 @@ impl CasCore {
                 TaskStatus::PendingSupervisorReview,
                 TaskStatus::Open,
                 &caller_id,
-                Some("Verification rejected; worker remains assigned but inactive. Resume the existing worker or replace it."),
+                Some(VERIFICATION_REJECTED_REOPEN_RECOVERY),
                 LifecycleTransition::VerificationRejectedReopened,
                 &occurrence_from_updated_at(reopened_at),
             )

--- a/cas-cli/src/mcp/tools/core/workflow/verification_tools.rs
+++ b/cas-cli/src/mcp/tools/core/workflow/verification_tools.rs
@@ -4,6 +4,9 @@ use crate::mcp::tools::core::imports::*;
 // creates the same short-lived, durable boundary that a normal worker close
 // would have created before an external merge left the task review-pending.
 const SUPERVISOR_DIRECT_RECOVERY_DISPATCH_TIMEOUT_SECS: i64 = 600;
+/// Structured task label marking an Open task that was reopened by a rejected
+/// supervisor review and therefore needs a supervisor recovery decision.
+pub const VERIFICATION_REJECTED_REOPEN_LABEL: &str = "verification-rejected-reopen";
 
 impl CasCore {
     pub async fn cas_verification_add(
@@ -699,13 +702,22 @@ impl CasCore {
                 } else {
                     format!("{}\n\n{}", task.notes.trim_end(), decision)
                 };
+                let mut labels = task.labels.clone();
+                if !labels.iter().any(|label| label == VERIFICATION_REJECTED_REOPEN_LABEL) {
+                    labels.push(VERIFICATION_REJECTED_REOPEN_LABEL.to_string());
+                }
+                let labels = serde_json::to_string(&labels).map_err(|e| McpError {
+                    code: ErrorCode::INTERNAL_ERROR,
+                    message: Cow::from(format!("Failed to serialize rejection recovery label: {e}")),
+                    data: None,
+                })?;
                 let reopened_at = chrono::Utc::now();
                 let changed = tx
                     .execute(
                         "UPDATE tasks
-                         SET status = 'open', pending_verification = 0, notes = ?2, updated_at = ?3
+                         SET status = 'open', pending_verification = 0, notes = ?2, labels = ?3, updated_at = ?4
                          WHERE id = ?1 AND status = 'pending_supervisor_review'",
-                        rusqlite::params![req.task_id, notes, reopened_at.to_rfc3339(),],
+                        rusqlite::params![req.task_id, notes, labels, reopened_at.to_rfc3339(),],
                     )
                     .map_err(|e| McpError {
                         code: ErrorCode::INTERNAL_ERROR,

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -1,4 +1,5 @@
 use crate::mcp::tools::service::imports::*;
+use crate::mcp::tools::core::workflow::verification_tools::VERIFICATION_REJECTED_REOPEN_LABEL;
 
 /// Resolve and validate an explicit Claude config directory before its spawn
 /// request reaches the daemon.  A partial profile otherwise starts a PTY that
@@ -2609,7 +2610,7 @@ impl CasService {
                     assigned_open_task.map(|t| (
                         t.id.as_str(),
                         t.title.as_str(),
-                        t.labels.iter().any(|label| label == "verification-rejected-reopen"),
+                        t.labels.iter().any(|label| label == VERIFICATION_REJECTED_REOPEN_LABEL),
                     )),
                     parked_tasks
                         .iter()

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -2609,7 +2609,7 @@ impl CasService {
                     assigned_open_task.map(|t| (
                         t.id.as_str(),
                         t.title.as_str(),
-                        t.notes.contains("Decision: supervisor review rejected"),
+                        t.labels.iter().any(|label| label == "verification-rejected-reopen"),
                     )),
                     parked_tasks
                         .iter()

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -563,7 +563,7 @@ const SPAWN_HISTORY_WINDOW_SECS: i64 = 1800;
 /// Pure over its inputs so every branch is testable without a store.
 fn format_assigned_task_info(
     in_progress: Option<(&str, &str)>,
-    assigned_open: Option<(&str, &str)>,
+    assigned_open: Option<(&str, &str, bool)>,
     parked: Option<(&str, &str, cas_types::TaskStatus)>,
 ) -> String {
     const TITLE_CAP: usize = 60;
@@ -583,7 +583,11 @@ fn format_assigned_task_info(
         // Assigned but not started: the dispatch grace window, or a worker that
         // never picked the task up. Naming it lets the supervisor tell those
         // apart without opening anything.
-        (None, Some((id, title)), _) => {
+        (None, Some((id, title, true)), _) => format!(
+            "\n    task: {id} (verification rejected; assigned worker inactive) — {} → WAITING ON YOU: resume the existing worker or replace it",
+            truncate(title)
+        ),
+        (None, Some((id, title, false)), _) => {
             format!(
                 "\n    task: {id} (assigned, not started) — {}",
                 truncate(title)
@@ -2602,7 +2606,11 @@ impl CasService {
                         .iter()
                         .find(|t| matches_agent(t.assignee.as_deref()))
                         .map(|t| (t.id.as_str(), t.title.as_str())),
-                    assigned_open_task.map(|t| (t.id.as_str(), t.title.as_str())),
+                    assigned_open_task.map(|t| (
+                        t.id.as_str(),
+                        t.title.as_str(),
+                        t.notes.contains("Decision: supervisor review rejected"),
+                    )),
                     parked_tasks
                         .iter()
                         .find(|t| matches_agent(t.assignee.as_deref()))
@@ -7820,10 +7828,21 @@ mod spawn_lifecycle_tests {
     /// up, and the supervisor must be able to tell those from an idle row.
     #[test]
     fn assigned_but_unstarted_is_distinguished_from_in_progress() {
-        let out = format_assigned_task_info(None, Some(("cas-4242", "Fix the thing")), None);
+        let out = format_assigned_task_info(None, Some(("cas-4242", "Fix the thing", false)), None);
         assert!(out.contains("cas-4242"), "{out}");
         assert!(out.contains("assigned, not started"), "{out}");
         assert!(!out.contains("in progress"), "{out}");
+    }
+
+    #[test]
+    fn rejected_review_reopen_is_waiting_on_supervisor() {
+        let out = format_assigned_task_info(
+            None,
+            Some(("cas-56f8", "Needs rework", true)),
+            None,
+        );
+        assert!(out.contains("WAITING ON YOU"), "{out}");
+        assert!(out.contains("resume the existing worker or replace it"), "{out}");
     }
 
     /// In-progress wins when a worker somehow holds both — the started task is
@@ -7832,7 +7851,7 @@ mod spawn_lifecycle_tests {
     fn in_progress_takes_precedence_over_open_assignment() {
         let out = format_assigned_task_info(
             Some(("cas-1111", "Started work")),
-            Some(("cas-2222", "Also assigned")),
+            Some(("cas-2222", "Also assigned", false)),
             None,
         );
         assert!(out.contains("cas-1111"), "{out}");

--- a/cas-cli/tests/mcp_tools_test/task_tools/supervisor_review_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/supervisor_review_flow.rs
@@ -567,6 +567,13 @@ async fn test_supervisor_verify_on_pending_review_task_works() {
     assert!(!rejected_task.pending_verification);
     assert!(
         rejected_task
+            .labels
+            .iter()
+            .any(|label| label == "verification-rejected-reopen"),
+        "rejection reopen must persist the structured worker-status signal"
+    );
+    assert!(
+        rejected_task
             .notes
             .contains("Decision: supervisor review rejected"),
         "the rejected verdict must leave an audited decision note"
@@ -589,6 +596,16 @@ async fn test_supervisor_verify_on_pending_review_task_works() {
             .unwrap()
             .status,
         TaskStatus::InProgress
+    );
+    assert!(
+        !open_task_store(&cas_dir)
+            .unwrap()
+            .get(&rejected_task_id)
+            .unwrap()
+            .labels
+            .iter()
+            .any(|label| label == "verification-rejected-reopen"),
+        "resuming the worker must clear the recovery marker"
     );
 
     let latest = open_verification_store(&cas_dir)


### PR DESCRIPTION
A worker closed into PendingSupervisorReview, the supervisor's verification was rejected, and the task returned to Open with its assignee preserved — but with no active lease and no fresh actionable relay. The worker read as `assigned, not started`, indistinguishable from a benign dispatch-grace window, and both sides could idle indefinitely until a human asked for status.

- Rejected PSR verification now emits one occurrence-idempotent, wake-eligible lifecycle relay (`VerificationRejectedReopened`) naming the exact recovery action: resume the existing worker or replace it.
- The state is marked by a structured `verification-rejected-reopen` label written in the same transaction as the status change, and cleared in the same way when the assigned worker resumes — so a later unrelated Open state cannot render as waiting on the supervisor.
- `worker_status` renders that lane as WAITING ON YOU with the recovery action, instead of benign assigned inactivity.
- The label and the recovery sentence are each declared once (`VERIFICATION_REJECTED_REOPEN_LABEL`, `VERIFICATION_REJECTED_REOPEN_RECOVERY`) and imported by every writer, reader and test, so rewording either cannot silently disable the detection.

## Verification

- `verification_rejection_reopen_wakes_once_and_replay_after_ack_is_quiet` emits the transition, asserts exactly one wake-eligible durable/prompt row carrying the recovery text, acknowledges it, replays the identical occurrence, and asserts `AlreadyComplete` with no second wake.
- Scoped `--lib supervisor_push`: **22/22 passed**. This run was executed by the supervisor in the worker's worktree — the worker's own pane could not retain the nextest child under fleet compile contention, and it correctly declined to claim a result it had not observed.
- Branch CI green on 356c87d1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)