### PR TITLE
fix(cas-a736): reconcile terminal-task relay backlog automatically instead of ten manual acks

### DIFF
--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -664,30 +664,14 @@ fn format_assigned_task_info(
 /// without a daemon, a queue, or a clock.
 fn format_undelivered_relay_section(
     rows: &[cas_store::UndeliveredLifecycleRelay],
-    terminal_rows: &[cas_store::UndeliveredLifecycleRelay],
+    total: usize,
 ) -> String {
-    if rows.is_empty() && terminal_rows.is_empty() {
+    if rows.is_empty() {
         return String::new();
     }
     let mut out = String::new();
-    if !terminal_rows.is_empty() {
-        let terminal_ids = terminal_rows
-            .iter()
-            .filter_map(lifecycle_relay_notification_id)
-            .map(|id| format!("`lifecycle-wake:{id}`"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        out.push_str(&format!(
-            "⚠ {} UNDELIVERED SUPERVISOR RELAY{} for terminal tasks suppressed: {terminal_ids}. Acknowledge each with `coordination action=message_ack notification_id=<id>` to dismiss it durably.\n",
-            terminal_rows.len(),
-            if terminal_rows.len() == 1 { "" } else { "s" }
-        ));
-    }
-    if rows.is_empty() {
-        return format!("{out}\n");
-    }
     out.push_str(&format!(
-        "⚠ UNDELIVERED SUPERVISOR RELAY ({}) — these never reached you:\n",
+        "⚠ UNDELIVERED SUPERVISOR RELAY ({total} total; displaying {}) — these never reached you:\n",
         rows.len()
     ));
     for row in rows {
@@ -717,46 +701,6 @@ fn format_undelivered_relay_section(
          (`task action=show id=<id>`) — a missing relay is not evidence the work was handled.\n\n",
     );
     out
-}
-
-/// Return the durable notification ID a lifecycle relay exposes to operators.
-/// Sources have evolved (`lifecycle-wake:<id>` and
-/// `lifecycle-wake:worker-attention:<id>`); the final numeric component is
-/// the public ACK identity for both forms.
-fn lifecycle_relay_notification_id(row: &cas_store::UndeliveredLifecycleRelay) -> Option<i64> {
-    row.source
-        .rsplit(':')
-        .next()
-        .and_then(|id| id.parse::<i64>().ok())
-}
-
-/// A lifecycle relay is only actionable while its named task remains open.
-/// Keep the terminal prompt row for doctor/forensics, but do not inject an
-/// already-closed lane into every supervisor `worker_status` response.
-fn unresolved_lifecycle_relays(
-    rows: Vec<cas_store::UndeliveredLifecycleRelay>,
-    closed_task_ids: &[String],
-) -> Vec<cas_store::UndeliveredLifecycleRelay> {
-    rows.into_iter()
-        .filter(|row| {
-            let Some(summary) = row.summary.as_deref() else {
-                return true;
-            };
-            !closed_task_ids.iter().any(|id| summary.contains(id))
-        })
-        .collect()
-}
-
-/// Task lifecycle summaries always carry one `cas-…` task ID. Keep extraction
-/// deliberately conservative: a row we cannot parse stays visible rather than
-/// letting a formatting drift hide a real undelivered relay.
-fn lifecycle_relay_task_id(row: &cas_store::UndeliveredLifecycleRelay) -> Option<&str> {
-    row.summary.as_deref().and_then(|summary| {
-        summary
-            .split_whitespace()
-            .find(|word| word.starts_with("cas-"))
-            .map(|word| word.trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '-'))
-    })
 }
 
 fn format_spawn_lifecycle_section(
@@ -1979,37 +1923,22 @@ impl CasService {
         // rendered even when no agents are registered — the whole failure mode
         // being fixed is that a lost relay left no trace anywhere, so the
         // fleet read silence as "nothing is waiting on me".
-        let undelivered_relays = crate::store::open_prompt_queue_store(&self.inner.cas_root)
+        let (undelivered_relays, undelivered_total) = crate::store::open_prompt_queue_store(&self.inner.cas_root)
             .ok()
-            .and_then(|queue| queue.list_undelivered_lifecycle_relays(10).ok())
-            .unwrap_or_default();
-        let closed_task_ids = crate::store::open_task_store(&self.inner.cas_root)
-            .ok()
-            .map(|tasks| {
-                undelivered_relays
-                    .iter()
-                    .filter_map(lifecycle_relay_task_id)
-                    .filter(|task_id| {
-                        tasks
-                            .get(task_id)
-                            .ok()
-                            .is_some_and(|task| task.status == cas_types::TaskStatus::Closed)
-                    })
-                    .map(str::to_owned)
-                    .collect::<Vec<_>>()
+            .map(|queue| {
+                // A terminal task is positive evidence that the lifecycle
+                // relay's requested supervisor action is moot. Reconcile it
+                // durably (while retaining the forensic prompt row) before
+                // sampling the remaining actionable backlog.
+                let _ = queue.reconcile_terminal_lifecycle_relays();
+                let total = queue.undelivered_lifecycle_relay_count().unwrap_or(0);
+                let rows = queue.list_undelivered_lifecycle_relays(10).unwrap_or_default();
+                (rows, total)
             })
             .unwrap_or_default();
-        let terminal_rows: Vec<_> = undelivered_relays
-            .iter()
-            .filter(|row| {
-                lifecycle_relay_task_id(row)
-                    .is_some_and(|task_id| closed_task_ids.iter().any(|id| id == task_id))
-            })
-            .cloned()
-            .collect();
         let undelivered_section = format_undelivered_relay_section(
-            &unresolved_lifecycle_relays(undelivered_relays, &closed_task_ids),
-            &terminal_rows,
+            &undelivered_relays,
+            undelivered_total,
         );
 
         if agents.is_empty() {
@@ -7669,7 +7598,7 @@ mod spawn_lifecycle_tests {
             &[lost_relay(
                 "task_awaiting_merge: cas-fe23 (2026-08-07T18:51:51Z)",
             )],
-            &[],
+            1,
         );
         assert!(
             out.contains("UNDELIVERED SUPERVISOR RELAY"),
@@ -7695,34 +7624,18 @@ mod spawn_lifecycle_tests {
     /// has to be believed the single time it fires.
     #[test]
     fn no_undelivered_relays_renders_nothing() {
-        assert!(format_undelivered_relay_section(&[], &[]).is_empty());
+        assert!(format_undelivered_relay_section(&[], 0).is_empty());
     }
 
     #[test]
-    fn reconciled_closed_task_relays_do_not_replay_in_worker_status() {
-        let closed = lost_relay("task_awaiting_merge: cas-reconciled (2026-08-09T15:56:36Z)");
-        let still_actionable = lost_relay("task_blocked: cas-open (2026-08-09T15:57:00Z)");
-        let remaining = unresolved_lifecycle_relays(
-            vec![closed.clone(), still_actionable],
-            &["cas-reconciled".to_string()],
-        );
-
-        let rendered = format_undelivered_relay_section(&remaining, &[closed]);
-        assert!(
-            !rendered.contains("cas-reconciled"),
-            "closed lane must not replay: {rendered}"
+    fn relay_banner_states_the_true_total_beyond_its_display_cap() {
+        let rendered = format_undelivered_relay_section(
+            &[lost_relay("task_blocked: cas-open (2026-08-09T15:57:00Z)")],
+            12,
         );
         assert!(
-            rendered.contains("cas-open"),
-            "open lane remains a real signal: {rendered}"
-        );
-        assert!(
-            rendered.contains("1 UNDELIVERED SUPERVISOR RELAY for terminal tasks suppressed"),
-            "terminal relays collapse to one count while live relays remain detailed: {rendered}"
-        );
-        assert!(
-            rendered.contains("`lifecycle-wake:3386`"),
-            "the terminal count must name the exact lifecycle-wake ID it demands: {rendered}"
+            rendered.contains("12 total; displaying 1"),
+            "the display cap must never conceal backlog depth: {rendered}"
         );
     }
 

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -2041,6 +2041,50 @@ async fn test_worker_status_empty() {
 }
 
 #[tokio::test]
+async fn cas_a736_worker_status_reconciles_the_full_terminal_relay_backlog() {
+    let env = FactoryTestEnv::new();
+    let task_id = "cas-terminal-relay-backlog";
+    let mut task = Task::new(task_id.to_string(), "terminal relay backlog".to_string());
+    env.task_store().add(&task).expect("add terminal task");
+    task.status = TaskStatus::Closed;
+    task.closed_at = Some(chrono::Utc::now());
+    env.task_store().update(&task).expect("close task");
+
+    let queue = env.prompt_queue();
+    for index in 0..12 {
+        let prompt_id = queue
+            .enqueue_full(
+                &format!("lifecycle-wake:{}", 6000 + index),
+                "supervisor",
+                "<task-lifecycle transition=\"task_awaiting_merge\">",
+                Some("historical-session"),
+                Some(&format!("task_awaiting_merge: {task_id} ({index})")),
+                None,
+            )
+            .expect("enqueue historical relay");
+        queue
+            .mark_suppressed(prompt_id, Some("historical lifecycle occurrence expired"))
+            .expect("suppress historical relay");
+    }
+    assert_eq!(queue.list_undelivered_lifecycle_relays(10).unwrap().len(), 10);
+
+    let text = get_text(
+        &env.service
+            .factory(Parameters(factory_req("worker_status")))
+            .await
+            .expect("worker_status"),
+    );
+    assert!(
+        !text.contains("UNDELIVERED SUPERVISOR RELAY"),
+        "the terminal backlog must fully self-reconcile rather than leave a banner: {text}"
+    );
+    assert!(
+        queue.list_undelivered_lifecycle_relays(10).unwrap().is_empty(),
+        "a second status read must not reintroduce an acknowledged terminal relay"
+    );
+}
+
+#[tokio::test]
 async fn test_worker_status_shows_agents() {
     // Acquire env mutex to prevent concurrent tests from setting CAS_AGENT_ROLE=supervisor
     // which would activate supervisor scoping and filter out our test workers.

--- a/crates/cas-store/src/prompt_queue_store.rs
+++ b/crates/cas-store/src/prompt_queue_store.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use crate::recording_store::capture_message_event;
+use crate::shared_db::ImmediateTx;
 use crate::supervisor_queue_store::NotificationPriority;
 use crate::{Result, StoreError};
 
@@ -1613,6 +1614,17 @@ pub trait PromptQueueStore: Send + Sync {
         &self,
         limit: usize,
     ) -> Result<Vec<UndeliveredLifecycleRelay>>;
+
+    /// Durably reconcile terminal lifecycle relays for tasks that can no
+    /// longer need supervisor action.  The forensic prompt row and its final
+    /// delivery stage are retained; only its replay eligibility is cleared.
+    /// Returns the number of previously-unacknowledged rows reconciled.
+    fn reconcile_terminal_lifecycle_relays(&self) -> Result<usize>;
+
+    /// Count all unresolved terminal lifecycle relay rows without applying a
+    /// display cap.  Status banners use this with a bounded sample so they
+    /// cannot hide backlog depth.
+    fn undelivered_lifecycle_relay_count(&self) -> Result<usize>;
 
     /// Get count of pending prompts
     fn pending_count(&self) -> Result<usize>;
@@ -3881,6 +3893,46 @@ impl PromptQueueStore for SqlitePromptQueueStore {
         Ok(out)
     }
 
+    fn reconcile_terminal_lifecycle_relays(&self) -> Result<usize> {
+        crate::shared_db::with_write_retry(|| {
+            let conn = crate::shared_db::lock_connection(&self.conn)?;
+            let tx = ImmediateTx::new(&conn)?;
+            let now = Utc::now().to_rfc3339();
+            let reconciled = tx.execute(
+                "UPDATE prompt_queue
+                 SET acked_at = ?, acked_via = 'terminal_task_reconciled'
+                 WHERE transport_delivered_at IS NULL
+                   AND acked_at IS NULL
+                   AND source LIKE 'lifecycle-wake:%'
+                   AND highest_stage IN ('suppressed', 'dropped', 'abandoned')
+                   AND EXISTS (
+                       SELECT 1 FROM tasks
+                       WHERE status IN ('closed', 'cancelled')
+                         AND (prompt_queue.summary = tasks.id
+                              OR prompt_queue.summary LIKE '%: ' || tasks.id
+                              OR prompt_queue.summary LIKE '%: ' || tasks.id || ' (%')
+                   )",
+                params![now],
+            )?;
+            tx.commit()?;
+            Ok(reconciled)
+        })
+    }
+
+    fn undelivered_lifecycle_relay_count(&self) -> Result<usize> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM prompt_queue
+             WHERE transport_delivered_at IS NULL
+               AND acked_at IS NULL
+               AND source LIKE 'lifecycle-wake:%'
+               AND highest_stage IN ('suppressed', 'dropped', 'abandoned')",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(count.try_into().unwrap_or(usize::MAX))
+    }
+
     fn ack_lifecycle_wake(&self, lifecycle_wake_id: i64) -> Result<Option<i64>> {
         let conn = crate::shared_db::lock_connection(&self.conn)?;
         let prompt_id = conn
@@ -4305,6 +4357,9 @@ impl SqlitePromptQueueStore {
 #[cfg(test)]
 mod tests {
     use crate::prompt_queue_store::*;
+    use crate::task_store::SqliteTaskStore;
+    use crate::TaskStore;
+    use cas_types::{Task, TaskStatus};
     use rusqlite::params;
     use tempfile::TempDir;
 
@@ -4544,6 +4599,53 @@ mod tests {
                 .unwrap()
                 .confirmed_at
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn terminal_task_reconciliation_drains_a_backlog_larger_than_the_display_cap() {
+        let (temp, store) = create_test_store();
+        let task_id = "cas-terminal-backlog";
+        let task_store = SqliteTaskStore::open(temp.path()).unwrap();
+        task_store.init().unwrap();
+        let mut task = Task::new(task_id.to_string(), "terminal backlog".to_string());
+        task_store.add(&task).unwrap();
+        task.status = TaskStatus::Closed;
+        task.closed_at = Some(Utc::now());
+        task_store.update(&task).unwrap();
+        for index in 0..12 {
+            let prompt_id = store
+                .enqueue_full(
+                    &format!("lifecycle-wake:{}", 5100 + index),
+                    "supervisor",
+                    "<task-lifecycle transition=\"task_awaiting_merge\">",
+                    Some("session"),
+                    Some(&format!("task_awaiting_merge: {task_id} ({index})")),
+                    Some(NotificationPriority::High),
+                )
+                .unwrap();
+            store
+                .mark_suppressed(prompt_id, Some("task lifecycle occurrence expired"))
+                .unwrap();
+        }
+
+        assert_eq!(store.undelivered_lifecycle_relay_count().unwrap(), 12);
+        assert_eq!(store.list_undelivered_lifecycle_relays(10).unwrap().len(), 10);
+        assert_eq!(
+            store
+                .reconcile_terminal_lifecycle_relays()
+                .unwrap(),
+            12,
+            "terminal reconciliation must drain the full queue, not only the displayed sample"
+        );
+        assert_eq!(store.undelivered_lifecycle_relay_count().unwrap(), 0);
+        assert!(store.list_undelivered_lifecycle_relays(10).unwrap().is_empty());
+        assert_eq!(
+            store
+                .reconcile_terminal_lifecycle_relays()
+                .unwrap(),
+            0,
+            "a reconciled relay must never reappear on a later status read"
         );
     }
 


### PR DESCRIPTION
Supervising this session, I acknowledged 30 suppressed terminal-task relays in three batches of ten — clearing ten revealed the next ten, all historical IDs from prior sessions. Each ack is its own MCP round trip, so draining a routine backlog cost 30 tool calls that produced no work, while the warning sat above the worker table on the highest-traffic supervisor read the entire time.

GH #318 fixed the IDs being invisible; this fixes the volume. Relays whose task reached a terminal state (Closed/Cancelled) now reconcile automatically and durably **inside the same SQLite update**, rather than requiring a supervisor ack each. Forensic rows are retained, and the banner reports the **true uncapped count** rather than only the ten it displays — the display cap was what hid the depth of the backlog.

The hazard being removed is not the tool calls. A permanently non-empty warning in that slot trains supervisors to skim past it, and the genuine warnings printed alongside it — dead workers, stranded child branches — lose their signal.

## Verification

- Public `worker_status` integration with a 12-relay backlog, larger than the display cap, proving full drain.
- cas-store backlog / no-replay regression: acknowledged relays do not reappear.
- Formatter true-total regression.
- `cargo check` clean; branch CI green on f77789ed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)