### PR TITLE
feat(cas-e7d9): give task notes a read path so supervisors stop pulling the whole record

### DIFF
--- a/cas-cli/src/mcp/tools/core/task/notes.rs
+++ b/cas-cli/src/mcp/tools/core/task/notes.rs
@@ -1,6 +1,32 @@
 use crate::mcp::tools::core::imports::*;
 
 impl CasCore {
+    pub async fn cas_task_notes_read(
+        &self,
+        Parameters(req): Parameters<IdRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let task_store = self.open_task_store()?;
+        let task = task_store.get(&req.id).map_err(|e| McpError {
+            code: ErrorCode::INVALID_PARAMS,
+            message: Cow::from(format!("Task not found: {e}")),
+            data: None,
+        })?;
+
+        if task.notes.is_empty() {
+            return Ok(Self::success(format!(
+                "No notes recorded for task {}",
+                task.id
+            )));
+        }
+
+        Ok(Self::success(format!(
+            "Notes for task {}\n{}\n\n{}",
+            task.id,
+            "=".repeat(task.id.len() + 15),
+            task.notes
+        )))
+    }
+
     pub async fn cas_task_notes(
         &self,
         Parameters(req): Parameters<TaskNotesRequest>,

--- a/cas-cli/src/mcp/tools/service/core.rs
+++ b/cas-cli/src/mcp/tools/service/core.rs
@@ -544,23 +544,26 @@ impl CasService {
     }
 
     pub(super) async fn task_notes(&self, req: TaskRequest) -> Result<CallToolResult, McpError> {
-        use crate::mcp::tools::TaskNotesRequest;
-        let inner_req = TaskNotesRequest {
-            id: req
-                .id
-                .ok_or_else(|| Self::error(ErrorCode::INVALID_PARAMS, "id required for notes — pass task ID as `id` (not `task_id`, `taskId`, or `_id`). Example: mcp__cas__task action=notes id=cas-abc1"))?,
-            note: req
-                .notes
-                .ok_or_else(|| {
-                    Self::error(
-                        ErrorCode::INVALID_PARAMS,
-                        "notes required — parameter name is `notes` (plural), not `note`. \
-                         Example: mcp__cas__task action=notes id=cas-abc1 notes=\"progress update\" note_type=\"progress\"",
-                    )
-                })?,
-            note_type: req.note_type.unwrap_or_else(|| "progress".to_string()),
-        };
-        self.inner.cas_task_notes(Parameters(inner_req)).await
+        use crate::mcp::tools::{IdRequest, TaskNotesRequest};
+        let id = req
+            .id
+            .ok_or_else(|| Self::error(ErrorCode::INVALID_PARAMS, "id required for notes — pass task ID as `id` (not `task_id`, `taskId`, or `_id`). Example: mcp__cas__task action=notes id=cas-abc1"))?;
+
+        match req.notes {
+            Some(note) => {
+                let inner_req = TaskNotesRequest {
+                    id,
+                    note,
+                    note_type: req.note_type.unwrap_or_else(|| "progress".to_string()),
+                };
+                self.inner.cas_task_notes(Parameters(inner_req)).await
+            }
+            None => {
+                self.inner
+                    .cas_task_notes_read(Parameters(IdRequest { id }))
+                    .await
+            }
+        }
     }
 
     pub(super) async fn task_dep_add(&self, req: TaskRequest) -> Result<CallToolResult, McpError> {

--- a/cas-cli/src/mcp/tools/service/mod.rs
+++ b/cas-cli/src/mcp/tools/service/mod.rs
@@ -258,7 +258,7 @@ impl CasService {
     // ========================================================================
 
     #[tool(
-        description = "Task operations. Actions: create (local, or cross-project proposal with explicit project), proposal_inbox, proposal_accept, proposal_reject, proposal_reconcile, show, update, start, close, cancel, reopen, request_changes, delete, list, ready (actionable), blocked, notes (add progress), dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine. Pending proposals are a dedicated cloud inbox, never TaskStatus rows. cancel is the supervisor-authorized, reason-required terminal path for work intentionally ended without delivery; it preserves history and accepts an optional superseded_by pointer. Supervisors use request_changes as the sanctioned exit from AwaitingMerge whenever review fails — declined merge, amendment required after merge, or rejected work — reopening the task with its assignee preserved (use reset only for tasks orphaned by a dead session). Prefer `start` for normal worker execution; use `claim` for manual lease control/recovery; use `reset` to revive a task orphaned by a dead session (atomic: force-releases lease, clears assignee, forces status=open). IMPORTANT for 'close': verification must pass first. Workers should attempt close; if close returns verification-required guidance, follow the indicated verifier ownership workflow."
+        description = "Task operations. Actions: create (local, or cross-project proposal with explicit project), proposal_inbox, proposal_accept, proposal_reject, proposal_reconcile, show, update, start, close, cancel, reopen, request_changes, delete, list, ready (actionable), blocked, notes, dep_add, dep_remove, dep_list, claim, release, reset, transfer, available, mine. For notes: pass only id to read that task's notes without the full task record; supply notes= to append, with optional note_type. Pending proposals are a dedicated cloud inbox, never TaskStatus rows. cancel is the supervisor-authorized, reason-required terminal path for work intentionally ended without delivery; it preserves history and accepts an optional superseded_by pointer. Supervisors use request_changes as the sanctioned exit from AwaitingMerge whenever review fails — declined merge, amendment required after merge, or rejected work — reopening the task with its assignee preserved (use reset only for tasks orphaned by a dead session). Prefer `start` for normal worker execution; use `claim` for manual lease control/recovery; use `reset` to revive a task orphaned by a dead session (atomic: force-releases lease, clears assignee, forces status=open). IMPORTANT for 'close': verification must pass first. Workers should attempt close; if close returns verification-required guidance, follow the indicated verifier ownership workflow."
     )]
     pub async fn task(
         &self,
@@ -278,7 +278,6 @@ impl CasService {
                     | "reopen"
                     | "request_changes"
                     | "delete"
-                    | "notes"
                     | "proposal_accept"
                     | "proposal_reject"
                     | "proposal_reconcile"
@@ -288,7 +287,7 @@ impl CasService {
                     | "release"
                     | "reset"
                     | "transfer"
-            );
+            ) || (req.action == "notes" && req.notes.is_some());
 
             let result = match req.action.as_str() {
                 "create" => this.task_create(req).await,

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -601,6 +601,76 @@ async fn test_task_notes() {
     );
 }
 
+/// GH #342: the unified `notes` action is a read when `notes` is absent and
+/// remains the existing append operation when `notes` is present.
+#[tokio::test]
+async fn task_notes_read_and_append_are_disambiguated_by_notes_presence() {
+    let (temp, core) = setup_cas();
+    let description_marker = "DESCRIPTION-MUST-NOT-LEAK";
+    let acceptance_marker = "ACCEPTANCE-MUST-NOT-LEAK";
+    let initial_note = "Initial worker progress";
+
+    let created = core
+        .cas_task_create(Parameters(TaskCreateRequest {
+            description: Some(format!("{description_marker}{}", "x".repeat(32_000))),
+            notes: Some(initial_note.to_string()),
+            acceptance_criteria: Some(acceptance_marker.to_string()),
+            ..basic_create("Long task whose notes are read frequently", None)
+        }))
+        .await
+        .expect("create long task");
+    let id = extract_task_id(&extract_text(created))
+        .expect("task id")
+        .to_string();
+    let service = CasService::new(core, None);
+
+    // `note_type` alone is metadata, not append intent. Without `notes`, this
+    // must stay read-only and return no heavyweight task fields.
+    let read_request: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
+        "action": "notes",
+        "id": id,
+        "note_type": "blocker"
+    }))
+    .unwrap();
+    let first_read = extract_text(service.task(Parameters(read_request)).await.unwrap());
+    assert!(first_read.contains(initial_note), "{first_read}");
+    assert!(!first_read.contains(description_marker), "{first_read}");
+    assert!(!first_read.contains(acceptance_marker), "{first_read}");
+    assert!(first_read.len() < 1_024, "notes read was {} bytes", first_read.len());
+
+    let append_request: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
+        "action": "notes",
+        "id": id,
+        "notes": "Supervisor-visible decision",
+        "note_type": "decision"
+    }))
+    .unwrap();
+    let appended = extract_text(service.task(Parameters(append_request)).await.unwrap());
+    assert!(appended.contains("Added decision note"), "{appended}");
+
+    let second_read: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
+        "action": "notes",
+        "id": id
+    }))
+    .unwrap();
+    let second_read = extract_text(service.task(Parameters(second_read)).await.unwrap());
+    assert!(second_read.contains(initial_note), "{second_read}");
+    assert!(second_read.contains("✅ DECISION Supervisor-visible decision"), "{second_read}");
+    assert!(!second_read.contains(description_marker), "{second_read}");
+
+    let persisted = open_task_store(&temp.path().join(".cas"))
+        .unwrap()
+        .get(&id)
+        .unwrap();
+    assert_eq!(persisted.notes.matches(initial_note).count(), 1);
+    assert_eq!(persisted.notes.matches("Supervisor-visible decision").count(), 1);
+    assert!(
+        !persisted.notes.contains("🚫 BLOCKER"),
+        "read with note_type must not append: {}",
+        persisted.notes
+    );
+}
+
 #[tokio::test]
 async fn test_task_notes_succeeds_when_activity_event_recording_fails() {
     let (temp, service) = setup_cas();

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -215,8 +215,11 @@ pub struct TaskRequest {
     #[serde(default)]
     pub labels: Option<String>,
 
-    /// Notes (for create, update, notes)
-    #[schemars(description = "Notes content or notes to append")]
+    /// Notes (for create, update, notes). For `action=notes`, omission reads
+    /// only the task's notes; presence appends the supplied value.
+    #[schemars(
+        description = "Notes content. For action=notes: omit to read only the task's notes; supply to append"
+    )]
     #[serde(default)]
     pub notes: Option<String>,
 


### PR DESCRIPTION
`task action=notes` reads like a getter but is append-only, and there was no read counterpart. The only way to read a task's notes was `action=show`, which returns the entire record — description, acceptance criteria, design, dependencies, deliverables and every note. On a long-lived task that is very expensive: the reporter's example carried a ~4,000-word description plus five progress notes plus a multi-paragraph `request_changes` decision, so checking the newest worker note meant pulling the whole thing every time. During an active supervision loop that is the single most repeated read.

I can confirm the cost first-hand: supervising this epic, I called `action=show` repeatedly for no reason other than to read the latest note on a task I already understood.

`task action=notes id=<id>` with no `notes=` now lists the task's notes. Supplying `notes=` preserves append exactly as before.

The alternatives were considered and rejected deliberately: `action=notes_list` proliferates actions for a read that the existing name already implies, and a `fields` / `notes_only` selector on `show` is less discoverable for the workflow that actually repeats. The read/append disambiguation is documented in the schema and tool copy rather than left implicit.

## Verification

- Regression covers all three shapes: read-only, append, and the empty/missing-parameter boundary between them.
- Full modified operations module: **60/60**. `cas` and `cas-mcp` lib/test `cargo check` clean, diff check clean.
- Branch CI green on 6fe202c3.

Note on provenance: the assigned worker checkpointed at ~8% context rather than polling CI into compaction — the correct call — and this lane was merged and closed by the supervisor after its CI came back green.

Fixes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)
