### PR TITLE
fix(cas-8fd4): make the scoped-test guard check proof coverage against the diff

### DIFF
--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -188,8 +188,8 @@ test-real-store-untouched:
 # reported and that the passed count is nonzero. Use it for the final-proof
 # run you intend to quote in a close note:
 #
-#   make -C cas-cli test-scoped SCOPED_ARGS='-p cas --lib my_module'
-#   make -C cas-cli test-scoped SCOPED_ARGS='-p cas --test cli_test'
+#   make -C cas-cli test-scoped SCOPED_ARGS='--proof -p cas --lib my_module'
+#   make -C cas-cli test-scoped SCOPED_ARGS='--proof -p cas --test cli_test'
 #
 # NOTE: like test-clean-env, this MUST stay an explicit rule — the `test-%`
 # pattern rule above would otherwise match it and run `cargo test -p cas scoped`.

--- a/cas-cli/src/builtins/codex/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker/references/discipline.md
@@ -106,6 +106,7 @@ then prove only the affected target:
 - `cargo check -p <crate> --lib --tests` — inner-loop compile feedback, no test execution
 - `scripts/run-scoped-tests.sh -p cas --lib <module>` — one library target/filter via nextest
 - `scripts/run-scoped-tests.sh -p cas --test <name>` — one integration-test file via nextest
+- `scripts/run-scoped-tests.sh --proof ...` — final receipt only; refuses a filter that misses a committed changed test module or integration target
 - `CARGO_CMD=test scripts/run-scoped-tests.sh ...` — diagnostic fallback only, not the default
 
 Package selection alone (`-p cas`) is not a scope here: that one package owns dozens of test
@@ -172,12 +173,13 @@ author (GH #173):
 Run your final-proof suite through the guard, which enforces all of that mechanically:
 
 ```bash
-make -C cas-cli test-scoped SCOPED_ARGS='-p cas --lib my_module'
-scripts/run-scoped-tests.sh -p cas --test cli_test        # same thing, directly
+make -C cas-cli test-scoped SCOPED_ARGS='--proof -p cas --lib my_module'
+scripts/run-scoped-tests.sh --proof -p cas --test cli_test # same thing, directly
 ```
 
-It fails the run unless cargo exited 0, **a test harness actually reported**, and the passed
-count is greater than zero. The middle condition is the one that matters: a wrapper or a
+It fails the run unless cargo exited 0, **a test harness actually reported**, the passed
+count is greater than zero, and (with `--proof`) the committed diff's changed test modules and
+integration targets are covered. The middle condition is the one that matters: a wrapper or a
 pipeline can drop a nonzero status, but nothing can invent a `test result:` line. It also
 rejects a relative `$ZIG` before spending a build on it, and reads `cargo nextest run`'s
 `Summary` line as well as `cargo test`'s.

--- a/cas-cli/src/builtins/grok/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker/references/discipline.md
@@ -106,6 +106,7 @@ then prove only the affected target:
 - `cargo check -p <crate> --lib --tests` — inner-loop compile feedback, no test execution
 - `scripts/run-scoped-tests.sh -p cas --lib <module>` — one library target/filter via nextest
 - `scripts/run-scoped-tests.sh -p cas --test <name>` — one integration-test file via nextest
+- `scripts/run-scoped-tests.sh --proof ...` — final receipt only; refuses a filter that misses a committed changed test module or integration target
 - `CARGO_CMD=test scripts/run-scoped-tests.sh ...` — diagnostic fallback only, not the default
 
 Package selection alone (`-p cas`) is not a scope here: that one package owns dozens of test
@@ -172,12 +173,13 @@ author (GH #173):
 Run your final-proof suite through the guard, which enforces all of that mechanically:
 
 ```bash
-make -C cas-cli test-scoped SCOPED_ARGS='-p cas --lib my_module'
-scripts/run-scoped-tests.sh -p cas --test cli_test        # same thing, directly
+make -C cas-cli test-scoped SCOPED_ARGS='--proof -p cas --lib my_module'
+scripts/run-scoped-tests.sh --proof -p cas --test cli_test # same thing, directly
 ```
 
-It fails the run unless cargo exited 0, **a test harness actually reported**, and the passed
-count is greater than zero. The middle condition is the one that matters: a wrapper or a
+It fails the run unless cargo exited 0, **a test harness actually reported**, the passed
+count is greater than zero, and (with `--proof`) the committed diff's changed test modules and
+integration targets are covered. The middle condition is the one that matters: a wrapper or a
 pipeline can drop a nonzero status, but nothing can invent a `test result:` line. It also
 rejects a relative `$ZIG` before spending a build on it, and reads `cargo nextest run`'s
 `Summary` line as well as `cargo test`'s.

--- a/cas-cli/src/builtins/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/skills/cas-worker/references/discipline.md
@@ -106,6 +106,7 @@ then prove only the affected target:
 - `cargo check -p <crate> --lib --tests` — inner-loop compile feedback, no test execution
 - `scripts/run-scoped-tests.sh -p cas --lib <module>` — one library target/filter via nextest
 - `scripts/run-scoped-tests.sh -p cas --test <name>` — one integration-test file via nextest
+- `scripts/run-scoped-tests.sh --proof ...` — final receipt only; refuses a filter that misses a committed changed test module or integration target
 - `CARGO_CMD=test scripts/run-scoped-tests.sh ...` — diagnostic fallback only, not the default
 
 Package selection alone (`-p cas`) is not a scope here: that one package owns dozens of test
@@ -172,12 +173,13 @@ author (GH #173):
 Run your final-proof suite through the guard, which enforces all of that mechanically:
 
 ```bash
-make -C cas-cli test-scoped SCOPED_ARGS='-p cas --lib my_module'
-scripts/run-scoped-tests.sh -p cas --test cli_test        # same thing, directly
+make -C cas-cli test-scoped SCOPED_ARGS='--proof -p cas --lib my_module'
+scripts/run-scoped-tests.sh --proof -p cas --test cli_test # same thing, directly
 ```
 
-It fails the run unless cargo exited 0, **a test harness actually reported**, and the passed
-count is greater than zero. The middle condition is the one that matters: a wrapper or a
+It fails the run unless cargo exited 0, **a test harness actually reported**, the passed
+count is greater than zero, and (with `--proof`) the committed diff's changed test modules and
+integration targets are covered. The middle condition is the one that matters: a wrapper or a
 pipeline can drop a nonzero status, but nothing can invent a `test result:` line. It also
 rejects a relative `$ZIG` before spending a build on it, and reads `cargo nextest run`'s
 `Summary` line as well as `cargo test`'s.

--- a/scripts/check-scoped-test-surface.sh
+++ b/scripts/check-scoped-test-surface.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# Check whether one scoped-test invocation covers the committed source and
+# integration-test surfaces it is being offered as proof for. This intentionally
+# does not run cargo: run-scoped-tests.sh owns execution and calls this only
+# after Cargo has reported a real, nonzero test count.
+
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 [--base <git-ref>] -- <cargo/nextest arguments>" >&2
+    exit 2
+}
+
+base_ref=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base)
+            [[ $# -ge 2 ]] || usage
+            base_ref="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *) usage ;;
+    esac
+done
+
+[[ $# -gt 0 ]] || usage
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "SCOPED PROOF SURFACE: cannot inspect the committed diff outside a Git repository." >&2
+    exit 2
+}
+cd "$repo_root"
+
+if [[ -z "$base_ref" ]]; then
+    if git rev-parse --verify --quiet origin/main >/dev/null; then
+        base_ref="origin/main"
+    elif git rev-parse --verify --quiet main >/dev/null; then
+        base_ref="main"
+    else
+        base_ref="HEAD^"
+    fi
+fi
+
+merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null)" || {
+    echo "SCOPED PROOF SURFACE: cannot find a merge-base between '$base_ref' and HEAD." >&2
+    exit 2
+}
+
+lib_requested=false
+test_targets=()
+filters=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --lib)
+            lib_requested=true
+            ;;
+        --test)
+            [[ $# -ge 2 ]] || usage
+            test_targets+=("$2")
+            shift
+            ;;
+        -p|--package|-E|--filter-expr)
+            [[ $# -ge 2 ]] || usage
+            shift
+            ;;
+        --*)
+            ;;
+        *)
+            filters+=("$1")
+            ;;
+    esac
+    shift
+done
+
+contains_exact() {
+    local wanted="$1" value
+    shift
+    for value in "$@"; do
+        [[ "$value" == "$wanted" ]] && return 0
+    done
+    return 1
+}
+
+integration_target_for() {
+    local nested_path="$1" directory candidate
+    directory="${nested_path%%/*}"
+    for candidate in cas-cli/tests/*.rs; do
+        [[ -f "$candidate" ]] || continue
+        if grep -qF "${directory}/" "$candidate"; then
+            basename "${candidate%.rs}"
+            return 0
+        fi
+    done
+    # An unfamiliar nested layout is still named loudly rather than skipped.
+    printf '%s\n' "$directory"
+}
+
+lib_filter_covers() {
+    local module="$1" filter
+    # An unfiltered --lib run covers every library module. A module filter must
+    # name the module itself, not one newly-added test inside it.
+    [[ ${#filters[@]} -eq 0 ]] && return 0
+    for filter in "${filters[@]}"; do
+        [[ "$filter" == "$module" || "$filter" == *"::$module" ]] && return 0
+    done
+    return 1
+}
+
+required_lib_modules=()
+required_test_targets=()
+while IFS= read -r path; do
+    case "$path" in
+        cas-cli/src/*.rs)
+            source_file="$repo_root/$path"
+            [[ -f "$source_file" ]] || continue
+            found_test_module=false
+            while IFS= read -r module; do
+                [[ -z "$module" ]] && continue
+                required_lib_modules+=("$module")
+                found_test_module=true
+            done < <(sed -nE 's/^[[:space:]]*mod[[:space:]]+([[:alnum:]_]*tests)[[:space:]]*\{.*/\1/p' "$source_file")
+            if ! "$found_test_module"; then
+                required_lib_modules+=("$(basename "${path%.rs}")")
+            fi
+            ;;
+        cas-cli/tests/*.rs)
+            required_test_targets+=("$(basename "${path%.rs}")")
+            ;;
+        cas-cli/tests/*/*.rs)
+            nested="${path#cas-cli/tests/}"
+            required_test_targets+=("$(integration_target_for "$nested")")
+            ;;
+    esac
+done < <(git diff --name-only "$merge_base" HEAD)
+
+missing=()
+for module in "${required_lib_modules[@]}"; do
+    if ! "$lib_requested" || ! lib_filter_covers "$module"; then
+        missing+=("library module '$module'")
+    fi
+done
+for target in "${required_test_targets[@]}"; do
+    if ! contains_exact "$target" "${test_targets[@]}"; then
+        missing+=("integration target '$target'")
+    fi
+done
+
+if [[ ${#missing[@]} -eq 0 ]]; then
+    echo "SCOPED PROOF SURFACE: covered committed diff from ${base_ref} ($(git rev-parse --short "$merge_base"))."
+    exit 0
+fi
+
+echo "SCOPED PROOF SURFACE INCOMPLETE: this invocation does not cover the committed diff from ${base_ref} ($(git rev-parse --short "$merge_base"))." >&2
+for item in "${missing[@]}"; do
+    echo "  - missing ${item}" >&2
+done
+echo "Use --proof only for a final receipt that covers every listed surface; ordinary narrow iteration is allowed without it." >&2
+exit 1

--- a/scripts/run-scoped-tests.sh
+++ b/scripts/run-scoped-tests.sh
@@ -38,10 +38,11 @@
 # Both harness formats are understood: `cargo test`'s "test result: ok. N
 # passed" and `cargo nextest run`'s "Summary [...] N tests run: M passed".
 #
-# Usage — every argument is passed through to the cargo subcommand verbatim:
+# Usage — every argument other than `--proof` is passed through to cargo:
 #
 #   scripts/run-scoped-tests.sh -p cas --lib my_module
-#   scripts/run-scoped-tests.sh -p cas --test cli_test
+#   scripts/run-scoped-tests.sh --proof -p cas --lib my_module
+#   scripts/run-scoped-tests.sh --proof -p cas --test cli_test
 #   scripts/run-scoped-tests.sh --lib -- --nocapture
 #   make -C cas-cli test-scoped SCOPED_ARGS='-p cas --lib my_module'
 #
@@ -54,13 +55,29 @@
 #                 path to keep the captured run log (default: a temp file)
 #
 # Exit codes: 0 = genuinely green with a nonzero passed count,
-#             1 = the run failed or executed nothing.
+#             1 = the run failed, executed nothing, or `--proof` missed a
+#                 committed source/test surface.
 
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CARGO="${CARGO:-cargo}"
 CARGO_CMD="${CARGO_CMD:-nextest run}"
+
+# `--proof` is deliberately opt-in. Workers need fast, narrow filters while
+# developing; the committed-diff check belongs to the final receipt they quote
+# at handoff, where an incomplete surface must fail loudly instead of reading
+# as a green proof.
+proof_mode=0
+proof_args=()
+for arg in "$@"; do
+    if [[ "$arg" == "--proof" ]]; then
+        proof_mode=1
+    else
+        proof_args+=("$arg")
+    fi
+done
+set -- "${proof_args[@]}"
 
 if [[ $# -eq 0 ]]; then
     echo "error: refusing to run unscoped." >&2
@@ -229,3 +246,9 @@ if [[ "${filtered}" -gt 0 ]]; then
     echo "      (${filtered} filtered out by the scope — expected for a scoped run.)"
 fi
 echo "Quote that passed count in your close note (rule-173)."
+
+if [[ "${proof_mode}" -eq 1 ]]; then
+    "${REPO_ROOT}/scripts/check-scoped-test-surface.sh" -- "$@"
+else
+    echo "      Iteration receipt only. Add --proof for committed-diff surface validation at handoff."
+fi

--- a/scripts/test-run-scoped-tests.sh
+++ b/scripts/test-run-scoped-tests.sh
@@ -297,6 +297,73 @@ expect fail "refusing to run unscoped" \
     "refuses to run with no scope arguments" \
     env CARGO="${stub}" "${GUARD}"
 
+# ---------------------------------------------------------------------------
+# Proof surface — GH #329 / cas-8fd4. The runner needs a final-receipt mode
+# that notices a test name is narrower than the test MODULE changed by the
+# committed diff, while leaving ordinary development filters unblocked.
+# ---------------------------------------------------------------------------
+SURFACE_GUARD="${SCRIPT_DIR}/check-scoped-test-surface.sh"
+surface_repo="${tmpdir}/surface-repo"
+mkdir -p "${surface_repo}/cas-cli/src/hooks" "${surface_repo}/cas-cli/tests"
+git -C "${surface_repo}" init -q -b main
+{
+    printf 'mod worker_commit_guard_tests {\n'
+    for test_number in $(seq 1 40); do
+        printf '    #[test] fn established_contract_%s() {}\n' "${test_number}"
+    done
+    printf '    #[test] fn cas_8fd4_added_one() {}\n'
+    printf '    #[test] fn cas_8fd4_added_two() {}\n'
+    printf '}\n'
+} >"${surface_repo}/cas-cli/src/hooks/pre_tool.rs"
+printf '// factory integration target\n' \
+    >"${surface_repo}/cas-cli/tests/factory_mcp_ops_test.rs"
+git -C "${surface_repo}" add .
+git -C "${surface_repo}" -c user.name=scoped-test-fixture -c user.email=scoped-test-fixture@example.invalid \
+    commit -qm base
+git -C "${surface_repo}" checkout -qb proof
+printf '\nfn fix_the_guard() {}\n' >>"${surface_repo}/cas-cli/src/hooks/pre_tool.rs"
+git -C "${surface_repo}" add .
+git -C "${surface_repo}" -c user.name=scoped-test-fixture -c user.email=scoped-test-fixture@example.invalid \
+    commit -qm source-change
+
+expect fail "missing library module 'worker_commit_guard_tests'" \
+    "proof: narrow two-test filter is refused for a changed 42-test module" \
+    bash -c "cd '${surface_repo}' && '${SURFACE_GUARD}' --base main -- -p cas --lib cas_8fd4"
+
+expect pass "SCOPED PROOF SURFACE: covered committed diff" \
+    "proof: complete changed-module filter is accepted" \
+    bash -c "cd '${surface_repo}' && '${SURFACE_GUARD}' --base main -- -p cas --lib worker_commit_guard_tests"
+
+printf '// contract changed with the implementation\n' >>"${surface_repo}/cas-cli/tests/factory_mcp_ops_test.rs"
+git -C "${surface_repo}" add .
+git -C "${surface_repo}" -c user.name=scoped-test-fixture -c user.email=scoped-test-fixture@example.invalid \
+    commit -qm integration-change
+
+expect fail "missing integration target 'factory_mcp_ops_test'" \
+    "proof: changed integration binary cannot be omitted" \
+    bash -c "cd '${surface_repo}' && '${SURFACE_GUARD}' --base main -- -p cas --lib worker_commit_guard_tests"
+
+expect pass "SCOPED PROOF SURFACE: covered committed diff" \
+    "proof: changed module plus integration target is accepted" \
+    bash -c "cd '${surface_repo}' && '${SURFACE_GUARD}' --base main -- -p cas --lib worker_commit_guard_tests --test factory_mcp_ops_test"
+
+docs_repo="${tmpdir}/docs-repo"
+mkdir -p "${docs_repo}/docs"
+git -C "${docs_repo}" init -q -b main
+printf 'base\n' >"${docs_repo}/docs/readme.md"
+git -C "${docs_repo}" add .
+git -C "${docs_repo}" -c user.name=scoped-test-fixture -c user.email=scoped-test-fixture@example.invalid \
+    commit -qm base
+git -C "${docs_repo}" checkout -qb proof
+printf 'non-test documentation only\n' >>"${docs_repo}/docs/readme.md"
+git -C "${docs_repo}" add .
+git -C "${docs_repo}" -c user.name=scoped-test-fixture -c user.email=scoped-test-fixture@example.invalid \
+    commit -qm docs-only
+
+expect pass "SCOPED PROOF SURFACE: covered committed diff" \
+    "proof: non-test-only diff does not invent a required target" \
+    bash -c "cd '${docs_repo}' && '${SURFACE_GUARD}' --base main -- -p cas --lib"
+
 echo
 echo "test result: ${pass_count} passed; ${fail_count} failed"
 if [[ "${fail_count}" -ne 0 ]]; then


### PR DESCRIPTION
Five separate lanes in one session delivered work whose quoted proof did not cover the surface the diff modified. None of those workers were careless — every one ran the guarded script and quoted a real passing count. The guard simply could not detect the failure.

`run-scoped-tests.sh` rejects a silent zero-test success (GH #173) but accepts **any** filter matching at least one test. With no view of the diff, it cannot tell a 2-test filter in a 42-test module from a correct one.

What that cost:

- **cas-0efb** proved "10 lib + 1 public MCP test" while having broken **9 of 42** tests in the module it modified — in both directions, including refusing *legitimate* commits on feature and epic branches. For the task whose purpose is preventing commits to the wrong branch, that would have wedged the fleet.
- **cas-8aee** proved its own two added tests while breaking the GH #127 contract in the `factory_mcp_ops_test` integration binary. Invisible to its proof *and* to branch CI, since `factory/*` runs Scoped Validation only. It surfaced solely because five lanes were assembled onto the epic branch for one integration run.
- **cas-4a27** quoted 1/1, 1/1, 1/1 having modified four files across three modules; supervisor-run full surfaces (11 and 144) were clean, but nothing in the pipeline would have said so.
- **cas-56f8** twice: `cargo check` offered as test proof, then a filtered `cargo test` matching **zero** tests reported as a pass — the exact case GH #173 exists to catch, evaded by bypassing the script.

The standing instruction "prove the surface you MODIFIED, not the surface you ADDED" is correct and was repeated to every worker. It kept happening, because it depends entirely on the worker choosing the right filter and nothing could verify that choice. **Discipline is the wrong mechanism for something a tool can check.**

## Design

`--proof` is a strict final-receipt mode: the committed diff is checked against the selected lib modules and integration targets, and a proof that misses a modified surface is refused. Ordinary narrow iteration stays unblocked but labels itself iteration-only, so fast development loops survive while the *claim* becomes checkable.

Integration binaries are included when their covered sources change — precisely what cas-8aee's filter missed.

Ambient-fixture hygiene (tests reading inherited git identity or `CAS_AGENT_NAME`, which cost two further lanes) was deliberately scoped **out** as a separate clean-env/lint concern rather than bolted on here.

## Verification

- Runner self-test 22/22, CI-tier guard 128/128, builtin flavor drift 9/9 — all executed **through `--proof`**, so the new mode validates its own change.
- New `scripts/check-scoped-test-surface.sh` plus `scripts/test-run-scoped-tests.sh` harness.
- Branch CI green on 1c8fe09e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
