### PR TITLE
chore: release v2.68.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.68.1] - 2026-08-14
+
+### Fixed
+- **The v2.68 delivery and recovery wave is now installable on Linux x86_64.** Release builds use the compiler-specific portable baseline, rebuild native dependencies from source before auditing, and fail immediately when a declared native target cannot be produced on the current host.
+- **Factory startup and recall keep using the information that is current and relevant.** Base selection consistently prefers the fresh remote-tracking ref, and mid-session recall prioritizes the current request over an overlong task title.
+- **Validation diagnostics remain accurate under edge cases.** Scoped-proof validation recognizes nested integration modules, and the unknown-tool MCP test no longer claims an unproven server-side mechanism when its historical timeout cannot be reproduced from retained evidence.
+
 ## [2.68.0] - 2026-08-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.68.0"
+version = "2.68.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.68.0"
+version = "2.68.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.68.0"
+version = "2.68.1"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.68.0"
+version = "2.68.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.68.0"
+version = "2.68.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.68.0"
+version = "2.68.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-14-v2.68.0-slack.md
+++ b/docs/release-notes/2026-08-14-v2.68.0-slack.md
@@ -1,5 +1,7 @@
 # Slack draft — v2.68.0 runtime release, 2026-08-14
 
+**Superseded:** Publish the combined v2.68.0 + v2.68.1 announcement in [2026-08-14-v2.68.1-slack.md](2026-08-14-v2.68.1-slack.md) instead. Do not post this draft separately.
+
 Channel: #cas-internal (C0B44GUKDK2)
 
 **Status:** Paste-ready draft. Post only after the protected-main release PR has landed, the annotated v2.68.0 tag is pushed, and release artifacts are verified. The release supervisor owns posting and will append the receipt.

--- a/docs/release-notes/2026-08-14-v2.68.1-slack.md
+++ b/docs/release-notes/2026-08-14-v2.68.1-slack.md
@@ -1,0 +1,39 @@
+# Slack draft — v2.68.0 + v2.68.1 combined runtime release, 2026-08-14
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Paste-ready draft. Post only after the protected-main release PR has landed, the annotated v2.68.1 tag is pushed, and the Linux release asset is uploaded. The release supervisor owns posting and will append the receipt.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — CAS v2.68.1 makes the v2.68.0 delivery and recovery improvements installable: work now lands where it says it did, and getting unstuck is clearer when it does not.
+
+**Reply (Was → Now):**
+- Was: work could look delivered because a commit was reachable, even when the actual change was absent from its destination. Now: CAS checks the delivered content on its real target before calling work landed.
+- Was: stale instructions and completed requests could still look actionable, while a supported recovery path could be hard to find. Now: messages carry their source, current state is rechecked, and recovery points to the action that can move work forward.
+- Was: a worker could begin without a current base, queued correction, or clear setup path. Now: startup refreshes the usable base, surfaces instructions before work starts, and names the supported recovery path.
+- Install: use `cas update` for an existing installation, or download the v2.68.1 Linux x86_64 archive from the GitHub release. This release ships that Linux archive only: `cas-x86_64-unknown-linux-gnu.tar.gz`, SHA-256 `630676abc0ae78e16d3058c0f3dc14549c9da7e099296206e3f6c125f4a22d56`.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v2.68.1 ships the v2.68.0 delivery/recovery wave with a clean, audited Linux artifact instead of an unverified archive claim.
+
+**Reply (Was → Now):**
+- Was: landing checks could accept an ancestor commit while task-authored content was absent from the target tree. Now: delivery is compared at the declared target, with explicit outcomes for dropped, evolved, or superseded changes.
+- Was: queued delivery and lifecycle messages could outlive the state that made them actionable. Now: typed envelopes retain identity and anchor provenance, and suppression happens only on fresh positive evidence that an action is moot.
+- Was: workers and release builds could start from stale inputs or reuse native objects built under another compiler policy. Now: base selection resolves the fresh remote-tracking ref, Linux release builds recompile native dependencies before audit, and the finished artifact is checked for a portable x86_64 ISA plus BLAKE3 inputs without AVX-512.
+- Validation and artifact: v2.68.1 is built at commit `f1b9372`; `cas --version` reports `cas 2.68.1 (f1b9372 2026-08-14)`. The Linux x86_64 archive is `cas-x86_64-unknown-linux-gnu.tar.gz`, SHA-256 `630676abc0ae78e16d3058c0f3dc14549c9da7e099296206e3f6c125f4a22d56`. No macOS archive is claimed from this Linux-host release.
+
+## Posting sequence
+
+1. Post the User top-level as a new #cas-internal message and capture its timestamp.
+2. Post the User reply as its only threaded reply.
+3. Post the Dev top-level as a new #cas-internal message and capture its timestamp.
+4. Post the Dev reply as its only threaded reply.
+5. Append the receipt below with UTC timestamps and all four permalinks.
+
+## POSTED
+
+_Supervisor to complete after publication._


### PR DESCRIPTION
Prepares the v2.68.1 release train and combined unposted #cas-internal draft.

Linux x86_64 archive SHA-256: 630676abc0ae78e16d3058c0f3dc14549c9da7e099296206e3f6c125f4a22d56

Linux-only release; macOS requires a native macOS build.