### PR TITLE
fix(cas-0337): prioritize the submitted turn in ambient recall lookup terms

### DIFF
--- a/cas-cli/src/ambient_recall.rs
+++ b/cas-cli/src/ambient_recall.rs
@@ -1089,16 +1089,31 @@ fn read_surface(
 
 fn query_terms(canonical: &str) -> Vec<String> {
     let mut terms = Vec::new();
-    for raw in canonical
-        .split(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '/' | '.')))
-    {
-        let term = raw.trim_matches(['-', '_', '/', '.']).to_ascii_lowercase();
-        if !is_content_bearing_term(&term) || terms.contains(&term) {
-            continue;
-        }
-        terms.push(term);
-        if terms.len() == 10 {
-            break;
+    // The submitted turn is the reason this recall is happening.  Prioritize
+    // it over durable task/epic metadata: the lexical retriever has a hard
+    // ten-term work budget, and putting request terms last made an active
+    // supervisor task title silently consume that entire budget (cas-0337).
+    // Preserve the remaining canonical context as a fallback after the turn.
+    let mut lines: Vec<&str> = canonical.lines().collect();
+    if let Some(request_index) = lines.iter().position(|line| {
+        line.strip_prefix("request=")
+            .is_some_and(|request| !request.eq_ignore_ascii_case("session start"))
+    }) {
+        let request = lines.remove(request_index);
+        lines.insert(0, request);
+    }
+    for line in lines {
+        for raw in line
+            .split(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '/' | '.')))
+        {
+            let term = raw.trim_matches(['-', '_', '/', '.']).to_ascii_lowercase();
+            if !is_content_bearing_term(&term) || terms.contains(&term) {
+                continue;
+            }
+            terms.push(term);
+            if terms.len() == 10 {
+                return terms;
+            }
         }
     }
     terms

--- a/cas-cli/src/hooks/handlers/handlers_tests/factory_inbox_surfacing.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/factory_inbox_surfacing.rs
@@ -15,6 +15,7 @@ use cas_store::{PromptQueueStore, SqlitePromptQueueStore};
 use tempfile::TempDir;
 
 use crate::hooks::handlers::handle_user_prompt_submit;
+use crate::types::{Entry, EntryType, Task, TaskStatus};
 
 const SESSION: &str = "cas-src-happy-jay-91";
 const WORKER: &str = "ready-cheetah-71";
@@ -295,6 +296,54 @@ fn the_supervisor_reminder_is_unchanged_when_there_is_no_mail() {
         !context.contains("[incoming messages]"),
         "an empty inbox must not announce itself: {context}"
     );
+}
+
+/// cas-0337: this is the actual factory supervisor turn path, not a direct
+/// retriever unit seam. A long active-task title must not hide a same-day
+/// Learning whose vocabulary is present in the submitted turn.
+#[test]
+fn supervisor_turn_surfaces_matching_same_day_learnings() {
+    let _lock = super::env_lock();
+    let _env = supervisor_env();
+    let project = TempDir::new().unwrap();
+    let cas_root = crate::store::init_cas_dir(project.path()).unwrap();
+    let entries = crate::store::open_store_local(&cas_root).unwrap();
+    let mut stale_refs = Entry::new(
+        "2026-08-14-5".into(),
+        "epic_status compares child branches against stale local main; fast-forward origin/main before trusting its unmerged report".into(),
+    );
+    stale_refs.entry_type = EntryType::Learning;
+    stale_refs.importance = 0.85;
+    entries.add(&stale_refs).unwrap();
+    let mut hermetic_ci = Entry::new(
+        "2026-08-14-3".into(),
+        "Local green is insufficient merge evidence: a populated developer HOME masks inherited git identity and CAS_AGENT_NAME failures that clean CI exposes".into(),
+    );
+    hermetic_ci.entry_type = EntryType::Learning;
+    hermetic_ci.importance = 0.90;
+    entries.add(&hermetic_ci).unwrap();
+
+    let tasks = crate::store::open_task_store_local(&cas_root).unwrap();
+    let mut task = Task::new(
+        "cas-ambient".into(),
+        "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima".into(),
+    );
+    task.status = TaskStatus::InProgress;
+    tasks.add(&task).unwrap();
+
+    let mut stale_input = input("supervisor");
+    stale_input.cwd = project.path().to_string_lossy().into_owned();
+    stale_input.user_prompt =
+        Some("Investigate epic_status before trusting stale refs on main".into());
+    let stale_context =
+        context_of(&handle_user_prompt_submit(&stale_input, Some(&cas_root)).unwrap());
+    assert!(stale_context.contains("2026-08-14-5"), "{stale_context}");
+
+    let mut ci_input = stale_input;
+    ci_input.user_prompt =
+        Some("Local green diverged from clean CI; audit inherited HOME, git identity, and CAS_AGENT_NAME".into());
+    let ci_context = context_of(&handle_user_prompt_submit(&ci_input, Some(&cas_root)).unwrap());
+    assert!(ci_context.contains("2026-08-14-3"), "{ci_context}");
 }
 
 /// Session isolation must hold on the surfacing path exactly as it does on the


### PR DESCRIPTION
Two high-importance learnings, written the same day and directly matching the work in progress, never surfaced across a five-hour supervisor session. The lesson in one of them was rediscovered from first principles and hit **six times**; the other described a CI failure class that then bit two lanes, both treated as novel. A near-duplicate memory was written late in the session precisely because the original was invisible.

## Root cause — not what the report assumed

The report hypothesised recall was never invoked mid-session. **That was wrong, and checking it first is what found the real bug.**

`handlers_middle/prompt_capture.rs:86-94` calls `build_ambient_recall_context(..., session_start=false)` on every meaningful factory `UserPromptSubmit`, supervisors included. Recall is live mid-session.

The defect is in lexical query construction at `ambient_recall.rs:1097`. The retriever has a hard **ten-term budget**, and terms were collected in canonical metadata order — active task, epic, then `request=` last. A long active task title therefore consumed the entire budget before the submitted prompt's own vocabulary was ever considered.

That matches the incident exactly. The session's active task titles were of the form *"V18-13 (GH #324): merge/close gate must verify content presence, not just commit reachability"*. Ten content-bearing terms, spent. A prompt about stale refs could never reach a memory about stale refs.

The fix moves a non-`session start` request to the front of the term list and keeps the remaining canonical context as fallback. SessionStart deliberately stays metadata-first — at launch there is no turn to prioritise.

A third hypothesis in the report — that `Preference` entries were crowding out `Learning` entries in the launch packet — was **investigated and refuted**: the launch banner is separate pinned context (`hooks/context.rs:424-458`) and does not rank against ambient cards.

## Verification

- New `supervisor_turn_surfaces_matching_same_day_learnings` exercises the real factory `handle_user_prompt_submit` path, seeds the two incident Learnings (importance 0.85 and 0.90) **plus an overlong active task title** to reproduce the budget exhaustion, and demonstrates `2026-08-14-5` surfacing for *epic_status / stale refs / main* and `2026-08-14-3` for *local green / clean CI / HOME / git identity / CAS_AGENT_NAME*.
- Full `--lib factory_inbox_surfacing`: **10 passed**, supervisor-re-run independently.

The regression pins the property that matters — a same-day high-importance Learning matching the working context is retrievable — rather than asserting that recall works.

Fixes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
