### PR TITLE
docs: record v2.68.1 publication receipt

### DIFF
--- a/docs/release-notes/2026-08-14-v2.68.0-slack.md
+++ b/docs/release-notes/2026-08-14-v2.68.0-slack.md
@@ -1,6 +1,6 @@
 # Slack draft — v2.68.0 runtime release, 2026-08-14
 
-**Superseded:** Publish the combined v2.68.0 + v2.68.1 announcement in [2026-08-14-v2.68.1-slack.md](2026-08-14-v2.68.1-slack.md) instead. Do not post this draft separately.
+**Superseded and posted:** The combined v2.68.0 + v2.68.1 announcement was published in [2026-08-14-v2.68.1-slack.md](2026-08-14-v2.68.1-slack.md). Do not post this draft separately.
 
 Channel: #cas-internal (C0B44GUKDK2)
 

--- a/docs/release-notes/2026-08-14-v2.68.1-slack.md
+++ b/docs/release-notes/2026-08-14-v2.68.1-slack.md
@@ -36,4 +36,11 @@ Live on production — **Dev** — v2.68.1 ships the v2.68.0 delivery/recovery w
 
 ## POSTED
 
-_Supervisor to complete after publication._
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-14T20:31:03.895319000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786739463895319 |
+| User reply (Was → Now) | 2026-08-14T20:31:11.815619000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786739471815619?thread_ts=1786739463.895319&cid=C0B44GUKDK2 |
+| Dev top-level | 2026-08-14T20:31:15.467239000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786739475467239 |
+| Dev reply (Was → Now) | 2026-08-14T20:31:22.908019000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786739482908019?thread_ts=1786739475.467239&cid=C0B44GUKDK2 |


### PR DESCRIPTION
Records the published User and Dev thread permalinks in the combined v2.68.1 draft and marks the obsolete v2.68.0 draft as superseded and posted.