### PR TITLE
release: v2.70.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.70.0] - 2026-08-15
+
+### Added
+- **Commander opens a session in kilobytes instead of megabytes.** Attaching sends an authoritative terminal keyframe built from current pane state and then streams live updates, so the first screen arrives in roughly 17 KB where it previously required about 44.7 MB, and history is fetched only when scrolled into view.
+- **Alerts are triaged instead of listed.** Attention cards are grouped by session, ranked critical, warning or info, and repeated failures collapse into a single card with a count that can be dismissed as a group.
+- **The pane you watch gets the room it deserves.** The supervisor pane is dominant by default, panes can be promoted and reordered, and the chosen layout is remembered.
+- **Optional AI enrichment can label session cards and attention events.** It ships default off, applies redaction inside the provider so callers cannot bypass it, and honors a deterministic severity floor that enrichment may raise but never lower.
+
+### Changed
+- **A failing connection explains itself.** Commander reports an explicit staged lifecycle with per-stage deadlines, jittered backoff, heartbeat latency and authenticated diagnosis, and distinguishes an expired credential from a revoked one, instead of showing an indefinite "Connecting" state.
+- **Reporting a viewport is now part of observing a pane, not controlling it.** A read-only viewer can size its own terminal, while a leased pane follows its controller, so an observer can no longer reflow a controller's screen.
+- **Browser pairing can request control when it is needed.** Control is no longer fixed at pairing time, and anything still unavailable states why.
+
+### Fixed
+- **Terminals render at the size of the pane showing them.** Panes no longer arrive as mangled, mid-word-wrapped text, and a replayed byte tail can no longer begin mid-escape or omit terminal modes.
+- **Stopping a registered server is verified rather than assumed.** A stop no longer reports success while a wrapped child process survives it.
+- **Release publication reflects the bytes users actually download.** Local audit archives stay local until publishing is explicit, and announced digests come from the published release.
+- **Integration and recovery handle real branch state.** Clean epic branches advance on integration, clean-behind receipt closes are unblocked, numeric stash recovery references are disambiguated, and relays no longer pollute session context.
+
 ## [2.69.1] - 2026-08-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.69.1"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.69.1"
+version = "2.70.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.69.1"
+version = "2.70.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.69.1"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.69.1"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.69.1"
+version = "2.70.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.69.1"
+version = "2.70.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.69.1"
+version = "2.70.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.69.1"
+version = "2.70.0"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.69.1"
+version = "2.70.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.69.1"
+version = "2.70.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.69.1"
+version = "2.70.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"


### PR DESCRIPTION
Cuts v2.70.0. Shipping since v2.69.1:

**Commander** (#403, #406) — session attach now sends an authoritative terminal keyframe built from current pane state rather than replaying a sliced byte tail, so the first screen arrives in ~17 KB instead of ~44.7 MB; alerts are grouped and ranked with repeat coalescing; the supervisor pane is dominant by default with remembered layout; connection state is an explicit staged lifecycle; viewport reporting is separated from input authority; optional AI enrichment ships default off behind provider-side redaction.

**Release publication** (#393, #396) — local audit archives stay local until publishing is explicit, and announced digests come from the published release.

**Integration and recovery** (#394, #395, #397, #398) — clean epic branches advance on integration, clean-behind receipt closes are unblocked, numeric stash recovery refs are disambiguated, and relays no longer pollute session context.

Version bump across the release-train crates, `Cargo.lock` regenerated with `cargo metadata --locked` verified, and the changelog section dated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)