### PR TITLE
Fix server_stop descendant cleanup

### DIFF
--- a/cas-cli/src/ui/factory/cgroup.rs
+++ b/cas-cli/src/ui/factory/cgroup.rs
@@ -151,16 +151,44 @@ pub(crate) fn describe_reaped(reaped: &[ReapedProcess]) -> String {
         .join(", ")
 }
 
-/// The cgroup directory this process belongs to, if the host provides a
-/// writable cgroup v2 tree we may create children in.
-///
-/// Writability is proven by actually creating and removing a probe directory —
-/// a delegated tree is not implied by the mount existing, and guessing wrong
-/// means every worker spawn logs a failure.
+/// The cgroup directory this process belongs to.
 #[cfg(target_os = "linux")]
-fn writable_parent() -> Option<PathBuf> {
+fn own_cgroup_dir() -> Option<PathBuf> {
     let own = parse_own_cgroup_path(&std::fs::read_to_string("/proc/self/cgroup").ok()?)?;
-    let parent = PathBuf::from(CGROUP_ROOT).join(own.trim_start_matches('/'));
+    Some(PathBuf::from(CGROUP_ROOT).join(own.trim_start_matches('/')))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn own_cgroup_dir() -> Option<PathBuf> {
+    None
+}
+
+#[cfg(test)]
+pub(super) fn own_scope_for_test() -> Option<PathBuf> {
+    own_cgroup_dir()
+}
+
+/// The containment root in which worker and shared-server scopes are siblings.
+///
+/// An MCP server invoked by a worker already runs *inside* that worker's
+/// `cas-worker-*` scope. Treating its current cgroup as the root nests a
+/// supposedly shared server below the worker, so the next worker teardown
+/// kills it. Ascend exactly one level for a recognized CAS worker scope; never
+/// ascend arbitrary host cgroups.
+fn containment_root(own: &Path) -> PathBuf {
+    let is_worker_scope = own
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("cas-worker-"));
+    if is_worker_scope {
+        own.parent().unwrap_or(own).to_path_buf()
+    } else {
+        own.to_path_buf()
+    }
+}
+
+/// Prove that `parent` is a writable delegated cgroup v2 tree.
+fn writable_scope_parent(parent: PathBuf) -> Option<PathBuf> {
     if !parent.join("cgroup.controllers").exists() {
         return None;
     }
@@ -176,6 +204,18 @@ fn writable_parent() -> Option<PathBuf> {
         }
         Err(_) => None,
     }
+}
+
+/// The containment root, if the host provides a writable cgroup v2 tree.
+///
+/// Worker scopes and shared-server scopes are created here as siblings.
+///
+/// Writability is proven by actually creating and removing a probe directory —
+/// a delegated tree is not implied by the mount existing, and guessing wrong
+/// means every worker spawn logs a failure.
+#[cfg(target_os = "linux")]
+fn writable_parent() -> Option<PathBuf> {
+    writable_scope_parent(containment_root(&own_cgroup_dir()?))
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -204,8 +244,29 @@ pub(crate) fn create_server_scope(factory_session: &str, server_name: &str) -> O
     )
 }
 
+/// Create a leaf cgroup for a **private registered server**.
+///
+/// Unlike a shared server, this scope is deliberately nested below the
+/// worker's current scope. Explicit `server_stop` can kill just this subtree,
+/// while worker teardown still kills it as part of the worker subtree.
+pub(crate) fn create_private_server_scope(
+    factory_session: &str,
+    server_name: &str,
+) -> Option<PathBuf> {
+    let parent = writable_scope_parent(own_cgroup_dir()?)?;
+    create_named_scope_in(
+        &parent,
+        prefixed_scope_name("cas-private-server", factory_session, server_name),
+        server_name,
+    )
+}
+
 fn create_named_scope(scope: String, label: &str) -> Option<PathBuf> {
     let parent = writable_parent()?;
+    create_named_scope_in(&parent, scope, label)
+}
+
+fn create_named_scope_in(parent: &Path, scope: String, label: &str) -> Option<PathBuf> {
     let dir = parent.join(scope);
     match std::fs::create_dir(&dir) {
         Ok(()) => Some(dir),
@@ -232,23 +293,36 @@ pub(crate) fn add_pid(dir: &Path, pid: u32) -> io::Result<()> {
 
 /// Describe every process currently in the cgroup, best effort.
 fn snapshot(dir: &Path) -> Vec<ReapedProcess> {
-    let Ok(contents) = std::fs::read_to_string(dir.join("cgroup.procs")) else {
-        return Vec::new();
-    };
-    let pids = parse_procs(&contents);
-    if pids.is_empty() {
-        return Vec::new();
-    }
     let listening = listening_ports_by_inode();
-    pids.into_iter()
-        .map(|pid| ReapedProcess {
-            pid,
-            comm: std::fs::read_to_string(format!("/proc/{pid}/comm"))
-                .map(|comm| comm.trim().to_string())
-                .unwrap_or_else(|_| "unknown".to_string()),
-            ports: listening_ports_for_pid(pid, &listening),
-        })
-        .collect()
+    let mut processes = Vec::new();
+    snapshot_into(dir, &listening, &mut processes);
+    processes
+}
+
+fn snapshot_into(dir: &Path, listening: &HashMap<u64, u16>, processes: &mut Vec<ReapedProcess>) {
+    if let Ok(contents) = std::fs::read_to_string(dir.join("cgroup.procs")) {
+        processes.extend(parse_procs(&contents).into_iter().map(|pid| {
+            ReapedProcess {
+                pid,
+                comm: std::fs::read_to_string(format!("/proc/{pid}/comm"))
+                    .map(|comm| comm.trim().to_string())
+                    .unwrap_or_else(|_| "unknown".to_string()),
+                ports: listening_ports_for_pid(pid, &listening),
+            }
+        }));
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for child in entries.flatten().filter_map(|entry| {
+        entry
+            .file_type()
+            .ok()
+            .filter(|kind| kind.is_dir())
+            .map(|_| entry.path())
+    }) {
+        snapshot_into(&child, listening, processes);
+    }
 }
 
 fn listening_ports_by_inode() -> HashMap<u64, u16> {
@@ -311,12 +385,29 @@ pub(crate) fn kill_scope(dir: &Path) -> io::Result<Vec<ReapedProcess>> {
             }
         }
     }
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let survivors = snapshot(dir);
+        if survivors.is_empty() {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(io::Error::other(format!(
+                "cgroup {} still contains surviving processes: {}",
+                dir.display(),
+                describe_reaped(&survivors)
+            )));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
     Ok(reaped)
 }
 
 /// Remove the (expected-empty) scope directory once its processes are gone.
 pub(crate) fn remove_scope(dir: &Path) {
     for _ in 0..20 {
+        remove_empty_descendant_scopes(dir);
         match std::fs::remove_dir(dir) {
             Ok(()) => return,
             Err(error) if error.kind() == io::ErrorKind::NotFound => return,
@@ -328,6 +419,25 @@ pub(crate) fn remove_scope(dir: &Path) {
         dir = %dir.display(),
         "cas-99f5: worker cgroup scope could not be removed; it may still hold processes"
     );
+}
+
+/// Remove empty child cgroups before their CAS-owned parent. Private server
+/// scopes are nested under worker scopes, so worker teardown legitimately
+/// leaves an empty hierarchy rather than a leaf.
+fn remove_empty_descendant_scopes(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for child in entries.flatten().filter_map(|entry| {
+        entry
+            .file_type()
+            .ok()
+            .filter(|kind| kind.is_dir())
+            .map(|_| entry.path())
+    }) {
+        remove_empty_descendant_scopes(&child);
+        let _ = std::fs::remove_dir(child);
+    }
 }
 
 #[cfg(test)]
@@ -397,17 +507,45 @@ mod tests {
         let name = scope_name("../../evil", "worker/../..");
         assert!(!name.contains('/'), "{name}");
         assert!(!name.contains(".."), "{name}");
-        assert_eq!(scope_name("cas-src-mighty-crane-74", "cosmic-crow-41"),
-            "cas-worker-cas-src-mighty-crane-74-cosmic-crow-41");
+        assert_eq!(
+            scope_name("cas-src-mighty-crane-74", "cosmic-crow-41"),
+            "cas-worker-cas-src-mighty-crane-74-cosmic-crow-41"
+        );
+    }
+
+    #[test]
+    fn shared_scope_root_ascends_out_of_a_worker_scope_only() {
+        let worker = Path::new("/delegated/session/cas-worker-factory-worker-a");
+        assert_eq!(
+            containment_root(worker),
+            PathBuf::from("/delegated/session")
+        );
+
+        let ordinary = Path::new("/delegated/session");
+        assert_eq!(containment_root(ordinary), ordinary);
+
+        let lookalike = Path::new("/delegated/session/not-cas-worker-a");
+        assert_eq!(containment_root(lookalike), lookalike);
     }
 
     #[test]
     fn reap_summary_names_pids_comms_and_ports() {
         let summary = describe_reaped(&[
-            ReapedProcess { pid: 4242, comm: "node".into(), ports: vec![5173, 24678] },
-            ReapedProcess { pid: 4243, comm: "esbuild".into(), ports: vec![] },
+            ReapedProcess {
+                pid: 4242,
+                comm: "node".into(),
+                ports: vec![5173, 24678],
+            },
+            ReapedProcess {
+                pid: 4243,
+                comm: "esbuild".into(),
+                ports: vec![],
+            },
         ]);
-        assert!(summary.contains("4242 (node, listening on 5173,24678)"), "{summary}");
+        assert!(
+            summary.contains("4242 (node, listening on 5173,24678)"),
+            "{summary}"
+        );
         assert!(summary.contains("4243 (esbuild)"), "{summary}");
         assert_eq!(describe_reaped(&[]), "no surviving processes");
     }

--- a/cas-cli/src/ui/factory/server_registry.rs
+++ b/cas-cli/src/ui/factory/server_registry.rs
@@ -43,6 +43,7 @@ const LOG_DIR: &str = "logs";
 const PID_PUBLISH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Grace between SIGTERM and SIGKILL on [`stop`].
+#[cfg(not(target_os = "linux"))]
 const STOP_GRACE: std::time::Duration = std::time::Duration::from_millis(1500);
 
 /// Lifecycle state of a registry entry.
@@ -126,8 +127,9 @@ pub(crate) struct RegisteredServer {
     pub factory_session: Option<String>,
     /// Whether this server was placed outside worker containment.
     pub shared: bool,
-    /// Its own cgroup scope, when the host delegates a writable v2 tree and
-    /// this server is shared.
+    /// Its own cgroup scope, when the host delegates a writable v2 tree.
+    /// Private scopes are children of the worker scope; shared scopes are
+    /// siblings of it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cgroup: Option<PathBuf>,
     /// Combined stdout/stderr capture — never inherited, because the MCP
@@ -381,16 +383,27 @@ pub(crate) fn start(cas_root: &Path, spec: &ServerSpec) -> io::Result<Registered
     let pid_dir = registry_dir(cas_root).join(".pid");
     fs::create_dir_all(&pid_dir)?;
     let pid_file = pid_dir.join(format!("{stamp}-{}.pid", std::process::id()));
+    let launcher_pid_file = pid_dir.join(format!("{stamp}-{}.launcher", std::process::id()));
+    let launch_file = pid_dir.join(format!("{stamp}-{}.go", std::process::id()));
     let _pid_file_guard = ScopedFile(pid_file.clone());
+    let _launcher_pid_file_guard = ScopedFile(launcher_pid_file.clone());
+    let _launch_file_guard = ScopedFile(launch_file.clone());
 
-    // The launcher: redirect, background the real command, publish its pid,
-    // exit. `$!` is the server itself, so the registry never records the
-    // launcher's pid.
+    // The launcher first publishes its own pid and waits. That barrier is
+    // load-bearing: CAS moves the launcher into the server's dedicated cgroup
+    // before it may fork the real command, so PTY wrappers that immediately
+    // call setsid cannot escape containment in the gap between spawn and
+    // add_pid. Once released, `$!` is the server itself; the launcher publishes
+    // it and exits.
     let script = format!(
-        "exec >>'{log}' 2>&1; {command} & printf '%s' \"$!\" > '{pid_file}'",
+        "exec >>'{log}' 2>&1; printf '%s' \"$$\" > '{launcher_pid_file}'; \
+         while [ ! -f '{launch_file}' ]; do sleep 0.01; done; \
+         {command} & printf '%s' \"$!\" > '{pid_file}'",
         log = log_path.display(),
         command = spec.command,
         pid_file = pid_file.display(),
+        launcher_pid_file = launcher_pid_file.display(),
+        launch_file = launch_file.display(),
     );
 
     let mut launcher = Command::new("sh");
@@ -421,46 +434,89 @@ pub(crate) fn start(cas_root: &Path, spec: &ServerSpec) -> io::Result<Registered
     }
 
     let mut child = launcher.spawn()?;
+    let launcher_pid = match read_published_pid(&launcher_pid_file) {
+        Ok(pid) => pid,
+        Err(error) => {
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(child.id() as libc::pid_t, libc::SIGKILL);
+            }
+            let _ = child.wait();
+            return Err(error);
+        }
+    };
+
+    // Every registered server gets a dedicated scope when cgroup v2 is
+    // delegated. Private scopes stay below the worker so teardown still owns
+    // them; shared scopes are true siblings so teardown cannot reach them.
+    let scope = if spec.shared {
+        super::cgroup::create_server_scope(
+            spec.factory_session.as_deref().unwrap_or("no-session"),
+            &spec.name,
+        )
+    } else {
+        super::cgroup::create_private_server_scope(
+            spec.factory_session.as_deref().unwrap_or("no-session"),
+            &spec.name,
+        )
+    };
+    let cgroup = match scope {
+        Some(dir) => match super::cgroup::add_pid(&dir, launcher_pid) {
+            Ok(()) => Some(dir),
+            Err(error) => {
+                tracing::warn!(
+                    server = %spec.name,
+                    launcher_pid,
+                    shared = spec.shared,
+                    error = %error,
+                    "cas-44d2: server launcher could not join its dedicated cgroup; \
+                     falling back to process-tree containment"
+                );
+                super::cgroup::remove_scope(&dir);
+                None
+            }
+        },
+        None => None,
+    };
+
+    if let Err(error) = fs::write(&launch_file, b"go\n") {
+        // The launcher has not forked the workload yet. Kill this exact child
+        // before returning so a failed registration cannot become an orphan.
+        #[cfg(unix)]
+        unsafe {
+            libc::kill(launcher_pid as libc::pid_t, libc::SIGKILL);
+        }
+        if let Some(ref dir) = cgroup {
+            let _ = super::cgroup::kill_scope(dir);
+            super::cgroup::remove_scope(dir);
+        }
+        let _ = child.wait();
+        return Err(error);
+    }
+
     // The launcher exits as soon as it has published the pid; waiting here is
     // what keeps it from becoming a zombie.
     let status = child.wait()?;
     if !status.success() {
+        if let Some(ref dir) = cgroup {
+            let _ = super::cgroup::kill_scope(dir);
+            super::cgroup::remove_scope(dir);
+        }
         return Err(io::Error::other(format!(
             "server launcher exited with {status}; see {}",
             log_path.display()
         )));
     }
 
-    let pid = read_published_pid(&pid_file)?;
-
-    // Move a shared server out of the worker's inherited cgroup scope. Without
-    // this, `cgroup.kill` at teardown takes it down no matter what session it
-    // is in — cgroup membership has no escape hatch, which is exactly why
-    // cas-99f5 chose it.
-    let cgroup = if spec.shared {
-        let scope = super::cgroup::create_server_scope(
-            spec.factory_session.as_deref().unwrap_or("no-session"),
-            &spec.name,
-        );
-        match scope {
-            Some(dir) => match super::cgroup::add_pid(&dir, pid) {
-                Ok(()) => Some(dir),
-                Err(error) => {
-                    tracing::warn!(
-                        server = %spec.name,
-                        pid,
-                        error = %error,
-                        "cas-7c93: shared server could not join its own cgroup scope; \
-                         session containment (setsid) remains the floor"
-                    );
-                    super::cgroup::remove_scope(&dir);
-                    None
-                }
-            },
-            None => None,
+    let pid = match read_published_pid(&pid_file) {
+        Ok(pid) => pid,
+        Err(error) => {
+            if let Some(ref dir) = cgroup {
+                let _ = super::cgroup::kill_scope(dir);
+                super::cgroup::remove_scope(dir);
+            }
+            return Err(error);
         }
-    } else {
-        None
     };
 
     let record = RegisteredServer {
@@ -529,13 +585,27 @@ pub(crate) fn stop(cas_root: &Path, record: &RegisteredServer) -> io::Result<Sto
     let outcome = match liveness(&record) {
         ServerLiveness::Live => {
             let ports = listening_ports(&record);
-            signal_server(&record);
+            terminate_server(&record)?;
             StopOutcome::Stopped {
                 pid: record.pid,
                 ports,
             }
         }
-        ServerLiveness::Gone => StopOutcome::AlreadyGone,
+        ServerLiveness::Gone if record.cgroup.is_some() => {
+            // The registered wrapper may exit before a detached descendant.
+            // Its dedicated scope remains authoritative even after reparenting,
+            // so drain it before claiming the workload was already gone.
+            terminate_server(&record)?;
+            StopOutcome::AlreadyGone
+        }
+        ServerLiveness::Gone => {
+            return Err(io::Error::other(format!(
+                "registered pid {} for server '{}' is gone, but this legacy record has no \
+                 containment scope; server_stop cannot prove that no detached descendants \
+                 survived",
+                record.pid, record.name
+            )));
+        }
         other => {
             // Do not touch the record's state on a refusal beyond marking it
             // dead: the server we started is provably no longer there, but
@@ -555,20 +625,6 @@ pub(crate) fn stop(cas_root: &Path, record: &RegisteredServer) -> io::Result<Sto
         }
     };
 
-    if let Some(dir) = record.cgroup.clone() {
-        // Only ever the server's *own* scope: created by `start`, containing
-        // nothing this registry did not put there.
-        match super::cgroup::kill_scope(&dir) {
-            Ok(_) => super::cgroup::remove_scope(&dir),
-            Err(error) => tracing::warn!(
-                server = %record.name,
-                dir = %dir.display(),
-                error = %error,
-                "cas-7c93: could not kill server cgroup scope"
-            ),
-        }
-    }
-
     record.state = ServerState::Stopped;
     record.ended_at = Some(Utc::now());
     record.ended_detail = Some(match &outcome {
@@ -577,6 +633,203 @@ pub(crate) fn stop(cas_root: &Path, record: &RegisteredServer) -> io::Result<Sto
     });
     write_record(cas_root, &record)?;
     Ok(outcome)
+}
+
+/// Terminate the registered workload and prove that the target is gone.
+///
+/// A dedicated cgroup is authoritative when available: it includes every
+/// descendant even after `setsid`, and `kill_scope` now refuses success while
+/// members remain. Older records and hosts without delegated cgroup v2 use a
+/// platform fallback below.
+fn terminate_server(record: &RegisteredServer) -> io::Result<()> {
+    if let Some(ref dir) = record.cgroup {
+        super::cgroup::kill_scope(dir)?;
+        super::cgroup::remove_scope(dir);
+        return verify_record_gone(record);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        return terminate_linux_process_tree(record);
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    {
+        signal_server(record);
+        return verify_record_gone(record);
+    }
+
+    #[cfg(not(unix))]
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "cannot prove termination of server '{}' descendants on this platform",
+                record.name
+            ),
+        ));
+    }
+}
+
+fn verify_record_gone(record: &RegisteredServer) -> io::Result<()> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        if !matches!(liveness(record), ServerLiveness::Live) {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(io::Error::other(format!(
+                "server_stop could not prove termination; surviving registered pid {} ({})",
+                record.pid, record.name
+            )));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProcessIdentity {
+    pid: u32,
+    starttime: u64,
+}
+
+/// Discover and freeze the full Linux descendant tree before killing it.
+///
+/// Freezing is what closes the fork/reparent race: once the root and every
+/// discovered descendant has received SIGSTOP, another scan must be stable
+/// before any parent is killed. Every signal is start-time fingerprinted so a
+/// recycled pid is never touched.
+#[cfg(target_os = "linux")]
+fn terminate_linux_process_tree(record: &RegisteredServer) -> io::Result<()> {
+    let mut tree = Vec::<ProcessIdentity>::new();
+    let root_starttime = record.pid_starttime.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing to stop server '{}' without a start-time fingerprint",
+                record.name
+            ),
+        )
+    })?;
+    tree.push(ProcessIdentity {
+        pid: record.pid,
+        starttime: root_starttime,
+    });
+    signal_fingerprinted(tree[0], libc::SIGSTOP)?;
+
+    for _ in 0..8 {
+        let before = tree.len();
+        let roots: Vec<u32> = tree.iter().map(|proc| proc.pid).collect();
+        for pid in roots {
+            collect_linux_descendants(pid, &mut tree)?;
+        }
+        for proc in &tree {
+            signal_fingerprinted(*proc, libc::SIGSTOP)?;
+        }
+        if tree.len() == before {
+            break;
+        }
+    }
+
+    // One final scan after all known members are frozen. Any child found here
+    // was forked during the preceding pass; freeze it and include it too.
+    let roots: Vec<u32> = tree.iter().map(|proc| proc.pid).collect();
+    for pid in roots {
+        collect_linux_descendants(pid, &mut tree)?;
+    }
+    for proc in &tree {
+        signal_fingerprinted(*proc, libc::SIGSTOP)?;
+    }
+
+    // Children first makes the survivor report easier to interpret and avoids
+    // relying on reparenting behavior. SIGKILL cannot be ignored.
+    for proc in tree.iter().rev() {
+        signal_fingerprinted(*proc, libc::SIGKILL)?;
+    }
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let survivors: Vec<_> = tree
+            .iter()
+            .copied()
+            .filter(|proc| process_identity_live(*proc))
+            .collect();
+        if survivors.is_empty() {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            let detail = survivors
+                .iter()
+                .map(|proc| proc.pid.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(io::Error::other(format!(
+                "server_stop could not terminate surviving descendant pid(s): {detail}"
+            )));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn collect_linux_descendants(pid: u32, tree: &mut Vec<ProcessIdentity>) -> io::Result<()> {
+    let path = format!("/proc/{pid}/task/{pid}/children");
+    let children = match fs::read_to_string(&path) {
+        Ok(children) => children,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(io::Error::new(
+                error.kind(),
+                format!("cannot inspect descendants through {path}: {error}"),
+            ));
+        }
+    };
+    for child in children
+        .split_whitespace()
+        .filter_map(|value| value.parse::<u32>().ok())
+    {
+        if tree.iter().any(|known| known.pid == child) {
+            continue;
+        }
+        if let Some(starttime) = crate::mcp::daemon::read_pid_starttime(child) {
+            let identity = ProcessIdentity {
+                pid: child,
+                starttime,
+            };
+            // Freeze on discovery, before recursing. If the child forked in
+            // the small scan-to-stop gap, the next scan of this now-frozen
+            // parent finds that last child deterministically.
+            signal_fingerprinted(identity, libc::SIGSTOP)?;
+            tree.push(identity);
+            collect_linux_descendants(child, tree)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn process_identity_live(proc: ProcessIdentity) -> bool {
+    crate::mcp::daemon::read_pid_starttime(proc.pid) == Some(proc.starttime) && !is_zombie(proc.pid)
+}
+
+#[cfg(target_os = "linux")]
+fn signal_fingerprinted(proc: ProcessIdentity, signal: libc::c_int) -> io::Result<()> {
+    if !process_identity_live(proc) {
+        return Ok(());
+    }
+    // SAFETY: the pid's start-time fingerprint was revalidated immediately
+    // above; ESRCH is an ordinary exit race.
+    let rc = unsafe { libc::kill(proc.pid as libc::pid_t, signal) };
+    if rc == 0 {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(error)
+    }
 }
 
 /// The process group `pid` belongs to, when the platform can tell us.
@@ -603,11 +856,13 @@ fn process_group_of(_pid: u32) -> Option<u32> {
 /// Pure, so the "never killpg a private server's group" rule is testable
 /// without spawning anything.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(any(test, not(target_os = "linux")))]
 pub(crate) enum SignalTarget {
     Pid(u32),
     ProcessGroup(u32),
 }
 
+#[cfg(any(test, not(target_os = "linux")))]
 pub(crate) fn signal_target(record: &RegisteredServer) -> SignalTarget {
     match (record.shared, record.pgid) {
         // Only signal the group when it is genuinely the server's own, not the
@@ -621,7 +876,7 @@ pub(crate) fn signal_target(record: &RegisteredServer) -> SignalTarget {
 }
 
 /// SIGTERM, brief grace, then SIGKILL to whatever is still there.
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn signal_server(record: &RegisteredServer) {
     let send = |signal: libc::c_int| {
         // SAFETY: identity was fingerprint-validated by the caller immediately
@@ -645,9 +900,6 @@ fn signal_server(record: &RegisteredServer) {
     }
     send(libc::SIGKILL);
 }
-
-#[cfg(not(unix))]
-fn signal_server(_record: &RegisteredServer) {}
 
 /// How long a stopped/dead entry stays visible as history before it is pruned.
 ///

--- a/cas-cli/src/ui/factory/server_registry_tests.rs
+++ b/cas-cli/src/ui/factory/server_registry_tests.rs
@@ -30,6 +30,129 @@ fn wait_until_gone(pid: u32) -> bool {
     false
 }
 
+#[cfg(target_os = "linux")]
+struct ProcessTreeGuard {
+    pid: u32,
+    armed: bool,
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for ProcessTreeGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // `script` makes the workload a session/group leader. Validate that
+        // relationship before group cleanup so a failed assertion can never
+        // signal the test runner's group.
+        let pgid = unsafe { libc::getpgid(self.pid as libc::pid_t) };
+        if pgid == self.pid as libc::pid_t {
+            unsafe {
+                libc::killpg(pgid, libc::SIGKILL);
+            }
+        } else {
+            unsafe {
+                libc::kill(self.pid as libc::pid_t, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+/// cas-44d2: reproduce the incident command shape, including a CAS-like child
+/// that survives TERM/HUP. `script` creates a new session for the workload;
+/// stopping only its registered wrapper pid used to return success while this
+/// child (and its own children) stayed alive.
+#[cfg(target_os = "linux")]
+#[test]
+fn server_stop_reaps_script_wrapped_cas_factory_descendants() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if Command::new("script").arg("--version").output().is_err() {
+        eprintln!("skipping: util-linux script is not installed");
+        return;
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let cas_root = temp.path().join("registry");
+    std::fs::create_dir_all(&cas_root).unwrap();
+    let bin = temp.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let fake_cas = bin.join("cas");
+    std::fs::write(
+        &fake_cas,
+        "#!/bin/sh\n\
+         test \"$1 $2 $3 $4\" = \"factory --new -n cas-44d2-proof\" || exit 64\n\
+         trap '' HUP TERM\n\
+         printf '%s' \"$$\" > \"$CAS_44D2_CHILD_PID\"\n\
+         while :; do sleep 300; done\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&fake_cas).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_cas, permissions).unwrap();
+
+    let child_pid_file = temp.path().join("cas-factory.pid");
+    let transcript = temp.path().join("typescript");
+    let command = format!(
+        "PATH='{}':\"$PATH\" CAS_44D2_CHILD_PID='{}' \
+         script -q -c 'cas factory --new -n cas-44d2-proof' '{}'",
+        bin.display(),
+        child_pid_file.display(),
+        transcript.display(),
+    );
+    let record = start(
+        &cas_root,
+        &spec("script-cas-factory", &command, temp.path(), false),
+    )
+    .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let workload_pid = loop {
+        if let Ok(contents) = std::fs::read_to_string(&child_pid_file)
+            && let Ok(pid) = contents.trim().parse::<u32>()
+        {
+            break pid;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "fake `cas factory` never published its pid; log: {:?}",
+            record
+                .log_path
+                .as_ref()
+                .and_then(|path| std::fs::read_to_string(path).ok())
+        );
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    };
+    let mut workload_guard = ProcessTreeGuard {
+        pid: workload_pid,
+        armed: true,
+    };
+
+    assert_ne!(
+        record.pid, workload_pid,
+        "the fixture must include a wrapper"
+    );
+    assert_eq!(
+        unsafe { libc::getpgid(workload_pid as libc::pid_t) },
+        workload_pid as libc::pid_t,
+        "precondition: util-linux script must put the workload in a new session/group"
+    );
+    assert!(crate::mcp::daemon::pid_alive(record.pid));
+    assert!(crate::mcp::daemon::pid_alive(workload_pid));
+
+    let outcome = stop(&cas_root, &record).unwrap();
+    assert!(matches!(outcome, StopOutcome::Stopped { .. }));
+    assert!(
+        wait_until_gone(record.pid),
+        "registered wrapper survived stop"
+    );
+    assert!(
+        wait_until_gone(workload_pid),
+        "server_stop returned success while script's `cas factory` descendant survived"
+    );
+    workload_guard.armed = false;
+}
+
 /// AC1: register, query, stop — the end-to-end shape a supervisor sees.
 #[test]
 fn start_records_ownership_then_list_and_stop_resolve_it() {
@@ -103,6 +226,30 @@ fn started_server_is_reparented_and_never_a_zombie_child() {
     let refreshed = refresh(&cas_root).unwrap();
     assert_eq!(refreshed.len(), 1);
     assert_eq!(refreshed[0].state, ServerState::Dead);
+}
+
+#[test]
+fn stop_does_not_claim_a_legacy_wrapper_is_the_whole_workload() {
+    let temp = tempfile::tempdir().unwrap();
+    let cas_root = temp.path().to_path_buf();
+    let mut record = start(
+        &cas_root,
+        &spec("legacy-gone", "sleep 0.02", temp.path(), false),
+    )
+    .unwrap();
+    assert!(wait_until_gone(record.pid));
+
+    // Records created before cas-44d2 have no dedicated scope. Once their
+    // wrapper pid is gone, a detached child is no longer discoverable by
+    // ancestry. Honest failure is the only provable outcome.
+    if let Some(scope) = record.cgroup.take() {
+        super::super::cgroup::remove_scope(&scope);
+    }
+    let error = stop(&cas_root, &record).unwrap_err();
+    assert!(
+        error.to_string().contains("cannot prove"),
+        "server_stop must report unverifiable descendants, not success: {error}"
+    );
 }
 
 /// AC: "dead pids are marked dead, not resurrected."
@@ -381,6 +528,27 @@ fn shared_server_leaves_the_callers_process_group_and_a_private_one_stays() {
         Some(caller_pgid),
         "a private server must stay in the caller's group so it dies with it"
     );
+    if let Some(own_scope) = super::super::cgroup::own_scope_for_test()
+        && own_scope
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("cas-worker-"))
+    {
+        if let (Some(shared_scope), Some(private_scope)) =
+            (shared.cgroup.as_ref(), private.cgroup.as_ref())
+        {
+            assert_eq!(
+                shared_scope.parent(),
+                own_scope.parent(),
+                "shared server scope must be a worker sibling, not a child that teardown kills"
+            );
+            assert_eq!(
+                private_scope.parent(),
+                Some(own_scope.as_path()),
+                "private server scope must stay under its worker so teardown still owns it"
+            );
+        }
+    }
 
     // And the signal targets follow from that: the shared server's own group
     // may be signalled; the private one may only ever be signalled by pid,


### PR DESCRIPTION
## Summary
- place registered workloads into dedicated cgroups before their commands can fork
- keep private scopes under worker containment while shared scopes are true siblings
- verify cgroup/process-tree termination and report unverifiable legacy survivors honestly
- reproduce the original script-wrapped cas factory escape

## Proof
- 25/25 scoped cgroup + server-registry tests (committed-diff proof)
- 7/7 server registry MCP integration tests
- 689/689 broader ui::factory tests passed (the proof wrapper rejected only the overly broad module-label receipt, then the exact proof passed)