### PR TITLE
fix(release): split the release preflight into local and CI lanes

### DIFF
--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -207,6 +207,7 @@ test-ci-tiers:
 	cd .. && ./scripts/test-ci-test-tiers.sh
 	cd .. && ./scripts/test-release-publication-policy.sh
 	cd .. && ./scripts/test-release-published-receipt.sh
+	cd .. && ./scripts/test-check-release-preflight.sh
 
 # Type check
 check:

--- a/cas-cli/docs/CONTRIBUTING.md
+++ b/cas-cli/docs/CONTRIBUTING.md
@@ -147,13 +147,20 @@ These require a major version bump:
 
    ```bash
    git tag -a vX.Y.Z -m "vX.Y.Z"
-   ./scripts/check-release-preflight.sh vX.Y.Z
+   ./scripts/check-release-preflight.sh --local vX.Y.Z
    ```
 
    This rejects a dirty tree, a lightweight/stale tag, mismatched release-train
    crate versions, a missing changelog heading, or lockfile drift before the
-   expensive release builds begin. `release.sh` runs the same guard before its
-   local audit and tag push.
+   expensive release builds begin. `release.sh` runs the same `--local` guard
+   before its local audit and tag push.
+
+   `--local` inspects the local tag object. Omit it only on the CI side, where
+   the tag is already pushed: the default lane re-fetches the exact remote tag
+   object first, so `actions/checkout` handing back a peeled ref cannot turn the
+   annotated-tag check into a check of checkout's local ref shape. Running the
+   default lane before the push always fails with
+   `couldn't find remote ref refs/tags/vX.Y.Z`.
 8. After reviewing the audit, `release.sh --publish-tag` pushes the tag and
    starts the workflow. Publishing is deliberately explicit: a bare
    `release.sh` invocation never touches the remote. It builds Linux on its

--- a/scripts/check-release-preflight.sh
+++ b/scripts/check-release-preflight.sh
@@ -3,16 +3,45 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 <annotated-tag>" >&2
-  echo "Example: $0 v2.57.0" >&2
+  echo "Usage: $0 [--local] <annotated-tag>" >&2
+  echo "Example: $0 v2.57.0            # CI lane: re-fetches the remote tag object" >&2
+  echo "Example: $0 --local v2.57.0    # pre-push lane: tag exists only locally" >&2
 }
 
-if [ "$#" -ne 1 ]; then
+# The remote tag re-fetch below is inherently CI-side: it can only pass once the
+# tag has been pushed. --local runs every other gate so the same checks can fail
+# a bad release *before* the tag is pushed.
+local_mode=false
+tag=""
+tag_seen=false
+for arg in "$@"; do
+  case "$arg" in
+    --local|--no-remote-tag) local_mode=true ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown option $arg" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      if "$tag_seen"; then
+        usage
+        exit 2
+      fi
+      tag="$arg"
+      tag_seen=true
+      ;;
+  esac
+done
+
+if ! "$tag_seen"; then
   usage
   exit 2
 fi
 
-tag="$1"
 if ! [[ "$tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
   echo "error: release tag must be v<semver>; got $tag" >&2
   exit 1
@@ -28,8 +57,14 @@ echo "ok: working tree is clean"
 # actions/checkout can materialize the event tag as its peeled commit/tree
 # rather than retaining the tag object. Re-fetch the exact remote tag object
 # before inspecting it, so this remains an annotated-tag check instead of an
-# accidental check of checkout's local ref shape.
-git fetch origin --no-tags --force "+refs/tags/$tag:refs/tags/$tag"
+# accidental check of checkout's local ref shape. In --local mode the tag has
+# not been pushed yet, so the local ref is authoritative and the fetch would
+# always fail with "couldn't find remote ref".
+if "$local_mode"; then
+  echo "ok: local mode; inspecting the local $tag object without a remote re-fetch"
+else
+  git fetch origin --no-tags --force "+refs/tags/$tag:refs/tags/$tag"
+fi
 if [ "$(git cat-file -t "refs/tags/$tag" 2>/dev/null || true)" != "tag" ]; then
   echo "error: $tag must exist locally as an annotated tag" >&2
   exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -129,7 +129,10 @@ ensure_release_tag() {
         echo "Creating annotated tag $TAG on HEAD before release audit..."
         git tag -a "$TAG" -m "$TAG"
     fi
-    ./scripts/check-release-preflight.sh "$TAG"
+    # --local: this runs before the tag is pushed, so the guard must inspect the
+    # local tag object instead of re-fetching one that cannot exist on origin
+    # yet. CI re-runs the same script without --local after the push.
+    ./scripts/check-release-preflight.sh --local "$TAG"
 }
 
 # A registered migration changes the doctor/status component snapshots, while

--- a/scripts/test-check-release-preflight.sh
+++ b/scripts/test-check-release-preflight.sh
@@ -39,6 +39,10 @@ run_guard() {
   (cd "$repo" && CARGO="$cargo_stub" "$guard" v1.2.3)
 }
 
+run_guard_local() {
+  (cd "$repo" && CARGO="$cargo_stub" "$guard" --local v1.2.3)
+}
+
 : >"$cargo_log"
 run_guard >/dev/null
 test "$(cat "$cargo_log")" = 'check --locked'
@@ -94,5 +98,113 @@ test "$lightweight_status" -ne 0
 grep -qF 'v1.2.3 must exist locally as an annotated tag' <<<"$lightweight_output"
 test ! -s "$cargo_log"
 echo 'ok   lightweight remote tag fails annotated-tag preflight'
+
+# --- pre-push (local) lane -------------------------------------------------
+# release.sh runs the guard before the tag is pushed, so a second fixture is
+# built whose annotated tag exists only locally.
+new_fixture() {
+  local name="$1"
+  local fixture_repo="$tmpdir/$name"
+  local fixture_remote="$tmpdir/$name-origin.git"
+  git init --bare -q "$fixture_remote"
+  git init -q "$fixture_repo"
+  git -C "$fixture_repo" config user.email release-guard@example.test
+  git -C "$fixture_repo" config user.name release-guard-test
+  git -C "$fixture_repo" remote add origin "$fixture_remote"
+  mkdir -p "$fixture_repo/cas-cli" "$fixture_repo/crates"/{cas-types,cas-search,cas-store,cas-core,cas-mcp}
+  for m in cas-cli/Cargo.toml crates/{cas-types,cas-search,cas-store,cas-core,cas-mcp}/Cargo.toml; do
+    printf '[package]\nversion = "1.2.3"\n' >"$fixture_repo/$m"
+  done
+  printf '## [1.2.3] - 2026-08-09\n\n- Release fixture.\n' >"$fixture_repo/CHANGELOG.md"
+  git -C "$fixture_repo" add .
+  git -C "$fixture_repo" commit -qm 'release fixture'
+  git -C "$fixture_repo" push -q origin HEAD:main
+  printf '%s' "$fixture_repo"
+}
+
+prepush="$(new_fixture prepush)"
+git -C "$prepush" tag -a v1.2.3 -m v1.2.3
+run_prepush() {
+  (cd "$prepush" && CARGO="$cargo_stub" "$guard" "$@")
+}
+
+: >"$cargo_log"
+run_prepush --local v1.2.3 >/dev/null
+test "$(cat "$cargo_log")" = 'check --locked'
+test -z "$(git -C "$prepush" ls-remote --tags origin 2>/dev/null)"
+echo 'ok   local lane passes with an annotated tag that is not on the remote yet'
+
+# The CI lane must keep re-fetching the remote tag object; without the push it
+# cannot pass, which is exactly why release.sh needs the --local lane.
+: >"$cargo_log"
+set +e
+ci_no_remote_output="$(run_prepush v1.2.3 2>&1)"
+ci_no_remote_status=$?
+set -e
+test "$ci_no_remote_status" -ne 0
+grep -qF "couldn't find remote ref" <<<"$ci_no_remote_output"
+test ! -s "$cargo_log"
+echo 'ok   CI lane still requires the tag to exist on the remote'
+
+# Local gates keep their teeth in --local mode.
+printf 'dirty\n' >"$prepush/uncommitted.txt"
+: >"$cargo_log"
+set +e
+local_dirty_output="$(run_prepush --local v1.2.3 2>&1)"
+local_dirty_status=$?
+set -e
+test "$local_dirty_status" -ne 0
+grep -qF 'release input is dirty' <<<"$local_dirty_output"
+test ! -s "$cargo_log"
+rm "$prepush/uncommitted.txt"
+echo 'ok   local lane rejects a dirty tree'
+
+git -C "$prepush" commit -q --allow-empty -m 'commit after tagging'
+: >"$cargo_log"
+set +e
+local_stale_output="$(run_prepush --local v1.2.3 2>&1)"
+local_stale_status=$?
+set -e
+test "$local_stale_status" -ne 0
+grep -qF 'but this build checks out' <<<"$local_stale_output"
+test ! -s "$cargo_log"
+echo 'ok   local lane rejects a tag that no longer peels to HEAD'
+
+git -C "$prepush" tag -d v1.2.3 >/dev/null
+git -C "$prepush" tag v1.2.3
+: >"$cargo_log"
+set +e
+local_lightweight_output="$(run_prepush --local v1.2.3 2>&1)"
+local_lightweight_status=$?
+set -e
+test "$local_lightweight_status" -ne 0
+grep -qF 'v1.2.3 must exist locally as an annotated tag' <<<"$local_lightweight_output"
+test ! -s "$cargo_log"
+echo 'ok   local lane rejects a lightweight tag'
+
+# --- CI lane rejects a re-pointed remote tag -------------------------------
+repointed="$(new_fixture repointed)"
+git -C "$repointed" tag -a v1.2.3 -m v1.2.3
+git -C "$repointed" push -q origin v1.2.3
+git -C "$repointed" commit -q --allow-empty -m 'commit published after the tag'
+git -C "$repointed" push -q origin HEAD:main
+: >"$cargo_log"
+set +e
+repointed_output="$( (cd "$repointed" && CARGO="$cargo_stub" "$guard" v1.2.3) 2>&1 )"
+repointed_status=$?
+set -e
+test "$repointed_status" -ne 0
+grep -qF 'but this build checks out' <<<"$repointed_output"
+test ! -s "$cargo_log"
+echo 'ok   CI lane rejects a remote tag that does not peel to the build commit'
+
+# Unknown flags are rejected rather than silently treated as the tag argument.
+set +e
+badflag_output="$(run_prepush --nope v1.2.3 2>&1)"
+badflag_status=$?
+set -e
+test "$badflag_status" -eq 2
+grep -qF 'unknown option --nope' <<<"$badflag_output"
+echo 'ok   unknown option is rejected'
 
 echo 'PASS: release preflight guard behavior verified.'

--- a/scripts/test-release-publication-policy.sh
+++ b/scripts/test-release-publication-policy.sh
@@ -39,3 +39,17 @@ test "$push_line" -lt "$manual_create_line"
 grep -qF 'dist/local-audit' "$release"
 grep -qF 'never the shipped bytes' "$release"
 echo 'ok   audit exits before the explicit tag push and manual publisher'
+
+# The pre-push preflight runs before `git push origin "$TAG"`, so it must use
+# the local lane; the CI-side remote tag re-fetch cannot pass before the push.
+preflight_line="$(grep -nF 'check-release-preflight.sh' "$release" | cut -d: -f1)"
+test -n "$preflight_line"
+test "$preflight_line" -lt "$push_line"
+grep -qF 'check-release-preflight.sh --local "$TAG"' "$release"
+echo 'ok   pre-push preflight uses the local lane instead of the CI remote-tag lane'
+
+# CI keeps the full lane, including the remote tag re-fetch.
+release_workflow="$(cd "$script_dir/.." && pwd)/.github/workflows/release.yml"
+grep -qE 'check-release-preflight\.sh "\$\{GITHUB_REF_NAME\}"' "$release_workflow"
+! grep -qF 'check-release-preflight.sh --local' "$release_workflow"
+echo 'ok   CI release workflow keeps the remote-tag preflight lane'


### PR DESCRIPTION
`./scripts/release.sh --publish-tag` could not run from a clean checkout. `ensure_release_tag` called `check-release-preflight.sh` *before* pushing the tag, but that script re-fetches the tag from the remote — a check that is inherently CI-side, since it exists to defend against `actions/checkout` materializing the event tag as a peeled ref. The documented publish command therefore aborted with a misleading `fatal: couldn't find remote ref`, producing no audit build and no tag push. Hit while cutting v2.70.0; that release was published by verifying every gate by hand and pushing the tag directly.

**Fix:** `check-release-preflight.sh` gains `--local`/`--no-remote-tag`, which skips *only* the remote re-fetch. Every other gate still runs in both lanes: clean tree, annotated-tag object, peels-to-HEAD, six-crate version match, CHANGELOG heading, `cargo check --locked`. `release.sh` uses `--local` pre-push; `.github/workflows/release.yml` is untouched and keeps the strict lane after the push.

Also fixes `cas-cli/docs/CONTRIBUTING.md` step 7, which told humans to run the CI lane pre-push — the same bug in prose.

**Coverage:** `test-check-release-preflight.sh` goes from 5 to 12 cases against real fixture repos with a bare remote, including the case none existed for — the local lane passing with the tag absent from the remote — plus proof the CI lane still fails without the push and that the local lane keeps rejecting a dirty tree, a stale tag, and a lightweight tag. `test-release-publication-policy.sh` adds a static contract that the preflight call precedes the tag push and uses `--local` while `release.yml` does not. The preflight test was wired into `make -C cas-cli test-ci-tiers`; it previously ran in no CI lane at all, which is why a 220-line rewrite of this path shipped broken.

Supervisor verified independently: ran the suite from the branch, 12/12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)