### PR TITLE
docs: record v2.69.0 Slack publication receipt

### DIFF
--- a/docs/release-notes/2026-08-14-v2.69.0-slack.md
+++ b/docs/release-notes/2026-08-14-v2.69.0-slack.md
@@ -2,7 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** Unposted announcement draft. Release workflow assets are published; post to Slack only after the held CI rerun clears. The release supervisor owns posting and will append the receipt.
+**Status:** Posted 2026-08-14 to #cas-internal. Both User and Dev threads have exactly one Was → Now reply; the receipt below records all four messages.
 
 ## User thread
 
@@ -35,3 +35,12 @@ Live on production — **Dev** — v2.69.0 restores the complete Commander rever
 5. Append the receipt below with UTC timestamps and all four permalinks.
 
 ## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-14T23:42:46.107119000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786750966107119 |
+| User reply (Was → Now) | 2026-08-14T23:42:56.750549000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786750976750549?thread_ts=1786750966.107119&cid=C0B44GUKDK2 |
+| Dev top-level | 2026-08-14T23:43:06.119999000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786750986119999 |
+| Dev reply (Was → Now) | 2026-08-14T23:43:15.251059000Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786750995251059?thread_ts=1786750986.119999&cid=C0B44GUKDK2 |


### PR DESCRIPTION
Records the four published #cas-internal v2.69.0 message permalinks and UTC timestamps derived from their Slack message IDs. Docs-only follow-up to #386.