### PR TITLE
docs: record v2.70.0 release receipt

### DIFF
--- a/docs/release-notes/2026-08-15-v2.70.0-slack.md
+++ b/docs/release-notes/2026-08-15-v2.70.0-slack.md
@@ -1,0 +1,80 @@
+# Slack draft — CAS v2.70.0 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** POSTED. Published 2026-08-15T13:20:22Z; announced 2026-08-15T13:21:35Z.
+Digests below were written by `release-published-receipt.sh --write-draft` from
+fresh downloads of the published assets.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — CAS v2.70.0 makes Commander usable on a phone: a session that used to take about 44.7 MB to open now opens in roughly 17 KB.
+
+**Reply (Was → Now):**
+- Was: opening a session pulled about 44.7 MB before a single character appeared, terminals arrived as mangled mid-word-wrapped text, a failing connection sat on "Connecting…" with no explanation, and every alert looked identical so a dead session read the same as a routine note. Now: roughly 17 KB puts your main pane on screen with history fetched only as you scroll, terminals render at the size of the pane showing them, a stalled connection names the step it is stuck on and offers Retry and Diagnose, and alerts are grouped by session and ranked critical / warning / info with repeats collapsed into one card you can dismiss as a group.
+- Install: use `cas update` for an existing installation, or download the
+  v2.70.0 archive for Linux x86_64 (SHA-256 `5784e8a57897263bbf0f2fbd9d59d9ab26e67adf5f8f00d97e1e96d6f38b96f1`) or macOS ARM64
+  (SHA-256 `28db27974714e6e06a3f3670312e19547748f9504cdf9aea0694dc59e422795a`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v2.70.0 replaces replayed byte-tail attach with an authoritative ANSI keyframe built from current terminal state, and separates pane geometry from input authority.
+
+**Reply (Was → Now):**
+- Was: attach replayed a bounded raw tail of each pane's ring buffer, which is not a valid terminal state — a slice can begin mid-escape or omit mode-setting, so panes garbled intermittently; `ResizePane` additionally required pane-input scope plus an active lease, so a read-only viewer could never report its viewport; and connection state was a boolean with two independent timers. Now: attach emits a pane keyframe generated from current terminal state under the same lock as tap registration and then streams live binary frames with scrollback paged on demand, measured at 44,718,217 B → 17,087 B before the main pane is ready; viewport reporting carries pane-read scope with lease policy enforced separately, so an unleased pane follows its observer and a leased pane follows its controller; and the connection exposes a staged lifecycle (resolving → dialing → auth → attaching → live) with per-stage deadlines, jittered backoff and expired-vs-revoked token handling. A single global size cap is replaced by layered ceilings — 32/64 KiB metadata, 128/256 KiB per keyframe, 256/512 KiB total before ready — so a regression names the stage that bloated. This release also keeps local release audits local until publishing is explicit, and makes published assets the authoritative source for announced digests.
+- Validation and artifact: the release commit landed through a reviewed PR with required checks green (Fast Validation preflight, full suite and doctests, plus the macOS check), and the tagged workflow verified release inputs before building both targets. Both digests below were taken from fresh downloads of the published assets and matched GitHub's recorded SHA-256, not from any local build. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `5784e8a57897263bbf0f2fbd9d59d9ab26e67adf5f8f00d97e1e96d6f38b96f1`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `28db27974714e6e06a3f3670312e19547748f9504cdf9aea0694dc59e422795a`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+Structure verified by a separate channel read after posting: two top-level
+messages, each with exactly one threaded reply on the correct parent.
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-15 13:21:35Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786800095831809 |
+| User reply (Was → Now) | 2026-08-15 13:21:47Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786800107049049?thread_ts=1786800095.831809&cid=C0B44GUKDK2 |
+| Dev top-level | 2026-08-15 13:21:51Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786800111644409 |
+| Dev reply (Was → Now) | 2026-08-15 13:22:06Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786800126516379?thread_ts=1786800111.644409&cid=C0B44GUKDK2 |
+
+## Release identity
+
+- Tag `v2.70.0` → commit `f9344fa7`, published 2026-08-15T13:20:22Z, not a draft.
+- Workflow run 31885996430: Verify Release Inputs, Build Linux x86_64, Build
+  macOS ARM64, Create Release — all success.
+- `cas-x86_64-unknown-linux-gnu.tar.gz` 22,783,903 B, SHA-256
+  `5784e8a57897263bbf0f2fbd9d59d9ab26e67adf5f8f00d97e1e96d6f38b96f1`.
+- `cas-aarch64-apple-darwin.tar.gz` 20,105,462 B, SHA-256
+  `28db27974714e6e06a3f3670312e19547748f9504cdf9aea0694dc59e422795a`.
+
+## Procedure note
+
+`./scripts/release.sh --publish-tag` could not be used for this release: it ran
+the full `check-release-preflight.sh` before pushing the tag, and that script
+re-fetches the tag from the remote, so it aborted with `couldn't find remote
+ref` without building or pushing. Every gate that gate encodes was verified by
+hand instead — clean tree, annotated tag peeling to HEAD, all six release-train
+crate versions at 2.70.0, CHANGELOG heading present, HEAD == origin/main,
+`cargo check --locked` exit 0 — and the annotated tag was pushed directly, so
+publication still went through the normal CI publisher. The local audit-evidence
+build was the only step skipped. Fixed for the next release by the local/CI
+preflight lane split; that change postdates this tag and belongs in the next
+release's notes, not these.


### PR DESCRIPTION
Posting receipt for the v2.70.0 announcement: four permalinks with UTC timestamps, verified thread structure, published asset digests and sizes, and the workflow run identity.

Also records that `./scripts/release.sh --publish-tag` could not be used for this release and what was verified by hand in its place, so the gap in the audit trail is documented rather than discovered later. The fix for that is in flight separately and postdates this tag.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)