### PR TITLE
fix(cas-9fd4): free a task held hostage by an idle worker's verification dispatch, and name the escape hatch

### DIFF
--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -1872,9 +1872,10 @@ impl CasCore {
                             req.id, timed_out.id, req.id, timed_out.id
                         )));
                     }
+                    let sup_ver = supervisor_verification_tool();
                     return Ok(Self::tool_error(format!(
-                        "⚠️ VERIFICATION REQUIRED\n\nTask {} cannot close until exact pending dispatch {} records its capability-bound verifier or registered supervisor-direct verdict.",
-                        req.id, dispatch.id
+                        "⚠️ VERIFICATION REQUIRED\n\nTask {} cannot close until exact pending dispatch {} records its capability-bound verifier or registered supervisor-direct verdict. If the bound worker or verifier is unavailable, a registered supervisor can recover without them: {} action=add task_id={} dispatch_id={} status=approved summary=\"...\", then retry task close.",
+                        req.id, dispatch.id, sup_ver, req.id, dispatch.id
                     )));
                 }
                 Ok(Some(dispatch))
@@ -3053,7 +3054,7 @@ impl CasCore {
 
                             let requester_id = self.get_agent_id()?;
                             let owner_id = self.verification_dispatch_owner(&requester_id)?;
-                            let supervisor_recovery = self
+                            let supervisor_direct_recovery = self
                                 .open_agent_store()?
                                 .get(&requester_id)
                                 .is_ok_and(|agent| {
@@ -3068,7 +3069,7 @@ impl CasCore {
                                 &proof_boundary,
                                 chrono::Utc::now()
                                     + chrono::Duration::seconds(VERIFICATION_DISPATCH_TIMEOUT_SECS),
-                                supervisor_recovery,
+                                supervisor_direct_recovery,
                             )
                             .map_err(|error| McpError {
                                 code: ErrorCode::INTERNAL_ERROR,
@@ -3167,16 +3168,23 @@ impl CasCore {
                                     req.id
                                 )
                             };
+                            let sup_ver = supervisor_verification_tool();
+                            let supervisor_recovery_hint = format!(
+                                "If the bound worker or verifier is unavailable, a registered supervisor can recover without them: {sup_ver} action=add task_id={} dispatch_id={} status=approved summary=\"...\", then retry task close.",
+                                req.id, dispatch.id
+                            );
 
                             return Ok(Self::tool_error(format!(
                                 "⚠️ VERIFICATION REQUIRED\n\n\
                                 Task {} requires verification before closing.\n\n\
                                 {}{}\n\n\
+                                {}\n\n\
                                 {}{}\n\n\
                                 {}",
                                 req.id,
                                 verification_gate,
                                 verification_desc,
+                                supervisor_recovery_hint,
                                 close_reason_section.as_str(),
                                 if is_worker_without_subagents {
                                     // cas-8aaf: harness-appropriate supervisor verification tool.

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -1,5 +1,5 @@
-use crate::mcp::tools::service::imports::*;
 use crate::mcp::tools::core::workflow::verification_tools::VERIFICATION_REJECTED_REOPEN_LABEL;
+use crate::mcp::tools::service::imports::*;
 
 /// Resolve and validate an explicit Claude config directory before its spawn
 /// request reaches the daemon.  A partial profile otherwise starts a PTY that
@@ -566,6 +566,7 @@ fn format_assigned_task_info(
     in_progress: Option<(&str, &str)>,
     assigned_open: Option<(&str, &str, bool)>,
     parked: Option<(&str, &str, cas_types::TaskStatus)>,
+    parked_merge_already_integrated: bool,
 ) -> String {
     const TITLE_CAP: usize = 60;
     let truncate = |title: &str| -> String {
@@ -602,29 +603,33 @@ fn format_assigned_task_info(
         (None, None, Some((id, title, status))) => {
             // Matched exhaustively on purpose: a catch-all would silently
             // relabel any status added to the parked set later.
-            let (label, action) = match status {
+            let (label, waiting) = match status {
+                cas_types::TaskStatus::AwaitingMerge if parked_merge_already_integrated => (
+                    "delivered-and-merged, awaiting worker re-close",
+                    "WAITING ON WORKER: the assigned worker must retry task close",
+                ),
                 cas_types::TaskStatus::AwaitingMerge => (
                     "finished, awaiting merge",
-                    "merge its branch, then it can close",
+                    "WAITING ON YOU: merge its branch, then it can close",
                 ),
                 cas_types::TaskStatus::PendingSupervisorReview => (
                     "finished, awaiting supervisor review",
-                    "review it, then it can close",
+                    "WAITING ON YOU: review it, then it can close",
                 ),
                 cas_types::TaskStatus::Blocked => (
                     "blocked",
-                    "clear the blocker or reassign — the worker cannot proceed",
+                    "WAITING ON YOU: clear the blocker or reassign — the worker cannot proceed",
                 ),
                 cas_types::TaskStatus::Open
                 | cas_types::TaskStatus::InProgress
-                | cas_types::TaskStatus::Closed => ("parked", "check the task"),
+                | cas_types::TaskStatus::Closed => ("parked", "WAITING ON YOU: check the task"),
                 cas_types::TaskStatus::Cancelled => (
                     "cancelled without delivery",
-                    "no delivery or merge action is pending",
+                    "WAITING ON YOU: no delivery or merge action is pending",
                 ),
             };
             format!(
-                "\n    task: {id} ({label}) — {} → WAITING ON YOU: {action}",
+                "\n    task: {id} ({label}) — {} → {waiting}",
                 truncate(title)
             )
         }
@@ -2602,20 +2607,31 @@ impl CasService {
                 let matches_agent = |assignee: Option<&str>| {
                     assignee == Some(agent.name.as_str()) || assignee == Some(agent.id.as_str())
                 };
+                let parked_task = parked_tasks
+                    .iter()
+                    .find(|t| matches_agent(t.assignee.as_deref()));
                 let task_info = format_assigned_task_info(
                     in_progress_tasks
                         .iter()
                         .find(|t| matches_agent(t.assignee.as_deref()))
                         .map(|t| (t.id.as_str(), t.title.as_str())),
-                    assigned_open_task.map(|t| (
-                        t.id.as_str(),
-                        t.title.as_str(),
-                        t.labels.iter().any(|label| label == VERIFICATION_REJECTED_REOPEN_LABEL),
-                    )),
-                    parked_tasks
-                        .iter()
-                        .find(|t| matches_agent(t.assignee.as_deref()))
-                        .map(|t| (t.id.as_str(), t.title.as_str(), t.status)),
+                    assigned_open_task.map(|t| {
+                        (
+                            t.id.as_str(),
+                            t.title.as_str(),
+                            t.labels
+                                .iter()
+                                .any(|label| label == VERIFICATION_REJECTED_REOPEN_LABEL),
+                        )
+                    }),
+                    parked_task.map(|t| (t.id.as_str(), t.title.as_str(), t.status)),
+                    parked_task.is_some_and(|task| {
+                        awaiting_merge_delivery_is_already_integrated(
+                            &self.inner.cas_root,
+                            task,
+                            clone_path.as_deref(),
+                        )
+                    }),
                 );
                 output.push_str(&format!(
                     "  • {} (heartbeat: {}){}{}{}{}{}{}{}{}{}{}{}{}{}\n    session: {}\n",
@@ -5097,6 +5113,61 @@ fn task_branch_affinity(
         return BranchAffinity::Branch(target.to_string());
     }
     BranchAffinity::Trunk
+}
+
+/// True when an `AwaitingMerge` task's parked factory branch is already
+/// reachable from the task's real integration target.
+///
+/// `AwaitingMerge` normally means the supervisor still has to land the branch,
+/// but a worker can go idle after that landing and before its required re-close.
+/// Reporting the normal merge instruction in that state sends the supervisor
+/// back to an action that is already complete. This is best-effort status
+/// evidence only: unknown Git state retains the conservative normal wording.
+fn awaiting_merge_delivery_is_already_integrated(
+    cas_root: &std::path::Path,
+    task: &cas_types::Task,
+    clone_path: Option<&str>,
+) -> bool {
+    if task.status != cas_types::TaskStatus::AwaitingMerge {
+        return false;
+    }
+    let Some(clone_path) = clone_path else {
+        return false;
+    };
+    let path = std::path::Path::new(clone_path);
+    let Ok(task_store) = crate::store::open_task_store_local(cas_root) else {
+        return false;
+    };
+    let target = match task_branch_affinity(task_store.as_ref(), task) {
+        BranchAffinity::Branch(branch) => branch,
+        // The normal trunk's exact name is repository-specific. Resolve the
+        // same local default signal Git uses for worker status, then retain the
+        // established `main` fallback for repositories without an origin HEAD.
+        BranchAffinity::Trunk => run_git(
+            path,
+            &["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+        )
+        .unwrap_or_else(|_| "main".to_string()),
+        BranchAffinity::Unknown => return false,
+    };
+    let source = task
+        .deliverables
+        .parked_branch
+        .as_deref()
+        .filter(|branch| !branch.trim().is_empty())
+        .unwrap_or("HEAD");
+
+    let target = target.trim();
+    if target.is_empty() {
+        return false;
+    }
+    let mut candidates = vec![target.to_string()];
+    if !target.starts_with("origin/") && !target.starts_with("refs/") {
+        candidates.push(format!("origin/{target}"));
+    }
+    candidates.into_iter().any(|candidate| {
+        run_git(path, &["merge-base", "--is-ancestor", source, &candidate]).is_ok()
+    })
 }
 
 /// Map worker display name -> the task binding sync must respect.
@@ -7818,6 +7889,7 @@ mod spawn_lifecycle_tests {
             Some(("cas-8b84", "Worker lifecycle observability")),
             None,
             None,
+            false,
         );
         assert!(out.contains("cas-8b84"), "{out}");
         assert!(out.contains("in progress"), "{out}");
@@ -7829,7 +7901,12 @@ mod spawn_lifecycle_tests {
     /// up, and the supervisor must be able to tell those from an idle row.
     #[test]
     fn assigned_but_unstarted_is_distinguished_from_in_progress() {
-        let out = format_assigned_task_info(None, Some(("cas-4242", "Fix the thing", false)), None);
+        let out = format_assigned_task_info(
+            None,
+            Some(("cas-4242", "Fix the thing", false)),
+            None,
+            false,
+        );
         assert!(out.contains("cas-4242"), "{out}");
         assert!(out.contains("assigned, not started"), "{out}");
         assert!(!out.contains("in progress"), "{out}");
@@ -7837,13 +7914,13 @@ mod spawn_lifecycle_tests {
 
     #[test]
     fn rejected_review_reopen_is_waiting_on_supervisor() {
-        let out = format_assigned_task_info(
-            None,
-            Some(("cas-56f8", "Needs rework", true)),
-            None,
-        );
+        let out =
+            format_assigned_task_info(None, Some(("cas-56f8", "Needs rework", true)), None, false);
         assert!(out.contains("WAITING ON YOU"), "{out}");
-        assert!(out.contains("resume the existing worker or replace it"), "{out}");
+        assert!(
+            out.contains("resume the existing worker or replace it"),
+            "{out}"
+        );
     }
 
     /// In-progress wins when a worker somehow holds both — the started task is
@@ -7854,6 +7931,7 @@ mod spawn_lifecycle_tests {
             Some(("cas-1111", "Started work")),
             Some(("cas-2222", "Also assigned", false)),
             None,
+            false,
         );
         assert!(out.contains("cas-1111"), "{out}");
         assert!(!out.contains("cas-2222"), "{out}");
@@ -7863,7 +7941,7 @@ mod spawn_lifecycle_tests {
     /// as missing data; "none assigned" is an answer.
     #[test]
     fn unassigned_worker_says_none_assigned() {
-        let out = format_assigned_task_info(None, None, None);
+        let out = format_assigned_task_info(None, None, None, false);
         assert!(out.contains("none assigned"), "{out}");
     }
 
@@ -7871,7 +7949,7 @@ mod spawn_lifecycle_tests {
     #[test]
     fn long_titles_are_truncated() {
         let long = "x".repeat(200);
-        let out = format_assigned_task_info(Some(("cas-9999", &long)), None, None);
+        let out = format_assigned_task_info(Some(("cas-9999", &long)), None, None, false);
         assert!(out.contains('…'), "{out}");
         assert!(
             out.len() < 140,
@@ -9089,6 +9167,7 @@ effort = "high"
             None,
             None,
             Some(("cas-block", "Stuck work", cas_types::TaskStatus::Blocked)),
+            false,
         );
         assert!(out.contains("cas-block"), "{out}");
         assert!(out.contains("blocked"), "{out}");
@@ -9486,6 +9565,7 @@ effort = "high"
                 "Done work",
                 cas_types::TaskStatus::AwaitingMerge,
             )),
+            false,
         );
         assert!(merge.contains("cas-1234"), "{merge}");
         assert!(merge.contains("awaiting merge"), "{merge}");
@@ -9500,6 +9580,7 @@ effort = "high"
                 "Reviewed work",
                 cas_types::TaskStatus::PendingSupervisorReview,
             )),
+            false,
         );
         assert!(review.contains("awaiting supervisor review"), "{review}");
     }
@@ -9515,6 +9596,7 @@ effort = "high"
                 "Old work",
                 cas_types::TaskStatus::AwaitingMerge,
             )),
+            false,
         );
         assert!(out.contains("cas-live"), "{out}");
         assert!(!out.contains("cas-parked"), "{out}");

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -1234,7 +1234,9 @@ async fn test_spawn_workers_undispatchable_task_id_is_rejected_without_epic() {
             // register this fixture holder to retain its live-owner contract.
             let mut agent = Agent::new("alpha-agent-id".to_string(), holder.to_string());
             agent.role = AgentRole::Worker;
-            env.agent_store().register(&agent).expect("register live holder");
+            env.agent_store()
+                .register(&agent)
+                .expect("register live holder");
         }
         let task_store = env.task_store();
         let id = task_store.generate_id().expect("generate_id");
@@ -2297,6 +2299,86 @@ async fn test_worker_status_names_finished_awaiting_merge_as_waiting_on_supervis
         done.assignee = None;
         task_store.update(&done).expect("clear");
     }
+}
+
+/// cas-9fd4 (GH #341): the normal AwaitingMerge advice becomes stale after a
+/// supervisor has already landed the parked factory branch. The worker still
+/// has to re-close, so status must name that real blocker instead of asking
+/// the supervisor to merge the same branch again.
+#[tokio::test]
+async fn test_worker_status_names_delivered_merge_awaiting_worker_reclose_cas_9fd4() {
+    use std::process::Command;
+
+    let _guard = EnvGuard::set(&[]);
+    let env = FactoryTestEnv::new();
+    env.register_supervisor("sup-1");
+    let worker = "cas-9fd4-wolf";
+    let worker_path = init_sync_repo(&env, worker);
+    let mut metadata = HashMap::new();
+    metadata.insert("clone_path".to_string(), worker_path.display().to_string());
+    env.register_worker_with_metadata(worker, metadata);
+
+    let git = |dir: &std::path::Path, args: &[&str]| {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("run git fixture command");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    std::fs::write(worker_path.join("delivered.txt"), "delivered\n").expect("write delivery");
+    git(&worker_path, &["add", "delivered.txt"]);
+    git(&worker_path, &["commit", "-m", "deliver cas-9fd4"]);
+
+    let project = env.cas_root.parent().expect("project root");
+    git(project, &["checkout", "epic/requested"]);
+    git(
+        project,
+        &[
+            "merge",
+            "--no-ff",
+            &format!("factory/{worker}"),
+            "-m",
+            "merge delivered worker branch",
+        ],
+    );
+    git(project, &["checkout", "main"]);
+
+    let task_store = env.task_store();
+    let id = task_store.generate_id().expect("id");
+    let mut task = Task::new(id.clone(), "Delivered task awaiting re-close".to_string());
+    task.status = TaskStatus::AwaitingMerge;
+    task.assignee = Some(worker.to_string());
+    task.deliverables.parked_branch = Some(format!("factory/{worker}"));
+    task.deliverables.work_target = Some(WorkTarget {
+        repo_selector: "project:active-project".to_string(),
+        target_branch: "epic/requested".to_string(),
+    });
+    task_store.add(&task).expect("add task");
+
+    let text = get_text(
+        &env.service
+            .factory(Parameters(factory_req("worker_status")))
+            .await
+            .expect("status"),
+    );
+    assert!(
+        text.contains("delivered-and-merged, awaiting worker re-close"),
+        "status must report the delivered state, not stale merge work: {text}"
+    );
+    assert!(
+        text.contains("WAITING ON WORKER") && text.contains("retry task close"),
+        "status must name the worker re-close as the blocker: {text}"
+    );
+    assert!(
+        !text.contains("merge its branch, then it can close"),
+        "already-integrated branch must not receive stale merge advice: {text}"
+    );
 }
 
 /// cas-e728 review follow-up: `all_workers` broadcasts are real inbox items

--- a/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
@@ -8440,6 +8440,52 @@ async fn test_close_unverified_task_still_blocked_by_own_missing_verification_ca
     );
 }
 
+/// cas-9fd4 (GH #341): the direct close gate must tell a supervisor exactly
+/// how to resolve a dispatch whose bound worker/verifier is unavailable.
+#[tokio::test]
+async fn test_pending_dispatch_close_gate_prints_supervisor_recovery_cas_9fd4() {
+    let (_temp, service) = setup_cas();
+    let _env_lock = env_test_lock();
+
+    let created = service
+        .cas_task_create(Parameters(simple_task_req(
+            "cas-9fd4: direct pending-dispatch recovery guidance",
+        )))
+        .await
+        .expect("create");
+    let id = extract_task_id(&extract_text(created))
+        .expect("task id")
+        .to_string();
+    service
+        .cas_task_start(Parameters(IdRequest { id: id.clone() }))
+        .await
+        .expect("start");
+
+    let text = extract_text(
+        service
+            .cas_task_close(Parameters(TaskCloseRequest {
+                id: id.clone(),
+                reason: Some("Ready for supervisor verification".to_string()),
+                bypass_code_review: None,
+                code_review_findings: None,
+                search_manifest: None,
+                commit_receipt: None,
+            }))
+            .await
+            .expect("direct close returns verification guidance"),
+    );
+    assert!(
+        text.contains("VERIFICATION REQUIRED") && text.contains("vdispatch-"),
+        "direct close must create and name the exact dispatch: {text}"
+    );
+    assert!(
+        text.contains(&format!(
+            "mcp__cas__verification action=add task_id={id} dispatch_id=vdispatch-"
+        )) && text.contains("status=approved"),
+        "gate must print the registered-supervisor recovery call: {text}"
+    );
+}
+
 /// cas-a3ca (replay sequence): the exact cas-cdee/cas-8236 scenario.
 ///
 /// Worker has task A (verified, merge-ready) and starts task B while A's close


### PR DESCRIPTION
A P0 task was delivered, merged and verified as an ancestor of main — then the worker went idle for five minutes without re-closing. `worker_status` still said "WAITING ON YOU: merge its branch", advice for a merge that was already complete and pushed. The supervisor's own close was refused with an opaque `vdispatch-...` ID and the phrase "registered supervisor-direct verdict", naming the requirement while withholding the remedy. Nothing in the error or the tool description pointed at `verification action=add` or its `dispatch_id` parameter, so a supervisor who had not hit this before had no path forward.

- The `VERIFICATION REQUIRED` error now prints the exact recovery call inline, with `task_id` and `dispatch_id` filled in, on both gate paths.
- `worker_status` distinguishes `delivered-and-merged, awaiting worker re-close` (**WAITING ON WORKER**) from `finished, awaiting merge` (**WAITING ON YOU**), so the supervisor is no longer sent to perform a merge that already landed.
- `awaiting_merge_delivery_is_already_integrated` is best-effort by design: unknown Git state keeps the conservative merge wording rather than claiming a merge that may not have happened.

Note on scope: this answers "did the supervisor land this branch", which reachability settles. That is deliberately narrower than cas-b278's content-presence check, which answers "are the delivered changes still in the tree". Both are now on main and the distinction is recorded rather than collapsed.

## Verification

- `test_pending_dispatch_close_gate_prints_supervisor_recovery_cas_9fd4` and `test_worker_status_names_delivered_merge_awaiting_worker_reclose_cas_9fd4`.
- Rebased onto main after cas-56f8 and cas-b278 landed; the `format_assigned_task_info` conflict was reconciled so both changes compose — signature carries cas-56f8's three-tuple `assigned_open` and this change's `parked_merge_already_integrated`, with both status renderings intact.
- Full-module proof: `factory_mcp_ops_test` 142 passed, `mcp_tools_test` 327 passed. Branch CI green on ae1c88ab.

Fixes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)