### PR TITLE
docs: correct v2.69.0 release asset receipt

### DIFF
--- a/docs/release-notes/2026-08-14-v2.69.0-slack.md
+++ b/docs/release-notes/2026-08-14-v2.69.0-slack.md
@@ -2,7 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** Unposted release draft. Post only after the release tag is pushed and the Linux x86_64 archive is uploaded. The release supervisor owns posting and will append the receipt.
+**Status:** Unposted announcement draft. Release workflow assets are published; post to Slack only after the held CI rerun clears. The release supervisor owns posting and will append the receipt.
 
 ## User thread
 
@@ -13,7 +13,7 @@ Live on production — **User** — CAS v2.69.0 makes pairing a machine from the
 - Was: the Commander page could create a pairing code and the target machine could accept it, but pairing stopped before the machine was delivered. Now: the same page-initiated flow completes and the machine is ready to use.
 - Was: a local setup problem could consume a one-time pairing code. Now: CAS checks the local hub first and lets the same machine resume its pairing attempt once it is ready.
 - Was: MCP setup guidance could differ by harness. Now: `cas update --sync` installs the same MCP integration and diagnosis guide for Claude, Codex, and Grok.
-- Install: use `cas update` for an existing installation, or download the v2.69.0 Linux x86_64 archive from the GitHub release. This release ships Linux only; no macOS archive is claimed from this Linux-host release.
+- Install: use `cas update` for an existing installation, or download the v2.69.0 archive for Linux x86_64 (SHA-256 `f7970e5f66325d54962e726b8f11ecd214a1775da910f89e0b693241808da3ad`) or macOS ARM64 (SHA-256 `e0ac76b950119ec243f4c8c66a439dafdc10f6e5995a0566dad0fdd72a0cd861`) from the GitHub release.
 
 ## Dev thread
 
@@ -24,7 +24,7 @@ Live on production — **Dev** — v2.69.0 restores the complete Commander rever
 - Was: the completion request serialized a trailing-slash hub URL, which failed the relay's exact origin comparison and ended in `invalid_invitation`. Now: CAS serializes the bare URL origin, and the relay accepts delivery.
 - Was: `cas hub authorize` claimed remotely before validating local readiness, and a fresh retry nonce could not resume that claim. Now: local preconditions run before claim and a persisted nonce makes same-machine retries idempotent.
 - Was: the MCP integration skill was not a distributed builtin. Now: Claude, Codex, and Grok catalogs each ship byte-identical skill and diagnosis-reference files through `cas update --sync`.
-- Validation and artifact: v2.69.0 is built from its annotated release tag and the shipped Linux x86_64 archive is independently SHA-256 verified and audited for no EVEX/AVX-512 ISA or BLAKE3 AVX-512 inputs. No macOS archive is claimed from this Linux-host release.
+- Validation and artifact: v2.69.0 is built from annotated tag `v2.69.0` at `3ef18c4a`; `cas --version` reports `cas 2.69.0 (3ef18c4 2026-08-14)`. The published archives are `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `f7970e5f66325d54962e726b8f11ecd214a1775da910f89e0b693241808da3ad`) and `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `e0ac76b950119ec243f4c8c66a439dafdc10f6e5995a0566dad0fdd72a0cd861`); Linux and macOS are both available.
 
 ## Posting sequence
 
@@ -35,4 +35,3 @@ Live on production — **Dev** — v2.69.0 restores the complete Commander rever
 5. Append the receipt below with UTC timestamps and all four permalinks.
 
 ## POSTED
-


### PR DESCRIPTION
Correct the saved v2.69.0 announcement draft to describe the workflow-published Linux and macOS assets with their published SHA-256 digests. Slack posting remains held pending the CI rerun.