### PR TITLE
fix(cas-9a29): preserve Commander terminal state

### DIFF
--- a/cas-cli/src/ui/factory/daemon/runtime/relay.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/relay.rs
@@ -210,12 +210,20 @@ pub(in crate::ui::factory::daemon) fn write_pane_snapshots(
 /// dimensions. This function captures that reflowed viewport as ANSI bytes
 /// suitable for replaying into a web terminal emulator (ghostty-web / xterm.js),
 /// preserving colors, bold/italic, and cursor position.
-fn snapshot_to_ansi(snap: &TerminalSnapshot) -> Vec<u8> {
+fn snapshot_to_ansi(snap: &TerminalSnapshot, in_alt_screen: bool) -> Vec<u8> {
     let cap = (snap.rows as usize) * (snap.cols as usize) * 4;
     let mut buf = Vec::with_capacity(cap);
     let mut tmp = String::new();
 
-    // Reset attributes, clear screen, cursor home
+    // The snapshot is taken from the currently visible buffer.  When that is
+    // an alternate screen, enter it before replaying the rows: a live Ink UI
+    // subsequently sends cursor-addressed incremental redraws and assumes
+    // that its alternate buffer is still selected.
+    if in_alt_screen {
+        buf.extend_from_slice(b"\x1b[?1049h");
+    }
+
+    // Reset attributes, clear screen, cursor home.
     buf.extend_from_slice(b"\x1b[0m\x1b[2J\x1b[H");
 
     let mut prev_fg: (u8, u8, u8) = (0, 0, 0);
@@ -453,7 +461,7 @@ impl FactoryDaemon {
         for pane_id in pane_ids {
             if let Some(pane) = self.app.mux.get(&pane_id) {
                 if let Ok(snapshot) = pane.get_full_snapshot() {
-                    let ansi = snapshot_to_ansi(&snapshot);
+                    let ansi = snapshot_to_ansi(&snapshot, pane.is_in_alt_screen());
                     if let Some(buffer) = self.pane_buffers.get_mut(&pane_id) {
                         buffer.replace_with(ansi);
                     }
@@ -508,7 +516,7 @@ impl FactoryDaemon {
                             // resize so the snapshot has correct content).
                             if let Some(p) = self.app.mux.get(&actual_pane) {
                                 if let Ok(snapshot) = p.get_full_snapshot() {
-                                    let ansi = snapshot_to_ansi(&snapshot);
+                                    let ansi = snapshot_to_ansi(&snapshot, p.is_in_alt_screen());
                                     self.pane_buffers
                                         .entry(actual_pane.clone())
                                         .or_default()
@@ -556,7 +564,7 @@ impl FactoryDaemon {
         // Rebuild the buffer from the reflowed vt snapshot
         if let Some(p) = self.app.mux.get(&actual_pane) {
             if let Ok(snapshot) = p.get_full_snapshot() {
-                let ansi = snapshot_to_ansi(&snapshot);
+                let ansi = snapshot_to_ansi(&snapshot, p.is_in_alt_screen());
                 self.pane_buffers
                     .entry(actual_pane)
                     .or_default()
@@ -702,5 +710,25 @@ mod tests {
         let mut buf = PaneBuffer::default();
         buf.append(b"\x1b[1;31mhello\x1b[0m world");
         assert_eq!(buf.as_plain_text(), "hello world");
+    }
+
+    #[test]
+    fn snapshot_replay_reenters_alternate_screen_before_ink_redraws() {
+        let snapshot = TerminalSnapshot {
+            cells: vec![cas_factory_protocol::TerminalCell {
+                codepoint: 'x' as u32,
+                fg: (0, 0, 0),
+                bg: (0, 0, 0),
+                flags: 0,
+                width: 1,
+            }],
+            cursor: cas_factory_protocol::CursorPosition { x: 0, y: 0 },
+            cols: 1,
+            rows: 1,
+        };
+
+        let replay = snapshot_to_ansi(&snapshot, true);
+        assert!(replay.starts_with(b"\x1b[?1049h\x1b[0m\x1b[2J\x1b[H"));
+        assert!(replay.ends_with(b"\x1b[0m\x1b[1;1H"));
     }
 }

--- a/hub-web/src/connection.ts
+++ b/hub-web/src/connection.ts
@@ -20,6 +20,8 @@ export interface HubCallbacks {
 }
 
 const RETRY_DELAYS = [1_000, 2_000, 4_000, 8_000, 16_000];
+const ATTACH_OPEN_TIMEOUT_MS = 10_000;
+const ATTACH_READY_TIMEOUT_MS = 10_000;
 
 class AuthenticationError extends Error {}
 
@@ -31,6 +33,9 @@ export class HubConnectionSupervisor {
   private readonly sockets = new Map<string, WebSocket>();
   private readonly socketAttempts = new Map<string, number>();
   private readonly attachRetryTimers = new Map<string, number>();
+  private readonly attachTimeouts = new Map<string, { open?: number; ready?: number }>();
+  private readonly timedOutSockets = new WeakSet<WebSocket>();
+  private readonly readySockets = new WeakSet<WebSocket>();
 
   constructor(readonly machine: StoredMachine, private readonly callbacks: HubCallbacks) {}
 
@@ -46,6 +51,7 @@ export class HubConnectionSupervisor {
     if (this.retryTimer !== undefined) window.clearTimeout(this.retryTimer);
     this.retryTimer = undefined;
     this.clearAttachRetries();
+    this.clearAttachTimeouts();
     for (const socket of this.sockets.values()) socket.close(1000, "machine removed");
     this.sockets.clear();
     this.callbacks.onState("idle");
@@ -158,6 +164,14 @@ export class HubConnectionSupervisor {
   }
 
   async attach(session: string): Promise<void> {
+    try {
+      await this.openAttach(session);
+    } catch (error) {
+      await this.handleAttachFailure(session, error);
+    }
+  }
+
+  private async openAttach(session: string): Promise<void> {
     if (!this.desired) return;
     const retryTimer = this.attachRetryTimers.get(session);
     if (retryTimer !== undefined) {
@@ -174,11 +188,25 @@ export class HubConnectionSupervisor {
     const socket = new WebSocket(endpoint);
     socket.binaryType = "arraybuffer";
     this.sockets.set(session, socket);
-    socket.onopen = () => this.socketAttempts.set(session, 0);
+    this.startOpenTimeout(session, socket);
+    socket.onopen = () => {
+      if (this.sockets.get(session) !== socket) return;
+      this.clearAttachTimeout(session, "open");
+      this.startReadyTimeout(session, socket);
+    };
     socket.onmessage = (message) => this.handleDaemonMessage(session, message.data);
     socket.onclose = (event) => {
+      const timedOut = this.timedOutSockets.has(socket);
+      const becameReady = this.readySockets.has(socket);
+      this.clearAttachTimeouts(session);
       if (this.sockets.get(session) === socket) this.sockets.delete(session);
       if (!this.desired || event.code === 1000) return;
+      if (!timedOut) {
+        this.callbacks.onSocketError(
+          session,
+          becameReady ? "Terminal connection closed. Retrying…" : "Terminal connection closed before it became ready. Retrying…",
+        );
+      }
       this.scheduleAttach(session);
     };
     socket.onerror = () => this.callbacks.onSocketError(session, "terminal transport error");
@@ -199,6 +227,8 @@ export class HubConnectionSupervisor {
       this.blockAuthentication("pairing expired or was revoked", session);
       return;
     }
+    const detail = error instanceof Error ? error.message : "unknown terminal attach failure";
+    this.callbacks.onSocketError(session, `Terminal attach failed: ${detail}. Retrying…`);
     this.scheduleAttach(session);
   }
 
@@ -223,6 +253,7 @@ export class HubConnectionSupervisor {
     if (this.retryTimer !== undefined) window.clearTimeout(this.retryTimer);
     this.retryTimer = undefined;
     this.clearAttachRetries();
+    this.clearAttachTimeouts();
     for (const socket of this.sockets.values()) socket.close(1000, "authentication blocked");
     this.sockets.clear();
     this.callbacks.onState("auth-blocked", detail);
@@ -237,7 +268,7 @@ export class HubConnectionSupervisor {
     const timer = window.setTimeout(() => {
       this.attachRetryTimers.delete(session);
       if (!this.desired) return;
-      void this.attach(session).catch((error) => this.handleAttachFailure(session, error));
+      void this.attach(session);
     }, delay);
     this.attachRetryTimers.set(session, timer);
   }
@@ -246,6 +277,53 @@ export class HubConnectionSupervisor {
     for (const timer of this.attachRetryTimers.values()) window.clearTimeout(timer);
     this.attachRetryTimers.clear();
     this.socketAttempts.clear();
+  }
+
+  private startOpenTimeout(session: string, socket: WebSocket): void {
+    this.clearAttachTimeouts(session);
+    const timeouts = this.attachTimeouts.get(session) ?? {};
+    timeouts.open = window.setTimeout(() => {
+      if (this.sockets.get(session) !== socket || socket.readyState !== WebSocket.CONNECTING) return;
+      this.timedOutSockets.add(socket);
+      this.callbacks.onSocketError(session, "Terminal connection timed out after 10 seconds before opening. Retrying…");
+      socket.close();
+    }, ATTACH_OPEN_TIMEOUT_MS);
+    this.attachTimeouts.set(session, timeouts);
+  }
+
+  private startReadyTimeout(session: string, socket: WebSocket): void {
+    const timeouts = this.attachTimeouts.get(session) ?? {};
+    timeouts.ready = window.setTimeout(() => {
+      if (this.sockets.get(session) !== socket || socket.readyState !== WebSocket.OPEN) return;
+      this.timedOutSockets.add(socket);
+      this.callbacks.onSocketError(session, "Terminal connection opened but sent no session state within 10 seconds. Retrying…");
+      socket.close();
+    }, ATTACH_READY_TIMEOUT_MS);
+    this.attachTimeouts.set(session, timeouts);
+  }
+
+  private clearAttachTimeout(session: string, kind: "open" | "ready"): void {
+    const timeouts = this.attachTimeouts.get(session);
+    const timer = timeouts?.[kind];
+    if (timer !== undefined) window.clearTimeout(timer);
+    if (timeouts) delete timeouts[kind];
+    if (timeouts && timeouts.open === undefined && timeouts.ready === undefined) this.attachTimeouts.delete(session);
+  }
+
+  private clearAttachTimeouts(session?: string): void {
+    const clear = (key: string, timeouts: { open?: number; ready?: number } | undefined) => {
+      if (!timeouts) return;
+      if (timeouts.open !== undefined) window.clearTimeout(timeouts.open);
+      if (timeouts.ready !== undefined) window.clearTimeout(timeouts.ready);
+      this.attachTimeouts.delete(key);
+    };
+    if (session) {
+      clear(session, this.attachTimeouts.get(session));
+      return;
+    }
+    for (const [key, timeouts] of this.attachTimeouts) {
+      clear(key, timeouts);
+    }
   }
 
   send(session: string, message: unknown): boolean {
@@ -259,6 +337,12 @@ export class HubConnectionSupervisor {
     const text = typeof input === "string" ? input : input instanceof Blob ? await input.text() : new TextDecoder().decode(input);
     const message = JSON.parse(text) as Record<string, any>;
     if (message.Welcome) {
+      const socket = this.sockets.get(session);
+      if (socket) {
+        this.readySockets.add(socket);
+        this.clearAttachTimeout(session, "ready");
+        this.socketAttempts.set(session, 0);
+      }
       this.callbacks.onSessionState(session, message.Welcome.state, message.Welcome.scrollback);
     } else if (message.StateUpdate) {
       this.callbacks.onSessionState(session, message.StateUpdate.state);

--- a/hub-web/src/invariants.test.ts
+++ b/hub-web/src/invariants.test.ts
@@ -148,6 +148,67 @@ describe("binding Commander browser invariants", () => {
     expect(source).toContain('this.callbacks.onState("auth-blocked", detail)');
   });
 
+  it("bounds a terminal that opens but never sends its initial session state", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", globalThis);
+    vi.stubGlobal("fetch", vi.fn(async () => ({ status: 200, ok: true, json: async () => ({ ticket: "unused" }) })));
+    class FakeWebSocket {
+      static readonly OPEN = 1;
+      static readonly CONNECTING = 0;
+      static instances: FakeWebSocket[] = [];
+      readyState = FakeWebSocket.CONNECTING;
+      binaryType = "";
+      onopen: (() => void) | null = null;
+      onmessage: ((message: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      onerror: (() => void) | null = null;
+      constructor() { FakeWebSocket.instances.push(this); }
+      open(): void { this.readyState = FakeWebSocket.OPEN; this.onopen?.(); }
+      close(): void { this.readyState = 3; this.onclose?.({ code: 1006 } as CloseEvent); }
+      send(): void {}
+    }
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+
+    const { privateKey, publicKey } = await createDeviceKey();
+    const machine = {
+      id: "machine", label: "Machine", baseUrl: "https://hub.example", deviceId: "device",
+      credentialId: "credential-id", credential: "opaque-credential", expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      scopes: ["pane-read"], publicKey, privateKey,
+    } satisfies StoredMachine;
+    const callbacks = {
+      onState: vi.fn(), onSessions: vi.fn(), onMachineEvent: vi.fn(),
+      onSessionState: vi.fn(), onOutput: vi.fn(), onSocketError: vi.fn(),
+    } satisfies HubCallbacks;
+    const supervisor = new HubConnectionSupervisor(machine, callbacks);
+    (supervisor as unknown as { desired: boolean }).desired = true;
+
+    await supervisor.attach("factory-a");
+    FakeWebSocket.instances[0].open();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(callbacks.onSocketError).toHaveBeenCalledWith(
+      "factory-a",
+      "Terminal connection opened but sent no session state within 10 seconds. Retrying…",
+    );
+    supervisor.stop();
+  });
+
+  it("turns terminal failures into an explanation and direct retry action", async () => {
+    const source = await readFile(new URL("main.ts", import.meta.url), "utf8");
+    const styles = await readFile(new URL("styles.css", import.meta.url), "utf8");
+    expect(source).toContain("Opening the terminal connection. This can take up to 10 seconds.");
+    expect(source).toContain("Terminal unavailable: ${detail}");
+    expect(source).toContain('retry.textContent = "Try again"');
+    expect(source).toContain("void connections.get(machineId)?.attach(session)");
+    expect(styles).toContain(".terminal-state");
+    expect(styles).toContain("#a36c2c");
+  });
+
+  it("removes the connecting instruction when the terminal state arrives", async () => {
+    const source = await readFile(new URL("main.ts", import.meta.url), "utf8");
+    expect(source).toContain('grid.querySelector(".empty")?.remove();');
+  });
+
   it.each(["stop", "auth-block"] as const)("cancels a scheduled attach retry on %s", async (terminalAction) => {
     vi.useFakeTimers();
     vi.stubGlobal("window", globalThis);

--- a/hub-web/src/main.ts
+++ b/hub-web/src/main.ts
@@ -80,14 +80,19 @@ function createConnection(machine: StoredMachine): HubConnectionSupervisor {
       if (selectedMachineId === machine.id && selectedSession) void loadStatus(machine.id, selectedSession);
       if (selectedMachineId === machine.id && selectedSession) void loadLease(machine.id, selectedSession);
     },
-    onSessionState: (session, state, scrollback) => void renderSessionState(machine.id, session, state, scrollback),
+    onSessionState: (session, state, scrollback) => {
+      void renderSessionState(machine.id, session, state, scrollback);
+    },
     onOutput: (session, pane, data) => {
       const key = paneKey(machine.id, session, pane);
       const buffered = [...(paneBuffers.get(key) ?? []), ...data];
       paneBuffers.set(key, buffered.slice(-2_000_000));
       surfaces.get(key)?.write(data);
     },
-    onSocketError: (session, detail) => void addAttention(machine, session, "session_transport", { headline: "Terminal transport problem", detail, severity: "incident" }),
+    onSocketError: (session, detail) => {
+      renderTerminalFailure(machine.id, session, detail);
+      void addAttention(machine, session, "session_transport", { headline: "Terminal transport problem", detail, severity: "incident" });
+    },
   });
 }
 
@@ -341,8 +346,39 @@ async function openSession(machineId: string, session: string): Promise<void> {
   selectedMachineId = machineId;
   selectedSession = session;
   render();
+  renderTerminalConnecting(machineId, session);
   await Promise.all([loadStatus(machineId, session), loadLease(machineId, session)]);
   await connections.get(machineId)?.attach(session);
+}
+
+function renderTerminalConnecting(machineId: string, session: string): void {
+  if (selectedMachineId !== machineId || selectedSession !== session) return;
+  const grid = document.querySelector<HTMLElement>("#pane-grid");
+  if (grid?.dataset.sessionKey !== sessionKey(machineId, session)) return;
+  const placeholder = grid.querySelector<HTMLElement>(".empty");
+  if (placeholder) {
+    placeholder.classList.remove("terminal-state");
+    placeholder.textContent = "Opening the terminal connection. This can take up to 10 seconds.";
+  }
+}
+
+function renderTerminalFailure(machineId: string, session: string, detail: string): void {
+  if (selectedMachineId !== machineId || selectedSession !== session) return;
+  const grid = document.querySelector<HTMLElement>("#pane-grid");
+  if (grid?.dataset.sessionKey !== sessionKey(machineId, session)) return;
+  const placeholder = grid.querySelector<HTMLElement>(".empty");
+  if (!placeholder) return;
+  const message = document.createElement("p");
+  message.textContent = `Terminal unavailable: ${detail}`;
+  const retry = document.createElement("button");
+  retry.className = "primary retry-terminal";
+  retry.textContent = "Try again";
+  retry.onclick = () => {
+    renderTerminalConnecting(machineId, session);
+    void connections.get(machineId)?.attach(session);
+  };
+  placeholder.classList.add("terminal-state");
+  placeholder.replaceChildren(message, retry);
 }
 
 async function loadStatus(machineId: string, session: string): Promise<void> {
@@ -401,6 +437,7 @@ async function renderSessionState(machineId: string, session: string, state: Ses
   if (selectedMachineId !== machineId || selectedSession !== session) return;
   const grid = document.querySelector<HTMLElement>("#pane-grid");
   if (!grid) return;
+  grid.querySelector(".empty")?.remove();
   const active = new Set(state.panes.filter((pane) => pane.kind !== "Director").map((pane) => pane.id));
   const selectedKey = sessionKey(machineId, session);
   const selectedPane = selectedPanes.get(selectedKey);

--- a/hub-web/src/styles.css
+++ b/hub-web/src/styles.css
@@ -31,7 +31,8 @@ main { min-width: 0; display: flex; flex-direction: column; overflow: hidden; }
 .t3-ghostty-canvas { display: block; width: 100%; height: 100%; cursor: text; }.t3-ghostty-canvas.link { cursor: pointer; }
 .t3-ghostty-input { position: absolute; left: 4px; top: 4px; width: 1px; height: 1px; opacity: 0; padding: 0; border: 0; resize: none; pointer-events: none; }
 .t3-ghostty-scrollbar { display: none; }
-.empty { place-self: center; color: #6e7681; }
+.empty { place-self: center; color: #8b949e; }
+.terminal-state { display: grid; gap: 12px; max-width: 360px; padding: 16px; border: 1px solid #a36c2c; border-radius: 10px; background: rgba(163,108,44,.16); color: #ffe2a8; font-size: 14px; line-height: 1.4; }.terminal-state p { margin: 0; }.terminal-state .retry-terminal { width: auto; justify-self: start; padding: 0 14px; }
 .context section { margin-bottom: 22px; }.badge { color: #f0f6fc; background: #da3633; border-radius: 999px; padding: 2px 7px; }
 .attention-group { margin: 0 0 12px; }.attention-group-header { display: flex; align-items: center; justify-content: space-between; gap: 6px; margin: 0 0 5px; }.attention-group-label { min-width: 0; overflow: hidden; color: #8b949e; font: 11px ui-monospace, monospace; text-overflow: ellipsis; white-space: nowrap; }.attention-group-ack { flex: none; min-height: 26px; padding: 2px 7px; font-size: 11px; }
 .attention-item, .status-row { border: 1px solid #30363d; border-radius: 8px; padding: 8px; margin: 6px 0; font-size: 12px; line-height: 1.35; }.attention-item--incident { border-color: #da3633; background: rgba(218,54,51,.12); box-shadow: inset 3px 0 #da3633; }.attention-item--incident .attention-title { color: #ff7b72; }.attention-item--notice { background: #0d1117; }


### PR DESCRIPTION
Preserves the active alternate-screen mode when replaying resize snapshots, bounds terminal attach readiness at 10 seconds with an actionable retry state, and removes the connecting instruction when session state arrives.\n\nValidation: hub-web tests/typecheck (75 tests) and scoped Rust relay regression.