### PR TITLE
fix: make published release assets authoritative

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,14 +224,6 @@ jobs:
         run: |
           mkdir -p release
           find artifacts -name "*.tar.gz" -exec mv {} release/ \;
-          # This manifest names the bytes that CI is about to publish. Release
-          # announcements must still run the receipt script against the
-          # downloaded assets, rather than copying a local-build checksum.
-          (
-            cd release
-            sha256sum cas-x86_64-unknown-linux-gnu.tar.gz \
-              cas-aarch64-apple-darwin.tar.gz > SHA256SUMS
-          )
           ls -la release/
 
       - name: Generate release notes
@@ -256,7 +248,14 @@ jobs:
 
           # A published release is immutable for announcement purposes. Do not
           # delete/recreate it on a re-tag: that would replace bytes after a
-          # receipt had already verified and announced their digests.
+          # receipt had already verified and announced their digests. A retry
+          # after a partial creation must fail loudly for deliberate recovery,
+          # never silently attach or replace assets.
+          if gh release view "$VERSION" --repo ${{ github.repository }} >/dev/null 2>&1; then
+            echo "::error::Release $VERSION already exists; refusing to replace its assets. Inspect the published release and perform documented recovery before rerunning."
+            exit 1
+          fi
+
           gh release create "$VERSION" \
             --repo ${{ github.repository }} \
             --title "CAS $VERSION" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,7 @@ jobs:
           # after a partial creation must fail loudly for deliberate recovery,
           # never silently attach or replace assets.
           if gh release view "$VERSION" --repo ${{ github.repository }} >/dev/null 2>&1; then
-            echo "::error::Release $VERSION already exists; refusing to replace its assets. Inspect the published release and perform documented recovery before rerunning."
+            echo "::error::Release $VERSION already exists; refusing to replace its assets. See docs/RELEASE_SLACK_RUBRIC.md#recovering-a-failed-or-partial-release before rerunning."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,14 @@ jobs:
         run: |
           mkdir -p release
           find artifacts -name "*.tar.gz" -exec mv {} release/ \;
+          # This manifest names the bytes that CI is about to publish. Release
+          # announcements must still run the receipt script against the
+          # downloaded assets, rather than copying a local-build checksum.
+          (
+            cd release
+            sha256sum cas-x86_64-unknown-linux-gnu.tar.gz \
+              cas-aarch64-apple-darwin.tar.gz > SHA256SUMS
+          )
           ls -la release/
 
       - name: Generate release notes
@@ -246,10 +254,9 @@ jobs:
         run: |
           VERSION="${GITHUB_REF#refs/tags/}"
 
-          # Delete existing release if it exists (handles retags)
-          gh release delete "$VERSION" --repo ${{ github.repository }} --yes 2>/dev/null || true
-
-          # Create the release
+          # A published release is immutable for announcement purposes. Do not
+          # delete/recreate it on a re-tag: that would replace bytes after a
+          # receipt had already verified and announced their digests.
           gh release create "$VERSION" \
             --repo ${{ github.repository }} \
             --title "CAS $VERSION" \

--- a/cas-cli/docs/CONTRIBUTING.md
+++ b/cas-cli/docs/CONTRIBUTING.md
@@ -135,9 +135,14 @@ These require a major version bump:
    That snapshot suite checks the doctor/status schema and ledger counts that a
    migration moves; the scoped release suites do not build it. If no previous
    tag is reachable, the guard runs the snapshots conservatively.
-6. Prefer `./scripts/release.sh --publish` for the local release path. It runs
-   the same guard before it can create or push a tag, so the check is enforced
-   even if the checklist step is missed.
+6. Run `./scripts/release.sh` to produce local audit evidence and push the
+   annotated tag. The tag-triggered GitHub Release workflow—not the local
+   `dist/local-audit/` archives—creates the normal release. A local archive is
+   evidence that the tagged source builds; it is never evidence of the shipped
+   bytes or an announcement digest. The emergency
+   `--manual-publish --acknowledge-workflow-conflict` path is only for a
+   disabled/unavailable workflow and still requires the published receipt in
+   step 9 before any digest is announced.
 7. Create an annotated tag, then run the fast release preflight **before pushing it**:
 
    ```bash
@@ -147,7 +152,20 @@ These require a major version bump:
 
    This rejects a dirty tree, a lightweight/stale tag, mismatched release-train
    crate versions, a missing changelog heading, or lockfile drift before the
-   expensive release builds begin. `release.sh` runs the same guard automatically
-   for non-`--build-only` releases.
-8. Push: `git push && git push --tags`.
-9. Create GitHub release: `gh release create vX.Y.Z --generate-notes`.
+   expensive release builds begin. `release.sh` runs the same guard before its
+   local audit and tag push.
+8. `release.sh` pushes the tag and starts the workflow. It builds Linux on its
+   host and, on macOS, also builds the Darwin audit target; this host-dependent
+   audit coverage does not change what ships. CI always builds and publishes
+   both Linux x86_64 and macOS ARM64 assets.
+9. Wait for the workflow-created release to be published, then derive every
+   announcement digest from freshly downloaded published bytes:
+
+   ```bash
+   ./scripts/release-published-receipt.sh vX.Y.Z
+   ```
+
+   The command fails closed while the release object is draft, either required
+   asset is still uploading, or a downloaded byte hash disagrees with GitHub.
+   Copy its emitted fields into the release-note draft; never transcribe a
+   digest from `dist/local-audit/`.

--- a/docs/RELEASE_SLACK_RUBRIC.md
+++ b/docs/RELEASE_SLACK_RUBRIC.md
@@ -28,7 +28,36 @@ directly to `main`, and do not create the release tag before the PR lands.
 4. After the required checks are green, merge explicitly:
    `gh pr merge "$PR_URL" --merge`. Do not use `--auto` or an admin bypass.
 5. Fetch the landed commit (`git fetch origin main`), tag that exact
-   `origin/main` commit, then run the artifact/release flow and push the tag.
+   `origin/main` commit, then run `./scripts/release.sh`. It pushes the tag;
+   the tag-triggered GitHub workflow is the normal release publisher.
+
+### Published assets before announcement
+
+The release object becoming visible is not publication proof: GitHub can expose
+it while one asset is still uploading. Do not upload a local `dist/local-audit/`
+archive or copy a digest from it into an announcement. A local audit says that
+the tagged source compiled; it says nothing about the bytes users download.
+
+After the workflow finishes, derive the exact announcement fields from the
+published release only:
+
+```bash
+./scripts/release-published-receipt.sh vX.Y.Z
+```
+
+It fails closed until the release is published, both required assets
+(`cas-x86_64-unknown-linux-gnu.tar.gz` and
+`cas-aarch64-apple-darwin.tar.gz`) exist, and fresh local downloads match
+GitHub's SHA-256 metadata. Use the printed fields mechanically in the draft.
+The workflow publishes macOS ARM64 from its macOS runner regardless of the host
+that tagged the release; never describe the release as Linux-only because a
+local audit host cannot build Darwin.
+
+`scripts/release.sh --manual-publish --acknowledge-workflow-conflict` is an
+emergency failover for a disabled or unavailable workflow, not a normal release
+lane. It deliberately competes after its tag push, so disable/cancel the CI
+workflow first when possible; it uses the same receipt command before any
+announcement digest is posted.
 
 If `coordination action=worktree_merge ... allow_trunk=true` encounters the
 ruleset first, it returns `PROTECTED_DEFAULT_BRANCH_REQUIRES_PR` with the
@@ -108,6 +137,9 @@ compatibility snapshot. Neither includes factory plumbing or ticket IDs.
 - [ ] PR URL + required-check status surfaced before the explicit merge (no `--auto` / admin bypass)
 - [ ] After every release-train version bump, regenerate `Cargo.lock` and verify `cargo metadata --locked` before tagging.
 - [ ] Release tag points at the fetched `origin/main` landing and is pushed
+- [ ] Workflow-created release has both Linux x86_64 and macOS ARM64 assets;
+  `release-published-receipt.sh` succeeded from fresh downloads before any
+  digest enters the draft (a local audit archive is not shipped-byte evidence)
 - [ ] Post 1 (user): punch (was→now) + plain-language details
 - [ ] Post 2 (dev): punch (was→now) + technical details
 - [ ] Both: zero ticket numbers, zero internal-agent narration

--- a/docs/RELEASE_SLACK_RUBRIC.md
+++ b/docs/RELEASE_SLACK_RUBRIC.md
@@ -38,17 +38,22 @@ it while one asset is still uploading. Do not upload a local `dist/local-audit/`
 archive or copy a digest from it into an announcement. A local audit says that
 the tagged source compiled; it says nothing about the bytes users download.
 
-After the workflow finishes, derive the exact announcement fields from the
+Start every runtime draft from
+[`docs/release-notes/runtime-release-template.md`](release-notes/runtime-release-template.md).
+After the workflow finishes, fill that draft's checksum placeholders from the
 published release only:
 
 ```bash
-./scripts/release-published-receipt.sh vX.Y.Z
+cp docs/release-notes/runtime-release-template.md docs/release-notes/YYYY-MM-DD-vX.Y.Z-slack.md
+./scripts/release-published-receipt.sh vX.Y.Z --write-draft docs/release-notes/YYYY-MM-DD-vX.Y.Z-slack.md
 ```
 
 It fails closed until the release is published, both required assets
 (`cas-x86_64-unknown-linux-gnu.tar.gz` and
 `cas-aarch64-apple-darwin.tar.gz`) exist, and fresh local downloads match
-GitHub's SHA-256 metadata. Use the printed fields mechanically in the draft.
+GitHub's SHA-256 metadata. `--write-draft` requires each digest placeholder
+and replaces every occurrence, so it fails rather than leaving a human to
+transcribe a local build's values.
 The workflow publishes macOS ARM64 from its macOS runner regardless of the host
 that tagged the release; never describe the release as Linux-only because a
 local audit host cannot build Darwin.
@@ -138,8 +143,9 @@ compatibility snapshot. Neither includes factory plumbing or ticket IDs.
 - [ ] After every release-train version bump, regenerate `Cargo.lock` and verify `cargo metadata --locked` before tagging.
 - [ ] Release tag points at the fetched `origin/main` landing and is pushed
 - [ ] Workflow-created release has both Linux x86_64 and macOS ARM64 assets;
-  `release-published-receipt.sh` succeeded from fresh downloads before any
-  digest enters the draft (a local audit archive is not shipped-byte evidence)
+  `release-published-receipt.sh --write-draft` succeeded from fresh downloads
+  before any digest enters the draft (a local audit archive is not
+  shipped-byte evidence)
 - [ ] Post 1 (user): punch (was→now) + plain-language details
 - [ ] Post 2 (dev): punch (was→now) + technical details
 - [ ] Both: zero ticket numbers, zero internal-agent narration

--- a/docs/RELEASE_SLACK_RUBRIC.md
+++ b/docs/RELEASE_SLACK_RUBRIC.md
@@ -64,6 +64,42 @@ lane. It deliberately competes after its tag push, so disable/cancel the CI
 workflow first when possible; it uses the same receipt command before any
 announcement digest is posted.
 
+### Recovering a failed or partial release
+
+1. Inspect, then run the receipt command. A complete release has both named
+   assets and succeeds; a partial release is one that exists but makes the
+   receipt command fail.
+
+   ```bash
+   gh release view vX.Y.Z --repo pippenz/cas --json isDraft,publishedAt,assets
+   ./scripts/release-published-receipt.sh vX.Y.Z
+   ```
+
+2. If the receipt succeeds, do not rerun or change the release: fill the draft
+   with `--write-draft` and continue to the announcement. Do **not** attach a
+   missing asset by hand; the workflow must remain the normal single publisher.
+3. If the release is partial and nothing has been announced from it, preserve
+   the existing tag, delete only the incomplete release, then rerun the same
+   failed workflow run. The release workflow will create fresh CI assets; it
+   refuses an existing object precisely to prevent replacement-by-rerun.
+
+   ```bash
+   gh release delete vX.Y.Z --repo pippenz/cas --yes
+   gh run rerun <failed-run-id> --repo pippenz/cas
+   ```
+
+   Do not use `--cleanup-tag`, force-push, or retag: the annotated tag remains
+   the source identity for both the retry and its receipt.
+4. If CI cannot publish after that recovery, use the explicitly acknowledged
+   `--manual-publish --acknowledge-workflow-conflict` failover only after the
+   incomplete release is deleted. In every case, run
+   `release-published-receipt.sh --write-draft` after publication and before an
+   announcement.
+5. If any announcement might already name the release, do not delete or replace
+   its assets. Stop and escalate to the release owner; publish a corrective new
+   version instead of making existing verification evidence change underneath
+   users.
+
 If `coordination action=worktree_merge ... allow_trunk=true` encounters the
 ruleset first, it returns `PROTECTED_DEFAULT_BRANCH_REQUIRES_PR` with the
 source/target-specific form of these commands. Follow that handoff and retry

--- a/docs/release-notes/runtime-release-template.md
+++ b/docs/release-notes/runtime-release-template.md
@@ -1,0 +1,51 @@
+# Slack draft — CAS vX.Y.Z runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — {{USER_IMPACT_PUNCH}}
+
+**Reply (Was → Now):**
+- Was: {{USER_WAS}} Now: {{USER_NOW}}
+- Install: use `cas update` for an existing installation, or download the
+  vX.Y.Z archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — {{DEV_IMPACT_PUNCH}}
+
+**Reply (Was → Now):**
+- Was: {{DEV_WAS}} Now: {{DEV_NOW}}
+- Validation and artifact: {{VALIDATION_SUMMARY}} The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run `./scripts/release.sh`.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |

--- a/scripts/release-published-receipt.sh
+++ b/scripts/release-published-receipt.sh
@@ -4,10 +4,10 @@
 set -euo pipefail
 
 usage() {
-    echo "Usage: scripts/release-published-receipt.sh <vX.Y.Z>" >&2
+    echo "Usage: scripts/release-published-receipt.sh <vX.Y.Z> [--write-draft <path>]" >&2
 }
 
-if [[ "$#" -ne 1 ]]; then
+if [[ "$#" -ne 1 && "$#" -ne 3 ]]; then
     usage
     exit 2
 fi
@@ -16,6 +16,15 @@ tag="$1"
 if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "error: expected an annotated release tag like vX.Y.Z; got $tag" >&2
     exit 2
+fi
+
+draft=""
+if [[ "$#" -eq 3 ]]; then
+    if [[ "$2" != "--write-draft" || ! -f "$3" ]]; then
+        echo "error: --write-draft requires an existing draft path" >&2
+        exit 2
+    fi
+    draft="$3"
 fi
 
 gh_bin="${GH_BIN:-gh}"
@@ -59,9 +68,36 @@ for asset in "$linux_asset" "$macos_asset"; do
     fi
 done
 
+linux_sha="$(sha256sum "$workdir/$linux_asset" | awk '{print $1}')"
+macos_sha="$(sha256sum "$workdir/$macos_asset" | awk '{print $1}')"
+
+replace_draft_token() {
+    local token="$1" value="$2" replacement
+    replacement="$(mktemp)"
+    if ! awk -v token="$token" -v value="$value" '
+        BEGIN { replacements = 0 }
+        {
+            occurrences = gsub(token, value)
+            replacements += occurrences
+            print
+        }
+        END { exit replacements >= 1 ? 0 : 1 }
+    ' "$draft" >"$replacement"; then
+        rm -f "$replacement"
+        echo "error: draft $draft must contain a $token placeholder" >&2
+        exit 1
+    fi
+    mv "$replacement" "$draft"
+}
+
+if [[ -n "$draft" ]]; then
+    replace_draft_token '{{LINUX_SHA256}}' "$linux_sha"
+    replace_draft_token '{{MACOS_SHA256}}' "$macos_sha"
+fi
+
 printf 'TAG=%s\n' "$tag"
 printf 'PUBLISHED_AT=%s\n' "$(jq -r '.publishedAt' "$release_json")"
 printf 'LINUX_ASSET=%s\n' "$linux_asset"
-printf 'LINUX_SHA256=%s\n' "$(sha256sum "$workdir/$linux_asset" | awk '{print $1}')"
+printf 'LINUX_SHA256=%s\n' "$linux_sha"
 printf 'MACOS_ASSET=%s\n' "$macos_asset"
-printf 'MACOS_SHA256=%s\n' "$(sha256sum "$workdir/$macos_asset" | awk '{print $1}')"
+printf 'MACOS_SHA256=%s\n' "$macos_sha"

--- a/scripts/release-published-receipt.sh
+++ b/scripts/release-published-receipt.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Print machine-readable digest fields only after the published GitHub release
+# contains both CI assets and locally downloaded bytes match GitHub metadata.
+set -euo pipefail
+
+usage() {
+    echo "Usage: scripts/release-published-receipt.sh <vX.Y.Z>" >&2
+}
+
+if [[ "$#" -ne 1 ]]; then
+    usage
+    exit 2
+fi
+
+tag="$1"
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: expected an annotated release tag like vX.Y.Z; got $tag" >&2
+    exit 2
+fi
+
+gh_bin="${GH_BIN:-gh}"
+repo="${RELEASE_REPO:-pippenz/cas}"
+linux_asset="cas-x86_64-unknown-linux-gnu.tar.gz"
+macos_asset="cas-aarch64-apple-darwin.tar.gz"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+release_json="$workdir/release.json"
+if ! "$gh_bin" release view "$tag" --repo "$repo" --json isDraft,publishedAt,assets >"$release_json"; then
+    echo "error: published release $tag is not available yet" >&2
+    exit 1
+fi
+
+if [[ "$(jq -r 'if has("isDraft") then .isDraft else true end' "$release_json")" != "false" ]] \
+    || [[ -z "$(jq -r '.publishedAt // empty' "$release_json")" ]]; then
+    echo "error: release $tag exists but is not published yet" >&2
+    exit 1
+fi
+
+digest_for() {
+    jq -r --arg name "$1" '.assets[]? | select(.name == $name) | .digest // empty' "$release_json"
+}
+
+for asset in "$linux_asset" "$macos_asset"; do
+    digest="$(digest_for "$asset")"
+    if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+        echo "error: release $tag is partial; required asset $asset with a SHA-256 digest is not published yet" >&2
+        exit 1
+    fi
+done
+
+for asset in "$linux_asset" "$macos_asset"; do
+    "$gh_bin" release download "$tag" --repo "$repo" --dir "$workdir" --pattern "$asset"
+    local_digest="$(sha256sum "$workdir/$asset" | awk '{print $1}')"
+    github_digest="$(digest_for "$asset" | sed 's/^sha256://')"
+    if [[ "$local_digest" != "$github_digest" ]]; then
+        echo "error: downloaded $asset digest $local_digest does not match GitHub digest $github_digest" >&2
+        exit 1
+    fi
+done
+
+printf 'TAG=%s\n' "$tag"
+printf 'PUBLISHED_AT=%s\n' "$(jq -r '.publishedAt' "$release_json")"
+printf 'LINUX_ASSET=%s\n' "$linux_asset"
+printf 'LINUX_SHA256=%s\n' "$(sha256sum "$workdir/$linux_asset" | awk '{print $1}')"
+printf 'MACOS_ASSET=%s\n' "$macos_asset"
+printf 'MACOS_SHA256=%s\n' "$(sha256sum "$workdir/$macos_asset" | awk '{print $1}')"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,25 +1,28 @@
 #!/usr/bin/env bash
 #
-# Local release build script for CAS
+# Local release audit and tag-push script for CAS.
 #
-# Builds release binaries for all targets from the local machine, packages them,
-# and optionally creates a GitHub release. The Darwin artifact uses a native
-# build and therefore requires a macOS host; the early host preflight below
-# reports that requirement before any compiler work begins.
-# Linux release builds deliberately recompile C dependencies from source, so
-# they are slower than an incremental build but reproducibly enforce the
-# portability policy that the post-build audits validate.
+# GitHub's tag-triggered Release workflow is the sole normal publisher. This
+# script builds local audit evidence and pushes the annotated tag that starts
+# that workflow; its dist/local-audit archives are never the shipped bytes and
+# must never supply an announced digest. Use release-published-receipt.sh only
+# after the workflow has published both assets.
+#
+# A deliberately loud manual failover remains for a disabled or unavailable CI
+# workflow. It deliberately competes with the tag-triggered workflow, so use
+# it only after disabling/cancelling that workflow or when its runners cannot
+# publish. That exceptional path still requires the published-release receipt
+# command before any digest is announced.
 #
 # Prerequisites:
 #   - Rust toolchain (rustup)
 #   - cargo-zigbuild: cargo install cargo-zigbuild
-#   - gh CLI (for GitHub release creation)
+#   - gh CLI (only for --manual-publish)
 #   - Environment variables: CAS_POSTHOG_API_KEY, CAS_SENTRY_DSN
 #
 # Usage:
-#   ./scripts/release.sh              # Build + prompt for GitHub release
-#   ./scripts/release.sh --build-only # Build without creating release
-#   ./scripts/release.sh --publish    # Build + create release without prompting
+#   ./scripts/release.sh
+#   ./scripts/release.sh --manual-publish --acknowledge-workflow-conflict
 
 set -euo pipefail
 
@@ -27,40 +30,56 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
 HOST_OS="$(uname -s)"
-TARGETS=(
-    "aarch64-apple-darwin"
-    "x86_64-unknown-linux-gnu"
-)
+TARGETS=("x86_64-unknown-linux-gnu")
+if [[ "$HOST_OS" == "Darwin" ]]; then
+    TARGETS=("aarch64-apple-darwin" "x86_64-unknown-linux-gnu")
+fi
 
-DIST_DIR="$REPO_ROOT/dist"
-BUILD_ONLY=false
-AUTO_PUBLISH=false
+DIST_DIR="$REPO_ROOT/dist/local-audit"
+MANUAL_PUBLISH=false
+ACKNOWLEDGED_CONFLICT=false
 
 for arg in "$@"; do
     case "$arg" in
-        --build-only) BUILD_ONLY=true ;;
-        --publish) AUTO_PUBLISH=true ;;
+        --manual-publish) MANUAL_PUBLISH=true ;;
+        --acknowledge-workflow-conflict) ACKNOWLEDGED_CONFLICT=true ;;
         -h|--help)
-            echo "Usage: $0 [--build-only | --publish]"
-            echo ""
-            echo "  --build-only   Build tarballs only, skip GitHub release"
-            echo "  --publish      Build and create GitHub release without prompting"
+            cat <<'EOF'
+Usage: scripts/release.sh [--manual-publish --acknowledge-workflow-conflict]
+
+Build local audit archives and push the annotated tag. The tag-triggered
+GitHub Release workflow creates the normal published release.
+
+  --manual-publish
+      Emergency failover only: create a release from local audit archives
+      after pushing the tag. Use only while the workflow is disabled or
+      unavailable; it deliberately conflicts with the normal CI publisher.
+  --acknowledge-workflow-conflict
+      Required with --manual-publish. Published digests must still come from
+      scripts/release-published-receipt.sh, never from dist/local-audit.
+EOF
             exit 0
             ;;
         *)
-            echo "Unknown argument: $arg"
+            echo "Unknown argument: $arg" >&2
             exit 1
             ;;
     esac
 done
 
+if "$MANUAL_PUBLISH" && ! "$ACKNOWLEDGED_CONFLICT"; then
+    echo "error: --manual-publish requires --acknowledge-workflow-conflict" >&2
+    exit 2
+fi
+if ! "$MANUAL_PUBLISH" && "$ACKNOWLEDGED_CONFLICT"; then
+    echo "error: --acknowledge-workflow-conflict is only valid with --manual-publish" >&2
+    exit 2
+fi
+
 # Reject unsupported host/target combinations before bootstrapping toolchains
 # or compiling, rather than failing deep in a native compiler invocation.
 ./scripts/check-release-host.sh "$HOST_OS" "${TARGETS[@]}"
 
-# ---------------------------------------------------------------------------
-# Load .env if present
-# ---------------------------------------------------------------------------
 if [ -f "$REPO_ROOT/.env" ]; then
     set -a
     # shellcheck disable=SC1091
@@ -68,113 +87,70 @@ if [ -f "$REPO_ROOT/.env" ]; then
     set +a
 fi
 
-# ---------------------------------------------------------------------------
-# Version & tag
-# ---------------------------------------------------------------------------
 VERSION="$(grep -m1 '^version = "' cas-cli/Cargo.toml | sed -E 's/^version = "([^"]+)"/\1/')"
 TAG="v$VERSION"
 
-echo "=== CAS Release Build ==="
+echo "=== CAS Local Release Audit ==="
 echo "Version:  $VERSION"
 echo "Tag:      $TAG"
 echo "Targets:  ${TARGETS[*]}"
+echo "Output:   $DIST_DIR (audit evidence only; not shipped bytes)"
 echo ""
 
-# ---------------------------------------------------------------------------
-# Pre-flight checks
-# ---------------------------------------------------------------------------
 if [ -z "${CAS_POSTHOG_API_KEY:-}" ]; then
-    echo "error: CAS_POSTHOG_API_KEY is not set"
+    echo "error: CAS_POSTHOG_API_KEY is not set" >&2
     exit 1
 fi
-
 if [ -z "${CAS_SENTRY_DSN:-}" ]; then
     echo "warning: CAS_SENTRY_DSN is not set — crash reporting will be disabled in this build"
 fi
-
 if ! command -v cargo-zigbuild &>/dev/null; then
-    echo "error: cargo-zigbuild not found. Install with: cargo install cargo-zigbuild"
+    echo "error: cargo-zigbuild not found. Install with: cargo install cargo-zigbuild" >&2
     exit 1
 fi
-
-if ! "$BUILD_ONLY" && ! command -v gh &>/dev/null; then
-    echo "error: gh CLI not found. Install with: brew install gh"
+if "$MANUAL_PUBLISH" && ! command -v gh &>/dev/null; then
+    echo "error: gh CLI not found. Install with: brew install gh" >&2
     exit 1
 fi
 
 ensure_release_tag() {
     if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1; then
-        echo "Creating annotated tag $TAG on HEAD before release build..."
+        echo "Creating annotated tag $TAG on HEAD before release audit..."
         git tag -a "$TAG" -m "$TAG"
     fi
-
     ./scripts/check-release-preflight.sh "$TAG"
 }
 
 # A registered migration changes the doctor/status component snapshots, while
-# the scoped release suites do not build that integration test.  Keep this
-# before builds and, crucially, before create_release can create or push TAG.
+# scoped release suites do not build that integration test.
 ./scripts/check-release-migration-snapshots.sh
 
-# ---------------------------------------------------------------------------
-# Bootstrap Zig if needed
-# ---------------------------------------------------------------------------
 if [ ! -x ".context/zig/zig" ]; then
     echo "Bootstrapping Zig..."
     ./scripts/bootstrap-zig.sh
 fi
 export ZIG="$REPO_ROOT/.context/zig/zig"
-# cargo-zigbuild resolves its Zig executable through PATH rather than $ZIG.
-# Keep $ZIG for build scripts that consume it and expose the same pinned binary
-# through PATH so cargo zigbuild is reproducible when run independently.
 export PATH="$REPO_ROOT/.context/zig:$PATH"
 echo "Zig: $(zig version)"
 
-# A local release must reject lockfile/version/changelog/tag mistakes before
-# starting the expensive artifact builds. Build-only remains a packaging aid,
-# not a release action, so it deliberately does not create a tag. This runs
-# after Zig is available because cargo check builds the native Ghostty layer.
-if ! "$BUILD_ONLY"; then
-    ensure_release_tag
-fi
-
-# ---------------------------------------------------------------------------
-# Ensure git submodules
-# ---------------------------------------------------------------------------
+ensure_release_tag
 git submodule update --init --recursive
 
-# ---------------------------------------------------------------------------
-# Ensure Rust targets are installed
-# ---------------------------------------------------------------------------
 INSTALLED_TARGETS="$(rustup target list --installed)"
 for target in "${TARGETS[@]}"; do
-    if ! echo "$INSTALLED_TARGETS" | grep -q "^${target}$"; then
+    if ! grep -q "^${target}$" <<<"$INSTALLED_TARGETS"; then
         echo "Installing Rust target: $target"
         rustup target add "$target"
     fi
 done
 
-# ---------------------------------------------------------------------------
-# Build
-# ---------------------------------------------------------------------------
 rm -rf "$DIST_DIR"
 mkdir -p "$DIST_DIR"
 
 for target in "${TARGETS[@]}"; do
     echo ""
     echo "=== Building $target ==="
-
     if [[ "$target" == *"linux"* ]]; then
-        # Cross-compile for Linux using zigbuild. Its target wrapper passes
-        # Zig's portable x86_64 CPU baseline to C/C++ contributors; the audits
-        # below remain the authoritative release portability proof.
-        # C build-script output records compiler flags. A release portability
-        # audit is meaningful only when its artifact reflects current source
-        # and compiler policy, not C objects inherited from target/. Clear the
-        # complete target so every C dependency recompiles with this release's
-        # baseline policy (including BLAKE3's no-AVX-512 inputs). This costs an
-        # incremental build, but prevents a cache-masked flag regression from
-        # producing an apparently portable release.
         cargo clean --release --target "$target"
         CFLAGS_x86_64_unknown_linux_gnu="-march=x86_64" \
         CXXFLAGS_x86_64_unknown_linux_gnu="-march=x86_64" \
@@ -187,71 +163,37 @@ for target in "${TARGETS[@]}"; do
         ./scripts/check-portable-x86_64-isa.sh "$ghostty_archive"
         ./scripts/check-blake3-no-avx512-build.sh "target/$target/release/build"
     else
-        # Native build for macOS
         cargo build -p cas --release --target "$target" --locked
     fi
 
-    echo "Packaging $target..."
-    STAGING="$(mktemp -d)"
-    cp "target/$target/release/cas" "$STAGING/"
-    cp LICENSE "$STAGING/"
+    staging="$(mktemp -d)"
+    cp "target/$target/release/cas" "$staging/"
+    cp LICENSE "$staging/"
     if [[ "$target" == "x86_64-unknown-linux-gnu" ]]; then
-        ./scripts/test-check-portable-x86_64-isa.sh "$STAGING/cas"
+        ./scripts/test-check-portable-x86_64-isa.sh "$staging/cas"
     fi
-    tar -czvf "$DIST_DIR/cas-$target.tar.gz" -C "$STAGING" cas LICENSE
-    rm -rf "$STAGING"
-
-    echo "Built: dist/cas-$target.tar.gz"
+    tar -czvf "$DIST_DIR/cas-$target.tar.gz" -C "$staging" cas LICENSE
+    rm -rf "$staging"
 done
 
 echo ""
-echo "=== Build Complete ==="
+echo "=== Local Audit Complete ==="
 ls -lh "$DIST_DIR"/*.tar.gz
 
-# ---------------------------------------------------------------------------
-# GitHub release
-# ---------------------------------------------------------------------------
-if "$BUILD_ONLY"; then
+echo "Pushing annotated tag $TAG to trigger the authoritative Release workflow..."
+git push origin "$TAG"
+
+if "$MANUAL_PUBLISH"; then
     echo ""
-    echo "Tarballs are in dist/. Skipping GitHub release (--build-only)."
-    exit 0
-fi
-
-create_release() {
-    # Push the tag
-    echo "Pushing tag $TAG..."
-    git push origin "$TAG"
-
-    # Generate release notes from commits since last tag
-    PREV_TAG=$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || echo "")
-    if [ -n "$PREV_TAG" ]; then
-        NOTES=$(git log --pretty=format:"- %s" "$PREV_TAG".."$TAG")
-    else
-        NOTES=$(git log --pretty=format:"- %s" -10)
-    fi
-
-    # Delete existing release if retag
-    gh release delete "$TAG" --repo codingagentsystem/cas --yes 2>/dev/null || true
-
-    # Create release on public repo
+    echo "WARNING: emergency manual publishing is intentionally competing with CI."
+    echo "Use only after disabling/cancelling the workflow or when its runners cannot publish."
     gh release create "$TAG" \
-        --repo codingagentsystem/cas \
+        --repo "${RELEASE_REPO:-pippenz/cas}" \
         --title "CAS $TAG" \
-        --notes "$NOTES" \
+        --generate-notes \
         "$DIST_DIR"/*.tar.gz
-
-    echo ""
-    echo "Release created: https://github.com/codingagentsystem/cas/releases/tag/$TAG"
-}
-
-if "$AUTO_PUBLISH"; then
-    create_release
+    echo "Manual release created. Run scripts/release-published-receipt.sh $TAG before announcing digests."
 else
-    echo ""
-    read -p "Create GitHub release $TAG on codingagentsystem/cas? [y/N] " confirm
-    if [[ "${confirm:-}" =~ ^[Yy]$ ]]; then
-        create_release
-    else
-        echo "Skipped. Tarballs are in dist/."
-    fi
+    echo "CI now owns release creation. Do not upload dist/local-audit archives or announce their digests."
+    echo "After CI publishes both assets, run scripts/release-published-receipt.sh $TAG."
 fi

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -193,8 +193,45 @@ fi
 require_text "$ci_text" 'SCCACHE_GHA_ENABLED: "true"' 'CI enables GitHub cache-v2 backend'
 require_text "$(<"$release")" 'SCCACHE_GHA_ENABLED: "true"' 'release enables GitHub cache-v2 backend'
 require_text "$(<"$release")" 'needs: [verify, build, build-macos]' 'release publication waits for both Linux and macOS builds'
-require_text "$(<"$release")" 'cas-aarch64-apple-darwin.tar.gz > SHA256SUMS' 'release emits a two-target checksum manifest'
 require_absent "$(<"$release")" 'gh release delete' 'release never replaces published assets after a receipt'
+require_text "$(<"$release")" 'refusing to replace its assets' 'release rerun with an existing release fails loudly'
+
+# Exercise the actual Create Release shell body with a fake gh client. A
+# release run that failed after creating its release object must not silently
+# attach/replace assets on retry; a release object that does not exist must
+# still proceed to its one normal create operation.
+release_create_body="$(awk '
+    $0 == "      - name: Create Release" { in_step = 1; next }
+    in_step && $0 == "        run: |" { in_body = 1; next }
+    in_body { sub(/^          /, ""); print }
+' "$release" | sed -E 's/\$\{\{[^}]+\}\}/workflow-expression/g')"
+retry_tmp="$(mktemp -d)"
+trap 'rm -rf "$retry_tmp"' EXIT
+mkdir -p "$retry_tmp/bin"
+cat >"$retry_tmp/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "release view") exit "${FAKE_RELEASE_EXISTS:?}" ;;
+  "release create") printf '%s\n' "$*" >>"${FAKE_GH_LOG:?}" ;;
+  *) echo "unexpected fake gh invocation: $*" >&2; exit 2 ;;
+esac
+EOF
+chmod +x "$retry_tmp/bin/gh"
+
+set +e
+existing_output="$(GITHUB_REF=refs/tags/v9.9.9 FAKE_RELEASE_EXISTS=0 FAKE_GH_LOG="$retry_tmp/creates" PATH="$retry_tmp/bin:$PATH" bash -c "$release_create_body" 2>&1)"
+existing_status=$?
+set -e
+test "$existing_status" -eq 1
+grep -qF 'Release v9.9.9 already exists; refusing to replace its assets' <<<"$existing_output"
+test ! -e "$retry_tmp/creates"
+echo 'ok   partial-release retry refuses loudly and does not upload replacement bytes'
+
+GITHUB_REF=refs/tags/v9.9.9 FAKE_RELEASE_EXISTS=1 FAKE_GH_LOG="$retry_tmp/creates" PATH="$retry_tmp/bin:$PATH" bash -c "$release_create_body"
+grep -qF 'release create v9.9.9' "$retry_tmp/creates"
+echo 'ok   first release run creates the release when no object exists'
+rm -rf "$retry_tmp"
+trap - EXIT
 
 # The cache is an optimization, never a CI availability dependency. The shared
 # Linux setup must survive both a failed action download and a failed backend

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -195,6 +195,8 @@ require_text "$(<"$release")" 'SCCACHE_GHA_ENABLED: "true"' 'release enables Git
 require_text "$(<"$release")" 'needs: [verify, build, build-macos]' 'release publication waits for both Linux and macOS builds'
 require_absent "$(<"$release")" 'gh release delete' 'release never replaces published assets after a receipt'
 require_text "$(<"$release")" 'refusing to replace its assets' 'release rerun with an existing release fails loudly'
+require_text "$(<"$release")" 'RELEASE_SLACK_RUBRIC.md#recovering-a-failed-or-partial-release' 'release rerun names its recovery procedure'
+require_text "$(<"$repo_root/docs/RELEASE_SLACK_RUBRIC.md")" '### Recovering a failed or partial release' 'release rubric documents partial-release recovery'
 
 # Exercise the actual Create Release shell body with a fake gh client. A
 # release run that failed after creating its release object must not silently

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -192,6 +192,9 @@ else
 fi
 require_text "$ci_text" 'SCCACHE_GHA_ENABLED: "true"' 'CI enables GitHub cache-v2 backend'
 require_text "$(<"$release")" 'SCCACHE_GHA_ENABLED: "true"' 'release enables GitHub cache-v2 backend'
+require_text "$(<"$release")" 'needs: [verify, build, build-macos]' 'release publication waits for both Linux and macOS builds'
+require_text "$(<"$release")" 'cas-aarch64-apple-darwin.tar.gz > SHA256SUMS' 'release emits a two-target checksum manifest'
+require_absent "$(<"$release")" 'gh release delete' 'release never replaces published assets after a receipt'
 
 # The cache is an optimization, never a CI availability dependency. The shared
 # Linux setup must survive both a failed action download and a failed backend

--- a/scripts/test-release-publication-policy.sh
+++ b/scripts/test-release-publication-policy.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Static contract for the normal CI-authoritative release lane.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+release="$script_dir/release.sh"
+
+help_output="$("$release" --help)"
+grep -qF 'GitHub Release workflow creates the normal published release.' <<<"$help_output"
+grep -qF -- '--manual-publish' <<<"$help_output"
+grep -qF -- '--acknowledge-workflow-conflict' <<<"$help_output"
+echo 'ok   help distinguishes CI authority from explicit manual failover'
+
+set +e
+missing_ack_output="$("$release" --manual-publish 2>&1)"
+missing_ack_status=$?
+set -e
+test "$missing_ack_status" -eq 2
+grep -qF -- '--manual-publish requires --acknowledge-workflow-conflict' <<<"$missing_ack_output"
+echo 'ok   manual publishing cannot begin without conflict acknowledgement'
+
+push_line="$(rg -nF 'git push origin "$TAG"' "$release" | cut -d: -f1)"
+manual_create_line="$(rg -nF 'gh release create "$TAG"' "$release" | cut -d: -f1)"
+test -n "$push_line"
+test -n "$manual_create_line"
+test "$push_line" -lt "$manual_create_line"
+rg -qF 'dist/local-audit' "$release"
+rg -qF 'never the shipped bytes' "$release"
+echo 'ok   tag starts CI before the exceptional competing manual publisher'

--- a/scripts/test-release-published-receipt.sh
+++ b/scripts/test-release-published-receipt.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 receipt="$script_dir/release-published-receipt.sh"
+template="$script_dir/../docs/release-notes/runtime-release-template.md"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
@@ -64,8 +65,22 @@ grep -qF 'does not match GitHub digest' <<<"$mismatch_output"
 echo 'ok   mismatched downloaded bytes fail closed'
 
 write_release "[{\"name\":\"cas-x86_64-unknown-linux-gnu.tar.gz\",\"digest\":\"sha256:$linux_sha\"},{\"name\":\"cas-aarch64-apple-darwin.tar.gz\",\"digest\":\"sha256:$macos_sha\"}]"
-success_output="$(FIXTURE="$fixture" GH_BIN="$fake_gh" "$receipt" v2.69.1)"
+draft="$fixture/draft.md"
+printf 'Linux {{LINUX_SHA256}} / {{LINUX_SHA256}}; macOS {{MACOS_SHA256}} / {{MACOS_SHA256}}\n' >"$draft"
+success_output="$(FIXTURE="$fixture" GH_BIN="$fake_gh" "$receipt" v2.69.1 --write-draft "$draft")"
 grep -qFx 'TAG=v2.69.1' <<<"$success_output"
 grep -qFx "LINUX_SHA256=$linux_sha" <<<"$success_output"
 grep -qFx "MACOS_SHA256=$macos_sha" <<<"$success_output"
-echo 'ok   complete published release emits freshly downloaded digests'
+grep -qF "$linux_sha" "$draft"
+grep -qF "$macos_sha" "$draft"
+test "$(rg -oF "$linux_sha" "$draft" | wc -l)" -eq 2
+test "$(rg -oF "$macos_sha" "$draft" | wc -l)" -eq 2
+if rg -qF '{{LINUX_SHA256}}|{{MACOS_SHA256}}' "$draft"; then
+    echo 'FAIL receipt left a digest placeholder in the draft' >&2
+    exit 1
+fi
+echo 'ok   complete published release emits and mechanically writes fresh digests'
+
+test "$(rg -oF '{{LINUX_SHA256}}' "$template" | wc -l)" -eq 2
+test "$(rg -oF '{{MACOS_SHA256}}' "$template" | wc -l)" -eq 2
+echo 'ok   runtime draft template exposes only receipt-fillable digest placeholders'

--- a/scripts/test-release-published-receipt.sh
+++ b/scripts/test-release-published-receipt.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Fixture tests for the release-publication state machine. No network access.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+receipt="$script_dir/release-published-receipt.sh"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fixture="$tmpdir/fixture"
+mkdir -p "$fixture/assets"
+printf 'linux published bytes\n' >"$fixture/assets/cas-x86_64-unknown-linux-gnu.tar.gz"
+printf 'macos published bytes\n' >"$fixture/assets/cas-aarch64-apple-darwin.tar.gz"
+linux_sha="$(sha256sum "$fixture/assets/cas-x86_64-unknown-linux-gnu.tar.gz" | awk '{print $1}')"
+macos_sha="$(sha256sum "$fixture/assets/cas-aarch64-apple-darwin.tar.gz" | awk '{print $1}')"
+
+fake_gh="$tmpdir/gh"
+cat >"$fake_gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+  "release view") cat "$FIXTURE/release.json" ;;
+  "release download")
+    pattern=""
+    directory=""
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        --pattern) pattern="$2"; shift 2 ;;
+        --dir) directory="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    cp "$FIXTURE/assets/$pattern" "$directory/$pattern"
+    ;;
+  *) echo "unexpected fake gh invocation: $*" >&2; exit 2 ;;
+esac
+EOF
+chmod +x "$fake_gh"
+
+write_release() {
+  cat >"$fixture/release.json" <<EOF
+{"isDraft":false,"publishedAt":"2026-08-15T00:57:26Z","assets":$1}
+EOF
+}
+
+# A release object alone is insufficient: this pins the exact half-uploaded
+# state that used to let a local digest reach the announcement.
+write_release "[{\"name\":\"cas-x86_64-unknown-linux-gnu.tar.gz\",\"digest\":\"sha256:$linux_sha\"}]"
+set +e
+partial_output="$(FIXTURE="$fixture" GH_BIN="$fake_gh" "$receipt" v2.69.1 2>&1)"
+partial_status=$?
+set -e
+test "$partial_status" -ne 0
+grep -qF 'release v2.69.1 is partial; required asset cas-aarch64-apple-darwin.tar.gz' <<<"$partial_output"
+echo 'ok   partial published release fails closed before announcement fields'
+
+write_release "[{\"name\":\"cas-x86_64-unknown-linux-gnu.tar.gz\",\"digest\":\"sha256:$(printf '0%.0s' {1..64})\"},{\"name\":\"cas-aarch64-apple-darwin.tar.gz\",\"digest\":\"sha256:$macos_sha\"}]"
+set +e
+mismatch_output="$(FIXTURE="$fixture" GH_BIN="$fake_gh" "$receipt" v2.69.1 2>&1)"
+mismatch_status=$?
+set -e
+test "$mismatch_status" -ne 0
+grep -qF 'does not match GitHub digest' <<<"$mismatch_output"
+echo 'ok   mismatched downloaded bytes fail closed'
+
+write_release "[{\"name\":\"cas-x86_64-unknown-linux-gnu.tar.gz\",\"digest\":\"sha256:$linux_sha\"},{\"name\":\"cas-aarch64-apple-darwin.tar.gz\",\"digest\":\"sha256:$macos_sha\"}]"
+success_output="$(FIXTURE="$fixture" GH_BIN="$fake_gh" "$receipt" v2.69.1)"
+grep -qFx 'TAG=v2.69.1' <<<"$success_output"
+grep -qFx "LINUX_SHA256=$linux_sha" <<<"$success_output"
+grep -qFx "MACOS_SHA256=$macos_sha" <<<"$success_output"
+echo 'ok   complete published release emits freshly downloaded digests'


### PR DESCRIPTION
## Summary
- keep tag-triggered CI as the normal release publisher and label local archives as audit-only
- reject partial release objects and hash freshly downloaded Linux/macOS assets before drafting digest fields
- make release retries refuse loudly rather than replacing published assets; retain explicit manual failover
- provide a runtime draft template whose digest placeholders are filled by the receipt command

## Validation
- scripts/test-release-publication-policy.sh
- scripts/test-release-published-receipt.sh
- scripts/test-ci-test-tiers.sh (131 passed)
- scripts/release-published-receipt.sh v2.69.1