### PR TITLE
docs: finalize Commander modernization release notes and posting receipt

### DIFF
--- a/docs/release-notes/2026-08-15-commander-modernization-slack.md
+++ b/docs/release-notes/2026-08-15-commander-modernization-slack.md
@@ -1,42 +1,54 @@
-# Slack draft — Commander UI modernization, 2026-08-15
+# Slack — Commander UI modernization, 2026-08-15
 
 Channel: #cas-internal (C0B44GUKDK2)
+Deploy target: **Live on production** (merged to `main` as `b6da4319`, PR #406)
 
-**Status:** Draft. Merged to main as `b6da4319` (PR #406) and already live on the
-operator's hub; not yet a tagged runtime release. Post after the operator has
-reviewed, or fold into the next version announcement.
+Four messages, in this order: user top-level → user reply → dev top-level (NEW
+top-level, not a reply) → dev reply.
 
 ## User thread
 
 **Top-level:**
-Live on production — **User** — Commander now shows you what your sessions are doing instead of a wall of identical grey boxes, and terminals actually open.
 
-**Reply (Was → Now):**
-- Was: terminals rendered as mangled, mid-word-wrapped text, and the main pane often sat on "Connecting to terminal…" forever with no explanation. Now: terminals render at the size of the pane you are looking at, and a connection that is failing tells you which step it is stuck on, how long it has been trying, and offers Retry and Diagnose.
-- Was: opening a session could transfer over 44 MB before anything appeared, which simply failed on some sessions and was brutal on a phone. Now: about 17 KB before the supervisor pane is ready — roughly 2,600 times smaller — with history fetched only when you scroll.
-- Was: every alert looked the same, so a dead daemon was indistinguishable from a routine note, each one prefixed by two lines of machine and session name. Now: alerts are grouped by session, ranked critical / warning / info, repeated failures collapse into one card with a count, and you can dismiss a whole group at once.
-- Was: the supervisor pane — the one you actually watch — got exactly as much space as everything else. Now: it is the dominant pane by default, panes can be promoted and reordered, and the layout is remembered.
-- Was: pairing from the browser could only ever grant read-only access, so "Take control" was permanently greyed out with no explanation. Now: control can be requested at runtime, and any control that is unavailable says why and what to do about it.
-- Also fixed: a hub that reported itself healthy after it had actually died, which is what caused Commander to serve errors and lose terminals entirely.
+Live on production — **User** — Commander now shows you what your sessions are actually doing, and terminals open instead of sitting on "Connecting…".
+
+**Reply:**
+
+Was → Now:
+
+• Was: terminals came up as mangled, mid-word-wrapped text, sized to something other than the pane you were looking at. Now: they render at the size of the pane on your screen, and text stays where it belongs.
+
+• Was: opening a session could pull about 44.7 MB before a single character appeared — slow on a laptop, often fatal on a phone. Now: roughly 17 KB gets your main pane on screen, and history is fetched only when you scroll back for it.
+
+• Was: a connection that was failing sat on "Connecting to terminal…" indefinitely, with nothing to tell you whether to wait or give up. Now: it names the step it is stuck on and how long it has been trying, and offers Retry and Diagnose.
+
+• Was: every alert looked identical, so a dead session was indistinguishable from a routine note. Now: alerts are grouped by session and ranked critical / warning / info, repeated failures collapse into a single card with a count, and you can dismiss a whole group at once.
+
+• Was: the pane you actually watch got exactly as much room as everything else. Now: it is the dominant pane by default, panes can be promoted and reordered, and your layout is remembered next time.
+
+• Was: pairing from the browser could only ever grant read-only access, so "Take control" stayed greyed out with no explanation. Now: control can be requested when you need it, and anything still unavailable tells you why.
 
 ## Dev thread
 
 **Top-level:**
-Live on production — **Dev** — Commander attach is now an authoritative ANSI keyframe instead of a replayed byte tail, and PTY geometry is decoupled from input authority.
 
-**Reply (Was → Now):**
-- Was: `snapshot_to_ansi` replayed a bounded raw tail of the pane ring. That is not a valid terminal state — a slice can begin mid-escape or omit mode-setting, so panes garbled intermittently. Now: attach emits `PaneKeyframe` generated from current terminal state under the same pane lock as tap registration, then live binary frames; scrollback is paged on demand. Initial payload fell from 44,718,217 B to 17,087 B before supervisor-ready (546 B metadata Welcome + 16,541 B keyframe) against a 256 KiB budget. Layered ceilings replace one global cap: 32/64 KiB metadata, 128/256 KiB per keyframe, 256/512 KiB total-before-ready.
-- Was: `ResizePane` was gated behind `pane-input` scope plus an active lease, so a read-only viewer could attach but never send its viewport size — a 281×65 PTY rendered into a ~51-column mount. Now: geometry is separate from input authority. With no lease any `pane-read` viewer may size; with a lease the holder owns geometry, so an observer cannot reflow a controller's terminal.
-- Was: connection state was a boolean with two independent 10s timers, and pairing scopes could only narrow. Now: an explicit staged lifecycle (resolving → dialing → auth → attaching → live) with per-stage deadlines, per-session `AttachSnapshot`, jittered backoff, heartbeat latency, authenticated Diagnose, runtime scope escalation against a grant ceiling without re-pairing, and expired-vs-revoked token handling. Transport is proto-2 multiplexed per machine with raw binary PTY frames.
-- Was: `server_stop` returned success while a PTY-wrapped child survived, and `shared` servers died with their worker. One root cause: the shared cgroup was nested beneath `cas-worker-*` instead of beside it, and the wrapper shared the worker PGID so a PID-only kill lost the reparented child. Now: shared scopes are siblings, private scopes children, launcher moves before fork, and teardown is verified rather than assumed.
-- Optional AI enrichment for session cards and attention events ships **default off**, with redaction applied inside the provider so callers cannot bypass it.
+Live on production — **Dev** — Attach now sends an authoritative ANSI keyframe built from current terminal state instead of replaying a sliced byte tail, and pane geometry is no longer gated behind input authority.
 
-## Posting sequence
+**Reply:**
 
-1. Confirm with the operator whether this posts standalone or folds into the next tagged release.
-2. Post the User top-level, then its single reply.
-3. Post the Dev top-level, then its single reply.
-4. Append the receipt below with UTC timestamps and all four permalinks.
+Was → Now:
+
+• Was: attach replayed a bounded raw tail of each pane's ring buffer. A byte slice is not a valid terminal state — it can begin mid-escape or omit mode-setting, so panes garbled intermittently. Now: attach emits a pane keyframe generated from current terminal state under the same lock as tap registration, then streams live binary frames, with scrollback paged on demand. Measured on a real session: 44,718,217 B → 17,087 B before the main pane is ready (546 B metadata + 16,541 B keyframe). Proven against a deliberately constructed worst case whose final 256 KiB began mid-SGR with no clear or home marker; the resulting keyframe still opened with RIS and re-established reset, clear and home.
+
+• Was: one global size cap, which only prevented transport failure and would let a payload near 500 KiB regress by ~100x undetected. Now: layered ceilings — 32/64 KiB metadata, 128/256 KiB per keyframe, 256/512 KiB total before the main pane is ready — so a regression names the stage that bloated.
+
+• Was: `ResizePane` required pane-input scope plus an active lease, so a read-only viewer could attach but never report its viewport, and a wide PTY rendered into a mount a fraction of its width. Now: reporting the viewport carries pane-read scope, with lease policy enforced separately — an unleased pane follows its observer, a leased pane follows its controller, so an observer cannot reflow a controller's terminal.
+
+• Was: connection state was a boolean with two independent timers. Now: an explicit staged lifecycle (resolving → dialing → auth → attaching → live) with per-stage deadlines, jittered backoff, heartbeat latency, authenticated Diagnose, and expired-vs-revoked token handling surfaced distinctly.
+
+• Was: stopping a registered server reported success while a wrapped child process survived it. Now: teardown is verified rather than assumed.
+
+• Was: nothing summarized a session or an alert for you. Now: optional AI enrichment can label session cards and attention events, shipping default off, with redaction applied inside the provider so callers cannot bypass it, and a deterministic severity floor that enrichment may raise but never lower.
 
 ## POSTED
 

--- a/docs/release-notes/2026-08-15-commander-modernization-slack.md
+++ b/docs/release-notes/2026-08-15-commander-modernization-slack.md
@@ -52,4 +52,16 @@ Was → Now:
 
 ## POSTED
 
-_Intentionally empty until publication._
+Published to **#cas-internal** (`C0B44GUKDK2`) on **2026-08-15**.
+Structure verified by a separate channel read: two top-level messages, each with
+exactly one threaded reply attached to the correct parent.
+
+| # | Message | Type | UTC | Permalink |
+|---|---------|------|-----|-----------|
+| 1 | User top-level | top-level | 2026-08-15 12:43:39Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786797819883899 |
+| 2 | User detail | reply to 1 | 2026-08-15 12:43:48Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786797828984089?thread_ts=1786797819.883899&cid=C0B44GUKDK2 |
+| 3 | Dev top-level | top-level | 2026-08-15 12:43:52Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786797832748759 |
+| 4 | Dev detail | reply to 3 | 2026-08-15 12:44:04Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786797844758099?thread_ts=1786797832.748759&cid=C0B44GUKDK2 |
+
+Announced as a `main` landing (`b6da4319`, PR #406), not a tagged runtime
+release. The next version tag should not re-announce this content.


### PR DESCRIPTION
Finalizes the Commander UI modernization announcement for the `b6da4319` (PR #406) landing and records its posting receipt.

- Replaces the draft with the postable announcement. Figures were verified against the delivery artifacts before publication: 546 B metadata + 16,541 B keyframe = 17,087 B before the main pane is ready, and the staged connection lifecycle names match `connection-state.ts`.
- Drops specifics that could not be verified from the shipped code.
- Adds the `## POSTED` receipt: four permalinks with UTC timestamps. Thread structure was confirmed by a separate channel read — two top-level messages, each with exactly one reply on the correct parent.

Announced as a `main` landing rather than a tagged runtime release, and the receipt notes that so the next version tag does not re-announce it.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)