### PR TITLE
fix(cas-4a27): message provenance so a worker can tell a fresh instruction from a replay

### DIFF
--- a/cas-cli/src/hooks/handlers/handlers_middle/factory_inbox.rs
+++ b/cas-cli/src/hooks/handlers/handlers_middle/factory_inbox.rs
@@ -148,10 +148,11 @@ pub(crate) fn render_surfaced(rows: &[QueuedPrompt]) -> String {
     );
     for row in rows {
         out.push_str(&format!(
-            "\n--- from {} (message {}{}) ---\n{}\n",
+            "\n--- from {} (message {}{}) ---\n{}\n{}\n",
             row.source,
             row.id,
             if row.urgent { ", urgent" } else { "" },
+            crate::mcp::tools::service::agent_search_system::message::queued_message_provenance(row),
             row.prompt.trim()
         ));
     }
@@ -190,6 +191,12 @@ mod tests {
         let rendered = render_surfaced(&[row(7640, "supervisor", "start cas-7a01")]);
         assert!(rendered.contains("supervisor"), "{rendered}");
         assert!(rendered.contains("7640"), "{rendered}");
+        assert!(
+            rendered.contains("origin=supervisor-authored")
+                && rendered.contains("queued_at=")
+                && rendered.contains("delivery=first-delivery"),
+            "every hook-surfaced message must retain actionable queue provenance: {rendered}"
+        );
         assert!(rendered.contains("start cas-7a01"), "{rendered}");
     }
 

--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -19,6 +19,43 @@ fn resolve_inbox_recipient(
 /// means the same thing on both delivery channels.
 pub(crate) const INBOX_REDELIVERY_MARKER: &str = "[redelivery]";
 
+/// Durable provenance rendered with every queue-backed message (cas-4a27).
+///
+/// A plain sender prefix cannot distinguish a late spawn task brief from a
+/// fresh supervisor reply. The queue already knows the facts a worker needs;
+/// keep them visible at the final render boundary instead of asking an agent
+/// to reconstruct them from prose and timing.
+pub(crate) fn queued_message_provenance(message: &cas_store::QueuedPrompt) -> String {
+    let origin = if message.source.eq_ignore_ascii_case("supervisor") {
+        "supervisor-authored"
+    } else if message.source.eq_ignore_ascii_case("director")
+        && message
+            .summary
+            .as_deref()
+            .is_some_and(|summary| summary.starts_with("Assigned task:"))
+    {
+        "spawn-boilerplate"
+    } else if message.source.eq_ignore_ascii_case("director") {
+        "director-generated"
+    } else if message.source.starts_with("lifecycle-wake:") {
+        "lifecycle-relay"
+    } else {
+        "agent-authored"
+    };
+    let delivery = if message.processed_at.is_some() {
+        "replay"
+    } else {
+        "first-delivery"
+    };
+    format!(
+        "CAS provenance: notification_id={} origin={} queued_at={} delivery={}",
+        message.id,
+        origin,
+        message.created_at.to_rfc3339(),
+        delivery,
+    )
+}
+
 /// cas-99d2 (GH #127): what to do with one row an inbox poll selected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InboxRedelivery {
@@ -519,6 +556,65 @@ impl CasService {
                 .unwrap_or_else(|| source.clone())
         };
 
+        // cas-4a27 (GH #334): reply inference intentionally requires a
+        // recipient-surfacing receipt, so it cannot turn an unrelated later
+        // message into proof that an escalation was read. A supervisor that
+        // DID read an escalation needs a precise way to say so. Link this
+        // reply to the durable notification explicitly, validate the two
+        // endpoints, and render the reference on the worker-facing message.
+        // This is strong evidence for exactly one row; the conservative
+        // generic reply-inference rule below remains unchanged.
+        let explicit_reply_to = req.in_reply_to;
+        if let Some(notification_id) = explicit_reply_to {
+            let prior = queue
+                .message_delivery_report(notification_id)
+                .map_err(|error| {
+                    Self::error(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to inspect in_reply_to message {notification_id}: {error}"),
+                    )
+                })?
+                .ok_or_else(|| {
+                    Self::error(
+                        ErrorCode::INVALID_PARAMS,
+                        format!("in_reply_to notification {notification_id} does not exist"),
+                    )
+                })?;
+            let expected_prior_sources = [
+                resolved_target.as_str(),
+                if addressed_logical_supervisor {
+                    "supervisor"
+                } else {
+                    ""
+                },
+            ];
+            let expected_prior_targets = [
+                display_name.as_str(),
+                env_agent_name.as_deref().unwrap_or_default(),
+                if role == "supervisor" { "supervisor" } else { "" },
+            ];
+            let source_matches = expected_prior_sources
+                .iter()
+                .filter(|name| !name.is_empty())
+                .any(|name| prior.source.eq_ignore_ascii_case(name));
+            let target_matches = expected_prior_targets
+                .iter()
+                .filter(|name| !name.is_empty())
+                .any(|name| prior.target.eq_ignore_ascii_case(name));
+            if !source_matches || !target_matches {
+                return Err(Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    format!(
+                        "in_reply_to notification {notification_id} is {} -> {}, not a direct message from {resolved_target} to this sender",
+                        prior.source, prior.target
+                    ),
+                ));
+            }
+            message = format!(
+                "[CAS reply: explicitly acknowledges notification_id={notification_id}]\n{message}"
+            );
+        }
+
         // cas-bc8c: a genuine merge request receives an immutable envelope so
         // transport can suppress it once its requested tip has landed. That
         // envelope is a message type, not a property of the sender's task
@@ -843,6 +939,17 @@ impl CasService {
             enqueue_outcome,
             cas_store::EnqueueOutcome::SuppressedDuplicate(_)
         );
+
+        if let Some(notification_id) = explicit_reply_to {
+            queue.ack(notification_id).map_err(|error| {
+                Self::error(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!(
+                        "Reply {message_id} queued but failed to confirm in_reply_to notification {notification_id}: {error}"
+                    ),
+                )
+            })?;
+        }
 
         // cas-85fd: an urgent halt is a course-correction exchange, not a
         // permanent worker state. Once the row exists, bind every halt this
@@ -1280,7 +1387,7 @@ impl CasService {
                     redelivered += 1;
                     body.push_str(&format!(
                         "**[{}] From: {} — {INBOX_REDELIVERY_MARKER} (already delivered {})**\n\
-                         Summary: {}\nCreated: {}\nMessage: {}\n\n",
+                        Summary: {}\n{}\nMessage: {}\n\n",
                         message.id,
                         message.source,
                         message
@@ -1288,17 +1395,17 @@ impl CasService {
                             .map(|at| at.to_rfc3339())
                             .unwrap_or_else(|| "earlier".to_string()),
                         message.summary.as_deref().unwrap_or("(no summary)"),
-                        message.created_at.to_rfc3339(),
+                        queued_message_provenance(message),
                         message.prompt,
                     ));
                 }
                 InboxRedelivery::FirstDelivery => {
                     body.push_str(&format!(
-                        "**[{}] From: {}**\nSummary: {}\nCreated: {}\nMessage: {}\n\n",
+                        "**[{}] From: {}**\nSummary: {}\n{}\nMessage: {}\n\n",
                         message.id,
                         message.source,
                         message.summary.as_deref().unwrap_or("(no summary)"),
-                        message.created_at.to_rfc3339(),
+                        queued_message_provenance(message),
                         message.prompt,
                     ));
                 }

--- a/cas-cli/src/mcp/tools/service/agent_search_system/mod.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/mod.rs
@@ -1,7 +1,7 @@
 mod agent_loop;
 mod code;
 mod history;
-mod message;
+pub(crate) mod message;
 mod search_context;
 mod supervisor_queue;
 mod system;

--- a/cas-cli/src/mcp/tools/service/mod.rs
+++ b/cas-cli/src/mcp/tools/service/mod.rs
@@ -1257,7 +1257,7 @@ impl CasService {
 // ============================================================================
 
 pub(crate) mod agent_liveness;
-mod agent_search_system;
+pub(crate) mod agent_search_system;
 mod core;
 pub(crate) mod factory_ops;
 mod factory_remind;

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -2907,6 +2907,16 @@ impl FactoryDaemon {
             let inbox_source =
                 self.inbox_source_name(&queued.source, &worker_names, &supervisor_name);
 
+            // cas-4a27 (GH #334): preserve the durable queue facts at the
+            // last shared delivery boundary. In particular, a task brief that
+            // was queued at spawn but reaches the worker after a supervisor
+            // reply must read as old spawn boilerplate, not a fresh reassignment.
+            prompt_with_instructions = format!(
+                "{}\n\n{}",
+                crate::mcp::tools::service::agent_search_system::message::queued_message_provenance(&queued),
+                prompt_with_instructions,
+            );
+
             // cas-ceae (GH #124 + #123): before doing anything else with a row
             // we already wrote and left pending, ask whether our copy is still
             // there — if the harness drained it, writing again appends a

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -489,6 +489,7 @@ fn coord_req(action: &str) -> CoordinationRequest {
         id: None,
         task_id: None,
         merge_request: None,
+        in_reply_to: None,
         target: None,
         message: None,
         summary: None,
@@ -4803,6 +4804,7 @@ fn coord_msg(
         id: None,
         task_id: None,
         merge_request: None,
+        in_reply_to: None,
         target: Some(target.to_string()),
         message: Some(message.to_string()),
         summary: Some("test".to_string()),
@@ -7403,6 +7405,106 @@ async fn cas99d2_reply_after_an_inbox_drain_still_confirms_gh126() {
         report.confirmation_source,
         cas_store::ConfirmationSource::InferredFromReply,
         "a reply that post-dates a real drain receipt still confirms: {report:?}"
+    );
+}
+
+/// cas-4a27 (GH #334): the field reproduction had both halves at once: a
+/// supervisor's real response was indistinguishable from delayed spawn
+/// boilerplate, while the worker's escalation remained AwaitingAck because
+/// the supervisor's transport had no surfacing receipt. A reply reference is
+/// explicit evidence for that ONE escalation, and every delivered row exposes
+/// durable provenance so the worker can act on the ordering mechanically.
+#[tokio::test]
+async fn cas4a27_supervisor_reply_is_linked_and_distinct_from_spawn_replay_gh334() {
+    let _guard = EnvGuard::set(&[
+        ("CAS_AGENT_ROLE", "supervisor"),
+        ("CAS_AGENT_NAME", "cosmic-bear-43"),
+    ]);
+    let env = FactoryTestEnv::with_agent_id_and_env("cosmic-bear-id", None);
+    let mut supervisor = Agent::new("cosmic-bear-id".to_string(), "cosmic-bear-43".to_string());
+    supervisor.role = AgentRole::Supervisor;
+    env.agent_store()
+        .register(&supervisor)
+        .expect("register calling supervisor");
+    env.register_worker_with_id("koala-agent-id", "watchful-koala-20", None);
+
+    let escalation_id = env
+        .prompt_queue()
+        .enqueue_urgent(
+            "watchful-koala-20",
+            "cosmic-bear-43",
+            "Blocked: the task needs a policy decision; recommend option A.",
+            None,
+            Some("blocked escalation"),
+            None,
+            false,
+        )
+        .expect("enqueue worker escalation");
+    env.prompt_queue()
+        .mark_transport_delivered(escalation_id)
+        .expect("supervisor transport handoff without a surfacing receipt");
+
+    let spawn_id = env
+        .prompt_queue()
+        .enqueue_urgent(
+            "director",
+            "watchful-koala-20",
+            "You were spawned for task cas-4a27 — start it now.",
+            None,
+            Some("Assigned task: cas-4a27"),
+            None,
+            false,
+        )
+        .expect("enqueue delayed spawn brief");
+
+    let mut reply = coord_msg(
+        "message",
+        "watchful-koala-20",
+        "I read your escalation, endorse option A, and assigned the follow-up.",
+        None,
+    );
+    reply.summary = Some("escalation acknowledged".to_string());
+    reply.in_reply_to = Some(escalation_id);
+    env.service
+        .coordination(Parameters(reply))
+        .await
+        .expect("explicit supervisor reply");
+
+    let escalation = env
+        .prompt_queue()
+        .message_delivery_report(escalation_id)
+        .expect("escalation delivery report")
+        .expect("escalation exists");
+    assert_eq!(
+        escalation.confirmation_source,
+        cas_store::ConfirmationSource::ExplicitAck,
+        "the precise reply reference must resolve the escalation even without a surfacing receipt: {escalation:?}"
+    );
+
+    let worker_core = CasCore::with_daemon(env.cas_root.clone(), None, None);
+    worker_core.set_agent_id_for_testing("koala-agent-id".to_string());
+    let worker_service = CasService::new(worker_core, None);
+    let text = get_text(
+        &worker_service
+            .coordination(Parameters(coord_req("inbox_poll")))
+            .await
+            .expect("worker inbox poll"),
+    );
+    assert!(
+        text.contains(&format!("notification_id={spawn_id} origin=spawn-boilerplate"))
+            && text.contains("delivery=first-delivery"),
+        "the delayed spawn brief needs machine-readable origin, ID, time, and delivery state: {text}"
+    );
+    assert!(
+        text.contains("origin=supervisor-authored")
+            && text.contains(&format!("notification_id={escalation_id}")),
+        "the actual supervisor reply must be visibly fresh and linked to the escalation: {text}"
+    );
+    assert!(
+        text.contains(&format!(
+            "[CAS reply: explicitly acknowledges notification_id={escalation_id}]"
+        )),
+        "the reply must name the exact escalation it acknowledges: {text}"
     );
 }
 

--- a/cas-cli/tests/worktree_surface_test.rs
+++ b/cas-cli/tests/worktree_surface_test.rs
@@ -210,6 +210,7 @@ fn coord_req(action: &str) -> CoordinationRequest {
         id: None,
         task_id: None,
         merge_request: None,
+        in_reply_to: None,
         target: None,
         message: None,
         summary: None,

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -860,6 +860,17 @@ pub struct AgentRequest {
     #[serde(default)]
     pub merge_request: Option<bool>,
 
+    /// Explicit notification this message acknowledges or answers.
+    ///
+    /// The recipient can use this durable queue ID to distinguish a real reply
+    /// from delayed spawn boilerplate; CAS confirms the referenced message
+    /// only after validating that this sender is its intended recipient.
+    #[schemars(
+        description = "message action only: notification_id of the prior direct message this response explicitly acknowledges. CAS validates the two endpoints, marks that exact prior message confirmed, and renders the reply with the durable reference."
+    )]
+    #[serde(default, deserialize_with = "deser::option_i64")]
+    pub in_reply_to: Option<i64>,
+
     /// Loop prompt (for loop_start)
     #[schemars(description = "The prompt to repeat each iteration")]
     #[serde(default)]

--- a/crates/cas-mcp/src/types/ops_secondary.rs
+++ b/crates/cas-mcp/src/types/ops_secondary.rs
@@ -746,6 +746,13 @@ pub struct CoordinationRequest {
     #[serde(default)]
     pub merge_request: Option<bool>,
 
+    /// Explicit notification this message acknowledges or answers.
+    #[schemars(
+        description = "message action only: notification_id of the direct message this response explicitly acknowledges. CAS validates the endpoints, confirms that exact message, and includes the reference in the delivered reply."
+    )]
+    #[serde(default, deserialize_with = "deser::option_i64")]
+    pub in_reply_to: Option<i64>,
+
     /// Target agent name for hold_worker/release_worker/clear_context/message/remind
     #[schemars(
         description = "Target agent name for hold_worker/release_worker/clear_context/message/remind (or 'all_workers' for broadcast where supported). For remind: agent who receives the reminder (defaults to self)"
@@ -1087,6 +1094,7 @@ impl CoordinationRequest {
             session_id: self.session_id.clone(),
             task_id: self.task_id.clone(),
             merge_request: self.merge_request,
+            in_reply_to: self.in_reply_to,
             prompt: self.prompt.clone(),
             max_iterations: self.max_iterations,
             completion_promise: self.completion_promise.clone(),

--- a/crates/cas-mcp/src/types_tests/tests.rs
+++ b/crates/cas-mcp/src/types_tests/tests.rs
@@ -304,6 +304,17 @@ fn coordination_merge_request_type_survives_agent_mapping() {
 }
 
 #[test]
+fn coordination_reply_reference_survives_agent_mapping() {
+    let req: CoordinationRequest = serde_json::from_str(
+        r#"{"action":"message","target":"worker-a","in_reply_to":7602,"summary":"acknowledged","message":"I read your escalation."}"#,
+    )
+    .unwrap();
+
+    assert_eq!(req.in_reply_to, Some(7602));
+    assert_eq!(req.to_agent_request("message").in_reply_to, Some(7602));
+}
+
+#[test]
 fn test_factory_older_than_secs_as_string() {
     let req: FactoryRequest =
         serde_json::from_str(r#"{"action": "gc_cleanup", "older_than_secs": "7200"}"#).unwrap();


### PR DESCRIPTION
A worker completed a task, deliberately set it blocked because it needed a decision rather than code, and escalated its findings. The supervisor read that escalation and replied — acknowledging it, endorsing the recommendation, and assigning the next task. The worker's reply opened with *"your re-assignment looks like spawn boilerplate replaying; my escalation shows delivered-but-unacked, so I don't think you've read it"* — and re-sent its entire escalation verbatim. A complete duplicated cycle on both sides.

The worker's reasoning was **correct given the signals available to it**. It had no way to distinguish a fresh, content-bearing supervisor message from a re-delivery of its own spawn prompt, and `message_status` showed transport succeeded with a reaction observed while `pending_reason` stayed `awaiting_ack`. Both signals pointed at "this is a replay, my escalation is unread" when in fact it had been read and answered.

- Queued messages now carry machine-readable provenance across the inbox, hook and daemon delivery paths: origin, id, `queued_at`, and first-delivery vs replay.
- An endpoint-validated `in_reply_to` acknowledges one exact escalation, without weakening generic reply inference.

That second part is the missing signal specifically: the reported worker re-sent because *delivered-but-unacked* was indistinguishable from *unread*. A targeted acknowledgement resolves the ambiguity rather than papering over it.

Context: the same failure family was observed repeatedly from the supervisor side during this session — identical CI red-run relays re-delivered for the same `run_id` after being acted on, and a `MERGE REQUIRED` relay redelivered after its delivery anchor had been declined. Same shape, different producers: a notification whose premise was consumed, re-announced as though new.

## Verification

- GH #334 integration regression: a real supervisor reply followed by a replayed spawn intro must be distinguishable.
- Full-surface proofs, supervisor-run in the worker's worktree: `inbox_poll_identity_tests` **11 passed**, full `factory_mcp_ops_test` binary **144 passed**. The lane's own quoted counts covered only its added tests, so these were re-run against the modules actually modified — `factory_inbox.rs`, `message.rs`, `queue_and_events.rs` and the cas-mcp types.
- cas-mcp mapping and hook render regressions pass. Branch CI green on 4d4e8ccf.

Fixes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
