### PR TITLE
fix(cas-c0e2): invalidated delivery anchors must not reach the supervisor as live merge requests

### DIFF
--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -502,7 +502,11 @@ impl CasService {
                     .clone()
                     .or_else(|| task.assignee.as_ref().map(|name| format!("factory/{name}")));
                 if let Some(branch) = branch
-                    && let Some(branch_tip) = resolve_branch_sha(&repo.repo_root, &branch)
+                    && let Some(branch_tip) = task
+                        .deliverables
+                        .factory_branch_anchor
+                        .clone()
+                        .or_else(|| resolve_branch_sha(&repo.repo_root, &branch))
                 {
                     match revalidate_merge_request(
                         &repo.repo_root,
@@ -1185,6 +1189,99 @@ impl CasService {
         let mut redelivered = 0usize;
         let mut body = String::new();
         for message in &messages {
+            // A supervisor can claim a queue row directly through inbox_poll,
+            // bypassing the daemon's transport-time check. Re-run the exact
+            // merge-request predicate here so an invalidated delivery anchor
+            // cannot become actionable merely because this is the first
+            // delivery surface the supervisor used.
+            let stale_merge_request = crate::prompt_revalidation::parse_merge_request_envelope(
+                &message.prompt,
+            )
+            .and_then(|envelope| {
+                let store = task_store.as_ref()?;
+                let task = store.get(&envelope.task_id).ok()?;
+                use crate::mcp::tools::core::task::repo_context::resolve_repo_context;
+                let repo_root = task
+                    .deliverables
+                    .work_target
+                    .as_ref()
+                    .and_then(|work_target| {
+                        resolve_repo_context(&self.inner.cas_root, work_target).ok()
+                    })
+                    .map(|repo| repo.repo_root)
+                    .unwrap_or_else(|| {
+                        self.inner
+                            .cas_root
+                            .parent()
+                            .unwrap_or(&self.inner.cas_root)
+                            .to_path_buf()
+                    });
+                let git = crate::prompt_revalidation::revalidate_merge_request(
+                    &repo_root,
+                    &envelope.branch_tip,
+                    &envelope.target_branch,
+                );
+                (!matches!(
+                    crate::prompt_revalidation::merge_request_delivery_decision(
+                        Some(&task),
+                        &envelope,
+                        &git,
+                    ),
+                    crate::prompt_revalidation::MergeRequestDelivery::Deliver
+                ))
+                .then_some(envelope.task_id)
+            });
+            if let Some(task_id) = stale_merge_request {
+                tracing::info!(
+                    target: "cas::coordination",
+                    stage = "inbox_withheld_stale_merge_request",
+                    prompt_id = message.id,
+                    recipient = %recipient,
+                    task_id = %task_id,
+                    "withheld a merge request whose delivery anchor no longer holds at inbox pop"
+                );
+                withheld.push((message.id, task_id));
+                continue;
+            }
+
+            // Lifecycle rows have the same direct-poll bypass. In particular,
+            // a queued MERGE REQUIRED relay must not survive request_changes,
+            // cancel, reset, or a completed merge merely because no daemon
+            // tick ran before the supervisor polled.
+            let stale_lifecycle = crate::prompt_revalidation::parse_lifecycle_envelope(
+                &message.prompt,
+            )
+            .is_some_and(|envelope| match task_store.as_ref() {
+                Some(store) => match store.get(&envelope.task_id).ok() {
+                    Some(task) => matches!(
+                        crate::prompt_revalidation::revalidate_lifecycle_prompt(
+                            &message.prompt,
+                            task.status,
+                            task.updated_at,
+                        ),
+                        crate::prompt_revalidation::LifecyclePromptDecision::SuppressStale { .. }
+                    ),
+                    None => true,
+                },
+                // Fails open when the store itself is unavailable: inability
+                // to inspect current state is not evidence that a relay died.
+                None => false,
+            });
+            if stale_lifecycle {
+                let task_id = crate::prompt_revalidation::parse_lifecycle_envelope(&message.prompt)
+                    .map(|envelope| envelope.task_id)
+                    .unwrap_or_default();
+                tracing::info!(
+                    target: "cas::coordination",
+                    stage = "inbox_withheld_stale_merge_relay",
+                    prompt_id = message.id,
+                    recipient = %recipient,
+                    task_id = %task_id,
+                    "withheld a stale lifecycle relay at inbox pop"
+                );
+                withheld.push((message.id, task_id));
+                continue;
+            }
             let solicited_task = assignment_solicited_task_id(&message.prompt);
             let terminal_assignment = match (&solicited_task, task_store.as_ref()) {
                 (Some(task_id), Some(store)) => store.get(task_id).ok().and_then(|task| {

--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -61,6 +61,26 @@ pub(crate) fn inbox_redelivery_decision(
     InboxRedelivery::MarkRedelivery
 }
 
+/// Inbox polling is a delivery surface, not an authority to discard a relay.
+/// A failed task read is uncertainty, so only a freshly-read task whose
+/// lifecycle occurrence is positively stale may be withheld.
+pub(crate) fn lifecycle_relay_is_stale_at_inbox_pop(
+    prompt: &str,
+    task: Option<&cas_types::Task>,
+) -> bool {
+    let Some(task) = task else {
+        return false;
+    };
+    matches!(
+        crate::prompt_revalidation::revalidate_lifecycle_prompt(
+            prompt,
+            task.status,
+            task.updated_at,
+        ),
+        crate::prompt_revalidation::LifecyclePromptDecision::SuppressStale { .. }
+    )
+}
+
 /// cas-7a01 (GH #155): render the wake evidence pair as a sentence.
 ///
 /// The two fields answer different questions and the failure the issue reported
@@ -1184,8 +1204,12 @@ impl CasService {
         // and mark the rest as repeats.
         let task_store = crate::store::open_task_store_local(&self.inner.cas_root).ok();
         let mut rendered = 0usize;
+        // Every withholding path below follows one policy: first identify the
+        // typed action the row requests, then require fresh positive evidence
+        // that action is moot. Missing/unreadable state delivers. A withheld
+        // row is always retained here with its notification id and an
+        // operator-readable reason; no suppression may disappear silently.
         let mut withheld: Vec<(i64, String)> = Vec::new();
-        let mut terminal_withheld: Vec<(i64, String, cas_types::TaskStatus)> = Vec::new();
         let mut redelivered = 0usize;
         let mut body = String::new();
         for message in &messages {
@@ -1240,7 +1264,10 @@ impl CasService {
                     task_id = %task_id,
                     "withheld a merge request whose delivery anchor no longer holds at inbox pop"
                 );
-                withheld.push((message.id, task_id));
+                withheld.push((
+                    message.id,
+                    format!("merge request for {task_id}, already done"),
+                ));
                 continue;
             }
 
@@ -1248,25 +1275,16 @@ impl CasService {
             // a queued MERGE REQUIRED relay must not survive request_changes,
             // cancel, reset, or a completed merge merely because no daemon
             // tick ran before the supervisor polled.
-            let stale_lifecycle = crate::prompt_revalidation::parse_lifecycle_envelope(
+            let lifecycle_task = crate::prompt_revalidation::parse_lifecycle_envelope(&message.prompt)
+                .and_then(|envelope| {
+                    task_store
+                        .as_ref()
+                        .and_then(|store| store.get(&envelope.task_id).ok())
+                });
+            let stale_lifecycle = lifecycle_relay_is_stale_at_inbox_pop(
                 &message.prompt,
-            )
-            .is_some_and(|envelope| match task_store.as_ref() {
-                Some(store) => match store.get(&envelope.task_id).ok() {
-                    Some(task) => matches!(
-                        crate::prompt_revalidation::revalidate_lifecycle_prompt(
-                            &message.prompt,
-                            task.status,
-                            task.updated_at,
-                        ),
-                        crate::prompt_revalidation::LifecyclePromptDecision::SuppressStale { .. }
-                    ),
-                    None => true,
-                },
-                // Fails open when the store itself is unavailable: inability
-                // to inspect current state is not evidence that a relay died.
-                None => false,
-            });
+                lifecycle_task.as_ref(),
+            );
             if stale_lifecycle {
                 let task_id = crate::prompt_revalidation::parse_lifecycle_envelope(&message.prompt)
                     .map(|envelope| envelope.task_id)
@@ -1279,7 +1297,10 @@ impl CasService {
                     task_id = %task_id,
                     "withheld a stale lifecycle relay at inbox pop"
                 );
-                withheld.push((message.id, task_id));
+                withheld.push((
+                    message.id,
+                    format!("lifecycle relay for {task_id}, already done"),
+                ));
                 continue;
             }
             let solicited_task = assignment_solicited_task_id(&message.prompt);
@@ -1300,7 +1321,10 @@ impl CasService {
                     status = %status,
                     "cas-8aee: withheld a queued assignment whose task is terminal"
                 );
-                terminal_withheld.push((message.id, task_id, status));
+                withheld.push((
+                    message.id,
+                    format!("assignment for {task_id}, already done: {status}"),
+                ));
                 continue;
             }
             // The transition an assignment solicits: the ADDRESSED recipient
@@ -1336,7 +1360,10 @@ impl CasService {
                         "cas-99d2: withheld an already-delivered assignment whose solicited \
                          task start is already recorded for this recipient"
                     );
-                    withheld.push((message.id, task_id));
+                    withheld.push((
+                        message.id,
+                        format!("assignment for {task_id}, already done"),
+                    ));
                     continue;
                 }
                 InboxRedelivery::MarkRedelivery => {
@@ -1372,16 +1399,13 @@ impl CasService {
         if rendered == 0 {
             let ids = withheld
                 .iter()
-                .map(|(id, task)| format!("{id} (assignment for {task}, already done)"))
-                .chain(terminal_withheld.iter().map(|(id, task, status)| {
-                    format!("{id} (assignment for {task}, already done: {status})")
-                }))
+                .map(|(id, reason)| format!("{id} ({reason})"))
                 .collect::<Vec<_>>()
                 .join(", ");
             return Ok(Self::success(format!(
-                "No unread messages for {recipient} — withheld {} assignment message(s) already \
+                "No unread messages for {recipient} — withheld {} message(s) already \
                  done: {ids}",
-                withheld.len() + terminal_withheld.len()
+                withheld.len()
             )));
         }
 
@@ -1398,24 +1422,11 @@ impl CasService {
         }
         if !withheld.is_empty() {
             output.push_str(&format!(
-                ". Withheld {} assignment message(s) already done: {}",
+                ". Withheld {} message(s) already done: {}",
                 withheld.len(),
                 withheld
                     .iter()
-                    .map(|(id, task)| format!("{id} (assignment for {task}, already done)"))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ));
-        }
-        if !terminal_withheld.is_empty() {
-            output.push_str(&format!(
-                ". Withheld {} terminal assignment message(s) already done: {}",
-                terminal_withheld.len(),
-                terminal_withheld
-                    .iter()
-                    .map(|(id, task, status)| {
-                        format!("{id} (assignment for {task}, already done: {status})")
-                    })
+                    .map(|(id, reason)| format!("{id} ({reason})"))
                     .collect::<Vec<_>>()
                     .join(", ")
             ));
@@ -1707,7 +1718,7 @@ fn enrich_report_from_harness_artifact(
 mod inbox_poll_identity_tests {
     use super::{
         enrich_report_from_harness_artifact, interrupt_unconfirmed_message,
-        recipient_transport_warning, resolve_inbox_recipient,
+        lifecycle_relay_is_stale_at_inbox_pop, recipient_transport_warning, resolve_inbox_recipient,
     };
     use cas_store::DeliveryStage;
 
@@ -1830,6 +1841,15 @@ mod inbox_poll_identity_tests {
             Some("env-worker".to_string())
         );
         assert_eq!(resolve_inbox_recipient(None, Some("  ".to_string())), None);
+    }
+
+    #[test]
+    fn unreadable_task_never_withholds_a_lifecycle_relay_at_inbox_pop() {
+        let prompt = "<task-lifecycle transition=\"task_awaiting_merge\" task_id=\"cas-live\" old=\"in_progress\" new=\"awaiting_merge\" actor=\"worker\" notification_id=\"1\" occurrence=\"2026-08-14T14:00:00Z\">\nMERGE REQUIRED\n</task-lifecycle>";
+        assert!(
+            !lifecycle_relay_is_stale_at_inbox_pop(prompt, None),
+            "a read failure is uncertainty, not evidence that a live relay is moot"
+        );
     }
 
     #[test]

--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -1275,16 +1275,16 @@ impl CasService {
             // a queued MERGE REQUIRED relay must not survive request_changes,
             // cancel, reset, or a completed merge merely because no daemon
             // tick ran before the supervisor polled.
-            let lifecycle_task = crate::prompt_revalidation::parse_lifecycle_envelope(&message.prompt)
-                .and_then(|envelope| {
-                    task_store
-                        .as_ref()
-                        .and_then(|store| store.get(&envelope.task_id).ok())
-                });
-            let stale_lifecycle = lifecycle_relay_is_stale_at_inbox_pop(
+            let lifecycle_task = crate::prompt_revalidation::parse_lifecycle_envelope(
                 &message.prompt,
-                lifecycle_task.as_ref(),
-            );
+            )
+            .and_then(|envelope| {
+                task_store
+                    .as_ref()
+                    .and_then(|store| store.get(&envelope.task_id).ok())
+            });
+            let stale_lifecycle =
+                lifecycle_relay_is_stale_at_inbox_pop(&message.prompt, lifecycle_task.as_ref());
             if stale_lifecycle {
                 let task_id = crate::prompt_revalidation::parse_lifecycle_envelope(&message.prompt)
                     .map(|envelope| envelope.task_id)
@@ -1718,7 +1718,8 @@ fn enrich_report_from_harness_artifact(
 mod inbox_poll_identity_tests {
     use super::{
         enrich_report_from_harness_artifact, interrupt_unconfirmed_message,
-        lifecycle_relay_is_stale_at_inbox_pop, recipient_transport_warning, resolve_inbox_recipient,
+        lifecycle_relay_is_stale_at_inbox_pop, recipient_transport_warning,
+        resolve_inbox_recipient,
     };
     use cas_store::DeliveryStage;
 

--- a/cas-cli/src/prompt_revalidation.rs
+++ b/cas-cli/src/prompt_revalidation.rs
@@ -93,7 +93,8 @@ pub(crate) enum MergeRequestDecision {
 ///
 /// - the branch tip is already an ancestor of the target branch (merged), or
 /// - the task is no longer parked awaiting a merge (re-closed, reopened,
-///   request_changes'd), so nothing is waiting on the supervisor at all.
+///   request_changes'd), so nothing is waiting on the supervisor at all, or
+/// - the task's delivery anchor no longer names this request's immutable tip.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum MergeRequestDelivery {
     /// Premise still holds — deliver, and tag the row so it can be retracted
@@ -103,13 +104,20 @@ pub(crate) enum MergeRequestDelivery {
     SuppressLanded { target_tip: String },
     /// The task left `AwaitingMerge` — the request is moot whatever git says.
     SuppressResolved { status: TaskStatus },
+    /// The task may have entered a later merge cycle, but the immutable tip
+    /// this message asked the supervisor to merge was invalidated. This is
+    /// deliberately distinct from `SuppressResolved`: a task can return to
+    /// `AwaitingMerge` after request_changes, reset, or a reopen.
+    SuppressInvalidatedAnchor {
+        current_anchor: Option<String>,
+    },
 }
 
 /// Decide a merge request's fate from live state only (cas-6eab).
 ///
-/// `task_status` is the task's status read fresh at transport time; `None`
-/// means the task could not be read at all. `git` is the live reachability
-/// check for the requested tip.
+/// `task` is read fresh at transport time; `None` means it could not be read
+/// at all. `envelope.branch_tip` is the delivery anchor captured when the
+/// message was queued. `git` is the live reachability check for that anchor.
 ///
 /// Fails open in exactly one direction: uncertainty (unreadable task,
 /// unverifiable git) delivers. A suppression requires positive evidence that
@@ -117,13 +125,21 @@ pub(crate) enum MergeRequestDelivery {
 /// a genuine merge request is a stalled task, while the cost of delivering a
 /// stale one is a supervisor round-trip.
 pub(crate) fn merge_request_delivery_decision(
-    task_status: Option<TaskStatus>,
+    task: Option<&Task>,
+    envelope: &MergeRequestEnvelope,
     git: &MergeRequestDecision,
 ) -> MergeRequestDelivery {
-    if let Some(status) = task_status
-        && status != TaskStatus::AwaitingMerge
-    {
-        return MergeRequestDelivery::SuppressResolved { status };
+    if let Some(task) = task {
+        if task.status != TaskStatus::AwaitingMerge {
+            return MergeRequestDelivery::SuppressResolved {
+                status: task.status,
+            };
+        }
+        if task.deliverables.factory_branch_anchor.as_deref() != Some(&envelope.branch_tip) {
+            return MergeRequestDelivery::SuppressInvalidatedAnchor {
+                current_anchor: task.deliverables.factory_branch_anchor.clone(),
+            };
+        }
     }
     match git {
         MergeRequestDecision::AlreadyIntegrated { target_tip } => {
@@ -135,6 +151,25 @@ pub(crate) fn merge_request_delivery_decision(
             MergeRequestDelivery::Deliver
         }
     }
+}
+
+/// Guidance sent to the worker when the exact delivery anchor named by its
+/// message has been invalidated. It may be tempting to describe an
+/// `AwaitingMerge` task as still actionable here, but that can be a *later*
+/// close cycle. Naming both anchors keeps the worker from asking the
+/// supervisor to merge a declined or superseded tip.
+pub(crate) fn merge_request_anchor_invalidated_guidance(
+    task_id: &str,
+    branch_tip: &str,
+    current_anchor: Option<&str>,
+) -> String {
+    let current = current_anchor.unwrap_or("none (the prior delivery was invalidated)");
+    format!(
+        "CAS suppressed your stale merge request for {task_id}: delivery anchor {branch_tip} \
+         is no longer current (current anchor: {current}). Do not ask the supervisor to merge \
+         the prior tip. Re-read the task with `task action=show id={task_id}` before sending \
+         anything further about it."
+    )
 }
 
 /// Guidance sent to the worker when its merge request is suppressed because
@@ -1232,14 +1267,32 @@ mod tests {
         assert_eq!(parse_lifecycle_envelope("ordinary free-form message"), None);
     }
 
+    fn merge_envelope() -> MergeRequestEnvelope {
+        MergeRequestEnvelope {
+            task_id: "cas-test".to_string(),
+            branch_tip: "worker-tip".to_string(),
+            target_branch: "main".to_string(),
+            target_branch_tip: "base-tip".to_string(),
+        }
+    }
+
+    fn merge_task(status: TaskStatus, anchor: Option<&str>) -> Task {
+        let mut task = Task::new("cas-test".to_string(), "merge test".to_string());
+        task.status = status;
+        task.deliverables.factory_branch_anchor = anchor.map(str::to_string);
+        task
+    }
+
     /// cas-6eab / GH #61: the reported sequence — supervisor merges and
     /// replies, THEN the worker's already-composed request reaches transport.
     /// It must be suppressed rather than delivered as an actionable ask.
     #[test]
     fn merge_request_delivered_after_the_merge_is_suppressed() {
+        let task = merge_task(TaskStatus::AwaitingMerge, Some("worker-tip"));
         assert_eq!(
             merge_request_delivery_decision(
-                Some(TaskStatus::AwaitingMerge),
+                Some(&task),
+                &merge_envelope(),
                 &MergeRequestDecision::AlreadyIntegrated {
                     target_tip: "abc123".to_string(),
                 },
@@ -1260,9 +1313,11 @@ mod tests {
             TaskStatus::Open,
             TaskStatus::PendingSupervisorReview,
         ] {
+            let task = merge_task(status, Some("worker-tip"));
             assert_eq!(
                 merge_request_delivery_decision(
-                    Some(status),
+                    Some(&task),
+                    &merge_envelope(),
                     &MergeRequestDecision::Pending {
                         target_tip: "abc123".to_string(),
                     },
@@ -1280,9 +1335,11 @@ mod tests {
     /// must anything CAS cannot verify. Suppression requires positive evidence.
     #[test]
     fn outstanding_and_unverifiable_merge_requests_are_delivered() {
+        let task = merge_task(TaskStatus::AwaitingMerge, Some("worker-tip"));
         assert_eq!(
             merge_request_delivery_decision(
-                Some(TaskStatus::AwaitingMerge),
+                Some(&task),
+                &merge_envelope(),
                 &MergeRequestDecision::Pending {
                     target_tip: "abc123".to_string(),
                 },
@@ -1291,20 +1348,22 @@ mod tests {
         );
         assert_eq!(
             merge_request_delivery_decision(
-                Some(TaskStatus::AwaitingMerge),
+                Some(&task),
+                &merge_envelope(),
                 &MergeRequestDecision::Unverifiable,
             ),
             MergeRequestDelivery::Deliver,
             "unverifiable git state must never suppress a merge request"
         );
         assert_eq!(
-            merge_request_delivery_decision(None, &MergeRequestDecision::Unverifiable),
+            merge_request_delivery_decision(None, &merge_envelope(), &MergeRequestDecision::Unverifiable),
             MergeRequestDelivery::Deliver,
             "an unreadable task is uncertainty, not evidence of staleness"
         );
         assert_eq!(
             merge_request_delivery_decision(
                 None,
+                &merge_envelope(),
                 &MergeRequestDecision::AlreadyIntegrated {
                     target_tip: "abc123".to_string(),
                 },
@@ -1313,6 +1372,47 @@ mod tests {
                 target_tip: "abc123".to_string(),
             },
             "git reachability is positive evidence even when the task is unreadable"
+        );
+    }
+
+    /// GH #340: request_changes clears the anchor before a queued worker
+    /// message reaches the supervisor. Even if the task later returns to
+    /// AwaitingMerge, the old request must never regain authority.
+    #[test]
+    fn invalidated_delivery_anchor_suppresses_a_queued_merge_request() {
+        let task = merge_task(TaskStatus::AwaitingMerge, None);
+        assert_eq!(
+            merge_request_delivery_decision(
+                Some(&task),
+                &merge_envelope(),
+                &MergeRequestDecision::Pending {
+                    target_tip: "base-tip".to_string(),
+                },
+            ),
+            MergeRequestDelivery::SuppressInvalidatedAnchor {
+                current_anchor: None,
+            }
+        );
+        let guidance = merge_request_anchor_invalidated_guidance("cas-test", "worker-tip", None);
+        assert!(guidance.contains("worker-tip"));
+        assert!(guidance.contains("no longer current"));
+    }
+
+    #[test]
+    fn prior_cycle_request_stays_suppressed_after_a_new_anchor_is_parked() {
+        let task = merge_task(TaskStatus::AwaitingMerge, Some("replacement-tip"));
+        assert_eq!(
+            merge_request_delivery_decision(
+                Some(&task),
+                &merge_envelope(),
+                &MergeRequestDecision::Pending {
+                    target_tip: "base-tip".to_string(),
+                },
+            ),
+            MergeRequestDelivery::SuppressInvalidatedAnchor {
+                current_anchor: Some("replacement-tip".to_string()),
+            },
+            "a later AwaitingMerge cycle must not revive the declined request"
         );
     }
 

--- a/cas-cli/src/prompt_revalidation.rs
+++ b/cas-cli/src/prompt_revalidation.rs
@@ -108,9 +108,7 @@ pub(crate) enum MergeRequestDelivery {
     /// this message asked the supervisor to merge was invalidated. This is
     /// deliberately distinct from `SuppressResolved`: a task can return to
     /// `AwaitingMerge` after request_changes, reset, or a reopen.
-    SuppressInvalidatedAnchor {
-        current_anchor: Option<String>,
-    },
+    SuppressInvalidatedAnchor { current_anchor: Option<String> },
 }
 
 /// Decide a merge request's fate from live state only (cas-6eab).
@@ -1356,7 +1354,11 @@ mod tests {
             "unverifiable git state must never suppress a merge request"
         );
         assert_eq!(
-            merge_request_delivery_decision(None, &merge_envelope(), &MergeRequestDecision::Unverifiable),
+            merge_request_delivery_decision(
+                None,
+                &merge_envelope(),
+                &MergeRequestDecision::Unverifiable,
+            ),
             MergeRequestDelivery::Deliver,
             "an unreadable task is uncertainty, not evidence of staleness"
         );

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -2696,8 +2696,7 @@ impl FactoryDaemon {
                 use crate::prompt_revalidation::{
                     MergeRequestDecision, MergeRequestDelivery, merge_landed_guidance,
                     merge_request_anchor_invalidated_guidance, merge_request_delivery_decision,
-                    merge_request_moot_guidance,
-                    revalidate_merge_request,
+                    merge_request_moot_guidance, revalidate_merge_request,
                 };
 
                 let task = crate::store::open_task_store_local(self.app.cas_dir())
@@ -2734,51 +2733,51 @@ impl FactoryDaemon {
                     &envelope.target_branch,
                 );
 
-                let (suppress_detail, guidance, summary) = match merge_request_delivery_decision(
-                    task.as_ref(),
-                    &envelope,
-                    &git,
-                ) {
-                    MergeRequestDelivery::Deliver => {
-                        if let MergeRequestDecision::Pending { target_tip } = &git
-                            && let Some(refreshed) =
-                                crate::prompt_revalidation::refresh_merge_request_target_tip(
-                                    &queued.prompt,
-                                    target_tip,
-                                )
-                        {
-                            prompt_with_instructions = refreshed;
+                let (suppress_detail, guidance, summary) =
+                    match merge_request_delivery_decision(task.as_ref(), &envelope, &git) {
+                        MergeRequestDelivery::Deliver => {
+                            if let MergeRequestDecision::Pending { target_tip } = &git
+                                && let Some(refreshed) =
+                                    crate::prompt_revalidation::refresh_merge_request_target_tip(
+                                        &queued.prompt,
+                                        target_tip,
+                                    )
+                            {
+                                prompt_with_instructions = refreshed;
+                            }
+                            merge_request_task = Some(envelope.task_id.clone());
+                            (None, None, "")
                         }
-                        merge_request_task = Some(envelope.task_id.clone());
-                        (None, None, "")
-                    }
-                    MergeRequestDelivery::SuppressLanded { target_tip } => (
-                        Some("merge request branch tip already integrated into target".to_string()),
-                        Some(merge_landed_guidance(
-                            &envelope.task_id,
-                            &envelope.branch_tip,
-                            &envelope.target_branch,
-                            &target_tip,
-                        )),
-                        "merge already landed — re-close task",
-                    ),
-                    MergeRequestDelivery::SuppressResolved { status } => (
-                        Some(format!(
-                            "merge request is moot: task is {status}, not awaiting merge"
-                        )),
-                        Some(merge_request_moot_guidance(&envelope.task_id, status)),
-                        "merge request no longer applies",
-                    ),
-                    MergeRequestDelivery::SuppressInvalidatedAnchor { current_anchor } => (
-                        Some("merge request delivery anchor was invalidated".to_string()),
-                        Some(merge_request_anchor_invalidated_guidance(
-                            &envelope.task_id,
-                            &envelope.branch_tip,
-                            current_anchor.as_deref(),
-                        )),
-                        "merge request delivery anchor no longer applies",
-                    ),
-                };
+                        MergeRequestDelivery::SuppressLanded { target_tip } => (
+                            Some(
+                                "merge request branch tip already integrated into target"
+                                    .to_string(),
+                            ),
+                            Some(merge_landed_guidance(
+                                &envelope.task_id,
+                                &envelope.branch_tip,
+                                &envelope.target_branch,
+                                &target_tip,
+                            )),
+                            "merge already landed — re-close task",
+                        ),
+                        MergeRequestDelivery::SuppressResolved { status } => (
+                            Some(format!(
+                                "merge request is moot: task is {status}, not awaiting merge"
+                            )),
+                            Some(merge_request_moot_guidance(&envelope.task_id, status)),
+                            "merge request no longer applies",
+                        ),
+                        MergeRequestDelivery::SuppressInvalidatedAnchor { current_anchor } => (
+                            Some("merge request delivery anchor was invalidated".to_string()),
+                            Some(merge_request_anchor_invalidated_guidance(
+                                &envelope.task_id,
+                                &envelope.branch_tip,
+                                current_anchor.as_deref(),
+                            )),
+                            "merge request delivery anchor no longer applies",
+                        ),
+                    };
 
                 if let (Some(detail), Some(guidance)) = (suppress_detail, guidance) {
                     match queue.enqueue_urgent_with_outcome(

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -2695,7 +2695,8 @@ impl FactoryDaemon {
                 use crate::mcp::tools::core::task::repo_context::resolve_repo_context;
                 use crate::prompt_revalidation::{
                     MergeRequestDecision, MergeRequestDelivery, merge_landed_guidance,
-                    merge_request_delivery_decision, merge_request_moot_guidance,
+                    merge_request_anchor_invalidated_guidance, merge_request_delivery_decision,
+                    merge_request_moot_guidance,
                     revalidate_merge_request,
                 };
 
@@ -2734,7 +2735,8 @@ impl FactoryDaemon {
                 );
 
                 let (suppress_detail, guidance, summary) = match merge_request_delivery_decision(
-                    task.as_ref().map(|task| task.status),
+                    task.as_ref(),
+                    &envelope,
                     &git,
                 ) {
                     MergeRequestDelivery::Deliver => {
@@ -2766,6 +2768,15 @@ impl FactoryDaemon {
                         )),
                         Some(merge_request_moot_guidance(&envelope.task_id, status)),
                         "merge request no longer applies",
+                    ),
+                    MergeRequestDelivery::SuppressInvalidatedAnchor { current_anchor } => (
+                        Some("merge request delivery anchor was invalidated".to_string()),
+                        Some(merge_request_anchor_invalidated_guidance(
+                            &envelope.task_id,
+                            &envelope.branch_tip,
+                            current_anchor.as_deref(),
+                        )),
+                        "merge request delivery anchor no longer applies",
                     ),
                 };
 


### PR DESCRIPTION
A worker's close was rejected with MERGE REQUIRED, parking the task at tip 60b3e7c6 and emitting a merge-request envelope. The supervisor then reviewed, found a material defect, and called `request_changes` — CAS correctly answered that the delivery anchor and proof were invalidated. **The worker's merge-request message was then delivered to the supervisor after that decline, still advertising the commit that had just been rejected.**

That is not stale noise: it is an actionable instruction carrying a SHA and an explicit please-merge ask. In the field report, the declined commit contained a reconciliation table calling 13 rows missing from QuickBooks when at least 6 existed — merging it would have put a document on main capable of driving a duplicate-billing decision against real customers.

**Reproduced three times during this session**, against the supervisor running it: after declining cas-56f8, the merge request for the declined tip was relayed with full merge instructions; the same happened again on the amended cycle. It was avoided only by diffing the message's SHA against live task state by hand — exactly the step this change removes.

- Suppression now keys on the task's current delivery anchor, with `SuppressInvalidatedAnchor` deliberately distinct from `SuppressResolved`, because a task can legitimately return to `AwaitingMerge` in a later cycle and the prior request must never regain authority.
- The `inbox_poll` bypass is closed for both merge-request envelopes and lifecycle relays, so claiming a row directly cannot make an invalidated anchor actionable.
- **The module's invariant is preserved:** suppression requires positive evidence that a message is moot; uncertainty always delivers. An unreadable task DELIVERS rather than withholds — an earlier revision inverted this and was declined, because silently dropping a real MERGE REQUIRED under a transient read failure is the exact failure this family exists to eliminate.

## Verification

- `invalidated_delivery_anchor_suppresses_a_queued_merge_request` and `prior_cycle_request_stays_suppressed_after_a_new_anchor_is_parked` — the latter covers the subtle half, where a later AwaitingMerge cycle could otherwise revive a declined request.
- `unreadable_task_never_withholds_a_lifecycle_relay_at_inbox_pop` pins the fail-open rule as a test rather than a comment.
- Premise verified independently: `request_changes_for_parked_delivery` in `crates/cas-store/src/verification_store.rs` does clear `factory_branch_anchor`, so the anchor check genuinely fires in the reported scenario.
- Scoped `inbox_poll_identity_tests` 12/12 (supervisor-run). Rebased onto current main; branch CI green on 7619d0c6.

Fixes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
