### PR TITLE
fix(cas-ffc2): canonicalize hub origin so page-initiated pairing completes (GH #226)

### DIFF
--- a/cas-cli/src/cli/hub_reverse_pairing.rs
+++ b/cas-cli/src/cli/hub_reverse_pairing.rs
@@ -106,11 +106,15 @@ impl RelayClient {
         body: &B,
     ) -> Result<T> {
         let url = format!("{}{}{}", self.endpoint, RELAY_PREFIX, suffix);
+        let diagnostic_body = relay_request_diagnostic(body);
         let response = ureq::post(&url)
             .set("Authorization", &format!("Bearer {}", self.token))
             .set("Content-Type", "application/json")
             .send_json(body)
-            .map_err(relay_error)?;
+            .map_err(relay_error)
+            .with_context(|| {
+                format!("relay POST {suffix} failed; request body: {diagnostic_body}")
+            })?;
         let response: T = response.into_json().context("invalid relay response")?;
         Ok(response)
     }
@@ -390,11 +394,11 @@ fn resolve_hub_url(paths: &HubRuntimePaths, explicit: Option<&str>) -> Result<St
     let url = explicit.or(record.public_url.as_deref()).context(
         "Hub has no public URL. Start it with `cas hub --tailscale-serve start` or pass --hub-url.",
     )?;
-    validate_hub_url(url)?;
-    Ok(url.to_owned())
+    let parsed = validate_hub_url(url)?;
+    Ok(parsed.origin().ascii_serialization())
 }
 
-fn validate_hub_url(url: &str) -> Result<()> {
+fn validate_hub_url(url: &str) -> Result<Url> {
     let parsed = Url::parse(url).context("invalid hub URL")?;
     anyhow::ensure!(
         parsed.username().is_empty()
@@ -409,7 +413,7 @@ fn validate_hub_url(url: &str) -> Result<()> {
         parsed.scheme() == "https" || is_loopback_origin(url),
         "hub URL must be an HTTPS origin or an HTTP IP-loopback origin"
     );
-    Ok(())
+    Ok(parsed)
 }
 
 fn is_loopback_origin(origin: &str) -> bool {
@@ -490,6 +494,39 @@ fn relay_error(error: ureq::Error) -> anyhow::Error {
     relay_error_from_parts(status, code, description)
 }
 
+fn relay_request_diagnostic(body: &impl Serialize) -> String {
+    let mut value = match serde_json::to_value(body) {
+        Ok(value) => value,
+        Err(error) => return format!("<could not serialize request: {error}>"),
+    };
+    redact_relay_secrets(&mut value);
+    serde_json::to_string(&value)
+        .unwrap_or_else(|error| format!("<could not format request: {error}>"))
+}
+
+fn redact_relay_secrets(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(fields) => {
+            for (name, value) in fields {
+                if matches!(
+                    name.as_str(),
+                    "authorize_nonce" | "invitation_url" | "user_code"
+                ) {
+                    *value = serde_json::Value::String("<redacted>".to_owned());
+                } else {
+                    redact_relay_secrets(value);
+                }
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                redact_relay_secrets(value);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn relay_error_from_parts(status: Option<u16>, code: &str, description: &str) -> anyhow::Error {
     match (status, code) {
         (Some(404), "invalid_code") => {
@@ -533,7 +570,7 @@ mod tests {
     }
 
     #[test]
-    fn section_four_completion_fixture_uses_kebab_case_scopes() {
+    fn section_four_completion_fixture_pins_relay_accepted_canonical_origin() {
         let expected: serde_json::Value = serde_json::from_str(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../hub-web/src/fixtures/hub-reverse-pairing/complete-request.json"
@@ -543,7 +580,7 @@ mod tests {
         let request = serde_json::to_value(CompleteRequest {
             wire_version: 1,
             authorize_nonce: "base64url-32-random-bytes",
-            hub_url: "https://workstation.tail.example:443/",
+            hub_url: "https://workstation.tail.example",
             machine_label: "Studio workstation",
             invitation_url: "https://commander.example/#pair=base64url-32-random-bytes&hub=machine-uuid",
             invitation_expires_at: "2026-08-11T20:11:30Z".parse().unwrap(),
@@ -555,6 +592,29 @@ mod tests {
             format!("{RELAY_PREFIX}/authorizations/id/complete"),
             "/api/hub/pairing/authorizations/id/complete"
         );
+    }
+
+    #[test]
+    fn completion_failure_diagnostic_shows_canonical_origin_without_secrets() {
+        let scopes = Scope::default_read_only();
+        let diagnostic = relay_request_diagnostic(&CompleteRequest {
+            wire_version: 1,
+            authorize_nonce: "secret-authorize-nonce",
+            hub_url: "https://workstation.tail.example",
+            machine_label: "Studio workstation",
+            invitation_url: "https://commander.example/#pair=secret-invitation-token",
+            invitation_expires_at: "2026-08-11T20:11:30Z".parse().unwrap(),
+            granted_scopes: &scopes,
+        });
+
+        assert!(
+            diagnostic.contains(r#""hub_url":"https://workstation.tail.example""#),
+            "{diagnostic}"
+        );
+        assert!(diagnostic.contains(r#""authorize_nonce":"<redacted>""#));
+        assert!(diagnostic.contains(r#""invitation_url":"<redacted>""#));
+        assert!(!diagnostic.contains("secret-authorize-nonce"));
+        assert!(!diagnostic.contains("secret-invitation-token"));
     }
 
     #[test]
@@ -606,17 +666,18 @@ mod tests {
     #[derive(Default)]
     struct RecordingRelay {
         claims: std::sync::Mutex<Vec<(String, String)>>,
+        completed_hub_urls: std::sync::Mutex<Vec<String>>,
         active_claim: std::sync::Mutex<Option<(String, String)>>,
         fail_first_completion: std::sync::atomic::AtomicBool,
     }
 
     impl RecordingRelay {
         fn failing_first_completion() -> Self {
-            Self {
-                claims: std::sync::Mutex::new(Vec::new()),
-                active_claim: std::sync::Mutex::new(None),
-                fail_first_completion: std::sync::atomic::AtomicBool::new(true),
-            }
+            let relay = Self::default();
+            relay
+                .fail_first_completion
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            relay
         }
     }
 
@@ -647,12 +708,16 @@ mod tests {
             &self,
             _authorization_id: &str,
             _nonce: &str,
-            _hub_url: &str,
+            hub_url: &str,
             _machine_label: &str,
             _invitation_url: &str,
             _invitation_expires_at: DateTime<Utc>,
             _granted_scopes: &BTreeSet<Scope>,
         ) -> Result<CompleteResponse> {
+            self.completed_hub_urls
+                .lock()
+                .unwrap()
+                .push(hub_url.to_owned());
             if self
                 .fail_first_completion
                 .swap(false, std::sync::atomic::Ordering::SeqCst)
@@ -755,6 +820,10 @@ mod tests {
         let claims = relay.claims.lock().unwrap();
         assert_eq!(claims.len(), 1);
         assert_eq!(claims[0].0, "K7MW-4H2Q");
+        assert_eq!(
+            *relay.completed_hub_urls.lock().unwrap(),
+            ["https://workstation.tail.example"]
+        );
     }
 
     #[test]
@@ -775,6 +844,13 @@ mod tests {
         assert_eq!(claims.len(), 2);
         assert_eq!(claims[0].1, claims[1].1);
         assert_eq!(URL_SAFE_NO_PAD.decode(&claims[0].1).unwrap().len(), 32);
+        assert_eq!(
+            *relay.completed_hub_urls.lock().unwrap(),
+            [
+                "https://workstation.tail.example",
+                "https://workstation.tail.example"
+            ]
+        );
     }
 
     #[test]

--- a/hub-web/src/fixtures/hub-reverse-pairing/complete-request.json
+++ b/hub-web/src/fixtures/hub-reverse-pairing/complete-request.json
@@ -1,7 +1,7 @@
 {
   "wire_version": 1,
   "authorize_nonce": "base64url-32-random-bytes",
-  "hub_url": "https://workstation.tail.example:443/",
+  "hub_url": "https://workstation.tail.example",
   "machine_label": "Studio workstation",
   "invitation_url": "https://commander.example/#pair=base64url-32-random-bytes&hub=machine-uuid",
   "invitation_expires_at": "2026-08-11T20:11:30Z",


### PR DESCRIPTION
Page-initiated Commander pairing now completes. This was the last broken step in GH #226 — the loop reached invitation delivery and stopped there with `invalid_invitation` on every attempt against production.

## The cause, established from the wire rather than guessed

CAS sent `hub_url` as `https://soundwave-linux.tailf5a734.ts.net/` — **with a trailing slash**. PSC's `canonicalOrigin` returns `url.origin`, which has none, and `machineOrigin` accepts a value only when `canonicalOrigin(value) === value`. The slash therefore nulled `hubUrl` and landed deterministically in the `invalid_invitation` branch.

That was found by capturing the exact 420-byte `CompleteRequest` against a registered local relay stub and diffing every field against wire-v1 §4.3 **and the live PSC validator source**. `wire_version`, `authorize_nonce`, `machine_label`, `invitation_url`, `invitation_expires_at` and `granted_scopes` were all confirmed conforming; `hub_url` was the sole nonconformance. CAS was out of contract, not the relay, so the fix lands here and nothing goes to the Richards-LLC board.

**A plausible theory was disproven rather than left open.** The supervisor proposed that nanosecond-precision RFC3339 expiry (`…848506907Z`) was the culprit, since it matches the error text. PSC uses `new Date(value)`; Node accepts the nine-digit form and normalizes it to `.096Z`, so `Number.isFinite` is true. Recorded so nobody re-derives it.

## The fixture was asserting the bug

`resolve_hub_url` now returns `Url::origin().ascii_serialization()`.

The more important half: the exact-serialization fixture pinned `"https://workstation.tail.example:443/"` — the broken shape, with both the trailing slash and an explicit default port. **The test asserted the defect as correct**, which is precisely why the suite stayed green while every production attempt failed. Both the Rust assertion and the shared `hub-web/src/fixtures/hub-reverse-pairing/complete-request.json` now pin the relay-accepted canonical origin, and `section_four_completion_fixture_pins_relay_accepted_canonical_origin` keeps it there.

A test pinning the wrong contract is worse than no test — it converts an open question into false confidence.

## Failed relay POSTs are now diagnosable

The original failure produced a terminal error with nothing in `hub.log` or `audit.jsonl`, so an operator could not see what was rejected. Failures now carry a redacted request-body diagnostic showing `hub_url`, expiry, scopes and label while withholding code, nonce and invitation token.

## Verified live against production, not only in tests

Given that passing tests are what let this reach production, the acceptance was a real run:

- Code `JRWW-ZKJJ` created through PSC → task build authorized it
- Relay poll returned `authorized` with canonical `hub_url=https://soundwave-linux.tailf5a734.ts.net`, expected label and scopes
- `/v1/auth/pairing/exchange` → **200**, device and credential created with the three requested scopes
- Relay acknowledge → **204**; local device count 5 → 6

The ephemeral-key proof device was then explicitly revoked, so no orphaned unusable credential remains.

Incidentally confirming the companion fix from cas-43d6: a first exchange attempt that omitted the browser `Origin` header failed **locally without consuming its invitation**.

Fresh `scripts/run-scoped-tests.sh -p cas --lib --proof`: **4586 passed, 6 skipped**, surface covering the committed diff from `4a64ec15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
