### PR TITLE
test: record irreducible MCP unknown-tool flake verdict

### DIFF
--- a/cas-cli/tests/mcp_protocol_test.rs
+++ b/cas-cli/tests/mcp_protocol_test.rs
@@ -77,7 +77,7 @@ struct JsonRpcError {
 /// being masked by the harness:
 ///   * `server_handler::call_tool` self-times-out at 55s and replies with a
 ///     structured "timed out after 55s" error.
-///   * `runtime::EAGER_INIT_BUDGET` aborts startup at 45s.
+///   * `runtime::EAGER_INIT_BUDGET` checks the startup sequence at 45s.
 /// 90s clears both with slack for loaded CI, and is ~6.6x under the 600s
 /// nextest kill, so a wedge can never again consume the slow-timeout.
 const RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
@@ -110,8 +110,9 @@ impl std::fmt::Display for TransportError {
             } => write!(
                 f,
                 "no JSON-RPC response to method '{method}' (id {id}) within {}s; \
-                 cas serve child status: {}. The server accepted the request and \
-                 never answered — this is a server-side non-response, not a slow test.",
+                 cas serve child status: {}. The request path produced no response; \
+                 this alone cannot distinguish a request that was never read, a \
+                 handler that never completed, or a response that was never flushed.",
                 waited.as_secs(),
                 match child_status {
                     Some(status) => format!("exited {status}"),
@@ -849,11 +850,11 @@ fn test_mcp_unknown_tool() {
 /// server that never answered produced an infinite wait instead of a test
 /// failure.
 ///
-/// This test pins the invariant that made the 600s possible: a server that
-/// accepts the request and never responds must surface as a bounded,
-/// legible `TransportError::Timeout` — never as an unbounded block. It
-/// drives a deliberately silent stub so the non-response is deterministic
-/// rather than relying on the rare natural trigger.
+/// This test pins the invariant that made the 600s possible: a request that
+/// produces no response must surface as a bounded, legible
+/// `TransportError::Timeout` — never as an unbounded block. It drives a
+/// deliberately silent stub so the non-response is deterministic rather than
+/// inferring which unobserved server phase caused the original CI occurrence.
 #[cfg(unix)]
 #[test]
 fn test_response_wait_is_bounded_when_server_never_answers() {
@@ -886,12 +887,16 @@ fn test_response_wait_is_bounded_when_server_never_answers() {
         "response wait must be bounded by the client timeout; waited {elapsed:?}"
     );
 
-    // The diagnostic must name the method and say the server went silent,
-    // so the next occurrence is triageable from CI logs alone.
+    // The diagnostic must name the method without claiming which unobserved
+    // phase failed. The original CI log did not establish that the server read
+    // the request, so "accepted the request" would turn a symptom into a false
+    // root-cause claim.
     let rendered = err.to_string();
     assert!(
-        rendered.contains("tools/list") && rendered.contains("never answered"),
-        "timeout diagnostic must identify the silent request: {rendered}"
+        rendered.contains("tools/list")
+            && rendered.contains("cannot distinguish")
+            && !rendered.contains("accepted the request"),
+        "timeout diagnostic must identify the silent request without overclaiming: {rendered}"
     );
 }
 

--- a/docs/analysis/2026-08-14-mcp-unknown-tool-flake.md
+++ b/docs/analysis/2026-08-14-mcp-unknown-tool-flake.md
@@ -1,0 +1,92 @@
+# `test_mcp_unknown_tool` CI flake: retained-evidence verdict
+
+Issue: [GH #164](https://github.com/pippenz/cas/issues/164)  
+Task: `cas-3ce4`  
+Original failing run: [31218177756, attempt 1](https://github.com/pippenz/cas/actions/runs/31218177756/attempts/1)  
+Parent run: [31216239877](https://github.com/pippenz/cas/actions/runs/31216239877)
+
+## Verdict
+
+The underlying event is irreducible from the retained evidence. It did not
+reproduce in the required provoking experiment: 1,000 fresh test processes at
+24-way concurrency all passed. No production-code defect is established, so a
+production change would be speculative.
+
+The earlier `cas-7bb94` change remains correct and is preserved: it bounds the
+test harness's stdout wait, preventing an unobserved non-response from consuming
+nextest's 600-second timeout. Its diagnostic, however, said the server had
+"accepted the request and never answered." The original log contains no phase
+markers and does not establish that. This task corrects the diagnostic to list
+the three possibilities it can actually distinguish only with more evidence:
+request not read, handler not completed, or response not flushed.
+
+## What the CI record proves
+
+- Head `3d58332e` differs from parent `af44ad4d` only in an insta doctor
+  snapshot. The MCP test, server, `rmcp` version, and lockfile implementation are
+  identical.
+- The parent completed `test_mcp_unknown_tool` in 0.254 seconds. Attempt 1 at
+  the head left only that test running until nextest terminated it at 600.012
+  seconds. Attempt 2 on the same head passed.
+- Attempt 1 emitted no harness phase marker, server stderr, process state, or
+  stack trace. It therefore cannot locate the wait inside server startup, MCP
+  initialization, `tools/call`, response delivery, or process teardown. (`cas
+  init` had its separate 300-second watchdog, making that phase inconsistent
+  with a test that remained alive for 600 seconds.)
+- The old unbounded `BufReader::read_line` explains why any absent line became a
+  600-second wedge. It does not explain why the line was absent.
+
+## Code-path and shared-state audit
+
+The test creates a fresh `TempDir`, `HOME`, `XDG_CONFIG_HOME`, `CAS_ROOT`, and
+`CAS_DIR` for each process. It scrubs inherited `CAS_*` variables. There is no
+application database, socket, index, or configuration path shared by two
+repetitions; only host resources such as the kernel and scheduler are shared.
+
+After initialization the test sends one `tools/call` request for
+`nonexistent_tool`. In `rmcp` 0.14.0, `ToolRouter::call` performs an immutable
+`HashMap::get` and immediately returns `invalid_params("tool not found")` on a
+miss. CAS wraps that future in the existing 55-second handler timeout. There is
+no alternate unknown-tool handler or state-dependent branch to select.
+
+Upstream `rmcp` issue
+[modelcontextprotocol/rust-sdk#941](https://github.com/modelcontextprotocol/rust-sdk/issues/941)
+describes the same outward symptom, but its mechanism does not apply. That bug
+was introduced after 0.14.0 when the transport replaced `FramedRead` with a
+`read_until` buffer that was cleared after cancellation. CAS's pinned 0.14.0
+uses `FramedRead` plus a codec-owned persistent buffer. The upstream fix
+([#947](https://github.com/modelcontextprotocol/rust-sdk/pull/947)) therefore
+cannot explain the August 7 CAS run.
+
+## Provoking experiment
+
+The already-built integration-test executable was invoked directly so every
+iteration was a fresh OS process while avoiding Cargo serialization. Every
+process ran exactly `test_mcp_unknown_tool`, which in turn spawned fresh
+`cas init` and `cas serve` children. An external 15-second deadline prevented
+the harness's 90-second diagnostic bound from hiding a wedge.
+
+```text
+iterations:  1,000
+concurrency: 24
+passes:      1,000
+failures:    0
+timeouts:    0
+elapsed:     18.51s
+head:        fb69a7dbc8605cd60edf9c94b102d71ae5fa5958
+```
+
+Durable artifacts:
+
+- `/home/pippenz/.cas/artifacts/cas-3ce4/run-stress.sh`
+- `/home/pippenz/.cas/artifacts/cas-3ce4/stress-before-v1.log`
+- result-log SHA-256:
+  `3f7c889d47548b26420b26791febf6cf6659674505d0ba94bd14a755d7c5a122`
+
+## Decision
+
+Preserve the bounded-read protection, correct the unsupported causal wording,
+and make no production change. A future occurrence is actionable only if it
+captures a phase or process stack in addition to the request id and child
+status. Without that new observation, attributing the one historical event to
+CAS, `rmcp`, SQLite, the kernel, or runner scheduling would be guesswork.


### PR DESCRIPTION
## Outcome

- establishes the historical GH #164 occurrence is irreducible from retained evidence
- records 1,000/1,000 fresh-process passes at 24-way concurrency
- preserves the bounded-read guard while removing its unsupported claim that the server accepted the request
- documents the CI comparison, isolated-state audit, and upstream rmcp exclusion

## Proof

- `scripts/run-scoped-tests.sh -p cas --test mcp_protocol_test --proof`
- 22/22 tests passed
- stress artifact SHA-256: `3f7c889d47548b26420b26791febf6cf6659674505d0ba94bd14a755d7c5a122`

Fixes #164