### PR TITLE
docs: record v2.68.1 tagged archive digest

### DIFF
--- a/docs/release-notes/2026-08-14-v2.68.1-slack.md
+++ b/docs/release-notes/2026-08-14-v2.68.1-slack.md
@@ -13,7 +13,7 @@ Live on production — **User** — CAS v2.68.1 makes the v2.68.0 delivery and r
 - Was: work could look delivered because a commit was reachable, even when the actual change was absent from its destination. Now: CAS checks the delivered content on its real target before calling work landed.
 - Was: stale instructions and completed requests could still look actionable, while a supported recovery path could be hard to find. Now: messages carry their source, current state is rechecked, and recovery points to the action that can move work forward.
 - Was: a worker could begin without a current base, queued correction, or clear setup path. Now: startup refreshes the usable base, surfaces instructions before work starts, and names the supported recovery path.
-- Install: use `cas update` for an existing installation, or download the v2.68.1 Linux x86_64 archive from the GitHub release. This release ships that Linux archive only: `cas-x86_64-unknown-linux-gnu.tar.gz`, SHA-256 `630676abc0ae78e16d3058c0f3dc14549c9da7e099296206e3f6c125f4a22d56`.
+- Install: use `cas update` for an existing installation, or download the v2.68.1 Linux x86_64 archive from the GitHub release. This release ships that Linux archive only: `cas-x86_64-unknown-linux-gnu.tar.gz`, SHA-256 `9b51150b29f251d0b9910bf87685e1bb5e91a87739edfbfff90e03c70ee10e37`.
 
 ## Dev thread
 
@@ -24,7 +24,7 @@ Live on production — **Dev** — v2.68.1 ships the v2.68.0 delivery/recovery w
 - Was: landing checks could accept an ancestor commit while task-authored content was absent from the target tree. Now: delivery is compared at the declared target, with explicit outcomes for dropped, evolved, or superseded changes.
 - Was: queued delivery and lifecycle messages could outlive the state that made them actionable. Now: typed envelopes retain identity and anchor provenance, and suppression happens only on fresh positive evidence that an action is moot.
 - Was: workers and release builds could start from stale inputs or reuse native objects built under another compiler policy. Now: base selection resolves the fresh remote-tracking ref, Linux release builds recompile native dependencies before audit, and the finished artifact is checked for a portable x86_64 ISA plus BLAKE3 inputs without AVX-512.
-- Validation and artifact: v2.68.1 is built at commit `f1b9372`; `cas --version` reports `cas 2.68.1 (f1b9372 2026-08-14)`. The Linux x86_64 archive is `cas-x86_64-unknown-linux-gnu.tar.gz`, SHA-256 `630676abc0ae78e16d3058c0f3dc14549c9da7e099296206e3f6c125f4a22d56`. No macOS archive is claimed from this Linux-host release.
+- Validation and artifact: v2.68.1 is built at tagged commit `995ed58`; `cas --version` reports `cas 2.68.1 (995ed58 2026-08-14)`. The Linux x86_64 archive is `cas-x86_64-unknown-linux-gnu.tar.gz`, SHA-256 `9b51150b29f251d0b9910bf87685e1bb5e91a87739edfbfff90e03c70ee10e37`. No macOS archive is claimed from this Linux-host release.
 
 ## Posting sequence
 


### PR DESCRIPTION
Updates the unposted release draft to the tag-matching Linux archive.\n\nArchive SHA-256: 9b51150b29f251d0b9910bf87685e1bb5e91a87739edfbfff90e03c70ee10e37\nBinary: cas 2.68.1 (995ed58)