### PR TITLE
fix: keep release audits local until publishing is explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,10 @@ jobs:
         if: steps.classify-diff.outputs.fast-pass != 'true'
         run: ./scripts/test-check-portable-x86_64-isa.sh
 
+      - name: Test release publication guards
+        if: steps.classify-diff.outputs.fast-pass != 'true'
+        run: make -C cas-cli test-ci-tiers
+
       - name: Build (without MCP proxy)
         if: steps.classify-diff.outputs.fast-pass != 'true'
         env:

--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -204,7 +204,9 @@ test-scoped-selftest:
 # Prove factory pushes stay scoped while epic/main/tag gates retain the full
 # matrix, including macOS, and reject the retired sccache cache protocol.
 test-ci-tiers:
-	../scripts/test-ci-test-tiers.sh
+	cd .. && ./scripts/test-ci-test-tiers.sh
+	cd .. && ./scripts/test-release-publication-policy.sh
+	cd .. && ./scripts/test-release-published-receipt.sh
 
 # Type check
 check:

--- a/cas-cli/docs/CONTRIBUTING.md
+++ b/cas-cli/docs/CONTRIBUTING.md
@@ -135,14 +135,14 @@ These require a major version bump:
    That snapshot suite checks the doctor/status schema and ledger counts that a
    migration moves; the scoped release suites do not build it. If no previous
    tag is reachable, the guard runs the snapshots conservatively.
-6. Run `./scripts/release.sh` to produce local audit evidence and push the
-   annotated tag. The tag-triggered GitHub Release workflow—not the local
+6. Run `./scripts/release.sh` to produce local audit evidence without touching
+   the remote. The tag-triggered GitHub Release workflow—not the local
    `dist/local-audit/` archives—creates the normal release. A local archive is
    evidence that the tagged source builds; it is never evidence of the shipped
    bytes or an announcement digest. The emergency
-   `--manual-publish --acknowledge-workflow-conflict` path is only for a
-   disabled/unavailable workflow and still requires the published receipt in
-   step 9 before any digest is announced.
+   `--publish-tag --manual-publish --acknowledge-workflow-conflict` path is
+   only for a disabled/unavailable workflow and still requires the published
+   receipt in step 9 before any digest is announced.
 7. Create an annotated tag, then run the fast release preflight **before pushing it**:
 
    ```bash
@@ -154,7 +154,9 @@ These require a major version bump:
    crate versions, a missing changelog heading, or lockfile drift before the
    expensive release builds begin. `release.sh` runs the same guard before its
    local audit and tag push.
-8. `release.sh` pushes the tag and starts the workflow. It builds Linux on its
+8. After reviewing the audit, `release.sh --publish-tag` pushes the tag and
+   starts the workflow. Publishing is deliberately explicit: a bare
+   `release.sh` invocation never touches the remote. It builds Linux on its
    host and, on macOS, also builds the Darwin audit target; this host-dependent
    audit coverage does not change what ships. CI always builds and publishes
    both Linux x86_64 and macOS ARM64 assets.

--- a/docs/RELEASE_SLACK_RUBRIC.md
+++ b/docs/RELEASE_SLACK_RUBRIC.md
@@ -28,8 +28,10 @@ directly to `main`, and do not create the release tag before the PR lands.
 4. After the required checks are green, merge explicitly:
    `gh pr merge "$PR_URL" --merge`. Do not use `--auto` or an admin bypass.
 5. Fetch the landed commit (`git fetch origin main`), tag that exact
-   `origin/main` commit, then run `./scripts/release.sh`. It pushes the tag;
-   the tag-triggered GitHub workflow is the normal release publisher.
+   `origin/main` commit, then run `./scripts/release.sh --publish-tag`. The
+   explicit flag pushes the tag; the tag-triggered GitHub workflow is the
+   normal release publisher. A bare `release.sh` is audit-only and never
+   touches the remote.
 
 ### Published assets before announcement
 
@@ -58,11 +60,11 @@ The workflow publishes macOS ARM64 from its macOS runner regardless of the host
 that tagged the release; never describe the release as Linux-only because a
 local audit host cannot build Darwin.
 
-`scripts/release.sh --manual-publish --acknowledge-workflow-conflict` is an
-emergency failover for a disabled or unavailable workflow, not a normal release
-lane. It deliberately competes after its tag push, so disable/cancel the CI
-workflow first when possible; it uses the same receipt command before any
-announcement digest is posted.
+`scripts/release.sh --publish-tag --manual-publish
+--acknowledge-workflow-conflict` is an emergency failover for a disabled or
+unavailable workflow, not a normal release lane. It deliberately competes
+after its tag push, so disable/cancel the CI workflow first when possible; it
+uses the same receipt command before any announcement digest is posted.
 
 ### Recovering a failed or partial release
 
@@ -91,8 +93,8 @@ announcement digest is posted.
    Do not use `--cleanup-tag`, force-push, or retag: the annotated tag remains
    the source identity for both the retry and its receipt.
 4. If CI cannot publish after that recovery, use the explicitly acknowledged
-   `--manual-publish --acknowledge-workflow-conflict` failover only after the
-   incomplete release is deleted. In every case, run
+   `--publish-tag --manual-publish --acknowledge-workflow-conflict` failover
+   only after the incomplete release is deleted. In every case, run
    `release-published-receipt.sh --write-draft` after publication and before an
    announcement.
 5. If any announcement might already name the release, do not delete or replace

--- a/docs/release-notes/runtime-release-template.md
+++ b/docs/release-notes/runtime-release-template.md
@@ -32,7 +32,9 @@ Live on production — **Dev** — {{DEV_IMPACT_PUNCH}}
 ## Posting sequence
 
 1. Replace the narrative placeholders after the release PR is merged.
-2. Tag the fetched `origin/main` landing and run `./scripts/release.sh`.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
 3. Run `release-published-receipt.sh --write-draft` against this draft. It
    downloads and hashes both published assets before replacing every digest
    placeholder; never type a digest from a local audit archive.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,10 +3,10 @@
 # Local release audit and tag-push script for CAS.
 #
 # GitHub's tag-triggered Release workflow is the sole normal publisher. This
-# script builds local audit evidence and pushes the annotated tag that starts
-# that workflow; its dist/local-audit archives are never the shipped bytes and
-# must never supply an announced digest. Use release-published-receipt.sh only
-# after the workflow has published both assets.
+# script builds local audit evidence by default. Only --publish-tag pushes the
+# annotated tag that starts that workflow; its dist/local-audit archives are
+# never the shipped bytes and must never supply an announced digest. Use
+# release-published-receipt.sh only after the workflow has published both assets.
 #
 # A deliberately loud manual failover remains for a disabled or unavailable CI
 # workflow. It deliberately competes with the tag-triggered workflow, so use
@@ -21,8 +21,9 @@
 #   - Environment variables: CAS_POSTHOG_API_KEY, CAS_SENTRY_DSN
 #
 # Usage:
-#   ./scripts/release.sh
-#   ./scripts/release.sh --manual-publish --acknowledge-workflow-conflict
+#   ./scripts/release.sh                 # local audit only; no remote mutation
+#   ./scripts/release.sh --publish-tag   # push tag and start CI publication
+#   ./scripts/release.sh --publish-tag --manual-publish --acknowledge-workflow-conflict
 
 set -euo pipefail
 
@@ -36,23 +37,29 @@ if [[ "$HOST_OS" == "Darwin" ]]; then
 fi
 
 DIST_DIR="$REPO_ROOT/dist/local-audit"
+PUBLISH_TAG=false
 MANUAL_PUBLISH=false
 ACKNOWLEDGED_CONFLICT=false
 
 for arg in "$@"; do
     case "$arg" in
+        --publish-tag) PUBLISH_TAG=true ;;
         --manual-publish) MANUAL_PUBLISH=true ;;
         --acknowledge-workflow-conflict) ACKNOWLEDGED_CONFLICT=true ;;
         -h|--help)
             cat <<'EOF'
-Usage: scripts/release.sh [--manual-publish --acknowledge-workflow-conflict]
+Usage: scripts/release.sh [--publish-tag [--manual-publish --acknowledge-workflow-conflict]]
 
-Build local audit archives and push the annotated tag. The tag-triggered
-GitHub Release workflow creates the normal published release.
+Build local audit archives without touching the remote. Add --publish-tag to
+push the annotated tag; the tag-triggered GitHub Release workflow creates the
+normal published release.
 
+  --publish-tag
+      Explicitly push the annotated tag after a successful local audit. This
+      starts the normal CI publisher.
   --manual-publish
       Emergency failover only: create a release from local audit archives
-      after pushing the tag. Use only while the workflow is disabled or
+      after --publish-tag. Use only while the workflow is disabled or
       unavailable; it deliberately conflicts with the normal CI publisher.
   --acknowledge-workflow-conflict
       Required with --manual-publish. Published digests must still come from
@@ -69,6 +76,10 @@ done
 
 if "$MANUAL_PUBLISH" && ! "$ACKNOWLEDGED_CONFLICT"; then
     echo "error: --manual-publish requires --acknowledge-workflow-conflict" >&2
+    exit 2
+fi
+if "$MANUAL_PUBLISH" && ! "$PUBLISH_TAG"; then
+    echo "error: --manual-publish requires --publish-tag" >&2
     exit 2
 fi
 if ! "$MANUAL_PUBLISH" && "$ACKNOWLEDGED_CONFLICT"; then
@@ -133,7 +144,11 @@ export ZIG="$REPO_ROOT/.context/zig/zig"
 export PATH="$REPO_ROOT/.context/zig:$PATH"
 echo "Zig: $(zig version)"
 
-ensure_release_tag
+if "$PUBLISH_TAG"; then
+    ensure_release_tag
+else
+    echo "Audit-only mode: no tag will be created or pushed."
+fi
 git submodule update --init --recursive
 
 INSTALLED_TARGETS="$(rustup target list --installed)"
@@ -179,6 +194,11 @@ done
 echo ""
 echo "=== Local Audit Complete ==="
 ls -lh "$DIST_DIR"/*.tar.gz
+
+if ! "$PUBLISH_TAG"; then
+    echo "Audit completed without creating or pushing a tag; no release was published."
+    exit 0
+fi
 
 echo "Pushing annotated tag $TAG to trigger the authoritative Release workflow..."
 git push origin "$TAG"

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -71,6 +71,7 @@ fi
 require_text "$ci_text" '- "factory/**"' 'factory pushes trigger CI'
 require_text "$ci_text" '- "epic/**"' 'epic pushes trigger CI'
 require_text "$ci_text" '- "v*"' 'release tags trigger CI'
+require_text "$ci_text" 'make -C cas-cli test-ci-tiers' 'Fast Validation invokes release publication guard scripts'
 
 scoped="$(job_block scoped-validation)"
 require_text "$scoped" "refs/heads/factory/" 'scoped tier selects factory branches'

--- a/scripts/test-release-publication-policy.sh
+++ b/scripts/test-release-publication-policy.sh
@@ -6,24 +6,36 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 release="$script_dir/release.sh"
 
 help_output="$("$release" --help)"
-grep -qF 'GitHub Release workflow creates the normal published release.' <<<"$help_output"
+grep -qF 'normal published release.' <<<"$help_output"
+grep -qF -- '--publish-tag' <<<"$help_output"
 grep -qF -- '--manual-publish' <<<"$help_output"
 grep -qF -- '--acknowledge-workflow-conflict' <<<"$help_output"
-echo 'ok   help distinguishes CI authority from explicit manual failover'
+echo 'ok   help distinguishes safe audit from explicit CI and manual publication'
 
 set +e
-missing_ack_output="$("$release" --manual-publish 2>&1)"
+missing_ack_output="$("$release" --publish-tag --manual-publish 2>&1)"
 missing_ack_status=$?
 set -e
 test "$missing_ack_status" -eq 2
 grep -qF -- '--manual-publish requires --acknowledge-workflow-conflict' <<<"$missing_ack_output"
 echo 'ok   manual publishing cannot begin without conflict acknowledgement'
 
+set +e
+missing_publish_output="$("$release" --manual-publish --acknowledge-workflow-conflict 2>&1)"
+missing_publish_status=$?
+set -e
+test "$missing_publish_status" -eq 2
+grep -qF -- '--manual-publish requires --publish-tag' <<<"$missing_publish_output"
+echo 'ok   manual publication cannot bypass explicit tag publication'
+
+audit_guard_line="$(rg -nF 'if ! "$PUBLISH_TAG"; then' "$release" | tail -n1 | cut -d: -f1)"
 push_line="$(rg -nF 'git push origin "$TAG"' "$release" | cut -d: -f1)"
 manual_create_line="$(rg -nF 'gh release create "$TAG"' "$release" | cut -d: -f1)"
+test -n "$audit_guard_line"
 test -n "$push_line"
 test -n "$manual_create_line"
+test "$audit_guard_line" -lt "$push_line"
 test "$push_line" -lt "$manual_create_line"
 rg -qF 'dist/local-audit' "$release"
 rg -qF 'never the shipped bytes' "$release"
-echo 'ok   tag starts CI before the exceptional competing manual publisher'
+echo 'ok   audit exits before the explicit tag push and manual publisher'

--- a/scripts/test-release-publication-policy.sh
+++ b/scripts/test-release-publication-policy.sh
@@ -28,14 +28,14 @@ test "$missing_publish_status" -eq 2
 grep -qF -- '--manual-publish requires --publish-tag' <<<"$missing_publish_output"
 echo 'ok   manual publication cannot bypass explicit tag publication'
 
-audit_guard_line="$(rg -nF 'if ! "$PUBLISH_TAG"; then' "$release" | tail -n1 | cut -d: -f1)"
-push_line="$(rg -nF 'git push origin "$TAG"' "$release" | cut -d: -f1)"
-manual_create_line="$(rg -nF 'gh release create "$TAG"' "$release" | cut -d: -f1)"
+audit_guard_line="$(grep -nF 'if ! "$PUBLISH_TAG"; then' "$release" | tail -n1 | cut -d: -f1)"
+push_line="$(grep -nF 'git push origin "$TAG"' "$release" | cut -d: -f1)"
+manual_create_line="$(grep -nF 'gh release create "$TAG"' "$release" | cut -d: -f1)"
 test -n "$audit_guard_line"
 test -n "$push_line"
 test -n "$manual_create_line"
 test "$audit_guard_line" -lt "$push_line"
 test "$push_line" -lt "$manual_create_line"
-rg -qF 'dist/local-audit' "$release"
-rg -qF 'never the shipped bytes' "$release"
+grep -qF 'dist/local-audit' "$release"
+grep -qF 'never the shipped bytes' "$release"
 echo 'ok   audit exits before the explicit tag push and manual publisher'

--- a/scripts/test-release-published-receipt.sh
+++ b/scripts/test-release-published-receipt.sh
@@ -44,6 +44,15 @@ write_release() {
 EOF
 }
 
+assert_no_digest_placeholders() {
+  local candidate="$1"
+
+  if grep -qF '{{LINUX_SHA256}}' "$candidate" || grep -qF '{{MACOS_SHA256}}' "$candidate"; then
+    echo 'FAIL receipt left a digest placeholder in the draft' >&2
+    return 1
+  fi
+}
+
 # A release object alone is insufficient: this pins the exact half-uploaded
 # state that used to let a local digest reach the announcement.
 write_release "[{\"name\":\"cas-x86_64-unknown-linux-gnu.tar.gz\",\"digest\":\"sha256:$linux_sha\"}]"
@@ -73,14 +82,20 @@ grep -qFx "LINUX_SHA256=$linux_sha" <<<"$success_output"
 grep -qFx "MACOS_SHA256=$macos_sha" <<<"$success_output"
 grep -qF "$linux_sha" "$draft"
 grep -qF "$macos_sha" "$draft"
-test "$(rg -oF "$linux_sha" "$draft" | wc -l)" -eq 2
-test "$(rg -oF "$macos_sha" "$draft" | wc -l)" -eq 2
-if rg -qF '{{LINUX_SHA256}}|{{MACOS_SHA256}}' "$draft"; then
-    echo 'FAIL receipt left a digest placeholder in the draft' >&2
-    exit 1
-fi
+test "$(grep -oF "$linux_sha" "$draft" | wc -l)" -eq 2
+test "$(grep -oF "$macos_sha" "$draft" | wc -l)" -eq 2
+assert_no_digest_placeholders "$draft"
 echo 'ok   complete published release emits and mechanically writes fresh digests'
 
-test "$(rg -oF '{{LINUX_SHA256}}' "$template" | wc -l)" -eq 2
-test "$(rg -oF '{{MACOS_SHA256}}' "$template" | wc -l)" -eq 2
+placeholder_draft="$fixture/draft-with-placeholder.md"
+printf 'Linux {{LINUX_SHA256}} / verified macOS digest\n' >"$placeholder_draft"
+set +e
+assert_no_digest_placeholders "$placeholder_draft" >/dev/null 2>&1
+placeholder_status=$?
+set -e
+test "$placeholder_status" -ne 0
+echo 'ok   residual digest placeholder is rejected'
+
+test "$(grep -oF '{{LINUX_SHA256}}' "$template" | wc -l)" -eq 2
+test "$(grep -oF '{{MACOS_SHA256}}' "$template" | wc -l)" -eq 2
 echo 'ok   runtime draft template exposes only receipt-fillable digest placeholders'


### PR DESCRIPTION
## Summary
- make bare release audits build local evidence without creating or pushing a tag
- run release authority fixtures from required Fast Validation preflight
- replace CI fixture ripgrep usage and exercise the residual placeholder failure path

## Verification
- make -C cas-cli test-ci-tiers
- bare ./scripts/release.sh reached audit-only mode without creating or pushing a tag before its intentionally stopped release build