### PR TITLE
fix(cas-d186): unbreak the cold Linux release build and add a release-host preflight

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,8 +14,7 @@ rustflags = [
     "-C", "link-arg=-fuse-ld=mold",
 ]
 
-[env]
-# Native C/C++ contributors must use the same portable baseline as rustc.
-# Target-qualified variables keep these flags out of macOS and ARM builds.
-CFLAGS_x86_64_unknown_linux_gnu = { value = "-march=x86-64 -mtune=generic", force = true }
-CXXFLAGS_x86_64_unknown_linux_gnu = { value = "-march=x86-64 -mtune=generic", force = true }
+# The Rust target baseline is pinned above. Do not force a CFLAGS -march value
+# here: GCC requires x86-64 while the Zig C compiler used for release builds
+# requires x86_64. The cargo-zigbuild release invocation supplies the latter,
+# and the release script audits the finished artifact's ISA.

--- a/scripts/check-release-host.sh
+++ b/scripts/check-release-host.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Fail early when a local release host cannot build one of its requested targets.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: scripts/check-release-host.sh <host-os> <target> [...]" >&2
+}
+
+if [[ "$#" -lt 2 ]]; then
+    usage
+    exit 2
+fi
+
+host_os="$1"
+shift
+
+for target in "$@"; do
+    case "$target" in
+        x86_64-unknown-linux-gnu)
+            # cargo-zigbuild cross-compiles this target from supported hosts.
+            ;;
+        aarch64-apple-darwin)
+            if [[ "$host_os" != "Darwin" ]]; then
+                echo "error: $target requires a macOS host for the native release build; run the macOS release job or a Mac checkout" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            echo "error: unsupported local release target: $target" >&2
+            exit 2
+            ;;
+    esac
+done
+
+echo "release host preflight passed: host=$host_os targets=$*"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,8 +2,13 @@
 #
 # Local release build script for CAS
 #
-# Builds release binaries for all targets from the local machine,
-# packages them, and optionally creates a GitHub release.
+# Builds release binaries for all targets from the local machine, packages them,
+# and optionally creates a GitHub release. The Darwin artifact uses a native
+# build and therefore requires a macOS host; the early host preflight below
+# reports that requirement before any compiler work begins.
+# Linux release builds deliberately recompile C dependencies from source, so
+# they are slower than an incremental build but reproducibly enforce the
+# portability policy that the post-build audits validate.
 #
 # Prerequisites:
 #   - Rust toolchain (rustup)
@@ -21,6 +26,7 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+HOST_OS="$(uname -s)"
 TARGETS=(
     "aarch64-apple-darwin"
     "x86_64-unknown-linux-gnu"
@@ -47,6 +53,10 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+# Reject unsupported host/target combinations before bootstrapping toolchains
+# or compiling, rather than failing deep in a native compiler invocation.
+./scripts/check-release-host.sh "$HOST_OS" "${TARGETS[@]}"
 
 # ---------------------------------------------------------------------------
 # Load .env if present
@@ -114,7 +124,11 @@ if [ ! -x ".context/zig/zig" ]; then
     ./scripts/bootstrap-zig.sh
 fi
 export ZIG="$REPO_ROOT/.context/zig/zig"
-echo "Zig: $("$ZIG" version)"
+# cargo-zigbuild resolves its Zig executable through PATH rather than $ZIG.
+# Keep $ZIG for build scripts that consume it and expose the same pinned binary
+# through PATH so cargo zigbuild is reproducible when run independently.
+export PATH="$REPO_ROOT/.context/zig:$PATH"
+echo "Zig: $(zig version)"
 
 # A local release must reject lockfile/version/changelog/tag mistakes before
 # starting the expensive artifact builds. Build-only remains a packaging aid,
@@ -151,9 +165,20 @@ for target in "${TARGETS[@]}"; do
     echo "=== Building $target ==="
 
     if [[ "$target" == *"linux"* ]]; then
-        # Cross-compile for Linux using zigbuild
-        cargo clean -p blake3 --release --target "$target"
-        cargo zigbuild -p cas --release --target "$target" --locked
+        # Cross-compile for Linux using zigbuild. Its target wrapper passes
+        # Zig's portable x86_64 CPU baseline to C/C++ contributors; the audits
+        # below remain the authoritative release portability proof.
+        # C build-script output records compiler flags. A release portability
+        # audit is meaningful only when its artifact reflects current source
+        # and compiler policy, not C objects inherited from target/. Clear the
+        # complete target so every C dependency recompiles with this release's
+        # baseline policy (including BLAKE3's no-AVX-512 inputs). This costs an
+        # incremental build, but prevents a cache-masked flag regression from
+        # producing an apparently portable release.
+        cargo clean --release --target "$target"
+        CFLAGS_x86_64_unknown_linux_gnu="-march=x86_64" \
+        CXXFLAGS_x86_64_unknown_linux_gnu="-march=x86_64" \
+            cargo zigbuild -p cas --release --target "$target" --locked
         ghostty_archive="$(find "target/$target/release/build" -path '*/ghostty_vt_sys-*/out/zig-out/lib/libghostty_vt.a' -print -quit)"
         if [[ -z "$ghostty_archive" ]]; then
             echo "error: built Ghostty archive not found for ISA audit" >&2

--- a/scripts/test-check-release-host.sh
+++ b/scripts/test-check-release-host.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check-release-host.sh without building release artifacts.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+guard="$script_dir/check-release-host.sh"
+
+linux_output="$($guard Linux x86_64-unknown-linux-gnu)"
+grep -qF 'host=Linux targets=x86_64-unknown-linux-gnu' <<<"$linux_output"
+echo 'ok   Linux host accepts the Zig-built Linux artifact'
+
+darwin_output="$($guard Darwin aarch64-apple-darwin x86_64-unknown-linux-gnu)"
+grep -qF 'host=Darwin targets=aarch64-apple-darwin x86_64-unknown-linux-gnu' <<<"$darwin_output"
+echo 'ok   macOS host accepts native Darwin plus Zig-built Linux artifacts'
+
+set +e
+wrong_host_output="$($guard Linux aarch64-apple-darwin 2>&1)"
+wrong_host_status=$?
+set -e
+if [[ "$wrong_host_status" -ne 1 ]]; then
+    echo "FAIL non-macOS Darwin target: expected exit 1, got $wrong_host_status" >&2
+    echo "$wrong_host_output" >&2
+    exit 1
+fi
+grep -qF 'requires a macOS host for the native release build' <<<"$wrong_host_output"
+echo 'ok   non-macOS Darwin request fails before build'
+
+echo 'PASS: release host preflight behavior verified.'


### PR DESCRIPTION
`scripts/release.sh --build-only` could not produce the Linux x86_64 artifact from a clean checkout. `.cargo/config.toml` forced `CFLAGS_x86_64_unknown_linux_gnu = "-march=x86-64 -mtune=generic"`, and the Linux release target compiles C through zig's clang, which rejects both spellings GCC accepts:

```
zig cc -march=x86-64 -mtune=generic   →  error: unknown target CPU 'generic'
zig cc -march=x86-64                  →  error: unknown CPU: 'x86'
```

GCC requires `x86-64`; zig requires `x86_64`. **A single forced CFLAGS value cannot express a compiler-neutral baseline**, so removing `-mtune=generic` alone was never sufficient. `force = true` meant it could not be overridden per-invocation either. Every C dependency failed identically — observed on `zstd-sys` and `ring`.

## Why this never showed up

Those flags landed 2026-08-09 04:00. The cached C objects in the main checkout are timestamped 2026-08-08 22:35 — **five and a half hours earlier**. v2.65.0, v2.66.0 and v2.67.0 all reused objects compiled before the incompatible flags existed and never recompiled a single C file. Cutting releases genuinely never failed; the break only surfaces from a cold checkout, which is what a new machine, CI, or a fresh worktree gets.

That masking is itself the argument for the second change here: **the Linux release target is now cleaned before the zigbuild.** This repo ships a portability guarantee enforced by `check-portable-x86_64-isa.sh` and `check-blake3-no-avx512-build.sh`, and those audits inspect the produced artifact. If C objects are reused from a build made under different flags, the artifact can pass the audit while not reflecting the current configuration — and a genuine flag regression stays invisible for months, which is exactly what happened. Release builds get slower because C dependencies recompile every time; that is the correct trade for a release path and is stated in the script so nobody optimises it away without understanding what it buys.

The ISA baseline is preserved where it is actually enforceable: the Rust target-cpu pin, zig's accepted `-march=x86_64` supplied at the release invocation, and the audits on the finished binary.

## Release host preflight

`scripts/release.sh` builds the darwin target with a native `cargo build --target aarch64-apple-darwin`, so on a Linux host it reached for the host `cc` and died ~90 seconds in with an unrecognised `-arch` flag. New `scripts/check-release-host.sh` asserts the host can produce each declared target and fails in seconds with a clear message instead. Also fixes zig discovery: `cargo-zigbuild` resolves zig via PATH while the script only exported `ZIG`, which made the Linux steps non-reproducible piecewise.

## Verification

- **Cold isolated Linux zig build passed (10m01s)** from a clean target — the case that was previously broken — followed by both ISA and BLAKE3 audits, each exit 0.
- `scripts/test-check-release-host.sh`: 3/3 — Linux host accepts the zig-built Linux artifact; macOS accepts native darwin plus zig Linux; a darwin request on a non-macOS host fails before the build.
- Branch CI green on 61ca224b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
