### PR TITLE
fix(cas-201e): resolve the remote-tracking ref wherever a base or comparison means 'main'

### DIFF
--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -531,13 +531,37 @@ impl CasCore {
                         .as_ref()
                         .map(|context| context.target_branch.clone())
                         .unwrap_or_else(|| git_ops.detect_default_branch());
+                    // The supervisor checkout normally never checks out its
+                    // delivery branch. Resolve the fetched tracking ref before
+                    // cutting the epic so its stale local copy cannot backdate
+                    // every worker that later inherits this branch.
+                    let resolved = match git_ops.resolve_fresh_base(&trunk) {
+                        Ok(resolved) => resolved,
+                        Err(error) => {
+                            eprintln!(
+                                "Warning: Failed to resolve a fresh epic base '{trunk}': {error}"
+                            );
+                            return Ok(Self::success(format!(
+                                "Created task: {} - {} (P{}){}{}",
+                                id,
+                                task.title,
+                                task.priority.0,
+                                related_context,
+                                no_code_external_ref_guidance(&task),
+                            )));
+                        }
+                    };
                     // cas-a85e (GH #99): trunk stays the default anchor, but a
                     // checkout sitting on the PREVIOUS epic branch must not
                     // silently strand that epic's commits — base from it, or
                     // say plainly what was left out.
-                    let base_choice = git_ops.resolve_epic_base(&trunk);
+                    let base_choice = git_ops.resolve_epic_base(&resolved.branch_ref);
                     let base_ref = base_choice.base_ref.clone();
-                    let base_sha = git_ops.ref_sha(&base_ref).unwrap_or_default();
+                    let base_sha = if base_choice.used_head {
+                        git_ops.ref_sha(&base_ref).unwrap_or_default()
+                    } else {
+                        resolved.sha.clone()
+                    };
                     let sha_preview = &base_sha[..base_sha.len().min(8)];
                     match git_ops.create_branch_from(&branch_name, &base_ref) {
                         Ok(created) => {
@@ -570,8 +594,24 @@ impl CasCore {
                                 .as_deref()
                                 .map(|notice| format!("\n   {notice}"))
                                 .unwrap_or_default();
+                            let freshness = (!base_choice.used_head
+                                && resolved.behind_count > 0)
+                                .then(|| {
+                                    if resolved.used_remote {
+                                        format!(
+                                            "\n   BASE REFRESHED: local '{trunk}' was {} commit(s) behind; used '{}' @ {sha_preview}.",
+                                            resolved.behind_count, resolved.branch_ref
+                                        )
+                                    } else {
+                                        format!(
+                                            "\n   BASE REF DIVERGED: local '{trunk}' has {} local-only and {} remote-only commit(s); used local '{base_ref}' @ {sha_preview}.",
+                                            resolved.ahead_count, resolved.behind_count
+                                        )
+                                    }
+                                })
+                                .unwrap_or_default();
                             Some(format!(
-                                "\n\n🌿 Epic branch created: {branch_name}\n   Base: '{base_ref}' @ {sha_preview}. Workers will branch from this when spawned.{divergence}"
+                                "\n\n🌿 Epic branch created: {branch_name}\n   Base: '{base_ref}' @ {sha_preview}. Workers will branch from this when spawned.{freshness}{divergence}"
                             ))
                         }
                         Err(e) => {

--- a/cas-cli/src/ui/factory/app/init.rs
+++ b/cas-cli/src/ui/factory/app/init.rs
@@ -68,7 +68,8 @@ impl FactoryApp {
         // Detect the configured trunk once — used both for epic branch creation
         // and as the base for worker worktrees when no epic is active.
         let git_ops = GitOperations::new(config.cwd.clone());
-        let trunk = git_ops.detect_default_branch();
+        let trunk = Config::configured_epic_base_branch(&config.cwd)
+            .unwrap_or_else(|| git_ops.detect_default_branch());
 
         let epic_branch = if let EpicState::Active { .. } = &epic_state {
             let branch_name = epic_branch_for_state(&director_data, &epic_state)
@@ -94,8 +95,15 @@ impl FactoryApp {
                     );
                 }
             }
-            if git_ops.create_branch_from(&branch_name, &trunk)? {
-                tracing::info!("Created epic branch {} from trunk '{}'", branch_name, trunk);
+            let resolved = git_ops.resolve_fresh_base(&trunk)?;
+            if git_ops.create_branch_from(&branch_name, &resolved.branch_ref)? {
+                tracing::info!(
+                    "Created epic branch {} from base '{}' (sha={}, behind={})",
+                    branch_name,
+                    resolved.branch_ref,
+                    &resolved.sha[..resolved.sha.len().min(7)],
+                    resolved.behind_count,
+                );
             } else {
                 tracing::info!("Using existing epic branch: {}", branch_name);
             }

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -595,6 +595,10 @@ fn prefer_fresher_base_ref(
     if base.starts_with("origin/") {
         return (None, None);
     }
+    // A remote-tracking ref is only evidence of the last fetch. Refresh it
+    // before comparing so a long-running supervisor does not keep cutting
+    // workers from an origin/main snapshot that is stale too.
+    let _ = crate::worktree::GitOperations::new(repo_root.to_path_buf()).fetch_branch(base);
     let remote = format!("origin/{base}");
     if !ref_exists(repo_root, base) || !ref_exists(repo_root, &remote) {
         return (None, None);
@@ -731,6 +735,9 @@ fn freshest_nondivergent_ref(repo_root: &std::path::Path, branch: &str) -> Resul
         return Ok(branch.to_string());
     }
     let local = branch.strip_prefix("refs/heads/").unwrap_or(branch);
+    // Keep the fast-forward decision authoritative to the remote observed at
+    // this spawn, rather than an origin/<branch> ref fetched hours earlier.
+    let _ = crate::worktree::GitOperations::new(repo_root.to_path_buf()).fetch_branch(local);
     let remote = format!("origin/{local}");
     if !ref_exists(repo_root, &remote) {
         return Ok(branch.to_string());
@@ -1466,6 +1473,11 @@ impl FactoryApp {
                 if let Some(notice) = freshness_notice {
                     notices.push(notice);
                 }
+                // `parent_branch` remains the local merge-back target, but a
+                // refreshed spawn is actually cut from `base_ref`. Warnings
+                // must assess that effective checkout ref or they contradict
+                // the successful origin-based refresh they just announced.
+                let effective_base = base_ref.as_deref().unwrap_or(&parent_branch);
                 let provenance = spawn_base_provenance_notice(
                     &parent_branch,
                     &base_source,
@@ -1487,7 +1499,7 @@ impl FactoryApp {
                     _ => self.epic_branch.clone(),
                 };
                 if let Some(notice) = epic_to_contain.as_deref().and_then(|epic_branch| {
-                    worker_base_mismatch_notice(manager, &parent_branch, epic_branch)
+                    worker_base_mismatch_notice(manager, effective_base, epic_branch)
                 }) {
                     notices.push(notice);
                 }
@@ -1508,7 +1520,7 @@ impl FactoryApp {
                 // spawn time instead of leaving it to whoever happens to read
                 // `behind:` in worker_status.
                 if let Some(notice) =
-                    stale_spawn_base_notice(manager.repo_root(), &parent_branch, &trunk)
+                    stale_spawn_base_notice(manager.repo_root(), effective_base, &trunk)
                 {
                     notices.push(notice);
                 }
@@ -2625,6 +2637,11 @@ mod spawn_base_tests {
         assert!(notice.contains(&local_sha), "{notice}");
         assert!(notice.contains(&remote_sha), "{notice}");
         assert!(notice.contains("origin/main"), "{notice}");
+        assert_eq!(
+            stale_spawn_base_notice(&repo, &base_ref, "main"),
+            None,
+            "the stale-base warning must inspect the effective origin checkout, not the old local parent"
+        );
 
         // End to end: the worker's files come from origin's tip while the
         // recorded parent branch stays the local, mergeable branch name.

--- a/cas-cli/src/ui/factory/daemon/fork_first.rs
+++ b/cas-cli/src/ui/factory/daemon/fork_first.rs
@@ -271,7 +271,8 @@ impl DaemonInitPhase {
         let preferred_epic_focus = preferred_epic_focus_from_session_metadata();
         let epic_state = resolve_epic_state_for_focus(&director_data, &preferred_epic_focus);
         let git_ops = GitOperations::new(self.factory_config.cwd.clone());
-        let trunk = git_ops.detect_default_branch();
+        let trunk = Config::configured_epic_base_branch(&self.factory_config.cwd)
+            .unwrap_or_else(|| git_ops.detect_default_branch());
         let epic_branch = if let EpicState::Active { .. } = &epic_state {
             let branch_name = epic_branch_for_state(&director_data, &epic_state)
                 .expect("active epic state must resolve a branch");
@@ -287,8 +288,15 @@ impl DaemonInitPhase {
                     );
                 }
             }
-            if git_ops.create_branch_from(&branch_name, &trunk)? {
-                tracing::info!("Created epic branch {} from trunk '{}'", branch_name, trunk);
+            let resolved = git_ops.resolve_fresh_base(&trunk)?;
+            if git_ops.create_branch_from(&branch_name, &resolved.branch_ref)? {
+                tracing::info!(
+                    "Created epic branch {} from base '{}' (sha={}, behind={})",
+                    branch_name,
+                    resolved.branch_ref,
+                    &resolved.sha[..resolved.sha.len().min(7)],
+                    resolved.behind_count,
+                );
             } else {
                 tracing::info!("Using existing epic branch: {}", branch_name);
             }

--- a/cas-cli/src/worktree/manager/worker_ops.rs
+++ b/cas-cli/src/worktree/manager/worker_ops.rs
@@ -79,13 +79,17 @@ impl WorktreeManager {
         let worktree_path = self.worktree_path_for_worker(worker_name);
         let branch_name = self.branch_name_for_worker(worker_name);
         let parent_branch = self.git.current_branch()?;
+        let resolved = self
+            .git
+            .resolve_fresh_base(&parent_branch)
+            .map_err(WorktreeError::Git)?;
 
         if let Some(parent) = worktree_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
         self.git
-            .create_worktree(&worktree_path, &branch_name, Some(&parent_branch))?;
+            .create_worktree(&worktree_path, &branch_name, Some(&resolved.branch_ref))?;
 
         let _ = self.git.mark_config_skip_worktree(&worktree_path);
         symlink_project_config(&self.repo_root, &worktree_path);
@@ -115,13 +119,17 @@ impl WorktreeManager {
 
         let worktree_path = self.worktree_path_for_worker(worker_name);
         let branch_name = self.branch_name_for_worker(worker_name);
+        let resolved = self
+            .git
+            .resolve_fresh_base(parent_branch)
+            .map_err(WorktreeError::Git)?;
 
         if let Some(parent) = worktree_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
         self.git
-            .create_worktree(&worktree_path, &branch_name, Some(parent_branch))?;
+            .create_worktree(&worktree_path, &branch_name, Some(&resolved.branch_ref))?;
 
         let _ = self.git.mark_config_skip_worktree(&worktree_path);
         symlink_project_config(&self.repo_root, &worktree_path);

--- a/cas-cli/tests/mcp_tools_test/task_tools/create_and_epic.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/create_and_epic.rs
@@ -306,7 +306,7 @@ async fn test_task_create_surfaces_dependency_write_failure() {
 
     let blocker = service
         .cas_task_create(Parameters(TaskCreateRequest {
-        depth: None,
+            depth: None,
             title: "Blocking task".to_string(),
             description: None,
             priority: 2,
@@ -342,7 +342,7 @@ async fn test_task_create_surfaces_dependency_write_failure() {
 
     let create_result = service
         .cas_task_create(Parameters(TaskCreateRequest {
-        depth: None,
+            depth: None,
             title: "Should fail dependency write".to_string(),
             description: None,
             priority: 2,
@@ -431,7 +431,10 @@ async fn test_task_create_with_light_depth_shows_light() {
             .await
             .expect("show should succeed"),
     );
-    assert!(show.contains("Depth: light"), "expected light depth: {show}");
+    assert!(
+        show.contains("Depth: light"),
+        "expected light depth: {show}"
+    );
 }
 
 #[tokio::test]
@@ -455,7 +458,10 @@ async fn test_task_create_without_depth_defaults_to_deep() {
             .await
             .expect("show should succeed"),
     );
-    assert!(show.contains("Depth: deep"), "expected deep default: {show}");
+    assert!(
+        show.contains("Depth: deep"),
+        "expected deep default: {show}"
+    );
 }
 
 #[tokio::test]
@@ -510,7 +516,10 @@ async fn test_task_update_depth_to_light() {
             .await
             .expect("update should succeed"),
     );
-    assert!(update_text.contains("depth"), "update should report depth change: {update_text}");
+    assert!(
+        update_text.contains("depth"),
+        "update should report depth change: {update_text}"
+    );
 
     let show = extract_text(
         service
@@ -521,7 +530,10 @@ async fn test_task_update_depth_to_light() {
             .await
             .expect("show should succeed"),
     );
-    assert!(show.contains("Depth: light"), "expected light after update: {show}");
+    assert!(
+        show.contains("Depth: light"),
+        "expected light after update: {show}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -551,6 +563,45 @@ fn init_repo_with_commit(repo: &std::path::Path) {
     std::fs::write(repo.join("README.md"), "# Test").unwrap();
     git_in(repo, &["add", "."]);
     git_in(repo, &["commit", "-q", "-m", "Initial commit"]);
+}
+
+/// Give the task-create fixture a real `origin`, then land a commit there
+/// without advancing the supervisor checkout. `cas_task_create` must fetch
+/// before it chooses a base, so this models the normal long-running factory
+/// session where local trunk is stale while origin/trunk moved remotely.
+fn remote_advance_without_local_fetch(repo: &std::path::Path) -> String {
+    let origin = repo.join("origin.git");
+    git_in(
+        repo,
+        &[
+            "clone",
+            "-q",
+            "--bare",
+            repo.to_str().expect("utf-8 repo path"),
+            origin.to_str().expect("utf-8 origin path"),
+        ],
+    );
+    git_in(repo, &["remote", "add", "origin", origin.to_str().unwrap()]);
+    let trunk = git_in(repo, &["branch", "--show-current"]);
+    git_in(repo, &["push", "-q", "-u", "origin", &trunk]);
+
+    let updater = repo.join("updater");
+    git_in(
+        repo,
+        &[
+            "clone",
+            "-q",
+            origin.to_str().expect("utf-8 origin path"),
+            updater.to_str().expect("utf-8 updater path"),
+        ],
+    );
+    git_in(&updater, &["config", "user.email", "updater@test.com"]);
+    git_in(&updater, &["config", "user.name", "Updater"]);
+    std::fs::write(updater.join("remote-only.txt"), "landed remotely").unwrap();
+    git_in(&updater, &["add", "."]);
+    git_in(&updater, &["commit", "-q", "-m", "remote advance"]);
+    git_in(&updater, &["push", "-q", "origin", &trunk]);
+    git_in(&updater, &["rev-parse", "HEAD"])
 }
 
 fn epic_create_request(title: &str) -> TaskCreateRequest {
@@ -686,5 +737,107 @@ async fn test_epic_create_keeps_trunk_and_warns_when_active_epic_has_diverged() 
     assert!(
         text.contains("DIVERGED") && text.contains("epic/first-cas-aaaa"),
         "divergence must be surfaced for the supervisor to resolve: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_epic_create_uses_fetched_origin_tip_when_local_trunk_is_stale_cas_201e() {
+    let (temp, service) = setup_cas();
+    let repo = temp.path();
+    init_repo_with_commit(repo);
+    let remote_tip = remote_advance_without_local_fetch(repo);
+    let trunk = git_in(repo, &["branch", "--show-current"]);
+    let stale_local_tip = git_in(repo, &["rev-parse", &trunk]);
+
+    let created = service
+        .cas_task_create(Parameters(epic_create_request("Fresh Remote Base")))
+        .await
+        .expect("epic create should succeed");
+    let text = extract_text(created);
+    let epic_id = extract_task_id(&text).expect("should have epic ID");
+    let branch = format!("epic/fresh-remote-base-{epic_id}");
+
+    assert_ne!(
+        stale_local_tip, remote_tip,
+        "fixture must leave local trunk stale"
+    );
+    assert_eq!(
+        git_in(repo, &["rev-parse", &branch]),
+        remote_tip,
+        "epic must be cut from the freshly fetched origin tip: {text}"
+    );
+    assert!(
+        git_in(repo, &["ls-tree", "-r", "--name-only", &branch]).contains("remote-only.txt"),
+        "epic must include the commit that existed only on origin: {text}"
+    );
+    assert!(text.contains(&format!("Base: 'origin/{trunk}'")), "{text}");
+    assert!(text.contains("BASE REFRESHED"), "{text}");
+}
+
+#[tokio::test]
+async fn test_epic_create_keeps_equal_local_and_remote_behavior_quiet_cas_201e() {
+    let (temp, service) = setup_cas();
+    let repo = temp.path();
+    init_repo_with_commit(repo);
+    let origin = repo.join("origin.git");
+    git_in(
+        repo,
+        &[
+            "clone",
+            "-q",
+            "--bare",
+            repo.to_str().unwrap(),
+            origin.to_str().unwrap(),
+        ],
+    );
+    git_in(repo, &["remote", "add", "origin", origin.to_str().unwrap()]);
+    let trunk = git_in(repo, &["branch", "--show-current"]);
+    git_in(repo, &["push", "-q", "-u", "origin", &trunk]);
+    let expected_tip = git_in(repo, &["rev-parse", &trunk]);
+
+    let created = service
+        .cas_task_create(Parameters(epic_create_request("Equal Remote Base")))
+        .await
+        .expect("epic create should succeed");
+    let text = extract_text(created);
+    let epic_id = extract_task_id(&text).expect("should have epic ID");
+    let branch = format!("epic/equal-remote-base-{epic_id}");
+
+    assert_eq!(git_in(repo, &["rev-parse", &branch]), expected_tip);
+    assert!(
+        !text.contains("BASE REFRESHED") && !text.contains("BASE REF DIVERGED"),
+        "equal refs must not manufacture a warning: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_epic_create_reports_divergent_local_and_remote_base_cas_201e() {
+    let (temp, service) = setup_cas();
+    let repo = temp.path();
+    init_repo_with_commit(repo);
+    let _remote_tip = remote_advance_without_local_fetch(repo);
+    let trunk = git_in(repo, &["branch", "--show-current"]);
+    std::fs::write(repo.join("local-only.txt"), "keep local work").unwrap();
+    git_in(repo, &["add", "."]);
+    git_in(repo, &["commit", "-q", "-m", "local divergence"]);
+    let local_tip = git_in(repo, &["rev-parse", &trunk]);
+
+    let created = service
+        .cas_task_create(Parameters(epic_create_request("Divergent Remote Base")))
+        .await
+        .expect("epic create should succeed");
+    let text = extract_text(created);
+    let epic_id = extract_task_id(&text).expect("should have epic ID");
+    let branch = format!("epic/divergent-remote-base-{epic_id}");
+
+    assert_eq!(
+        git_in(repo, &["rev-parse", &branch]),
+        local_tip,
+        "a genuinely divergent local branch must not be silently overridden: {text}"
+    );
+    assert!(text.contains("BASE REF DIVERGED"), "{text}");
+    assert!(
+        text.contains("local-only") && text.contains("remote-only"),
+        "{text}"
     );
 }


### PR DESCRIPTION
A supervisor checkout never checks out its delivery branch — every merge lands remotely — so its local `main` goes stale within minutes and stays stale. CAS resolved that local ref in several places where it meant the remote-tracking one.

**Six occurrences in a single session**, each needing the same manual repair:

- **Epic creation** cut a new epic branch at a local ref **53 commits behind** origin. Every worker spawned from it would have started on history predating an entire completed wave.
- **Worker spawn base**, three times — once cutting four workers at once from a base missing a lane merged minutes earlier.
- **Close-time diff stat** attributed every commit merged upstream since the local ref last moved to whichever task closed next: an eleven-file stat for a three-file task.
- A spawn emitted **two contradictory messages about the same operation** — `SPAWN BASE REFRESHED … cut from origin/… (fb69a7db)` immediately followed by `⚠️ STALE WORKER BASE … being cut from 'epic/…' (dc1281c0)`. One path resolved the remote ref correctly and cited its own earlier fix; the warning path reported the stale local one.

## Approach

One `resolve_fresh_base` helper in `worktree/git/branch_ops.rs`, applied at every site — epic creation, worker spawn, fork-first daemon bootstrap, worktree ops, and lifecycle — rather than five independent patches that could drift apart again. The dynamic spawn path now fetches before comparing, and the stale-worker warning evaluates the effective remote checkout instead of contradicting the refresh that just happened.

The model was already in the codebase: the MERGE REQUIRED relay reads both refs, notices they disagree, and states which it used. That behaviour is now the rule rather than the exception.

## Verification

Three regressions on the epic-creation path — the one that failed live today — pinning all three states:

- **stale** local ref → uses the fetched origin tip
- **equal** refs → behaviour unchanged, stays quiet
- **divergent** refs → **reported**, not silently overridden

That last case matters: a genuinely diverged base is a different situation from a lagging one, and silently advancing past it would be a new bug rather than a fix.

Supervisor-run full surfaces: `--test mcp_tools_test` **332 passed**, `resolve_fresh_base` **6 passed**. Branch CI green on 71b5e5d8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
