### PR TITLE
fix(cas-d518): make focused-context retrieval deterministic — legacy index schema silently disabled the lexical scorer

### DIFF
--- a/cas-cli/src/hybrid_search/mod.rs
+++ b/cas-cli/src/hybrid_search/mod.rs
@@ -193,6 +193,35 @@ pub struct SearchIndex {
     cached_query_parser: Mutex<Option<QueryParser>>,
 }
 
+impl Clone for SearchIndex {
+    fn clone(&self) -> Self {
+        Self {
+            index: self.index.clone(),
+            schema: self.schema.clone(),
+            id_field: self.id_field,
+            content_field: self.content_field,
+            tags_field: self.tags_field,
+            type_field: self.type_field,
+            title_field: self.title_field,
+            doc_type_field: self.doc_type_field,
+            language_field: self.language_field,
+            kind_field: self.kind_field,
+            file_path_field: self.file_path_field,
+            module_field: self.module_field,
+            track_field: self.track_field,
+            problem_type_field: self.problem_type_field,
+            severity_field: self.severity_field,
+            root_cause_field: self.root_cause_field,
+            mem_date_field: self.mem_date_field,
+            writer_memory: self.writer_memory,
+            // Readers and parsers are cheap, instance-local caches. Rebuilding
+            // them avoids sharing synchronization state between CasCore clones.
+            cached_reader: Mutex::new(None),
+            cached_query_parser: Mutex::new(None),
+        }
+    }
+}
+
 /// Options for search queries
 #[derive(Debug, Clone)]
 pub struct SearchOptions {

--- a/cas-cli/src/mcp/server/mod.rs
+++ b/cas-cli/src/mcp/server/mod.rs
@@ -15,9 +15,10 @@ use crate::store::{
     WorktreeStore, open_agent_store, open_entity_store, open_rule_store, open_skill_store,
     open_store, open_task_store, open_verification_store, open_worktree_store,
 };
-use cas_core::SearchIndex;
 use cas_core::{SkillSyncer, Syncer};
 use tracing::{debug, info, warn};
+
+use crate::hybrid_search::SearchIndex;
 
 use crate::mcp::daemon::{ActivityTracker, EmbeddedDaemon, EmbeddedDaemonStatus};
 

--- a/cas-cli/src/mcp/tools/core/search.rs
+++ b/cas-cli/src/mcp/tools/core/search.rs
@@ -550,6 +550,24 @@ impl CasCore {
                         },
                     )
                 }
+                DocType::KnowledgePage => (
+                    format!("[Knowledge] {}", result.id),
+                    scope_filter != ScopeFilter::Global && tags_filter.is_empty(),
+                    HitMetadata {
+                        origin: Some("knowledge_index".to_string()),
+                        scope: "project".to_string(),
+                        ..Default::default()
+                    },
+                ),
+                DocType::HistoryCommit | DocType::HistoryDoc => (
+                    format!("[History] {}", result.id),
+                    scope_filter != ScopeFilter::Global && tags_filter.is_empty(),
+                    HitMetadata {
+                        origin: Some("history_index".to_string()),
+                        scope: "project".to_string(),
+                        ..Default::default()
+                    },
+                ),
             };
 
             if matches_filters {

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -172,7 +172,7 @@ fn recent_other_epic_planner(
 /// noise or friction to task creation/spawning.
 impl CasCore {
     pub(crate) fn related_recall(&self, query: &str) -> Option<String> {
-        use cas_core::search::{DocType, SearchOptions};
+        use crate::hybrid_search::{DocType, SearchOptions};
 
         let query = query.trim();
         if query.is_empty() {

--- a/cas-cli/src/mcp/tools/mod.rs
+++ b/cas-cli/src/mcp/tools/mod.rs
@@ -18,7 +18,7 @@ use crate::types::{
     SkillStatus, SkillType, Task, TaskStatus, TaskType, Verification, VerificationIssue,
     VerificationStatus, VerificationType, WorktreeStatus,
 };
-use cas_core::{DocType, SearchIndex, SearchOptions};
+use crate::hybrid_search::{DocType, SearchIndex, SearchOptions};
 
 // Include all request types
 mod types;

--- a/cas-cli/src/mcp/tools/service/core.rs
+++ b/cas-cli/src/mcp/tools/service/core.rs
@@ -789,7 +789,7 @@ impl CasService {
         req: RuleRequest,
     ) -> Result<CallToolResult, McpError> {
         use crate::store::open_rule_store;
-        use cas_core::{DocType, SearchOptions};
+        use crate::hybrid_search::{DocType, SearchOptions};
 
         let content = req.content.ok_or_else(|| {
             Self::error(

--- a/cas-cli/tests/mcp_tools_test/system_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/system_tools.rs
@@ -54,7 +54,7 @@ async fn test_context() {
 /// lexical task matches instead of filling Helpful Memories with generic picks.
 #[tokio::test]
 async fn task_focused_context_surfaces_preferences_and_task_content_matches() {
-    let (_temp, core) = setup_cas();
+    let (temp, core) = setup_cas();
     let service = CasService::new(core.clone(), None);
 
     let task = TaskCreateRequest {
@@ -146,6 +146,24 @@ async fn task_focused_context_surfaces_preferences_and_task_content_matches() {
         )
         .await;
     }
+
+    // cas-d518: CasCore's write path and task-focused context must use the
+    // same rich search schema. The former once cached cas-core's legacy
+    // six-field index while HybridContextScorer expected cas-cli's 15-field
+    // schema at the same path. Opening context then destructively rebuilt a
+    // live index and could fail with ENOTEMPTY under suite concurrency.
+    let index = tantivy::Index::open_in_dir(temp.path().join(".cas/index/tantivy"))
+        .expect("the production write path should create a readable search index");
+    let field_names: Vec<String> = index
+        .schema()
+        .fields()
+        .map(|(_, field)| field.name().to_string())
+        .collect();
+    assert_eq!(field_names.len(), 15, "unexpected search schema: {field_names:?}");
+    assert!(
+        field_names.iter().any(|field| field == "module"),
+        "rich schema missing: {field_names:?}"
+    );
 
     let request: SearchContextRequest = serde_json::from_value(json!({
         "action": "context",


### PR DESCRIPTION
`task_focused_context_surfaces_preferences_and_task_content_matches` failed in the full suite and passed on rerun of the identical commit. It blocked two unrelated P1 merges today (PR #343 and PR #346) and was previously filed and closed as cas-1c22 on an unrelated PR, so the earlier fix did not make it deterministic.

## Root cause (proven, not inferred)

CasCore wrote a live legacy 6-field Tantivy index while focused context expected 15 fields at the same path. The destructive rebuild that reconciles them intermittently failed with `ENOTEMPTY`, which left `HybridContextScorer` as `None` — silently bypassing the lexical bonus that cas-1c22 added. The assertion that a task's title/description match must surface then failed, with no error surfaced anywhere: a scorer that fails to construct degraded to "no lexical scoring" rather than to an error.

That is why it looked nondeterministic. The outcome depended on whether the rebuild happened to win its race, not on anything in the code under test.

## Verification

- Exact test binary run **1,000/1,000 across fresh processes at 24-way concurrency** — determinism demonstrated by repetition under the concurrency that provoked it, not by a single green run.
- MCP search integration 10/10; the focused-context contract test is unchanged and still passes, so the assertion's meaning was preserved rather than weakened.
- Branch CI green on e6359743.

Merging this first, ahead of the rest of the queue, because every subsequent full-suite run is exposed to this flake until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)