### PR TITLE
Release v2.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.68.0] - 2026-08-14
+
+### Added
+- **Workers can flag a same-session peer collision without leaving the supervisor blind.** Peer warnings stay scoped to the active factory session and include a supervisor copy, while task notes can now be read directly without loading the full task record.
+
+### Changed
+- **Delivery and merge decisions now prove the work's content is on its declared target.** Freshness, merge relays, close receipts, and diff attribution follow the actual destination and distinguish present work from commits that were rebased, resolved away, or superseded.
+- **Review and recovery state now reflect the real owner and live task state.** Value-only edits retain normal supervisor review, verification recovery names the available escape hatch, and terminal relay backlogs reconcile automatically.
+
+### Fixed
+- **Lifecycle instructions no longer turn stale or uncertain state into a misleading action.** Replayed prompts carry provenance, terminal assignments are withheld only with positive current evidence, declined merge anchors cannot reappear as live requests, and urgent stops expire with their acknowledged exchange.
+- **Workers start and operate in the correct context more reliably.** Spawned work uses a fresher non-divergent epic base, workers receive queued supervisor corrections before starting, the target checkout is protected from foreign Git writes, and missing local prerequisites are made explicit.
+- **Focused recall and memory saving are more dependable under real workloads.** Search opens a consistent schema under concurrency and overlap scoring measures meaningful content similarity rather than shared note structure.
+
 ## [2.67.0] - 2026-08-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.67.0"
+version = "2.68.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.67.0"
+version = "2.68.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.67.0"
+version = "2.68.0"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.67.0"
+version = "2.68.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.67.0"
+version = "2.68.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.67.0"
+version = "2.68.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-14-v2.68.0-slack.md
+++ b/docs/release-notes/2026-08-14-v2.68.0-slack.md
@@ -1,0 +1,39 @@
+# Slack draft — v2.68.0 runtime release, 2026-08-14
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Paste-ready draft. Post only after the protected-main release PR has landed, the annotated v2.68.0 tag is pushed, and release artifacts are verified. The release supervisor owns posting and will append the receipt.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — CAS now tells the truth about delivery: work reported as delivered is present where it belongs, and the system makes the recovery path clear when it is not.
+
+**Reply (Was → Now):**
+- Was: a task could appear delivered because its commit was reachable, even when its actual change had been resolved away or superseded. Now: CAS checks the delivered content on the task’s real destination before calling work landed.
+- Was: a declined or already-finished request could still arrive looking actionable, while a real recovery path could be hard to find. Now: stale instructions are rechecked against current state, messages show their source, and recovery points to the action that can move work forward.
+- Was: a worker could begin without a recent base, its queued correction, or the local setup it needed. Now: startup refreshes the usable base, surfaces instructions before work starts, and names the supported setup or recovery path.
+- Install: use `cas update` for an existing installation, or download the v2.68.0 archive for Linux x86_64 or Apple Silicon from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — CAS v2.68.0 makes close and merge gates prove target-tree content, not merely commit reachability.
+
+**Reply (Was → Now):**
+- Was: landing checks could accept an ancestor commit while task-authored content was absent from the target tree. Now: delivery content is compared at the declared target, with explicit outcomes for dropped, evolved, or superseded changes.
+- Was: queued delivery and lifecycle messages could outlive the anchor or state that made them actionable. Now: typed envelopes carry identity and anchor provenance, and delivery suppresses only on fresh positive evidence that the requested action is moot.
+- Was: constrained value edits, verification recovery, worker branches, and terminal relays could take incorrect close or ownership routes. Now: value-only edits remain supervisor-reviewable, verification recovery names its escape hatch, worker Git writes verify their branch, and terminal relays reconcile durably.
+- Validation: the annotated v2.68.0 tag points to the protected-main release commit; the release preflight and required tag/main checks pass; Linux x86_64 and macOS ARM64 archives are built from that tag and recorded with SHA-256 digests.
+
+## Posting sequence
+
+1. Post the User top-level as a new #cas-internal message and capture its timestamp.
+2. Post the User reply as its only threaded reply.
+3. Post the Dev top-level as a new #cas-internal message and capture its timestamp.
+4. Post the Dev reply as its only threaded reply.
+5. Append the receipt below with UTC timestamps and all four permalinks.
+
+## POSTED
+
+_Supervisor to complete after publication._


### PR DESCRIPTION
Release v2.68.0: version train, lockfile, v18 changelog, and paste-ready #cas-internal draft.\n\nValidation: cargo check -p cas --lib --tests; cargo metadata --locked --format-version 1 --no-deps.