### PR TITLE
fix: prevent factory relays from polluting Context

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -67,7 +67,7 @@ Your scope is locked at assignment:
   - Bad (observed): after a `/dev/null` denial, retry it or switch to an arbitrary host path.
   - Good: stop, classify the output as source, durable proof, or ephemeral, then use its sanctioned location.
 - **Document important choices.** Use `mcp__cs__task action=notes note_type=decision` for non-obvious decisions.
-- **Keep durable discoveries deliberately.** Factory-worker relay turns are retained for attribution but are not auto-saved as Context; use `mcp__cs__memory action=remember` for a cross-session fact or decision.
+- **Keep durable discoveries deliberately.** Relays are attributed, not auto-saved; use `mcp__cs__memory action=remember` for cross-session facts.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
 - **Report context headroom** ("context: ~60% used") in every milestone progress note.
 - **Checkpoint, never compact.** When context is low: commit, push, leave a handoff note, and ask for respawn. Prefer small pushed commits. See [discipline.md](cas-worker/references/discipline.md).

--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -67,6 +67,7 @@ Your scope is locked at assignment:
   - Bad (observed): after a `/dev/null` denial, retry it or switch to an arbitrary host path.
   - Good: stop, classify the output as source, durable proof, or ephemeral, then use its sanctioned location.
 - **Document important choices.** Use `mcp__cs__task action=notes note_type=decision` for non-obvious decisions.
+- **Keep durable discoveries deliberately.** Factory-worker relay turns are retained for attribution but are not auto-saved as Context; use `mcp__cs__memory action=remember` for a cross-session fact or decision.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
 - **Report context headroom** ("context: ~60% used") in every milestone progress note.
 - **Checkpoint, never compact.** When context is low: commit, push, leave a handoff note, and ask for respawn. Prefer small pushed commits. See [discipline.md](cas-worker/references/discipline.md).

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -67,6 +67,7 @@ Your scope is locked at assignment:
   - Bad (observed): after a `/dev/null` denial, retry it or switch to an arbitrary host path.
   - Good: stop, classify the output as source, durable proof, or ephemeral, then use its sanctioned location.
 - **Document important choices.** Use `cas__task action=notes note_type=decision` for non-obvious decisions.
+- **Keep durable discoveries deliberately.** Factory-worker relay turns are retained for attribution but are not auto-saved as Context; use `cas__memory action=remember` for a cross-session fact or decision.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
 - **Report context headroom** ("context: ~60% used") in every milestone progress note.
 - **Checkpoint, never compact.** When context is low: commit, push, leave a handoff note, and ask for respawn. Prefer small pushed commits. See [discipline.md](cas-worker/references/discipline.md).

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -67,7 +67,7 @@ Your scope is locked at assignment:
   - Bad (observed): after a `/dev/null` denial, retry it or switch to an arbitrary host path.
   - Good: stop, classify the output as source, durable proof, or ephemeral, then use its sanctioned location.
 - **Document important choices.** Use `cas__task action=notes note_type=decision` for non-obvious decisions.
-- **Keep durable discoveries deliberately.** Factory-worker relay turns are retained for attribution but are not auto-saved as Context; use `cas__memory action=remember` for a cross-session fact or decision.
+- **Keep durable discoveries deliberately.** Relays are attributed, not auto-saved; use `cas__memory action=remember` for cross-session facts.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
 - **Report context headroom** ("context: ~60% used") in every milestone progress note.
 - **Checkpoint, never compact.** When context is low: commit, push, leave a handoff note, and ask for respawn. Prefer small pushed commits. See [discipline.md](cas-worker/references/discipline.md).

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -67,7 +67,7 @@ Your scope is locked at assignment:
   - Bad (observed): after a `/dev/null` denial, retry it or switch to an arbitrary host path.
   - Good: stop, classify the output as source, durable proof, or ephemeral, then use its sanctioned location.
 - **Document important choices.** Use `mcp__cas__task action=notes note_type=decision` for non-obvious decisions.
-- **Keep durable discoveries deliberately.** Factory-worker relay turns are retained for attribution but are not auto-saved as Context; use `mcp__cas__memory action=remember` for a cross-session fact or decision.
+- **Keep durable discoveries deliberately.** Relays are attributed, not auto-saved; use `mcp__cas__memory action=remember` for cross-session facts.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
 - **Report context headroom** ("context: ~60% used") in every milestone progress note.
 - **Checkpoint, never compact.** When context is low: commit, push, leave a handoff note, and ask for respawn. Prefer small pushed commits. See [discipline.md](cas-worker/references/discipline.md).

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -67,6 +67,7 @@ Your scope is locked at assignment:
   - Bad (observed): after a `/dev/null` denial, retry it or switch to an arbitrary host path.
   - Good: stop, classify the output as source, durable proof, or ephemeral, then use its sanctioned location.
 - **Document important choices.** Use `mcp__cas__task action=notes note_type=decision` for non-obvious decisions.
+- **Keep durable discoveries deliberately.** Factory-worker relay turns are retained for attribution but are not auto-saved as Context; use `mcp__cas__memory action=remember` for a cross-session fact or decision.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
 - **Report context headroom** ("context: ~60% used") in every milestone progress note.
 - **Checkpoint, never compact.** When context is low: commit, push, leave a handoff note, and ask for respawn. Prefer small pushed commits. See [discipline.md](cas-worker/references/discipline.md).

--- a/cas-cli/src/hooks/handlers/handlers_middle/prompt_capture.rs
+++ b/cas-cli/src/hooks/handlers/handlers_middle/prompt_capture.rs
@@ -152,7 +152,16 @@ fn handle_user_prompt_submit_capture(
     // stricter gate: conversational questions and recursive control-plane
     // prompts do not earn a durable context entry merely by containing a
     // question word or being very long.
-    if is_context_memory_worthy_prompt(prompt_text) {
+    // Factory-worker turns include bare relay and lifecycle prose as user
+    // prompts.  Native team delivery strips sender/origin provenance before
+    // this hook runs, so the capture path cannot distinguish that traffic from
+    // a human instruction without guessing from content.  Keep complete prompt
+    // attribution above, but do not let ephemeral coordination compete in
+    // ambient recall as durable Context.  cas-b657 will carry typed provenance
+    // into HookInput and restore selective capture.
+    let factory_worker = crate::harness_policy::is_factory_agent(input)
+        && crate::harness_policy::is_worker(input);
+    if !factory_worker && is_context_memory_worthy_prompt(prompt_text) {
         if let Ok(store) = open_store(cas_root) {
             if let Ok(id) = store.generate_id() {
                 let entry = Entry {

--- a/cas-cli/src/hooks/handlers/handlers_tests/factory_inbox_surfacing.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/factory_inbox_surfacing.rs
@@ -11,7 +11,7 @@
 //! worked, and there was simply no code path from the queue back to a turn.
 
 use cas_core::hooks::types::{HookInput, HookSpecificOutput};
-use cas_store::{PromptQueueStore, PromptStore, SqlitePromptQueueStore, Store};
+use cas_store::{PromptQueueStore, SqlitePromptQueueStore};
 use tempfile::TempDir;
 
 use crate::hooks::handlers::handle_user_prompt_submit;

--- a/cas-cli/src/hooks/handlers/handlers_tests/factory_inbox_surfacing.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/factory_inbox_surfacing.rs
@@ -11,7 +11,7 @@
 //! worked, and there was simply no code path from the queue back to a turn.
 
 use cas_core::hooks::types::{HookInput, HookSpecificOutput};
-use cas_store::{PromptQueueStore, SqlitePromptQueueStore};
+use cas_store::{PromptQueueStore, PromptStore, SqlitePromptQueueStore, Store};
 use tempfile::TempDir;
 
 use crate::hooks::handlers::handle_user_prompt_submit;
@@ -344,6 +344,47 @@ fn supervisor_turn_surfaces_matching_same_day_learnings() {
         Some("Local green diverged from clean CI; audit inherited HOME, git identity, and CAS_AGENT_NAME".into());
     let ci_context = context_of(&handle_user_prompt_submit(&ci_input, Some(&cas_root)).unwrap());
     assert!(ci_context.contains("2026-08-14-3"), "{ci_context}");
+}
+
+/// cas-2880 (GH #375): native factory delivery supplies workers bare relay
+/// prose as UserPromptSubmit input. The hook has no sender/origin provenance,
+/// so automatic Context is deliberately disabled for factory workers rather
+/// than pretending content can distinguish a relay from an operator request.
+/// Prompt attribution remains complete; an unmarked decision relay is the
+/// explicit accepted loss until cas-b657 adds typed provenance to HookInput.
+#[test]
+fn factory_worker_turns_keep_attribution_but_never_auto_capture_context() {
+    let _lock = super::env_lock();
+    let project = TempDir::new().unwrap();
+    let cas_root = crate::store::init_cas_dir(project.path()).unwrap();
+
+    let mut worker = input("worker");
+    worker.cwd = project.path().to_string_lossy().into_owned();
+    {
+        let _env = worker_env();
+        worker.user_prompt = Some(
+            "PR #392 merged; Scoped Validation remains in progress. Hold the branch clean and wait for the re-close instruction.".into(),
+        );
+        handle_user_prompt_submit(&worker, Some(&cas_root)).unwrap();
+
+        worker.user_prompt = Some(
+            "GitHub check-run updatedAt changes only on state transitions; use status/conclusion and a known wall-clock bound before declaring CI stalled.".into(),
+        );
+        handle_user_prompt_submit(&worker, Some(&cas_root)).unwrap();
+    }
+
+    let prompt_store = crate::store::open_prompt_store(&cas_root).unwrap();
+    assert_eq!(
+        prompt_store.list_by_session(&worker.session_id, 10).unwrap().len(),
+        2,
+        "factory-worker relay turns remain available for attribution"
+    );
+
+    let entries = crate::store::open_store_local(&cas_root).unwrap().list().unwrap();
+    assert!(
+        entries.iter().all(|entry| entry.entry_type != EntryType::Context),
+        "routine and decision-bearing relay prose are an explicit accepted loss from auto Context: {entries:#?}"
+    );
 }
 
 /// Session isolation must hold on the surfacing path exactly as it does on the

--- a/cas-cli/src/hooks/mod.rs
+++ b/cas-cli/src/hooks/mod.rs
@@ -204,6 +204,10 @@ mod internal_llm_tests {
         // The marker is the boundary, not the prompt shape: a real user turn
         // still follows the ordinary memory path.
         env.remove(crate::internal_llm::INTERNAL_LLM_ENV);
+        env.remove("CAS_AGENT_ROLE");
+        env.remove("CAS_AGENT_NAME");
+        env.remove("CAS_SESSION_ID");
+        env.remove("CAS_FACTORY_MODE");
         handle_hook(
             "UserPromptSubmit",
             HookInput {


### PR DESCRIPTION
Suppress automatic durable Context capture for factory-worker prompt turns while retaining prompt attribution. Adds a real UserPromptSubmit regression, preserves ordinary-user capture with an explicit non-factory fixture phase, and keeps Claude/Codex/Grok worker guidance synchronized within the SessionStart budget.\n\nProof: Scoped Validation run 31857333728 passed at 956574a43464932e843682e36efd3d5190f37a72; local targeted behavior checks 3/3 and built-in flavor drift 9/9 passed.