### PR TITLE
feat(cas-5068): scoped worker-to-worker warnings with a supervisor copy

### DIFF
--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -258,6 +258,9 @@ impl CasService {
             .ok()
             .or_else(|| agent_from_store.as_ref().map(|a| a.role.to_string()))
             .unwrap_or_else(|| "primary".to_string());
+        let factory_session = std::env::var("CAS_FACTORY_SESSION")
+            .ok()
+            .filter(|session| !session.trim().is_empty());
 
         let resolve_supervisor_name = || -> Option<String> {
             if let Ok(name) = std::env::var("CAS_SUPERVISOR_NAME") {
@@ -283,6 +286,7 @@ impl CasService {
         };
 
         let addressed_logical_supervisor = target.eq_ignore_ascii_case("supervisor");
+        let mut peer_supervisor_copy = None;
         let resolved_target = if role == "worker" {
             if target == "supervisor" {
                 resolve_supervisor_name().ok_or_else(|| {
@@ -296,16 +300,79 @@ impl CasService {
                 ));
             } else {
                 let supervisor_name = resolve_supervisor_name();
-                if supervisor_name.as_deref() != Some(&target) {
-                    return Err(Self::error(
-                        ErrorCode::INVALID_REQUEST,
-                        format!(
-                            "Workers can only message their supervisor. Use target='supervisor' or '{}'",
-                            supervisor_name.unwrap_or_else(|| "<supervisor>".to_string())
-                        ),
-                    ));
+                let named_supervisor_is_registered = supervisor_name.as_deref() == Some(&target)
+                    && crate::store::open_agent_store(&self.inner.cas_root)
+                        .ok()
+                        .and_then(|store| store.list(None).ok())
+                        .is_some_and(|agents| {
+                            agents.iter().any(|agent| {
+                                agent.role == cas_types::AgentRole::Supervisor
+                                    && agent.name.eq_ignore_ascii_case(&target)
+                            })
+                        });
+                if named_supervisor_is_registered {
+                    target
+                } else {
+                    // cas-5068 / GH #335: peer contact is a narrow,
+                    // supervisor-visible collision-warning lane, not general
+                    // worker chat. Environment names alone must not grant
+                    // cross-session access; both sides are typed store rows.
+                    use crate::store::open_agent_store;
+                    use cas_types::AgentRole;
+
+                    let session = factory_session.as_deref().ok_or_else(|| {
+                        Self::error(
+                            ErrorCode::INVALID_REQUEST,
+                            "Workers can only message their supervisor or a same-session registered peer; this caller has no named factory session. Use target='supervisor' instead",
+                        )
+                    })?;
+                    let source_agent = agent_from_store.as_ref().filter(|agent| {
+                        agent.role == AgentRole::Worker
+                            && agent.factory_session.as_deref() == Some(session)
+                    }).ok_or_else(|| {
+                        Self::error(
+                            ErrorCode::INVALID_REQUEST,
+                            "Workers can only message their supervisor or a same-session registered peer; this caller is not a registered worker in the current factory session. Use target='supervisor' instead",
+                        )
+                    })?;
+                    let agent_store = open_agent_store(&self.inner.cas_root).map_err(|error| {
+                        Self::error(
+                            ErrorCode::INTERNAL_ERROR,
+                            format!("Failed to resolve peer message scope: {error}"),
+                        )
+                    })?;
+                    let agents = agent_store.list(None).map_err(|error| {
+                        Self::error(
+                            ErrorCode::INTERNAL_ERROR,
+                            format!("Failed to resolve peer message scope: {error}"),
+                        )
+                    })?;
+                    let peer = agents.iter().find(|agent| {
+                        agent.role == AgentRole::Worker
+                            && agent.id != source_agent.id
+                            && agent.name.eq_ignore_ascii_case(&target)
+                            && agent.factory_session.as_deref() == Some(session)
+                    }).ok_or_else(|| {
+                        Self::error(
+                            ErrorCode::INVALID_REQUEST,
+                            format!(
+                                "Workers can only message their supervisor or another registered worker in factory session '{session}'. Use target='supervisor' for '{}'",
+                                supervisor_name.unwrap_or_else(|| "<supervisor>".to_string())
+                            ),
+                        )
+                    })?;
+                    let supervisor = agents.iter().find(|agent| {
+                        agent.role == AgentRole::Supervisor
+                            && agent.factory_session.as_deref() == Some(session)
+                    }).ok_or_else(|| {
+                        Self::error(
+                            ErrorCode::INVALID_REQUEST,
+                            "Peer messages require a registered supervisor in the same factory session; use target='supervisor' instead",
+                        )
+                    })?;
+                    peer_supervisor_copy = Some(supervisor.name.clone());
+                    peer.name.clone()
                 }
-                target
             }
         } else {
             target
@@ -482,15 +549,13 @@ impl CasService {
             use crate::store::open_task_store_local;
             use cas_types::TaskStatus;
 
-            let merge_task = open_task_store_local(&self.inner.cas_root).ok().and_then(|store| {
-                let parked = store.list(Some(TaskStatus::AwaitingMerge)).ok()?;
-                select_unambiguous_merge_task(
-                    &parked,
-                    &display_name,
-                    req.task_id.as_deref(),
-                )
-                .cloned()
-            });
+            let merge_task = open_task_store_local(&self.inner.cas_root)
+                .ok()
+                .and_then(|store| {
+                    let parked = store.list(Some(TaskStatus::AwaitingMerge)).ok()?;
+                    select_unambiguous_merge_task(&parked, &display_name, req.task_id.as_deref())
+                        .cloned()
+                });
 
             if let Some(task) = merge_task
                 && let Some(work_target) = task.deliverables.work_target.as_ref()
@@ -568,7 +633,6 @@ impl CasService {
             || resolved_target.eq_ignore_ascii_case("director")
             || resolved_target_agent.is_some();
 
-        let factory_session = std::env::var("CAS_FACTORY_SESSION").ok();
         let urgent = req.urgent.unwrap_or(false);
         // Urgent messages break the target's in-flight turn, so they must jump
         // the queue ahead of any backlog: force Critical priority when urgent
@@ -753,41 +817,72 @@ impl CasService {
         // at debug so normal sessions stay quiet; enable via
         // `RUST_LOG=cas::coordination=debug`.
         let enqueue_started = std::time::Instant::now();
-        let enqueue_outcome = match queue.enqueue_urgent_with_outcome(
-            &display_name,
-            &resolved_target,
-            &message,
-            factory_session.as_deref(),
-            Some(summary.as_str()),
-            priority,
-            urgent,
-        ) {
-            Ok(id) => id,
-            Err(error) => {
-                // Compensate halt fan-out so we never leave halt without the
-                // corresponding urgent message (all-or-none).
-                if !halt_compensation.is_empty() {
-                    use crate::store::open_agent_store;
-                    if let Ok(agent_store) = open_agent_store(&self.inner.cas_root) {
-                        for (id, prev) in halt_compensation.drain(..) {
-                            if let Ok(mut a) = agent_store.get(&id) {
-                                a.metadata = prev;
-                                let _ = agent_store.update(&a);
-                            }
-                        }
+        let peer_copy_message = peer_supervisor_copy.as_ref().map(|_| {
+            format!(
+                "Peer worker message copy — from {display_name} to {resolved_target}.\n\n{message}"
+            )
+        });
+        let (message_id, duplicate_suppressed, supervisor_copy_id) =
+            if let Some(supervisor) = peer_supervisor_copy.as_deref() {
+                let session = factory_session
+                    .as_deref()
+                    .expect("peer scope requires a factory session");
+                match queue.enqueue_worker_peer_with_supervisor_copy(
+                    &display_name,
+                    &resolved_target,
+                    supervisor,
+                    &message,
+                    peer_copy_message.as_deref().expect("peer copy text"),
+                    session,
+                    Some(summary.as_str()),
+                    priority,
+                    urgent,
+                ) {
+                    Ok(ids) => (ids.recipient_id, false, Some(ids.supervisor_copy_id)),
+                    Err(error) => {
+                        return Err(Self::error(
+                            ErrorCode::INVALID_REQUEST,
+                            format!("Could not queue scoped peer message: {error}"),
+                        ));
                     }
                 }
-                return Err(Self::error(
-                    ErrorCode::INTERNAL_ERROR,
-                    format!("Failed to queue message: {error}"),
-                ));
-            }
-        };
-        let message_id = enqueue_outcome.id();
-        let duplicate_suppressed = matches!(
-            enqueue_outcome,
-            cas_store::EnqueueOutcome::SuppressedDuplicate(_)
-        );
+            } else {
+                let enqueue_outcome = match queue.enqueue_urgent_with_outcome(
+                    &display_name,
+                    &resolved_target,
+                    &message,
+                    factory_session.as_deref(),
+                    Some(summary.as_str()),
+                    priority,
+                    urgent,
+                ) {
+                    Ok(id) => id,
+                    Err(error) => {
+                        // Compensate halt fan-out so we never leave halt without the
+                        // corresponding urgent message (all-or-none).
+                        if !halt_compensation.is_empty() {
+                            use crate::store::open_agent_store;
+                            if let Ok(agent_store) = open_agent_store(&self.inner.cas_root) {
+                                for (id, prev) in halt_compensation.drain(..) {
+                                    if let Ok(mut a) = agent_store.get(&id) {
+                                        a.metadata = prev;
+                                        let _ = agent_store.update(&a);
+                                    }
+                                }
+                            }
+                        }
+                        return Err(Self::error(
+                            ErrorCode::INTERNAL_ERROR,
+                            format!("Failed to queue message: {error}"),
+                        ));
+                    }
+                };
+                let duplicate_suppressed = matches!(
+                    enqueue_outcome,
+                    cas_store::EnqueueOutcome::SuppressedDuplicate(_)
+                );
+                (enqueue_outcome.id(), duplicate_suppressed, None)
+            };
 
         // cas-85fd: an urgent halt is a course-correction exchange, not a
         // permanent worker state. Once the row exists, bind every halt this
@@ -1038,9 +1133,12 @@ impl CasService {
         }
 
         Ok(Self::success(format!(
-            "{} queued\n\nnotification_id: {}\nFrom: {} ({})\nTo: {}\n{}Message: {}",
+            "{} queued\n\nnotification_id: {}\n{}From: {} ({})\nTo: {}\n{}Message: {}",
             if urgent { "URGENT message" } else { "Message" },
             message_id,
+            supervisor_copy_id
+                .map(|id| format!("supervisor_copy_notification_id: {id}\n"))
+                .unwrap_or_default(),
             display_name,
             role,
             resolved_target,
@@ -1066,11 +1164,11 @@ impl CasService {
             std::env::var("CAS_AGENT_NAME").ok(),
         )
         .ok_or_else(|| {
-                Self::error(
-                    ErrorCode::INVALID_REQUEST,
-                    "inbox_poll requires a registered agent identity",
-                )
-            })?;
+            Self::error(
+                ErrorCode::INVALID_REQUEST,
+                "inbox_poll requires a registered agent identity",
+            )
+        })?;
         let factory_session = std::env::var("CAS_FACTORY_SESSION")
             .ok()
             .filter(|session| !session.trim().is_empty())
@@ -1168,9 +1266,7 @@ impl CasService {
         crate::harness_policy::mirror_receipts_across_aliases(&*queue, &messages, &aliases);
 
         if messages.is_empty() {
-            return Ok(Self::success(format!(
-                "No unread messages for {recipient}"
-            )));
+            return Ok(Self::success(format!("No unread messages for {recipient}")));
         }
 
         // cas-99d2 (GH #127): a row the daemon already handed to this
@@ -1574,26 +1670,25 @@ fn enrich_report_from_harness_artifact(
     };
     let Some(agent) = agents.into_iter().find(|agent| {
         (agent.name == report.target || agent.id == report.target)
-            && report.factory_session.as_ref().is_none_or(|session| {
-                agent.factory_session.as_ref() == Some(session)
-            })
+            && report
+                .factory_session
+                .as_ref()
+                .is_none_or(|session| agent.factory_session.as_ref() == Some(session))
     }) else {
         return;
     };
     let cli = crate::mcp::tools::service::factory_ops::worker_cli_from_agent(&agent);
-    let Some(path) = crate::mcp::tools::service::factory_ops::worker_transcript_path_for_agent(
-        cas_root,
-        &agent,
-    ) else {
+    let Some(path) =
+        crate::mcp::tools::service::factory_ops::worker_transcript_path_for_agent(cas_root, &agent)
+    else {
         return;
     };
-    let observations =
-        crate::mcp::tools::service::harness_observation::observations_after_delivery(
-            &path,
-            cli,
-            delivered_at,
-            &report.prompt,
-        );
+    let observations = crate::mcp::tools::service::harness_observation::observations_after_delivery(
+        &path,
+        cli,
+        delivered_at,
+        &report.prompt,
+    );
     if let Some(wake) = observations.wake {
         report.wake = ObservationStatus::Observed;
         report.wake_observed_at = Some(wake.at);
@@ -1653,7 +1748,11 @@ mod inbox_poll_identity_tests {
         let mut unique = lines.clone();
         unique.sort();
         unique.dedup();
-        assert_eq!(unique.len(), 3, "wake states collapse to the same text: {lines:?}");
+        assert_eq!(
+            unique.len(),
+            3,
+            "wake states collapse to the same text: {lines:?}"
+        );
     }
 
     /// A confirmed surfacing outranks whatever the nudge did: the message
@@ -1769,10 +1868,8 @@ mod inbox_poll_identity_tests {
         unsafe { std::env::set_var("CODEX_HOME", &codex_home) };
 
         let agent_store = crate::store::open_agent_store(&cas_root).unwrap();
-        let mut agent = cas_types::Agent::new(
-            "live-worker-session".to_string(),
-            "worker-a".to_string(),
-        );
+        let mut agent =
+            cas_types::Agent::new("live-worker-session".to_string(), "worker-a".to_string());
         agent.role = cas_types::AgentRole::Worker;
         agent.factory_session = Some("factory-1".to_string());
         agent
@@ -1787,7 +1884,12 @@ mod inbox_poll_identity_tests {
         queue.mark_transport_delivered(message_id).unwrap();
         let mut report = queue.message_delivery_report(message_id).unwrap().unwrap();
         assert_eq!(report.wake, ObservationStatus::Unobserved);
-        assert!(serde_json::to_value(&report).unwrap().get("prompt").is_none());
+        assert!(
+            serde_json::to_value(&report)
+                .unwrap()
+                .get("prompt")
+                .is_none()
+        );
 
         enrich_report_from_harness_artifact(&cas_root, &mut report);
 

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -5450,6 +5450,140 @@ async fn test_worker_unresolvable_message_target_fails_without_enqueue() {
     );
 }
 
+/// cas-5068 / GH #335: a worker may warn a same-session peer about a live
+/// collision, but CAS persists an inseparable supervisor-visible copy rather
+/// than opening an unobserved worker chat channel.
+#[tokio::test]
+async fn cas_5068_same_session_peer_warning_reaches_peer_and_supervisor_copy() {
+    let _guard = EnvGuard::set(&[
+        ("CAS_AGENT_ROLE", "worker"),
+        ("CAS_AGENT_NAME", "worker-a"),
+        ("CAS_FACTORY_SESSION", "collision-session"),
+        ("CAS_SUPERVISOR_NAME", "supervisor-a"),
+    ]);
+    let env = FactoryTestEnv::new();
+    env.register_worker_with_id("test-agent-id", "worker-a", Some("collision-session"));
+    env.register_worker_in_session("worker-b", "collision-session");
+    let supervisor_id = env.register_supervisor_in_session("supervisor-a", "collision-session");
+
+    let result = env
+        .service
+        .coordination(Parameters(coord_msg(
+            "message",
+            "worker-b",
+            "Stop: I own customer thread #42; do not send a second draft.",
+            None,
+        )))
+        .await
+        .expect("same-session peer warning must queue");
+    let text = get_text(&result);
+    assert!(text.contains("To: worker-b"), "{text}");
+    assert!(text.contains("supervisor_copy_notification_id:"), "{text}");
+
+    let rows = env.prompt_queue().peek_all(10).expect("queued rows");
+    assert_eq!(rows.len(), 2, "peer warning and supervisor copy: {rows:?}");
+    assert!(
+        rows.iter()
+            .any(|row| row.target == "worker-b" && !row.urgent)
+    );
+    assert!(rows.iter().any(|row| {
+        row.target == "supervisor-a"
+            && !row.urgent
+            && row
+                .prompt
+                .contains("Peer worker message copy — from worker-a to worker-b")
+            && row.prompt.contains("customer thread #42")
+    }));
+
+    let supervisor_core = CasCore::with_daemon(env.cas_root.clone(), None, None);
+    supervisor_core.set_agent_id_for_testing(supervisor_id);
+    let supervisor_service = CasService::new(supervisor_core, None);
+    let supervisor_poll = supervisor_service
+        .coordination(Parameters(coord_req("inbox_poll")))
+        .await
+        .expect("supervisor must retain peer-message visibility");
+    let supervisor_text = get_text(&supervisor_poll);
+    assert!(
+        supervisor_text.contains("Peer worker message copy — from worker-a to worker-b"),
+        "supervisor copy must be readable through the public inbox: {supervisor_text}"
+    );
+}
+
+#[tokio::test]
+async fn cas_5068_peer_warning_refuses_cross_session_target_without_enqueue() {
+    let _guard = EnvGuard::set(&[
+        ("CAS_AGENT_ROLE", "worker"),
+        ("CAS_AGENT_NAME", "worker-a"),
+        ("CAS_FACTORY_SESSION", "session-a"),
+        ("CAS_SUPERVISOR_NAME", "supervisor-a"),
+    ]);
+    let env = FactoryTestEnv::new();
+    env.register_worker_with_id("test-agent-id", "worker-a", Some("session-a"));
+    env.register_supervisor_in_session("supervisor-a", "session-a");
+    env.register_worker_in_session("worker-b", "session-b");
+
+    let error = env
+        .service
+        .coordination(Parameters(coord_msg(
+            "message",
+            "worker-b",
+            "do not queue across sessions",
+            None,
+        )))
+        .await
+        .expect_err("cross-session worker route must be refused");
+    assert!(
+        error
+            .message
+            .contains("registered worker in factory session 'session-a'")
+            && error.message.contains("target='supervisor'"),
+        "refusal must name the bounded scope and supported alternative: {error:?}"
+    );
+    assert!(env.prompt_queue().peek_all(10).expect("peek").is_empty());
+}
+
+#[tokio::test]
+async fn cas_5068_peer_warning_is_rate_limited_per_recipient() {
+    let _guard = EnvGuard::set(&[
+        ("CAS_AGENT_ROLE", "worker"),
+        ("CAS_AGENT_NAME", "worker-a"),
+        ("CAS_FACTORY_SESSION", "collision-session"),
+        ("CAS_SUPERVISOR_NAME", "supervisor-a"),
+    ]);
+    let env = FactoryTestEnv::new();
+    env.register_worker_with_id("test-agent-id", "worker-a", Some("collision-session"));
+    env.register_worker_in_session("worker-b", "collision-session");
+    env.register_supervisor_in_session("supervisor-a", "collision-session");
+
+    for warning in 0..cas_store::WORKER_PEER_MESSAGE_BURST_LIMIT {
+        env.service
+            .coordination(Parameters(coord_msg(
+                "message",
+                "worker-b",
+                &format!("collision warning #{warning}"),
+                None,
+            )))
+            .await
+            .expect("warning inside peer burst limit");
+    }
+    let error = env
+        .service
+        .coordination(Parameters(coord_msg(
+            "message",
+            "worker-b",
+            "one warning too many",
+            None,
+        )))
+        .await
+        .expect_err("sixth one-minute peer warning must be rate limited");
+    assert!(error.message.contains("rate limit"), "{error:?}");
+    assert_eq!(
+        env.prompt_queue().peek_all(20).expect("queued rows").len(),
+        (cas_store::WORKER_PEER_MESSAGE_BURST_LIMIT * 2) as usize,
+        "each allowed warning must retain its supervisor copy"
+    );
+}
+
 /// cas-c061: exact-content dedup is an observable send outcome. Reusing the
 /// existing row ID must not be reported as a newly queued message.
 #[tokio::test]
@@ -5505,10 +5639,17 @@ async fn test_worker_peer_message_does_not_confirm_supervisor_instruction() {
     let _guard = EnvGuard::set(&[
         ("CAS_AGENT_ROLE", "worker"),
         ("CAS_AGENT_NAME", "swift-fox"),
-        ("CAS_SUPERVISOR_NAME", "peer-worker"),
+        ("CAS_SUPERVISOR_NAME", "supervisor"),
+        ("CAS_FACTORY_SESSION", "peer-message-session"),
     ]);
     let env = FactoryTestEnv::new();
-    env.register_worker("peer-worker");
+    env.register_worker_with_id(
+        "test-agent-id",
+        "swift-fox",
+        Some("peer-message-session"),
+    );
+    env.register_worker_in_session("peer-worker", "peer-message-session");
+    env.register_supervisor_in_session("supervisor", "peer-message-session");
     let instruction = env
         .prompt_queue()
         .enqueue_urgent(

--- a/crates/cas-store/src/lib.rs
+++ b/crates/cas-store/src/lib.rs
@@ -201,7 +201,8 @@ pub use prompt_queue_store::{
     MessageDeliveryReport, MessageStatus, ObservationStatus, PROMPT_QUEUE_STALE_TTL_SECS,
     PROMPT_RETRY_MAX_AGE_SECS, PendingReason, PromptQueueStore, PromptRetryDisposition,
     QueuedPrompt, RetriedPrompt, SqlitePromptQueueStore, SurfacingSource,
-    UndeliveredLifecycleRelay, WakeAttempt, reply_confirms_delivered_message,
+    UndeliveredLifecycleRelay, WORKER_PEER_MESSAGE_BURST_LIMIT, WakeAttempt,
+    WorkerPeerMessageEnqueue, reply_confirms_delivered_message,
 };
 
 // Reminder store for supervisor "Remind Me" feature

--- a/crates/cas-store/src/prompt_queue_store.rs
+++ b/crates/cas-store/src/prompt_queue_store.rs
@@ -30,6 +30,12 @@ const PROMPT_RETRY_MAX_DELAY_MS: i64 = 5_000;
 /// transport-delivered copy is still awaiting confirmation.
 const PROMPT_DUPLICATE_WINDOW_SECS: i64 = 30;
 
+/// A peer warning is for an immediate shared-resource collision, not a
+/// general worker chat channel. Keep one sender from monopolizing a peer's
+/// queue while still allowing several independent collision warnings.
+pub const WORKER_PEER_MESSAGE_BURST_LIMIT: i64 = 5;
+const WORKER_PEER_MESSAGE_BURST_WINDOW_SECS: i64 = 60;
+
 /// Age after which an *undelivered* queue row is treated as stale and is
 /// quarantined instead of delivered (cas-d047, GH #69).
 ///
@@ -388,6 +394,17 @@ pub enum EnqueueOutcome {
     Created(i64),
     /// A recent, delivered, still-unconfirmed identical worker report exists.
     SuppressedDuplicate(i64),
+}
+
+/// The two durable rows created for an authorized worker-to-worker warning.
+///
+/// The supervisor row is deliberately part of the same store transaction as
+/// the recipient row: a peer route without supervisory visibility is not a
+/// valid route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkerPeerMessageEnqueue {
+    pub recipient_id: i64,
+    pub supervisor_copy_id: i64,
 }
 
 impl EnqueueOutcome {
@@ -1164,6 +1181,22 @@ pub trait PromptQueueStore: Send + Sync {
         priority: Option<NotificationPriority>,
         urgent: bool,
     ) -> Result<EnqueueOutcome>;
+
+    /// Atomically enqueue a same-factory-session worker warning and a visible
+    /// copy for its supervisor. The store enforces the bounded peer burst so
+    /// every service surface shares the same durable policy.
+    fn enqueue_worker_peer_with_supervisor_copy(
+        &self,
+        source: &str,
+        recipient: &str,
+        supervisor: &str,
+        prompt: &str,
+        supervisor_copy: &str,
+        factory_session: &str,
+        summary: Option<&str>,
+        priority: Option<NotificationPriority>,
+        urgent: bool,
+    ) -> Result<WorkerPeerMessageEnqueue>;
 
     /// Queue a prompt with structured sender attribution persisted on the same
     /// durable row. Existing MCP senders pass `None`; Commander messages pass
@@ -2307,6 +2340,60 @@ impl PromptQueueStore for SqlitePromptQueueStore {
             urgent,
             None,
         )
+    }
+
+    fn enqueue_worker_peer_with_supervisor_copy(
+        &self,
+        source: &str,
+        recipient: &str,
+        supervisor: &str,
+        prompt: &str,
+        supervisor_copy: &str,
+        factory_session: &str,
+        summary: Option<&str>,
+        priority: Option<NotificationPriority>,
+        urgent: bool,
+    ) -> Result<WorkerPeerMessageEnqueue> {
+        crate::shared_db::with_write_retry(|| {
+            let conn = crate::shared_db::lock_connection(&self.conn)?;
+            let tx = crate::shared_db::ImmediateTx::new(&conn)?;
+            let now = Utc::now();
+            let cutoff = (now - chrono::Duration::seconds(WORKER_PEER_MESSAGE_BURST_WINDOW_SECS))
+                .to_rfc3339();
+            let recent: i64 = tx.query_row(
+                "SELECT COUNT(*) FROM prompt_queue \
+                 WHERE source = ?1 AND target = ?2 AND factory_session = ?3 AND created_at >= ?4",
+                params![source, recipient, factory_session, cutoff],
+                |row| row.get(0),
+            )?;
+            if recent >= WORKER_PEER_MESSAGE_BURST_LIMIT {
+                return Err(StoreError::Other(format!(
+                    "worker peer message rate limit: at most {WORKER_PEER_MESSAGE_BURST_LIMIT} messages per minute to one peer"
+                )));
+            }
+
+            let now_text = now.to_rfc3339();
+            let priority: i32 = priority.unwrap_or(NotificationPriority::Normal).into();
+            tx.execute(
+                "INSERT INTO prompt_queue (source, target, prompt, created_at, factory_session, summary, priority, urgent) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, 0)",
+                params![source, supervisor, supervisor_copy, now_text, factory_session, summary, priority],
+            )?;
+            let supervisor_copy_id = tx.last_insert_rowid();
+            tx.execute(
+                "INSERT INTO prompt_queue (source, target, prompt, created_at, factory_session, summary, priority, urgent) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                params![source, recipient, prompt, now_text, factory_session, summary, priority, i64::from(urgent)],
+            )?;
+            let recipient_id = tx.last_insert_rowid();
+            let _ = capture_message_event(&tx, source, supervisor);
+            let _ = capture_message_event(&tx, source, recipient);
+            tx.commit()?;
+            Ok(WorkerPeerMessageEnqueue {
+                recipient_id,
+                supervisor_copy_id,
+            })
+        })
     }
 
     fn enqueue_attributed_urgent_with_outcome(


### PR DESCRIPTION
A supervisor told a worker "if you find overlap, message it directly". The worker found a live double-send risk on a customer thread, called exactly what it had been told to call, and got `MCP error -32600: Workers can only message their supervisor`. The instruction and the capability disagreed, and the worker discovered it at the only moment it mattered — with a duplicate customer email pending.

Rather than simply unblocking the call, this adds a **scoped** channel:

- Same factory session only, with both ends verified as registered workers in that session.
- The supervisor copy is written by `enqueue_worker_peer_with_supervisor_copy` in the same operation, so a peer message cannot be delivered without the supervisor seeing it.
- Rate limited per recipient.
- The refusal names the supported alternative, so a worker that hits the boundary knows what to do next — the original defect was a refusal with no path forward.

Unrestricted worker chatter was explicitly not the target; supervisor visibility is structural rather than advisory.

## Verification

- `cas_5068_same_session_peer_warning_reaches_peer_and_supervisor_copy`
- `cas_5068_peer_warning_refuses_cross_session_target_without_enqueue` — proves the scope is enforced rather than merely intended, and that a refused message enqueues nothing
- `cas_5068_peer_warning_is_rate_limited_per_recipient`
- Full `factory_mcp_ops_test` binary 147/147; branch CI green on 899084a6.

Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)