### PR TITLE
fix(cas-770a): resolve nested integration test modules to their owning binary

### DIFF
--- a/scripts/check-scoped-test-surface.sh
+++ b/scripts/check-scoped-test-surface.sh
@@ -128,12 +128,12 @@ while IFS= read -r path; do
                 required_lib_modules+=("$(basename "${path%.rs}")")
             fi
             ;;
-        cas-cli/tests/*.rs)
-            required_test_targets+=("$(basename "${path%.rs}")")
-            ;;
         cas-cli/tests/*/*.rs)
             nested="${path#cas-cli/tests/}"
             required_test_targets+=("$(integration_target_for "$nested")")
+            ;;
+        cas-cli/tests/*.rs)
+            required_test_targets+=("$(basename "${path%.rs}")")
             ;;
     esac
 done < <(git diff --name-only "$merge_base" HEAD)

--- a/scripts/test-run-scoped-tests.sh
+++ b/scripts/test-run-scoped-tests.sh
@@ -317,6 +317,15 @@ git -C "${surface_repo}" init -q -b main
 } >"${surface_repo}/cas-cli/src/hooks/pre_tool.rs"
 printf '// factory integration target\n' \
     >"${surface_repo}/cas-cli/tests/factory_mcp_ops_test.rs"
+mkdir -p "${surface_repo}/cas-cli/tests/mcp_tools_test/task_tools"
+printf '#[path = "mcp_tools_test/task_tools/mod.rs"]\nmod task_tools;\n' \
+    >"${surface_repo}/cas-cli/tests/mcp_tools_test.rs"
+printf 'mod operations;\nmod verification_flow;\n' \
+    >"${surface_repo}/cas-cli/tests/mcp_tools_test/task_tools/mod.rs"
+printf '// nested operations module\n' \
+    >"${surface_repo}/cas-cli/tests/mcp_tools_test/task_tools/operations.rs"
+printf '// nested verification module\n' \
+    >"${surface_repo}/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs"
 git -C "${surface_repo}" add .
 git -C "${surface_repo}" -c user.name=scoped-test-fixture -c user.email=scoped-test-fixture@example.invalid \
     commit -qm base
@@ -346,6 +355,20 @@ expect fail "missing integration target 'factory_mcp_ops_test'" \
 expect pass "SCOPED PROOF SURFACE: covered committed diff" \
     "proof: changed module plus integration target is accepted" \
     bash -c "cd '${surface_repo}' && '${SURFACE_GUARD}' --base main -- -p cas --lib worker_commit_guard_tests --test factory_mcp_ops_test"
+
+printf '// nested operation changed\n' >>"${surface_repo}/cas-cli/tests/mcp_tools_test/task_tools/operations.rs"
+printf '// nested verification flow changed\n' >>"${surface_repo}/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs"
+git -C "${surface_repo}" add .
+git -C "${surface_repo}" -c user.name=scoped-test-fixture -c user.email=scoped-test-fixture@example.invalid \
+    commit -qm nested-integration-change
+
+expect fail "missing integration target 'mcp_tools_test'" \
+    "proof: changed nested integration module cannot be omitted" \
+    bash -c "cd '${surface_repo}' && '${SURFACE_GUARD}' --base main -- -p cas --lib worker_commit_guard_tests --test factory_mcp_ops_test"
+
+expect pass "SCOPED PROOF SURFACE: covered committed diff" \
+    "proof: nested integration module resolves to its owning binary" \
+    bash -c "cd '${surface_repo}' && '${SURFACE_GUARD}' --base main -- -p cas --lib worker_commit_guard_tests --test factory_mcp_ops_test --test mcp_tools_test"
 
 docs_repo="${tmpdir}/docs-repo"
 mkdir -p "${docs_repo}/docs"


### PR DESCRIPTION
The `--proof` guard added by cas-8fd4 reported `cas-cli/tests/mcp_tools_test/task_tools/operations.rs` and `verification_flow.rs` as standalone integration targets needing their own `--test` invocation. They are not — both are modules compiled into the single `mcp_tools_test` binary, and both were already covered by the run being checked.

Cause is a case-pattern ordering bug. In bash `case`, `*` matches across `/`, so `cas-cli/tests/*.rs` matched nested paths before `cas-cli/tests/*/*.rs` could. Swapping the two arms lets the specific pattern win, and nested files now resolve to their owning binary.

Direction of the original error mattered: it OVER-reported, so no proof gap was ever hidden and nothing unsafe could merge. But it would have fired on most lanes touching task lifecycle, and a guard that cries wolf gets ignored — which would have squandered the leverage cas-8fd4 just bought.

Found by a worker within an hour of cas-8fd4 landing, while delivering an unrelated task. It reported the false positive and scoped it out of its own lane rather than silently satisfying it.

## Verification

- Fixture builds a real nested structure (`mcp_tools_test.rs` with `task_tools/{operations,verification_flow}.rs`), commits it, and pins **both** directions: omitting `--test mcp_tools_test` must fail with "missing integration target", including it must pass.
- The fixture sets `user.name`/`user.email` explicitly, so it cannot inherit developer git config — the hermeticity lesson two other lanes learned the hard way today.
- Full guard self-test: **24 passed, 0 failed**, supervisor-run. The real check is preserved: a diff touching an integration-covered source with no integration run is still refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)