### PR TITLE
feat(cas-8ad8): value-only execution note for copy/i18n edits, still fully reviewed

### DIFF
--- a/cas-cli/src/builtins/agents/task-verifier.md
+++ b/cas-cli/src/builtins/agents/task-verifier.md
@@ -216,6 +216,8 @@ Read the `execution_note` field from `mcp__cas__task action=show id=<task-id>`. 
 
 - **`execution_note=additive-only`** — SKIP this advisory check. `additive-only` is hard-enforced by `close_ops.rs` (cas-e235). If the worker got this far with additive-only, the close-gate already verified no M/D/R files in the diff. Nothing to do here.
 
+- **`execution_note=value-only`** — SKIP this advisory check. `value-only` is hard-enforced by `close_ops.rs` (cas-8ad8): it permits M entries for existing copy/i18n values but rejects added, deleted, copied, or renamed files. It remains subject to ordinary review; do not treat it as additive-only.
+
 - **`execution_note=no-code`** — SKIP: close requires portable `external_ref` proof and rejects task-attributed code.
 
 - **`execution_note=null` or missing** — SKIP this check. No posture was declared, no posture applies.

--- a/cas-cli/src/builtins/codex/agents/task-verifier.md
+++ b/cas-cli/src/builtins/codex/agents/task-verifier.md
@@ -216,6 +216,8 @@ Read the `execution_note` field from `mcp__cs__task action=show id=<task-id>`. I
 
 - **`execution_note=additive-only`** — SKIP this advisory check. `additive-only` is hard-enforced by `close_ops.rs` (cas-e235). If the worker got this far with additive-only, the close-gate already verified no M/D/R files in the diff. Nothing to do here.
 
+- **`execution_note=value-only`** — SKIP this advisory check. `value-only` is hard-enforced by `close_ops.rs` (cas-8ad8): it permits M entries for existing copy/i18n values but rejects added, deleted, copied, or renamed files. It remains subject to ordinary review; do not treat it as additive-only.
+
 - **`execution_note=no-code`** — SKIP: close requires portable `external_ref` proof and rejects task-attributed code.
 
 - **`execution_note=null` or missing** — SKIP this check. No posture was declared, no posture applies.

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/planning.md
@@ -60,7 +60,7 @@ Canonical template:
   - Modify: `path/to/existing_file.rs`
   - Test: `path/to/test_file.rs`
 **Approach:** Key design or sequencing decision
-**Execution note:** test-first | characterization-first | additive-only | (omit)
+**Execution note:** test-first | characterization-first | additive-only | value-only | (omit)
 **Patterns to follow:** Reference existing code to mirror
 **Test scenarios:**
   - Happy path: input X -> expected Y
@@ -76,7 +76,7 @@ Field purposes (write decisions, not code — "Approach" is 1–3 sentences of s
 - **Dependencies** — hard blockers go in `blocked_by`; soft ordering or "after X lands" notes stay as prose.
 - **Files** — the layer boundary. What the worker owns and must not touch outside of. Boundary violation is a rejection condition.
 - **Approach** — the sequencing or design decision already made. Not a code sketch, not a pseudocode draft. If you find yourself writing pseudocode, you are doing the worker's job.
-- **Execution note** — maps 1:1 to the task `execution_note` field. One of `test-first`, `characterization-first`, `additive-only`, or omitted. **Warning:** `additive-only` hard-blocks close on ANY file modification (M/D/R in git status). Only use for truly new-file-only tasks. If a task needs to edit existing files, do not set `additive-only`.
+- **Execution note** — maps 1:1 to the task `execution_note` field. One of `test-first`, `characterization-first`, `additive-only`, `value-only`, or omitted. **Warning:** `additive-only` hard-blocks close on ANY file modification (M/D/R in git status). Only use for truly new-file-only tasks. Use `value-only` for copy/i18n edits to existing values; it permits M but rejects A/C/D/R and still goes through normal review. For broader edits, omit the field.
 - **Patterns to follow** — pointer to existing code or a prior commit the worker should mirror. Reduces stylistic drift.
 - **Test scenarios** — name the scenarios, including at least one error path. Don't leave test design entirely to the worker.
 - **Verification** — observable outcome. What can be demonstrated when done. Maps to `demo_statement`.

--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -45,6 +45,7 @@ Tasks may set `execution_note` to:
 - **`test-first`** — Commit a failing test before implementation; the verifier expects a new test file.
 - **`characterization-first`** — Pin current behavior in tests before edits; the verifier inspects notes and evidence.
 - **`additive-only`** — New files only; close rejects `M`/`D`/`R`. Ask the supervisor before changing scope.
+- **`value-only`** — Existing copy/i18n values only; close allows `M` but rejects `A`/`C`/`D`/`R`. Normal review and merge gates still apply.
 - **`no-code`** — Zero-code ops/artifact work. Set portable `external_ref` proof; close rejects missing proof or task-attributed code.
 
 Null means use judgment; other values are invalid.

--- a/cas-cli/src/builtins/grok/agents/task-verifier.md
+++ b/cas-cli/src/builtins/grok/agents/task-verifier.md
@@ -216,6 +216,8 @@ Read the `execution_note` field from `cas__task action=show id=<task-id>`. If se
 
 - **`execution_note=additive-only`** — SKIP this advisory check. `additive-only` is hard-enforced by `close_ops.rs` (cas-e235). If the worker got this far with additive-only, the close-gate already verified no M/D/R files in the diff. Nothing to do here.
 
+- **`execution_note=value-only`** — SKIP this advisory check. `value-only` is hard-enforced by `close_ops.rs` (cas-8ad8): it permits M entries for existing copy/i18n values but rejects added, deleted, copied, or renamed files. It remains subject to ordinary review; do not treat it as additive-only.
+
 - **`execution_note=no-code`** — SKIP: close requires portable `external_ref` proof and rejects task-attributed code.
 
 - **`execution_note=null` or missing** — SKIP this check. No posture was declared, no posture applies.

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor/references/planning.md
@@ -60,7 +60,7 @@ Canonical template:
   - Modify: `path/to/existing_file.rs`
   - Test: `path/to/test_file.rs`
 **Approach:** Key design or sequencing decision
-**Execution note:** test-first | characterization-first | additive-only | (omit)
+**Execution note:** test-first | characterization-first | additive-only | value-only | (omit)
 **Patterns to follow:** Reference existing code to mirror
 **Test scenarios:**
   - Happy path: input X -> expected Y
@@ -76,7 +76,7 @@ Field purposes (write decisions, not code — "Approach" is 1–3 sentences of s
 - **Dependencies** — hard blockers go in `blocked_by`; soft ordering or "after X lands" notes stay as prose.
 - **Files** — the layer boundary. What the worker owns and must not touch outside of. Boundary violation is a rejection condition.
 - **Approach** — the sequencing or design decision already made. Not a code sketch, not a pseudocode draft. If you find yourself writing pseudocode, you are doing the worker's job.
-- **Execution note** — maps 1:1 to the task `execution_note` field. One of `test-first`, `characterization-first`, `additive-only`, or omitted. **Warning:** `additive-only` hard-blocks close on ANY file modification (M/D/R in git status). Only use for truly new-file-only tasks. If a task needs to edit existing files, do not set `additive-only`.
+- **Execution note** — maps 1:1 to the task `execution_note` field. One of `test-first`, `characterization-first`, `additive-only`, `value-only`, or omitted. **Warning:** `additive-only` hard-blocks close on ANY file modification (M/D/R in git status). Only use for truly new-file-only tasks. Use `value-only` for copy/i18n edits to existing values; it permits M but rejects A/C/D/R and still goes through normal review. For broader edits, omit the field.
 - **Patterns to follow** — pointer to existing code or a prior commit the worker should mirror. Reduces stylistic drift.
 - **Test scenarios** — name the scenarios, including at least one error path. Don't leave test design entirely to the worker.
 - **Verification** — observable outcome. What can be demonstrated when done. Maps to `demo_statement`.

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -45,6 +45,7 @@ Tasks may set `execution_note` to:
 - **`test-first`** — Commit a failing test before implementation; the verifier expects a new test file.
 - **`characterization-first`** — Pin current behavior in tests before edits; the verifier inspects notes and evidence.
 - **`additive-only`** — New files only; close rejects `M`/`D`/`R`. Ask the supervisor before changing scope.
+- **`value-only`** — Existing copy/i18n values only; close allows `M` but rejects `A`/`C`/`D`/`R`. Normal review and merge gates still apply.
 - **`no-code`** — Zero-code ops/artifact work. Set portable `external_ref` proof; close rejects missing proof or task-attributed code.
 
 Null means use judgment; other values are invalid.

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/planning.md
@@ -60,7 +60,7 @@ Canonical template:
   - Modify: `path/to/existing_file.rs`
   - Test: `path/to/test_file.rs`
 **Approach:** Key design or sequencing decision
-**Execution note:** test-first | characterization-first | additive-only | (omit)
+**Execution note:** test-first | characterization-first | additive-only | value-only | (omit)
 **Patterns to follow:** Reference existing code to mirror
 **Test scenarios:**
   - Happy path: input X -> expected Y
@@ -76,7 +76,7 @@ Field purposes (write decisions, not code — "Approach" is 1–3 sentences of s
 - **Dependencies** — hard blockers go in `blocked_by`; soft ordering or "after X lands" notes stay as prose.
 - **Files** — the layer boundary. What the worker owns and must not touch outside of. Boundary violation is a rejection condition.
 - **Approach** — the sequencing or design decision already made. Not a code sketch, not a pseudocode draft. If you find yourself writing pseudocode, you are doing the worker's job.
-- **Execution note** — maps 1:1 to the task `execution_note` field. One of `test-first`, `characterization-first`, `additive-only`, or omitted. **Warning:** `additive-only` hard-blocks close on ANY file modification (M/D/R in git status). Only use for truly new-file-only tasks. If a task needs to edit existing files, do not set `additive-only`.
+- **Execution note** — maps 1:1 to the task `execution_note` field. One of `test-first`, `characterization-first`, `additive-only`, `value-only`, or omitted. **Warning:** `additive-only` hard-blocks close on ANY file modification (M/D/R in git status). Only use for truly new-file-only tasks. Use `value-only` for copy/i18n edits to existing values; it permits M but rejects A/C/D/R and still goes through normal review. For broader edits, omit the field.
 - **Patterns to follow** — pointer to existing code or a prior commit the worker should mirror. Reduces stylistic drift.
 - **Test scenarios** — name the scenarios, including at least one error path. Don't leave test design entirely to the worker.
 - **Verification** — observable outcome. What can be demonstrated when done. Maps to `demo_statement`.

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -45,6 +45,7 @@ Tasks may set `execution_note` to:
 - **`test-first`** — Commit a failing test before implementation; the verifier expects a new test file.
 - **`characterization-first`** — Pin current behavior in tests before edits; the verifier inspects notes and evidence.
 - **`additive-only`** — New files only; close rejects `M`/`D`/`R`. Ask the supervisor before changing scope.
+- **`value-only`** — Existing copy/i18n values only; close allows `M` but rejects `A`/`C`/`D`/`R`. Normal review and merge gates still apply.
 - **`no-code`** — Zero-code ops/artifact work. Set portable `external_ref` proof; close rejects missing proof or task-attributed code.
 
 Null means use judgment; other values are invalid.

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -3649,34 +3649,34 @@ impl CasCore {
         // keep the previous signal).
         let effective_has_reviewable = task.execution_note.as_deref() == Some("value-only")
             || if let Some(worker_wt) = worker_worktree_path.as_ref() {
-            commit_receipt_window
-                .as_ref()
-                .and_then(|window| {
-                    has_task_attributable_reviewable_changes(
-                        worker_wt,
-                        &resolved_parent_branch,
-                        window,
-                    )
-                })
-                .unwrap_or_else(|| {
-                    has_worker_committed_reviewable_changes(worker_wt, &resolved_parent_branch)
-                })
-        } else {
-            shared_checkout_has_reviewable_changes(SharedCheckoutReviewScope {
-                task_type: task.task_type,
-                execution_note: task.execution_note.as_deref(),
-                attributable_reviewable_changes: commit_receipt_window.as_ref().and_then(
-                    |window| {
+                commit_receipt_window
+                    .as_ref()
+                    .and_then(|window| {
                         has_task_attributable_reviewable_changes(
-                            &close_project_root,
+                            worker_wt,
                             &resolved_parent_branch,
                             window,
                         )
-                    },
-                ),
-                checkout_has_reviewable_changes: has_reviewable_changes(&close_project_root),
-            })
-        };
+                    })
+                    .unwrap_or_else(|| {
+                        has_worker_committed_reviewable_changes(worker_wt, &resolved_parent_branch)
+                    })
+            } else {
+                shared_checkout_has_reviewable_changes(SharedCheckoutReviewScope {
+                    task_type: task.task_type,
+                    execution_note: task.execution_note.as_deref(),
+                    attributable_reviewable_changes: commit_receipt_window.as_ref().and_then(
+                        |window| {
+                            has_task_attributable_reviewable_changes(
+                                &close_project_root,
+                                &resolved_parent_branch,
+                                window,
+                            )
+                        },
+                    ),
+                    checkout_has_reviewable_changes: has_reviewable_changes(&close_project_root),
+                })
+            };
 
         // `no-code` is an explicit operations/artifact contract, not a broad
         // review bypass. It must retain a portable proof pointer, and any code
@@ -6077,10 +6077,7 @@ fn check_branch_violations(
                     worker_worktree_path,
                     &anchor_parent,
                     identity,
-                    parse_name_status_filtered(
-                        &String::from_utf8_lossy(&o.stdout),
-                        &is_violation,
-                    ),
+                    parse_name_status_filtered(&String::from_utf8_lossy(&o.stdout), &is_violation),
                 ),
                 _ => Vec::new(),
             };
@@ -6112,10 +6109,7 @@ fn check_branch_violations(
             worker_worktree_path,
             &merge_base,
             identity,
-            parse_name_status_filtered(
-                &String::from_utf8_lossy(&o.stdout),
-                &is_violation,
-            ),
+            parse_name_status_filtered(&String::from_utf8_lossy(&o.stdout), &is_violation),
         ),
         _ => Vec::new(),
     }
@@ -10508,8 +10502,7 @@ pub(crate) fn run_code_review_gate(
     // is the explicit exception: it represents a customer-visible existing
     // value edit and must follow the ordinary review route even when the file
     // classifier cannot distinguish it from a docs-only asset.
-    if task.execution_note.as_deref() != Some("value-only")
-        && !has_reviewable_changes(project_root)
+    if task.execution_note.as_deref() != Some("value-only") && !has_reviewable_changes(project_root)
     {
         return CodeReviewGateOutcome::Proceed;
     }
@@ -14392,16 +14385,16 @@ mod code_review_gate_tests {
     #[test]
     fn value_only_task_still_requires_code_review() {
         let _g = env_lock();
+        // Value-only worker closes must follow the supervisor-owned route,
+        // not the legacy solo caller path that asks for an envelope.
+        let _role = CallerRoleEnv::factory_worker();
         let dir = repo_with_staged(&[("src/locales.rs", "localized value\n")]);
         let mut t = base_task();
         t.execution_note = Some("value-only".to_string());
         let req = base_req(&t.id);
         match run_code_review_gate(&t, &req, dir.path(), true) {
             CodeReviewGateOutcome::Reject(message) => {
-                assert!(
-                    message.contains("SUPERVISOR-OWNED REVIEW"),
-                    "{message}"
-                );
+                assert!(message.contains("SUPERVISOR-OWNED REVIEW"), "{message}");
             }
             other => panic!("value-only must follow the normal review gate, got {other:?}"),
         }

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -3548,6 +3548,41 @@ impl CasCore {
             }
         }
 
+        // cas-8ad8: copy and i18n changes legitimately modify existing
+        // values, but must not be mislabeled as additive-only. value-only is
+        // the complementary constrained posture: committed task changes may
+        // modify existing files, but cannot add, delete, copy, or rename a
+        // file. It intentionally does *not* bypass review or merge-delivery
+        // gates below; unlike an additive-only task, it has a real modified
+        // diff for those gates to inspect.
+        if close_disposition.requires_delivery_gates()
+            && task.execution_note.as_deref() == Some("value-only")
+        {
+            if let Some(worker_wt) = worker_worktree_path.as_ref() {
+                let violations = check_value_only_branch_violations(
+                    worker_wt,
+                    &resolved_parent_branch,
+                    task.deliverables.factory_branch_anchor.as_deref(),
+                    &task_commit_identity,
+                );
+                if !violations.is_empty() {
+                    let file_list = violations
+                        .iter()
+                        .map(|v| format!("  {} ({})", v.path, v.status))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    return Ok(Self::tool_error(format!(
+                        "⚠️ VALUE-ONLY VIOLATION\n\n\
+                        task close rejected: execution_note=value-only permits only \
+                        modifications to existing files.\n\n\
+                        Added/deleted/copied/renamed files:\n{file_list}\n\n\
+                        Use execution_note=additive-only for new-file-only work, or \
+                        execution_note=null or test-first for broader changes."
+                    )));
+                }
+            }
+        }
+
         // cas-b39f: cas-code-review P0 close gate (Unit 9).
         //
         // This is the integration point for the multi-persona code review
@@ -5944,6 +5979,45 @@ pub(crate) fn check_additive_only_branch_violations(
     factory_branch_anchor: Option<&str>,
     identity: &TaskCommitIdentity,
 ) -> Vec<AdditiveOnlyViolation> {
+    check_branch_violations(
+        worker_worktree_path,
+        parent_branch,
+        factory_branch_anchor,
+        identity,
+        |status| matches!(status, 'M' | 'D' | 'R'),
+    )
+}
+
+/// Return task-attributed changes which violate `execution_note=value-only`.
+/// A value-only task may modify existing files but cannot add, delete, copy,
+/// or rename them. Git cannot prove that a modification is semantically a
+/// copy or translation value, so that intent remains task metadata; this gate
+/// enforces the mechanically observable no-new-file-surface boundary.
+pub(crate) fn check_value_only_branch_violations(
+    worker_worktree_path: &std::path::Path,
+    parent_branch: &str,
+    factory_branch_anchor: Option<&str>,
+    identity: &TaskCommitIdentity,
+) -> Vec<AdditiveOnlyViolation> {
+    check_branch_violations(
+        worker_worktree_path,
+        parent_branch,
+        factory_branch_anchor,
+        identity,
+        |status| status != 'M',
+    )
+}
+
+/// Inspect a task's committed diff and retain entries selected by
+/// `is_violation`. Both constrained execution-note gates share this exact
+/// task-window and post-merge attribution logic.
+fn check_branch_violations(
+    worker_worktree_path: &std::path::Path,
+    parent_branch: &str,
+    factory_branch_anchor: Option<&str>,
+    identity: &TaskCommitIdentity,
+    is_violation: impl Fn(char) -> bool,
+) -> Vec<AdditiveOnlyViolation> {
     use std::process::Command;
 
     // cas-3f7f: once the parked worker tip is integrated, HEAD and the
@@ -5977,7 +6051,10 @@ pub(crate) fn check_additive_only_branch_violations(
                                     worker_worktree_path,
                                     commits[1],
                                     identity,
-                                    parse_name_status(&String::from_utf8_lossy(&o.stdout)),
+                                    parse_name_status_filtered(
+                                        &String::from_utf8_lossy(&o.stdout),
+                                        &is_violation,
+                                    ),
                                 ),
                                 _ => Vec::new(),
                             };
@@ -5999,7 +6076,10 @@ pub(crate) fn check_additive_only_branch_violations(
                     worker_worktree_path,
                     &anchor_parent,
                     identity,
-                    parse_name_status(&String::from_utf8_lossy(&o.stdout)),
+                    parse_name_status_filtered(
+                        &String::from_utf8_lossy(&o.stdout),
+                        &is_violation,
+                    ),
                 ),
                 _ => Vec::new(),
             };
@@ -6031,7 +6111,10 @@ pub(crate) fn check_additive_only_branch_violations(
             worker_worktree_path,
             &merge_base,
             identity,
-            parse_name_status(&String::from_utf8_lossy(&o.stdout)),
+            parse_name_status_filtered(
+                &String::from_utf8_lossy(&o.stdout),
+                &is_violation,
+            ),
         ),
         _ => Vec::new(),
     }
@@ -10767,10 +10850,12 @@ pub(crate) fn has_task_attributable_reviewable_changes(
     }))
 }
 
-/// Parse the output of `git diff --name-status` into violations. Only rows
-/// whose status starts with M, D, or R are returned. A, C, T, U, and ?? are
-/// considered additive or uninteresting.
-fn parse_name_status(output: &str) -> Vec<AdditiveOnlyViolation> {
+/// Parse name-status rows and retain exactly the statuses a constrained
+/// execution-note gate rejects.
+fn parse_name_status_filtered(
+    output: &str,
+    is_violation: &impl Fn(char) -> bool,
+) -> Vec<AdditiveOnlyViolation> {
     let mut violations = Vec::new();
     for line in output.lines() {
         let line = line.trim_end();
@@ -10787,19 +10872,16 @@ fn parse_name_status(output: &str) -> Vec<AdditiveOnlyViolation> {
         };
         let second_path = parts.next();
         let first_char = status.chars().next().unwrap_or(' ');
-        match first_char {
-            'M' | 'D' => violations.push(AdditiveOnlyViolation {
+        if is_violation(first_char) {
+            let path = if matches!(first_char, 'R' | 'C') {
+                second_path.unwrap_or(first_path).to_string()
+            } else {
+                first_path.to_string()
+            };
+            violations.push(AdditiveOnlyViolation {
                 status: status.to_string(),
-                path: first_path.to_string(),
-            }),
-            'R' => {
-                let path = second_path.unwrap_or(first_path).to_string();
-                violations.push(AdditiveOnlyViolation {
-                    status: status.to_string(),
-                    path,
-                });
-            }
-            _ => {}
+                path,
+            });
         }
     }
     violations
@@ -10852,12 +10934,22 @@ mod additive_only_tests {
     #[test]
     fn parse_name_status_mixed() {
         let out = "A\tadded.txt\nM\tmodified.txt\nD\tdeleted.txt\nR100\told.txt\tnew.txt\n";
-        let v = parse_name_status(out);
+        let v = parse_name_status_filtered(out, &|status| matches!(status, 'M' | 'D' | 'R'));
         assert_eq!(v.len(), 3);
         assert_eq!(v[0].path, "modified.txt");
         assert_eq!(v[1].path, "deleted.txt");
         assert_eq!(v[2].path, "new.txt");
         assert!(v[2].status.starts_with('R'));
+    }
+
+    #[test]
+    fn value_only_parser_allows_modifications_but_rejects_new_surface() {
+        let out = "A\tadded.txt\nM\tlocalized.ftl\nD\tdeleted.txt\nR100\told.ftl\tnew.ftl\n";
+        let v = parse_name_status_filtered(out, &|status| status != 'M');
+        assert_eq!(v.len(), 3, "only M is allowed for value-only: {v:?}");
+        assert_eq!(v[0].path, "added.txt");
+        assert_eq!(v[1].path, "deleted.txt");
+        assert_eq!(v[2].path, "new.ftl");
     }
 
     // --- cas-895d: check_uncommitted_work ---------------------------------
@@ -14288,6 +14380,26 @@ mod code_review_gate_tests {
         req.code_review_findings = Some(autofix_envelope(vec![p0_finding()]));
         let out = run_code_review_gate(&t, &req, dir.path(), true);
         assert!(matches!(out, CodeReviewGateOutcome::Proceed));
+    }
+
+    /// cas-8ad8: value-only may modify existing source values, so it must not
+    /// inherit additive-only's review bypass.
+    #[test]
+    fn value_only_task_still_requires_code_review() {
+        let _g = env_lock();
+        let dir = repo_with_staged(&[("src/locales.rs", "localized value\n")]);
+        let mut t = base_task();
+        t.execution_note = Some("value-only".to_string());
+        let req = base_req(&t.id);
+        match run_code_review_gate(&t, &req, dir.path(), true) {
+            CodeReviewGateOutcome::Reject(message) => {
+                assert!(
+                    message.contains("SUPERVISOR-OWNED REVIEW"),
+                    "{message}"
+                );
+            }
+            other => panic!("value-only must follow the normal review gate, got {other:?}"),
+        }
     }
 
     /// cas-acf83 (GH #108): the reported incident. Every persona failed to

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -3647,7 +3647,8 @@ impl CasCore {
         // `shared_checkout_has_reviewable_changes` for the exact fallbacks
         // (code tasks with no no-code declaration, and unknowable git state,
         // keep the previous signal).
-        let effective_has_reviewable = if let Some(worker_wt) = worker_worktree_path.as_ref() {
+        let effective_has_reviewable = task.execution_note.as_deref() == Some("value-only")
+            || if let Some(worker_wt) = worker_worktree_path.as_ref() {
             commit_receipt_window
                 .as_ref()
                 .and_then(|window| {
@@ -10503,9 +10504,13 @@ pub(crate) fn run_code_review_gate(
         }
     }
 
-    // Skip 3: docs-only / test-only / empty diffs. The gate is not a
-    // SPOF for changes it cannot meaningfully review.
-    if !has_reviewable_changes(project_root) {
+    // Skip 3: docs-only / test-only / empty diffs. A value-only declaration
+    // is the explicit exception: it represents a customer-visible existing
+    // value edit and must follow the ordinary review route even when the file
+    // classifier cannot distinguish it from a docs-only asset.
+    if task.execution_note.as_deref() != Some("value-only")
+        && !has_reviewable_changes(project_root)
+    {
         return CodeReviewGateOutcome::Proceed;
     }
 

--- a/cas-cli/src/mcp/tools/types/task.rs
+++ b/cas-cli/src/mcp/tools/types/task.rs
@@ -17,6 +17,7 @@ pub const EXECUTION_NOTE_VALUES: &[&str] = &[
     "test-first",
     "characterization-first",
     "additive-only",
+    "value-only",
     "no-code",
 ];
 
@@ -134,7 +135,7 @@ pub struct TaskCreateRequest {
 
     /// Execution methodology note
     #[schemars(
-        description = "Execution methodology for this task. One of: test-first, characterization-first, additive-only, no-code. no-code declares an operations/artifact task and requires an external_ref proof reference at close. Omit or leave null if no methodology is declared."
+        description = "Execution methodology for this task. One of: test-first, characterization-first, additive-only, value-only, no-code. value-only permits edits to existing values but rejects added, deleted, copied, or renamed files at close. no-code declares an operations/artifact task and requires an external_ref proof reference at close. Omit or leave null if no methodology is declared."
     )]
     #[serde(default)]
     pub execution_note: Option<String>,
@@ -352,7 +353,7 @@ pub struct TaskUpdateRequest {
 
     /// Update execution note
     #[schemars(
-        description = "Execution methodology for this task. One of: test-first, characterization-first, additive-only, no-code. no-code declares an operations/artifact task and requires an external_ref proof reference at close. Pass an empty string to clear."
+        description = "Execution methodology for this task. One of: test-first, characterization-first, additive-only, value-only, no-code. value-only permits edits to existing values but rejects added, deleted, copied, or renamed files at close. no-code declares an operations/artifact task and requires an external_ref proof reference at close. Pass an empty string to clear."
     )]
     #[serde(default)]
     pub execution_note: Option<String>,

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -281,9 +281,37 @@ async fn test_execution_note_invalid_enum_rejected() {
     assert!(
         msg.contains("test-first")
             && msg.contains("characterization-first")
-            && msg.contains("additive-only"),
+            && msg.contains("additive-only")
+            && msg.contains("value-only"),
         "error must list allowed values, got: {msg}"
     );
+}
+
+/// cas-8ad8: value-only is an accepted declaration for copy/i18n work that
+/// modifies existing values without claiming a new-file-only posture.
+#[tokio::test]
+async fn test_execution_note_value_only_create_and_show() {
+    let (_temp, service) = setup_cas();
+
+    let created = service
+        .cas_task_create(Parameters(basic_create(
+            "Copy-value correction",
+            Some("value-only".to_string()),
+        )))
+        .await
+        .expect("value-only must be accepted");
+    let id = extract_task_id(&extract_text(created))
+        .expect("id")
+        .to_string();
+
+    let shown = service
+        .cas_task_show(Parameters(TaskShowRequest {
+            id,
+            with_deps: false,
+        }))
+        .await
+        .expect("show should succeed");
+    assert!(extract_text(shown).contains("Execution Note: value-only"));
 }
 
 /// Update path: create without execution_note, then set it via update.

--- a/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
@@ -4347,6 +4347,53 @@ enabled = false
         cas::types::TaskStatus::Closed,
         "violation must not transition task to Closed"
     );
+
+    // --- Scenario C: value-only is the accurate posture for a copy/i18n
+    //     change to an existing file. It must close normally, without a
+    //     supervisor bypass or weakening additive-only.
+    git(&["checkout", "-q", "main"]);
+    git(&["checkout", "-q", "-b", "factory/value-only"]);
+    std::fs::write(worktree_path.join("existing.txt"), "localized value\n").unwrap();
+    git(&["add", "existing.txt"]);
+    git(&["commit", "-q", "-m", "fix: localize existing value"]);
+    let id_c = extract_task_id(&extract_text(
+        service
+            .cas_task_create(Parameters(TaskCreateRequest {
+                execution_note: Some("value-only".to_string()),
+                ..additive_req("cas-8ad8: value-only branch commit")
+            }))
+            .await
+            .expect("task_create"),
+    ))
+    .expect("task id")
+    .to_string();
+    {
+        let mut t = task_store.get(&id_c).expect("task");
+        t.status = cas::types::TaskStatus::InProgress;
+        t.worktree_id = Some(worktree_id.clone());
+        task_store.update(&t).expect("update task");
+    }
+    let resp_c = extract_text(
+        service
+            .cas_task_close(Parameters(TaskCloseRequest {
+                id: id_c.clone(),
+                reason: Some("localized existing value".to_string()),
+                bypass_code_review: None,
+                code_review_findings: None,
+                search_manifest: None,
+                commit_receipt: None,
+            }))
+            .await
+            .expect("close returns"),
+    );
+    assert!(
+        resp_c.contains("Closed task:"),
+        "value-only modification must close normally: {resp_c}"
+    );
+    assert_eq!(
+        task_store.get(&id_c).expect("task").status,
+        cas::types::TaskStatus::Closed
+    );
 }
 
 /// cas-895d + cas-bc1b follow-up regression: a task with `worktree_id = None`

--- a/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
@@ -4181,9 +4181,11 @@ async fn test_additive_only_uses_worker_branch_not_main_worktree() {
     // cas-bc1b fix, we intentionally leave the worker worktree clean
     // and rely on the fact that pre-fix code would have looked at the
     // MAIN worktree (cas_root.parent()) where unrelated drift lives.
-    // Since cas_root.parent() here is a tempdir (not a git repo),
-    // we can't put a stray file there and prove anything — instead,
-    // prove the fix by committing a modification on the branch and
+    // The CAS root's parent is a clean Git repository, separate from
+    // the worker worktree below. That lets the factory close path pass
+    // its repository-identity check while still proving the constrained
+    // execution-note gate reads the worker branch rather than main.
+    // We prove the fix by committing a modification on the branch and
     // asserting the gate now catches it (which it wouldn't have
     // under the legacy `git diff HEAD` in main path — that one is
     // empty in tempdir because tempdir isn't a git repo).
@@ -4199,6 +4201,12 @@ enabled = false
 "#,
     )
     .expect("write config");
+
+    proof_boundary_git(temp.path(), &["init", "-q", "-b", "main"]);
+    std::fs::write(temp.path().join(".gitignore"), ".cas/\nworker-worktree/\n").unwrap();
+    std::fs::write(temp.path().join("main.txt"), "main checkout\n").unwrap();
+    proof_boundary_git(temp.path(), &["add", ".gitignore", "main.txt"]);
+    proof_boundary_git(temp.path(), &["commit", "-q", "-m", "main: initial"]);
 
     // Real git repo playing the role of a worker worktree.
     let worktree_path = temp.path().join("worker-worktree");
@@ -4349,8 +4357,9 @@ enabled = false
     );
 
     // --- Scenario C: value-only is the accurate posture for a copy/i18n
-    //     change to an existing file. It must close normally, without a
-    //     supervisor bypass or weakening additive-only.
+    //     change to an existing file. It must reach ordinary supervisor
+    //     review, without a worker-supplied envelope or weakening
+    //     additive-only.
     git(&["checkout", "-q", "main"]);
     git(&["checkout", "-q", "-b", "factory/value-only"]);
     std::fs::write(worktree_path.join("existing.txt"), "localized value\n").unwrap();
@@ -4373,6 +4382,11 @@ enabled = false
         t.worktree_id = Some(worktree_id.clone());
         task_store.update(&t).expect("update task");
     }
+    // Customer-visible value changes are reviewable under the default
+    // owner=supervisor policy. Make the fixture a factory worker explicitly:
+    // setup_cas clears ambient factory env so the test cannot accidentally
+    // exercise a solo caller's close behavior.
+    let _worker = FactoryWorkerEnv::enter();
     let resp_c = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
@@ -4387,12 +4401,13 @@ enabled = false
             .expect("close returns"),
     );
     assert!(
-        resp_c.contains("Closed task:"),
-        "value-only modification must close normally: {resp_c}"
+        resp_c.contains("supervisor review") || resp_c.contains("pending_supervisor_review"),
+        "value-only modification must queue ordinary supervisor review: {resp_c}"
     );
     assert_eq!(
         task_store.get(&id_c).expect("task").status,
-        cas::types::TaskStatus::Closed
+        cas::types::TaskStatus::PendingSupervisorReview,
+        "value-only must not bypass supervisor-owned review"
     );
 }
 

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -425,7 +425,7 @@ pub struct TaskRequest {
 
     /// Execution note (for create, update) - methodology used to execute this task
     #[schemars(
-        description = "Execution methodology for this task. One of: test-first, characterization-first, additive-only, no-code. no-code declares an operations/artifact task and requires external_ref proof at close. Pass empty string to clear on update."
+        description = "Execution methodology for this task. One of: test-first, characterization-first, additive-only, value-only, no-code. value-only permits edits to existing values but rejects added, deleted, copied, or renamed files at close. no-code declares an operations/artifact task and requires external_ref proof at close. Pass empty string to clear on update."
     )]
     #[serde(default)]
     pub execution_note: Option<String>,

--- a/crates/cas-types/src/task.rs
+++ b/crates/cas-types/src/task.rs
@@ -507,8 +507,9 @@ pub struct Task {
     pub demo_statement: String,
 
     /// Execution methodology for this task. One of `test-first`,
-    /// `characterization-first`, or `additive-only`. Validated at the MCP
-    /// tool layer rather than the database. None = no methodology declared.
+    /// `characterization-first`, `additive-only`, `value-only`, or `no-code`.
+    /// Validated at the MCP tool layer rather than the database. None = no
+    /// methodology declared.
     /// See cas-7fc1.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_note: Option<String>,


### PR DESCRIPTION
`execution_note=additive-only` hard-blocks close on **any** file modification, which makes it unsatisfiable for i18n and copy work — every such fix modifies an existing value rather than adding a new one. In the incident that surfaced this, the note had been mis-set on a value-modification task, and the resulting close rejection is what wedged the worker in the first place.

Adds `execution_note=value-only`: close permits `M` but rejects `A`/`C`/`D`/`R`, so copy and i18n edits get an honest declaration without the note becoming a general escape hatch. Documented across all three harness variants (the worker skill and the supervisor planning references) so supervisors stop reaching for `additive-only` on copy work.

## The part worth reading

A new execution_note must never become a quiet review exemption. `value-only` changes customer-visible strings, and "it's only values" is exactly the reasoning that makes such an exemption feel reasonable.

The first delivery let `value-only` be classified non-reviewable and skip ordinary review entirely. The second forced reviewability but still rejected via the **worker-owned** `CODE_REVIEW_REQUIRED` envelope path, while the correct behaviour under the default `code_review.owner=supervisor` is to route to PendingSupervisorReview. This delivery completes it: `value-only` is excluded from the docs-only/test-only/empty-diff skip and follows the ordinary supervisor-owned review route.

That gap was caught by a guard the first worker wrote against **its own change** — `value_only_task_still_requires_code_review`, with the comment "value-only may modify existing source values, so it must not inherit additive-only's review bypass". It failed twice, and was honoured both times rather than relaxed. The assertion is unchanged in this delivery; only the routing moved.

## Verification

- `value_only_task_still_requires_code_review` asserts the refusal carries `SUPERVISOR-OWNED REVIEW`, unchanged from when it was written as a guard.
- A/C/D/R enforcement test: only `M` is permitted under `value-only`.
- Full `--lib code_review_gate_tests` **43/43**, re-run independently by the supervisor in the worker's worktree — this lane twice reported a local pass that CI contradicted, so the count was verified rather than accepted.
- Branch CI green on dbed6778.

Split out of GH #328 by the worker fixing that issue's primary defect, which correctly declined to couple a task-metadata policy question into a messaging-envelope fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
