### PR TITLE
fix(cas-3407): stop verify_death's zombie assertion racing its own child under load

### DIFF
--- a/cas-cli/src/cli/factory/wedged.rs
+++ b/cas-cli/src/cli/factory/wedged.rs
@@ -3208,18 +3208,29 @@ mod tests {
             .spawn()
             .expect("spawn short-lived child");
         let pid = child.id();
-        // Give it a moment to exit — a zombie exists once the process exits
-        // but before THIS process (its parent) reaps it via wait().
-        std::thread::sleep(Duration::from_millis(100));
+        // A zombie exists once the child exits but before THIS process (its
+        // parent) reaps it via wait(). Do not assume a fixed delay is enough:
+        // factory churn can defer scheduling this short-lived child beyond an
+        // arbitrary 100ms sleep. Poll only this test-owned PID for a bounded
+        // interval, so unrelated host zombies cannot affect the assertion.
+        let mut became_zombie = false;
+        for _ in 0..100 {
+            if pid_is_zombie(pid) {
+                became_zombie = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let confirmed_dead = became_zombie && verify_death(pid);
+        let _ = child.wait(); // reap even when an assertion below fails
         assert!(
-            pid_is_zombie(pid),
-            "child should be a zombie by now (exited, not yet reaped)"
+            became_zombie,
+            "owned child should become a zombie within one second (exited, not yet reaped)"
         );
         assert!(
-            verify_death(pid),
+            confirmed_dead,
             "a zombie must be treated as confirmed-dead, not timed-out-alive"
         );
-        let _ = child.wait(); // reap so no zombie leaks past the test
     }
 
     #[test]


### PR DESCRIPTION
`cli::factory::wedged::tests::verify_death_treats_zombie_as_confirmed_dead` failed CI on a lane that changed only `ambient_recall.rs` and one hooks test — it never touched `wedged.rs`.

Isolated before filing: PASSED on origin/main, FAILED on the lane branch, branch confirmed to contain the recent `wedged.rs` commits and only 9 behind main, then **PASSED again on the same branch commit** minutes later with no changes.

## Cause — not ambient zombies

The reported suspicion (including mine) was that unrelated host zombies were confusing the probe. That was wrong: `pid_is_zombie` only ever inspects the test's own direct child.

The real defect is a **fixed 100ms sleep** assuming the child would have exited and become a zombie by then. Under factory churn — this host had spawned and retired 19 workers — scheduling that short-lived child can be deferred past an arbitrary deadline, so the assertion fired before the zombie existed.

The fix polls **only the test-owned PID** for a bounded interval instead of assuming a delay, and reaps on every path via `let _ = child.wait()` — including when an assertion fails, so the test can no longer leak zombies into the very population that destabilises other tests.

## Verification

- Full `--proof -p cas --lib`: **4580 passed, 6 skipped**.
- The exact test **500/500 under deliberate concurrent spawn / SIGTERM / reap churn**, reproducing the provoking condition rather than a quiet machine. Artifact: `~/.cas/artifacts/cas-3407/churn-500.log`.
- Branch CI green on bc37b410.

Third flake root-caused today, and the only self-inflicted one: the factory's own process churn was destabilising a test that could itself leak zombies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)