### PR TITLE
fix(cas-8aee): assignment notifications consult task status, and withheld rows stay named

### DIFF
--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -1213,15 +1213,15 @@ impl CasService {
         if rendered == 0 {
             let ids = withheld
                 .iter()
-                .map(|(id, task)| format!("{id} (assignment for {task})"))
+                .map(|(id, task)| format!("{id} (assignment for {task}, already done)"))
                 .chain(terminal_withheld.iter().map(|(id, task, status)| {
-                    format!("{id} (assignment for {task}, already {status})")
+                    format!("{id} (assignment for {task}, already done: {status})")
                 }))
                 .collect::<Vec<_>>()
                 .join(", ");
             return Ok(Self::success(format!(
-                "No unread messages for {recipient} — withheld {} stale or already-consumed \
-                 assignment message(s): {ids}",
+                "No unread messages for {recipient} — withheld {} assignment message(s) already \
+                 done: {ids}",
                 withheld.len() + terminal_withheld.len()
             )));
         }
@@ -1239,24 +1239,24 @@ impl CasService {
         }
         if !withheld.is_empty() {
             output.push_str(&format!(
-                ". Withheld {} already-delivered message(s) whose requested action is already \
-                 recorded: {}",
+                ". Withheld {} assignment message(s) already done: {}",
                 withheld.len(),
                 withheld
                     .iter()
-                    .map(|(id, task)| format!("{id} (assignment for {task})"))
+                    .map(|(id, task)| format!("{id} (assignment for {task}, already done)"))
                     .collect::<Vec<_>>()
                     .join(", ")
             ));
         }
         if !terminal_withheld.is_empty() {
             output.push_str(&format!(
-                ". Withheld {} assignment message(s) because their task is already Closed or \
-                 Cancelled: {}",
+                ". Withheld {} terminal assignment message(s) already done: {}",
                 terminal_withheld.len(),
                 terminal_withheld
                     .iter()
-                    .map(|(_, task, status)| format!("{task} ({status})"))
+                    .map(|(id, task, status)| {
+                        format!("{id} (assignment for {task}, already done: {status})")
+                    })
                     .collect::<Vec<_>>()
                     .join(", ")
             ));

--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -1,4 +1,5 @@
 use crate::mcp::tools::service::imports::*;
+use crate::prompt_revalidation::{assignment_solicited_task_id, assignment_targets_terminal_task};
 
 fn resolve_inbox_recipient(
     registered_name: Option<String>,
@@ -58,62 +59,6 @@ pub(crate) fn inbox_redelivery_decision(
         return InboxRedelivery::WithholdConsumed;
     }
     InboxRedelivery::MarkRedelivery
-}
-
-/// cas-99d2 (GH #127): the task id an assignment message solicits a `start`
-/// for, if this message is an assignment at all.
-///
-/// Two shapes exist in the wild and both must parse:
-/// - the director's generated prompt — `"You have been assigned a new task:\n
-///   Task ID: cas-7587\n…"`;
-/// - a supervisor's hand-written dispatch — `"You are assigned task cas-7587
-///   (P2 bug, …). Run `… action=show id=cas-7587` then `… action=start
-///   id=cas-7587`."` (this is the literal shape of notification 7112).
-///
-/// Requires BOTH an assignment phrase and an explicit task id: a status
-/// question or review note that merely mentions a task id must not be treated
-/// as an assignment, because that would let unrelated task progress silence a
-/// message that was never about assigning work.
-pub(crate) fn assignment_solicited_task_id(prompt: &str) -> Option<String> {
-    let lowered = prompt.to_lowercase();
-    const ASSIGNMENT_PHRASES: [&str; 4] = [
-        "you have been assigned",
-        "you are assigned",
-        "you're assigned",
-        "assigned task",
-    ];
-    if !ASSIGNMENT_PHRASES
-        .iter()
-        .any(|phrase| lowered.contains(phrase))
-    {
-        return None;
-    }
-    // `action=start id=<task>` is the most explicit statement of the solicited
-    // transition; fall back to the declared `Task ID:` field, then to the first
-    // task-shaped token anywhere in the assignment text.
-    for marker in ["action=start id=", "task id:", "assigned task "] {
-        if let Some(index) = lowered.find(marker)
-            && let Some(id) = first_task_id_token(&prompt[index + marker.len()..])
-        {
-            return Some(id);
-        }
-    }
-    first_task_id_token(prompt)
-}
-
-/// First `cas-<hex>` token in `text`, stripped of surrounding punctuation.
-fn first_task_id_token(text: &str) -> Option<String> {
-    text.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-'))
-        .find(|token| {
-            let Some(suffix) = token
-                .strip_prefix("cas-")
-                .or_else(|| token.strip_prefix("CAS-"))
-            else {
-                return false;
-            };
-            suffix.len() >= 4 && suffix.chars().all(|c| c.is_ascii_alphanumeric())
-        })
-        .map(|token| format!("cas-{}", &token[4..]))
 }
 
 /// cas-7a01 (GH #155): render the wake evidence pair as a sentence.
@@ -1174,10 +1119,31 @@ impl CasService {
         let task_store = crate::store::open_task_store_local(&self.inner.cas_root).ok();
         let mut rendered = 0usize;
         let mut withheld: Vec<(i64, String)> = Vec::new();
+        let mut terminal_withheld: Vec<(i64, String, cas_types::TaskStatus)> = Vec::new();
         let mut redelivered = 0usize;
         let mut body = String::new();
         for message in &messages {
             let solicited_task = assignment_solicited_task_id(&message.prompt);
+            let terminal_assignment = match (&solicited_task, task_store.as_ref()) {
+                (Some(task_id), Some(store)) => store.get(task_id).ok().and_then(|task| {
+                    assignment_targets_terminal_task(&message.prompt, task.status)
+                        .map(|task_id| (task_id, task.status))
+                }),
+                _ => None,
+            };
+            if let Some((task_id, status)) = terminal_assignment {
+                tracing::info!(
+                    target: "cas::coordination",
+                    stage = "inbox_withheld_terminal_assignment",
+                    prompt_id = message.id,
+                    recipient = %recipient,
+                    task_id = %task_id,
+                    status = %status,
+                    "cas-8aee: withheld a queued assignment whose task is terminal"
+                );
+                terminal_withheld.push((message.id, task_id, status));
+                continue;
+            }
             // The transition an assignment solicits: the ADDRESSED recipient
             // started that task. `assignee` must match — another worker
             // starting the task says nothing about whether this recipient ever
@@ -1248,12 +1214,15 @@ impl CasService {
             let ids = withheld
                 .iter()
                 .map(|(id, task)| format!("{id} (assignment for {task})"))
+                .chain(terminal_withheld.iter().map(|(id, task, status)| {
+                    format!("{id} (assignment for {task}, already {status})")
+                }))
                 .collect::<Vec<_>>()
                 .join(", ");
             return Ok(Self::success(format!(
-                "No unread messages for {recipient} — withheld {} already-delivered \
-                 message(s) whose requested action is already done: {ids}",
-                withheld.len()
+                "No unread messages for {recipient} — withheld {} stale or already-consumed \
+                 assignment message(s): {ids}",
+                withheld.len() + terminal_withheld.len()
             )));
         }
 
@@ -1276,6 +1245,18 @@ impl CasService {
                 withheld
                     .iter()
                     .map(|(id, task)| format!("{id} (assignment for {task})"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        if !terminal_withheld.is_empty() {
+            output.push_str(&format!(
+                ". Withheld {} assignment message(s) because their task is already Closed or \
+                 Cancelled: {}",
+                terminal_withheld.len(),
+                terminal_withheld
+                    .iter()
+                    .map(|(_, task, status)| format!("{task} ({status})"))
                     .collect::<Vec<_>>()
                     .join(", ")
             ));
@@ -1764,10 +1745,8 @@ mod inbox_poll_identity_tests {
 
 #[cfg(test)]
 mod cas99d2_redelivery_tests {
-    use super::{
-        INBOX_REDELIVERY_MARKER, InboxRedelivery, assignment_solicited_task_id,
-        inbox_redelivery_decision,
-    };
+    use super::{INBOX_REDELIVERY_MARKER, InboxRedelivery, inbox_redelivery_decision};
+    use crate::prompt_revalidation::assignment_solicited_task_id;
 
     /// The literal text of notification 7112 (supervisor hand-written dispatch).
     #[test]

--- a/cas-cli/src/prompt_revalidation.rs
+++ b/cas-cli/src/prompt_revalidation.rs
@@ -7,6 +7,66 @@ use std::str::FromStr;
 const MERGE_ENVELOPE_OPEN: &str = "<cas-merge-request>";
 const MERGE_ENVELOPE_CLOSE: &str = "</cas-merge-request>";
 
+/// The task id an assignment-like prompt asks its recipient to start.
+///
+/// This is deliberately shared by daemon delivery and `inbox_poll`: an
+/// assignment queued before a task reaches a terminal state must not become a
+/// fresh-looking `task start` instruction merely because it took a different
+/// transport. Spawn briefs use the same imperative shape and therefore belong
+/// to this contract too.
+pub(crate) fn assignment_solicited_task_id(prompt: &str) -> Option<String> {
+    let lowered = prompt.to_lowercase();
+    const ASSIGNMENT_PHRASES: [&str; 5] = [
+        "you have been assigned",
+        "you are assigned",
+        "you're assigned",
+        "assigned task",
+        "you were spawned for task",
+    ];
+    if !ASSIGNMENT_PHRASES
+        .iter()
+        .any(|phrase| lowered.contains(phrase))
+    {
+        return None;
+    }
+    for marker in [
+        "action=start id=",
+        "task id:",
+        "assigned task ",
+        "spawned for task ",
+    ] {
+        if let Some(index) = lowered.find(marker)
+            && let Some(id) = first_task_id_token(&prompt[index + marker.len()..])
+        {
+            return Some(id);
+        }
+    }
+    first_task_id_token(prompt)
+}
+
+/// Terminal task states make an assignment's `task start` imperative stale.
+/// Missing/unreadable state deliberately returns false: delivery must fail
+/// open unless CAS has positive terminal evidence.
+pub(crate) fn assignment_targets_terminal_task(prompt: &str, status: TaskStatus) -> Option<String> {
+    matches!(status, TaskStatus::Closed | TaskStatus::Cancelled)
+        .then(|| assignment_solicited_task_id(prompt))
+        .flatten()
+}
+
+fn first_task_id_token(text: &str) -> Option<String> {
+    text.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-'))
+        .find(|token| {
+            let Some(suffix) = token
+                .strip_prefix("cas-")
+                .or_else(|| token.strip_prefix("CAS-"))
+            else {
+                return false;
+            };
+            suffix.len() >= 4 && suffix.chars().all(|c| c.is_ascii_alphanumeric())
+        })
+        .map(|token| format!("cas-{}", &token[4..]))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct MergeRequestEnvelope {
     pub task_id: String,
@@ -570,6 +630,49 @@ pub(crate) fn revalidate_lifecycle_prompt(
         };
     }
     LifecyclePromptDecision::Deliver
+}
+
+#[cfg(test)]
+mod cas_8aee_assignment_delivery_tests {
+    use super::{assignment_solicited_task_id, assignment_targets_terminal_task};
+    use cas_types::TaskStatus;
+
+    #[test]
+    fn queued_assignment_closed_before_delivery_is_not_startable() {
+        let prompt = "You have been assigned a new task:\n\
+                      Task ID: cas-8aee\n\
+                      Start working: mcp__cas__task action=start id=cas-8aee\n\
+                      Then send an ACK to supervisor with your execution plan.";
+
+        assert_eq!(
+            assignment_targets_terminal_task(prompt, TaskStatus::Closed).as_deref(),
+            Some("cas-8aee"),
+            "the queued assignment must be withdrawn rather than render its stale start/ACK instructions"
+        );
+        assert!(
+            assignment_targets_terminal_task(prompt, TaskStatus::InProgress).is_none(),
+            "only positive terminal evidence may suppress a worker wake"
+        );
+    }
+
+    #[test]
+    fn queued_spawn_intro_closed_before_delivery_is_not_startable() {
+        let prompt = "You were spawned for task cas-bc5c — \"Customer communications\" — and it is assigned to you now.\n\
+                      Start with `mcp__cas__task action=show id=cas-bc5c`, then \
+                      `mcp__cas__task action=start id=cas-bc5c` before you change any code.";
+
+        assert_eq!(
+            assignment_solicited_task_id(prompt).as_deref(),
+            Some("cas-bc5c")
+        );
+        for status in [TaskStatus::Closed, TaskStatus::Cancelled] {
+            assert_eq!(
+                assignment_targets_terminal_task(prompt, status).as_deref(),
+                Some("cas-bc5c"),
+                "a terminal spawn intro must not reach any renderer with task-start guidance"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -836,6 +836,19 @@ pub(crate) fn assign_task_to_new_worker(
         }
     };
 
+    if matches!(
+        task.status,
+        cas_types::TaskStatus::Closed | cas_types::TaskStatus::Cancelled
+    ) {
+        tracing::warn!(
+            task_id,
+            worker_name,
+            status = %task.status,
+            "cas-8aee: refusing spawn-time pre-assignment for terminal task"
+        );
+        return false;
+    }
+
     if let Some(ref existing) = task.assignee {
         if existing == worker_name {
             // Early-assign already pinned this worker (cas-7a94 isolate path).
@@ -3544,6 +3557,27 @@ mod tests {
             store.get("cas-abc1").unwrap().assignee.as_deref(),
             Some("recipes-fixer")
         );
+    }
+
+    /// cas-8aee (GH #336): a spawn that races a terminal close must not make
+    /// the close look like a new assignment or queue start instructions.
+    #[test]
+    fn assign_task_to_new_worker_refuses_terminal_tasks() {
+        let (_temp, cas_dir) = seeded_cas_dir();
+        let store = crate::store::open_task_store(&cas_dir).unwrap();
+        for (id, status) in [
+            ("cas-closed", TaskStatus::Closed),
+            ("cas-cancelled", TaskStatus::Cancelled),
+        ] {
+            store.add(&task_with(id, None, status)).unwrap();
+            assert!(
+                !assign_task_to_new_worker(&cas_dir, id, "swift-fox"),
+                "terminal task {id} must not be rebound during worker spawn"
+            );
+            let task = store.get(id).unwrap();
+            assert_eq!(task.status, status);
+            assert_eq!(task.assignee, None);
+        }
     }
 
     // --- cas-7a94: shutdown / cancel must release pre-assigns -----------

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -334,6 +334,17 @@ fn preassign_failure_reason(
         }
     };
     match store.get(task_id) {
+        Ok(task)
+            if matches!(
+                task.status,
+                cas_types::TaskStatus::Closed | cas_types::TaskStatus::Cancelled
+            ) =>
+        {
+            Some(format!(
+                "task {task_id} is terminal ({}) and must not be pre-assigned or briefed",
+                task.status
+            ))
+        }
         Ok(task) => match task.assignee.as_deref() {
             Some(assignee) if assignee == worker_name => None,
             Some(assignee) => Some(format!(
@@ -2898,6 +2909,39 @@ impl FactoryDaemon {
                         continue;
                     }
                 }
+            }
+
+            // cas-8aee (GH #336): assignment and spawn-intro prompts carry a
+            // `task start` imperative. They can wait in the durable queue
+            // while that task closes, so inspect its live status at this final
+            // shared transport boundary instead of injecting stale work.
+            // Unreadable/missing tasks fail open; only Closed/Cancelled is
+            // positive evidence that the instruction is unsafe.
+            if let Some(task_id) =
+                crate::prompt_revalidation::assignment_solicited_task_id(&queued.prompt)
+                && let Ok(store) = crate::store::open_task_store_local(self.app.cas_dir())
+                && let Ok(task) = store.get(&task_id)
+                && crate::prompt_revalidation::assignment_targets_terminal_task(
+                    &queued.prompt,
+                    task.status,
+                )
+                .is_some()
+            {
+                let detail = format!(
+                    "withdrawn before transport: assignment for {task_id} is stale because the task is {}",
+                    task.status
+                );
+                let _ = queue.mark_superseded(queued.id, &detail);
+                self.forget_row_delivery_state(queued.id);
+                tracing::info!(
+                    target: "cas::coordination",
+                    stage = "suppress_terminal_assignment",
+                    prompt_id = queued.id,
+                    task_id = %task_id,
+                    status = %task.status,
+                    "cas-8aee: suppressed a queued assignment/start instruction for a terminal task"
+                );
+                continue;
             }
 
             // Resolve the queue source to a valid team member name for inbox writes.
@@ -8167,6 +8211,32 @@ mod tests {
         assert!(
             ensure_worker_preassignment(&cas_dir, "cas-missing", "young-jay-62").is_err(),
             "a vanished task must surface as a failure, not silence"
+        );
+    }
+
+    /// cas-8aee (GH #336): registration can race a completed/cancelled task.
+    /// Do not treat a terminal same-assignee row as a successful preassignment
+    /// and queue the worker a stale spawn intro with `task action=start`.
+    #[test]
+    fn registration_preassignment_refuses_terminal_task_without_briefing_worker() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let cas_dir = crate::store::init_cas_dir(temp.path()).unwrap();
+        let store = crate::store::open_task_store(&cas_dir).unwrap();
+        let mut task = Task::new("cas-closed".to_string(), "already done".to_string());
+        task.status = TaskStatus::Closed;
+        task.assignee = Some("cosmic-crow-41".to_string());
+        store.add(&task).unwrap();
+
+        let error = ensure_worker_preassignment(&cas_dir, "cas-closed", "cosmic-crow-41")
+            .expect_err("a terminal task must not confirm a spawn-time assignment");
+        assert!(error.contains("terminal (closed)"), "{error}");
+        assert!(
+            crate::store::open_prompt_queue_store(&cas_dir)
+                .unwrap()
+                .peek_all(10)
+                .unwrap()
+                .is_empty(),
+            "a terminal preassignment must never create a worker start brief"
         );
     }
 

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -7274,6 +7274,89 @@ async fn cas99d2_inbox_poll_withholds_a_consumed_assignment_gh127() {
     );
 }
 
+/// cas-8aee (GH #336): a task can reach a terminal state while an assignment
+/// or spawn-intro prompt is queued. `inbox_poll` must name each withheld row
+/// and say it is already done, but must never repeat its task-start imperative.
+#[tokio::test]
+async fn cas8aee_inbox_poll_names_terminal_assignment_and_spawn_intro_gh336() {
+    let _guard = EnvGuard::set(&[
+        ("CAS_AGENT_ROLE", "worker"),
+        ("CAS_AGENT_NAME", "watchful-koala-20"),
+    ]);
+    let env = FactoryTestEnv::with_agent_id_and_env("koala-agent-id", None);
+    env.register_worker_with_id("koala-agent-id", "watchful-koala-20", None);
+
+    let (closed_task_id, cancelled_task_id) = {
+        let store = env.task_store();
+        let closed_task_id = store.generate_id().expect("generate closed id");
+        let cancelled_task_id = store.generate_id().expect("generate cancelled id");
+        let mut closed = Task::new(closed_task_id.clone(), "already closed".to_string());
+        closed.status = TaskStatus::Closed;
+        closed.assignee = Some("watchful-koala-20".to_string());
+        store.add(&closed).expect("add closed task");
+        let mut cancelled = Task::new(cancelled_task_id.clone(), "already cancelled".to_string());
+        cancelled.status = TaskStatus::Cancelled;
+        cancelled.assignee = Some("watchful-koala-20".to_string());
+        store.add(&cancelled).expect("add cancelled task");
+        (closed_task_id, cancelled_task_id)
+    };
+
+    let assignment_id = env
+        .prompt_queue()
+        .enqueue_urgent(
+            "supervisor",
+            "watchful-koala-20",
+            &format!(
+                "You have been assigned a new task:\nTask ID: {closed_task_id}\nStart working: \
+                 mcp__cas__task action=start id={closed_task_id}\nThen send an ACK to supervisor."
+            ),
+            None,
+            Some("terminal assignment"),
+            None,
+            false,
+        )
+        .expect("enqueue terminal assignment");
+    let spawn_intro_id = env
+        .prompt_queue()
+        .enqueue_urgent(
+            "director",
+            "watchful-koala-20",
+            &format!(
+                "You were spawned for task {cancelled_task_id} — \"already cancelled\" — and it \
+                 is assigned to you now.\nStart with `mcp__cas__task action=show \
+                 id={cancelled_task_id}`, then `mcp__cas__task action=start \
+                 id={cancelled_task_id}` before you change any code."
+            ),
+            None,
+            Some("terminal spawn intro"),
+            None,
+            false,
+        )
+        .expect("enqueue terminal spawn intro");
+
+    let text = get_text(
+        &env.service
+            .coordination(Parameters(coord_req("inbox_poll")))
+            .await
+            .expect("inbox_poll"),
+    );
+
+    for id in [assignment_id, spawn_intro_id] {
+        assert!(
+            text.contains(&id.to_string()),
+            "every withheld notification must remain named: {text}"
+        );
+    }
+    assert!(
+        text.contains("already done"),
+        "a terminal assignment must explain why it is not actionable: {text}"
+    );
+    assert!(
+        !text.contains("Start working") && !text.contains("action=start"),
+        "terminal rows must not re-render task-start guidance: {text}"
+    );
+}
+
 /// cas-99d2 AC4 (GH #127): a repeat delivery that IS handed over carries an
 /// explicit machine-checkable marker, so a recipient can discard duplicates
 /// without reasoning about timestamps. A row that was never transport-delivered


### PR DESCRIPTION
Twice in one shift a worker received "You have been assigned a new task — Start working: task action=start" for a task it had **already completed and closed**, proof reference recorded. The imperative was generated without consulting task status, so it fired for terminal tasks. On a customer-communications task that meant a compliant worker would have produced a fourth draft to a customer who already had three — duplicate delivered work, not noise. A third occurrence followed in the same shift.

Assignment and spawn-intro notifications now resolve task status at render time: a terminal task never gets a "Start working" imperative.

## The correction that mattered

The first delivery suppressed terminal rows **entirely**, which broke the GH #127 contract at `factory_mcp_ops_test.rs:7387` — *a withheld row must be named, not silently dropped*, carrying its notification id and "already done". That trades a wrong signal for no signal, and #127 exists because the silent version is worse: a worker cannot distinguish "nothing arrived" from "something was hidden from me".

The landed change keeps both properties: the misleading imperative is suppressed, and every withheld row is still named by notification ID as `already done`.

That regression was invisible to branch CI — `factory/*` runs Scoped Validation only, and the lane's original proof was `--lib cas_8aee`, the two tests it added. It surfaced when the lane was assembled with four others, and was isolated to this lane alone by running the contract test against each branch independently.

## Verification

- New real-service integration covers a Closed assignment and a Cancelled spawn intro, asserting the notification IDs and `already done` are present and that no `Start working` / `action=start` imperative appears.
- Full `agent_search_system::message` module 17 passed; full `factory_mcp_ops_test` binary 142 passed — the modified surface, not just the added tests.
- The GH #127 contract test re-run by the supervisor on this tip: passes. Branch CI green on f2fd9d91.

Fixes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)