### PR TITLE
docs: correct v2.69.0 release asset receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.69.0] - 2026-08-14
+
+### Added
+- **Every CAS harness now receives the MCP integration runbook.** `cas update --sync` distributes the same installation and diagnosis guidance to Claude, Codex, and Grok.
+
+### Fixed
+- **Commander page-initiated machine pairing now completes.** The pairing handoff sends the hub's canonical origin, so the relay accepts the invitation instead of rejecting it at delivery.
+- **A local pairing precondition failure no longer consumes the one-time code.** CAS checks the local hub before claiming and retains the same-machine nonce for a safe retry.
+
 ## [2.68.1] - 2026-08-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.68.1"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.68.1"
+version = "2.69.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.68.1"
+version = "2.69.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.68.1"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.68.1"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.68.1"
+version = "2.69.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.68.1"
+version = "2.69.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.68.1"
+version = "2.69.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.68.1"
+version = "2.69.0"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.68.1"
+version = "2.69.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.68.1"
+version = "2.69.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.68.1"
+version = "2.69.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-14-v2.69.0-slack.md
+++ b/docs/release-notes/2026-08-14-v2.69.0-slack.md
@@ -1,0 +1,38 @@
+# Slack draft — v2.69.0 runtime release, 2026-08-14
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Unposted release draft. Post only after the release tag is pushed and the Linux x86_64 archive is uploaded. The release supervisor owns posting and will append the receipt.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — CAS v2.69.0 makes pairing a machine from the Commander page work from start to finish.
+
+**Reply (Was → Now):**
+- Was: the Commander page could create a pairing code and the target machine could accept it, but pairing stopped before the machine was delivered. Now: the same page-initiated flow completes and the machine is ready to use.
+- Was: a local setup problem could consume a one-time pairing code. Now: CAS checks the local hub first and lets the same machine resume its pairing attempt once it is ready.
+- Was: MCP setup guidance could differ by harness. Now: `cas update --sync` installs the same MCP integration and diagnosis guide for Claude, Codex, and Grok.
+- Install: use `cas update` for an existing installation, or download the v2.69.0 Linux x86_64 archive from the GitHub release. This release ships Linux only; no macOS archive is claimed from this Linux-host release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v2.69.0 restores the complete Commander reverse-pairing contract and ships the MCP integration builtin across all harness catalogs.
+
+**Reply (Was → Now):**
+- Was: the completion request serialized a trailing-slash hub URL, which failed the relay's exact origin comparison and ended in `invalid_invitation`. Now: CAS serializes the bare URL origin, and the relay accepts delivery.
+- Was: `cas hub authorize` claimed remotely before validating local readiness, and a fresh retry nonce could not resume that claim. Now: local preconditions run before claim and a persisted nonce makes same-machine retries idempotent.
+- Was: the MCP integration skill was not a distributed builtin. Now: Claude, Codex, and Grok catalogs each ship byte-identical skill and diagnosis-reference files through `cas update --sync`.
+- Validation and artifact: v2.69.0 is built from its annotated release tag and the shipped Linux x86_64 archive is independently SHA-256 verified and audited for no EVEX/AVX-512 ISA or BLAKE3 AVX-512 inputs. No macOS archive is claimed from this Linux-host release.
+
+## Posting sequence
+
+1. Post the User top-level as a new #cas-internal message and capture its timestamp.
+2. Post the User reply as its only threaded reply.
+3. Post the Dev top-level as a new #cas-internal message and capture its timestamp.
+4. Post the Dev reply as its only threaded reply.
+5. Append the receipt below with UTC timestamps and all four permalinks.
+
+## POSTED
+

--- a/docs/release-notes/2026-08-14-v2.69.0-slack.md
+++ b/docs/release-notes/2026-08-14-v2.69.0-slack.md
@@ -2,7 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** Unposted release draft. Post only after the release tag is pushed and the Linux x86_64 archive is uploaded. The release supervisor owns posting and will append the receipt.
+**Status:** Unposted announcement draft. Release workflow assets are published; post to Slack only after the held CI rerun clears. The release supervisor owns posting and will append the receipt.
 
 ## User thread
 
@@ -13,7 +13,7 @@ Live on production — **User** — CAS v2.69.0 makes pairing a machine from the
 - Was: the Commander page could create a pairing code and the target machine could accept it, but pairing stopped before the machine was delivered. Now: the same page-initiated flow completes and the machine is ready to use.
 - Was: a local setup problem could consume a one-time pairing code. Now: CAS checks the local hub first and lets the same machine resume its pairing attempt once it is ready.
 - Was: MCP setup guidance could differ by harness. Now: `cas update --sync` installs the same MCP integration and diagnosis guide for Claude, Codex, and Grok.
-- Install: use `cas update` for an existing installation, or download the v2.69.0 Linux x86_64 archive from the GitHub release. This release ships Linux only; no macOS archive is claimed from this Linux-host release.
+- Install: use `cas update` for an existing installation, or download the v2.69.0 archive for Linux x86_64 (SHA-256 `f7970e5f66325d54962e726b8f11ecd214a1775da910f89e0b693241808da3ad`) or macOS ARM64 (SHA-256 `e0ac76b950119ec243f4c8c66a439dafdc10f6e5995a0566dad0fdd72a0cd861`) from the GitHub release.
 
 ## Dev thread
 
@@ -24,7 +24,7 @@ Live on production — **Dev** — v2.69.0 restores the complete Commander rever
 - Was: the completion request serialized a trailing-slash hub URL, which failed the relay's exact origin comparison and ended in `invalid_invitation`. Now: CAS serializes the bare URL origin, and the relay accepts delivery.
 - Was: `cas hub authorize` claimed remotely before validating local readiness, and a fresh retry nonce could not resume that claim. Now: local preconditions run before claim and a persisted nonce makes same-machine retries idempotent.
 - Was: the MCP integration skill was not a distributed builtin. Now: Claude, Codex, and Grok catalogs each ship byte-identical skill and diagnosis-reference files through `cas update --sync`.
-- Validation and artifact: v2.69.0 is built from its annotated release tag and the shipped Linux x86_64 archive is independently SHA-256 verified and audited for no EVEX/AVX-512 ISA or BLAKE3 AVX-512 inputs. No macOS archive is claimed from this Linux-host release.
+- Validation and artifact: v2.69.0 is built from annotated tag `v2.69.0` at `3ef18c4a`; `cas --version` reports `cas 2.69.0 (3ef18c4 2026-08-14)`. The published archives are `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `f7970e5f66325d54962e726b8f11ecd214a1775da910f89e0b693241808da3ad`) and `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `e0ac76b950119ec243f4c8c66a439dafdc10f6e5995a0566dad0fdd72a0cd861`); Linux and macOS are both available.
 
 ## Posting sequence
 
@@ -35,4 +35,3 @@ Live on production — **Dev** — v2.69.0 restores the complete Commander rever
 5. Append the receipt below with UTC timestamps and all four permalinks.
 
 ## POSTED
-


### PR DESCRIPTION
Correct the saved v2.69.0 announcement draft to describe the workflow-published Linux and macOS assets with their published SHA-256 digests. Slack posting remains held pending the CI rerun.