### PR TITLE
fix(ci): wire the last two release-guard self-tests into a lane, and repair the stale one

### DIFF
--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -203,11 +203,20 @@ test-scoped-selftest:
 
 # Prove factory pushes stay scoped while epic/main/tag gates retain the full
 # matrix, including macOS, and reject the retired sccache cache protocol.
+#
+# Every scripts/test-*.sh suite that guards the release path runs here. A
+# release guard whose own self-test runs in no lane drifts silently and only
+# surfaces mid-release with a tag already pushed: that is how the publish-path
+# preflight shipped unable to pass (cas-069d), and how this target's own
+# migration-snapshot suite went stale for five days (cas-66ee). Keep this list
+# exhaustive — if you add a scripts/test-*.sh, wire it into a lane here.
 test-ci-tiers:
 	cd .. && ./scripts/test-ci-test-tiers.sh
 	cd .. && ./scripts/test-release-publication-policy.sh
 	cd .. && ./scripts/test-release-published-receipt.sh
 	cd .. && ./scripts/test-check-release-preflight.sh
+	cd .. && ./scripts/test-check-release-host.sh
+	cd .. && ./scripts/test-check-release-migration-snapshots.sh
 
 # Type check
 check:

--- a/cas-cli/docs/CONTRIBUTING.md
+++ b/cas-cli/docs/CONTRIBUTING.md
@@ -131,7 +131,8 @@ These require a major version bump:
    ```
 
    When `cas-cli/src/migration/migrations/mod.rs` changed since the last tag,
-   this runs the required command `cargo test -p cas --test component_output_test`.
+   this runs the required command
+   `cargo nextest run -p cas --test component_output_test`.
    That snapshot suite checks the doctor/status schema and ledger counts that a
    migration moves; the scoped release suites do not build it. If no previous
    tag is reachable, the guard runs the snapshots conservatively.

--- a/scripts/test-check-release-migration-snapshots.sh
+++ b/scripts/test-check-release-migration-snapshots.sh
@@ -40,9 +40,12 @@ assert_no_cargo() {
   fi
 }
 
+# Deliberately an exact match, not a substring or regex. The guard must run the
+# component-output snapshots and nothing else, so any change to the invocation
+# should fail here loudly and be re-confirmed on purpose.
 assert_exact_cargo() {
   local description="$1"
-  if [[ "$(cat "$cargo_log")" != 'test -p cas --test component_output_test' ]]; then
+  if [[ "$(cat "$cargo_log")" != 'nextest run -p cas --test component_output_test' ]]; then
     echo "FAIL $description: wrong cargo invocation" >&2
     cat "$cargo_log" >&2
     exit 1


### PR DESCRIPTION
Follow-up to #410. Completes the sweep: after this, **zero** `scripts/test-*.sh` suites run in no lane.

**The pre-wiring gate caught a live problem.** `test-check-release-migration-snapshots.sh` was **red on main**. Wiring it blind would have turned Fast Validation red on every PR in the repo.

Cause: `c7727872` ("make nextest the standard test runner") changed the guard to `cargo nextest run -p cas --test component_output_test` but did not update the guard's self-test, whose exact-match assertion still expected `cargo test …`. The **guard is correct**; only the test's expectation was stale. `CONTRIBUTING.md:134` carried the same stale string. It went five days undetected for exactly one reason — the suite ran in no CI lane, which is `cas-069d`'s failure mode reproducing on a sibling suite.

The assertion is deliberately kept an **exact** match rather than loosened to a substring. Exactness did not cause the drift; running in no lane did. Once wired, exactness is what fails loudly on the next invocation change.

**Supervisor verified independently, not on report:** perturbed the guard two ways in a throwaway worktree — reverting to `cargo test`, and pointing at a different test target — and the suite returned non-zero on both while passing clean unperturbed. So it has teeth, rather than having had its goalposts moved. `make -C cas-cli test-ci-tiers` exits 0 in 1.09s with all six suites; marginal cost of the two additions is ~0.09s.

No guard behavior changed; `release.yml` and `release.sh` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)