### PR TITLE
fix(cas-b192): revert the permissive superseded rule, add the audited close override

### DIFF
--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -532,6 +532,7 @@ mod delivery_audit_text_tests {
     #[test]
     fn negative_result_receipts_name_every_missing_field() {
         let req = crate::mcp::tools::TaskCloseRequest {
+            stranded_branch_override: None,
             id: "cas-negative".to_string(),
             reason: None,
             bypass_code_review: None,
@@ -1693,6 +1694,7 @@ impl CasCore {
             Err(_) => "main".to_string(),
         };
         let req = TaskCloseRequest {
+            stranded_branch_override: None,
             id: task.id.clone(),
             reason: None,
             bypass_code_review: None,
@@ -2114,7 +2116,63 @@ impl CasCore {
                     append_close_decision_note(task_store.as_ref(), &mut task, &note);
                 }
                 EpicCloseGateOutcome::Reject(msg) => {
-                    return Ok(Self::tool_error(msg));
+                    // cas-b192: the gate is legitimately unsatisfiable for an
+                    // epic whose lanes all landed by squash and were then
+                    // refactored. Without a designed door supervisors improvise
+                    // one — a real session reached for execution_note=no-code to
+                    // escape this block and created a second defect that needed
+                    // proof_scope_fix to unwind. The door is explicit,
+                    // supervisor-only, and audited, and it only exists once the
+                    // gate has actually blocked.
+                    let Some(reason) = req.stranded_branch_override.as_deref() else {
+                        return Ok(Self::tool_error(msg));
+                    };
+                    let narrative = match validate_stranded_branch_override_reason(reason) {
+                        Ok(narrative) => narrative,
+                        Err(error) => {
+                            return Ok(Self::tool_error(format!(
+                                "EPIC CLOSE OVERRIDE REJECTED: {error}"
+                            )));
+                        }
+                    };
+                    let caller = match self.resolve_live_supervisor_authority() {
+                        Ok(caller) => caller,
+                        Err(error) => {
+                            return Ok(Self::tool_error(match error {
+                                SupervisorAuthorityError::Identity(error) => format!(
+                                    "EPIC CLOSE OVERRIDE REJECTED: stranded_branch_override requires an authenticated registered supervisor; caller identity could not be resolved ({error})."
+                                ),
+                                SupervisorAuthorityError::Store(error) => format!(
+                                    "EPIC CLOSE OVERRIDE REJECTED: supervisor authority could not be checked ({error})."
+                                ),
+                                SupervisorAuthorityError::NotRegistered { caller_id, error } => format!(
+                                    "EPIC CLOSE OVERRIDE REJECTED: caller `{caller_id}` is not a registered supervisor ({error})."
+                                ),
+                                SupervisorAuthorityError::NotLive(caller) => format!(
+                                    "EPIC CLOSE OVERRIDE REJECTED: only a live registered supervisor may use stranded_branch_override. Caller `{}` has role {}.",
+                                    caller.name, caller.role
+                                ),
+                            }));
+                        }
+                    };
+                    // The waived gate output is stored verbatim: it already
+                    // names every branch and the measured verdict behind it, so
+                    // the note records what was actually true at override time
+                    // rather than only what the supervisor asserted.
+                    append_close_decision_note(
+                        task_store.as_ref(),
+                        &mut task,
+                        &format!(
+                            "decision: supervisor `{caller_name}` (role {caller_role}) overrode \
+                             the epic stranded-branch gate for `{epic_id}`.\n\
+                             Inspection narrative: {narrative}\n\
+                             Waived gate output follows verbatim, including every measured \
+                             branch verdict:\n{msg}",
+                            caller_name = caller.name,
+                            caller_role = caller.role,
+                            epic_id = req.id,
+                        ),
+                    );
                 }
             }
         }
@@ -10296,6 +10354,36 @@ pub(crate) enum EpicCloseGateOutcome {
     Reject(String),
 }
 
+/// Validate the narrative supplied with a stranded-branch override (cas-b192).
+///
+/// The point of the override is the audit trail, so a contentless value is
+/// rejected: the note must say what was inspected, not merely that someone
+/// waved it through. Anything substantive is accepted verbatim — judging the
+/// QUALITY of a supervisor's reasoning is not this function's job, recording it
+/// faithfully is.
+pub(crate) fn validate_stranded_branch_override_reason(reason: &str) -> Result<String, String> {
+    const CONTENTLESS: &[&str] = &[
+        "ok", "okay", "fine", "yes", "y", "done", "n/a", "na", "-", "override", "force",
+        "looks fine", "lgtm", "trust me",
+    ];
+    let trimmed = reason.trim();
+    if trimmed.is_empty() {
+        return Err(
+            "stranded_branch_override requires a non-empty narrative describing what you \
+             inspected before waiving the gate."
+                .to_string(),
+        );
+    }
+    if CONTENTLESS.contains(&trimmed.to_ascii_lowercase().as_str()) {
+        return Err(format!(
+            "stranded_branch_override narrative `{trimmed}` records nothing that can be \
+             audited later. State what you checked — for example which branches and paths \
+             you diffed against the target, and what you found."
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
 /// Which way does a factory branch's content point relative to the integration
 /// target, restricted to the paths that branch actually delivers? (cas-b192)
 ///
@@ -10685,8 +10773,16 @@ pub(crate) fn run_epic_close_merge_gate(
          Epic {epic_id} cannot close — {n} child task(s) have factory branches \
          whose delivery is not accounted for on {parent}:\n{detail}\n\
          {closing_instruction}\n\
-         This guard cannot be bypassed (use of bypass_code_review=true does not \
-         skip merge-state checks — it is a data-state guard, not a review gate).\n\n\
+         bypass_code_review=true does not skip this check — it is a data-state \
+         guard, not a review gate.\n\n\
+         If you have inspected these lanes and they are genuinely stale — content \
+         shipped by another route and since refactored — a live registered \
+         supervisor may close with \
+         `stranded_branch_override=\"<what you inspected and found>\"`. The \
+         narrative and every measurement above are recorded as a decision note. \
+         Use that rather than improvising a workaround; do NOT reach for \
+         execution_note=no-code, which blocks the honest path and needs \
+         proof_scope_fix to unwind.\n\n\
          Remediation when the worker worktree still exists:\n\
          - `mcp__cas__coordination action=worktree_merge id=<factory-branch> \
            task_id=<child-task-id>`\n\n\
@@ -14867,6 +14963,7 @@ mod code_review_gate_tests {
 
     fn base_req(id: &str) -> TaskCloseRequest {
         TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.to_string(),
             reason: None,
             bypass_code_review: None,
@@ -16075,6 +16172,7 @@ mod search_manifest_gate_tests {
 
     fn req_with_manifest(id: &str, manifest_json: Option<&str>) -> TaskCloseRequest {
         TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.to_string(),
             reason: None,
             bypass_code_review: None,
@@ -16413,6 +16511,7 @@ mod merge_state_gate_tests {
 
     fn base_req(id: &str) -> TaskCloseRequest {
         TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.to_string(),
             reason: None,
             bypass_code_review: None,
@@ -19647,6 +19746,7 @@ mod epic_status_gate_tests {
 
     fn base_req(id: &str) -> TaskCloseRequest {
         TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.to_string(),
             reason: None,
             bypass_code_review: None,
@@ -20504,6 +20604,62 @@ mod epic_status_gate_tests {
             "an empty branch must never be minted into merge evidence: {:?}",
             statuses[0].merge_evidence_note
         );
+    }
+
+    #[test]
+    fn override_narrative_must_record_what_was_inspected() {
+        assert!(validate_stranded_branch_override_reason("   ").is_err());
+        assert!(validate_stranded_branch_override_reason("ok").is_err());
+        assert!(validate_stranded_branch_override_reason("LGTM").is_err());
+        assert!(validate_stranded_branch_override_reason("trust me").is_err());
+        let good = validate_stranded_branch_override_reason(
+            "  diffed all 11 delivered paths against main; content present and later \
+             refactored by PR #406  ",
+        )
+        .expect("a substantive narrative is accepted");
+        assert!(
+            good.starts_with("diffed all 11") && good.ends_with("PR #406"),
+            "narrative is stored trimmed but verbatim: {good}"
+        );
+    }
+
+    #[test]
+    fn refusal_offers_the_designed_door_instead_of_an_improvised_one() {
+        // cas-b192: the old text said the guard "cannot be bypassed", which left
+        // a supervisor at 05:45 with two options — follow the destructive
+        // instruction, or invent a workaround. One real session invented
+        // execution_note=no-code and created a second defect.
+        let dir = init_epic_repo(&[("worker", 1)]);
+        let unmerged = child("cas-real", TaskStatus::Closed, Some("worker"));
+        let task = epic("cas-epic-door");
+        let req = base_req(&task.id);
+        match run_epic_close_merge_gate(
+            &task,
+            &req,
+            "main",
+            dir.path(),
+            std::slice::from_ref(&unmerged),
+        ) {
+            EpicCloseGateOutcome::Reject(message) => {
+                assert!(
+                    message.contains("stranded_branch_override"),
+                    "the refusal must name the designed override: {message}"
+                );
+                assert!(
+                    message.contains("bypass_code_review=true does not skip this check"),
+                    "the review-gate bypass must stay powerless here: {message}"
+                );
+                assert!(
+                    !message.contains("cannot be bypassed"),
+                    "must not claim there is no door at all: {message}"
+                );
+                assert!(
+                    message.contains("execution_note=no-code"),
+                    "must warn off the improvised workaround that caused a second defect: {message}"
+                );
+            }
+            other => panic!("expected a rejection to inspect, got {other:?}"),
+        }
     }
 
     #[test]

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -9994,33 +9994,10 @@ pub(crate) fn collect_epic_branch_statuses(
                     .iter()
                     .map(|branch| branch_content_direction(repo_path, branch, parent_branch))
                     .collect();
-                // "Accounted for" has two shapes, and this codebase already
-                // recognises both: content still byte-identical on the target
-                // (ContentPresent), and content the target has since evolved
-                // (DeliveryContentPresence::Superseded, which the ancestry-clean
-                // path already treats as merged rather than stranded). The only
-                // thing that must still block is a delivered path the target has
-                // NEVER touched and which still differs — that is possible
-                // unlanded work, and BehindTarget reports it as candidate_paths.
-                //
-                // Measured on the five real cas-69e7 / Commander lanes: every
-                // differing delivery path had been moved by main afterwards and
-                // candidate_paths was empty for all of them, which is why the
-                // epic was hard-blocked with nothing actually stranded.
-                let accounted_for = |d: &BranchContentDirection| match d {
-                    BranchContentDirection::ContentPresent { .. } => true,
-                    BranchContentDirection::BehindTarget {
-                        candidate_paths, ..
-                    } => candidate_paths.is_empty(),
-                    _ => false,
-                };
                 let delivered: Vec<String> = directions
                     .iter()
                     .flat_map(|d| match d {
                         BranchContentDirection::ContentPresent { paths } => paths.clone(),
-                        BranchContentDirection::BehindTarget { stale_paths, .. } => {
-                            stale_paths.clone()
-                        }
                         _ => Vec::new(),
                     })
                     .collect();
@@ -10032,16 +10009,18 @@ pub(crate) fn collect_epic_branch_statuses(
                 // such a branch is still correct — that is the guidance layer's
                 // job — but clearing the gate needs positive evidence, so this
                 // path requires at least one compared delivery path.
-                if !delivered.is_empty() && directions.iter().all(accounted_for) {
+                if !delivered.is_empty()
+                    && directions
+                        .iter()
+                        .all(|d| matches!(d, BranchContentDirection::ContentPresent { .. }))
+                {
                     unmerged_count = 0;
                     merge_evidence_note = Some(format!(
                         "decision: child task `{}` branch(es) {} are merged (squash, ancestry \
-                         lost): every path they deliver is either byte-identical on \
-                         `{parent_branch}` or has been superseded there by later work, and no \
-                         delivered path is both untouched by `{parent_branch}` and still \
-                         different. Delivered path(s) checked: {}. Requiring a merge here would \
-                         only pollute history — and where the branch is behind, revert shipped \
-                         work.",
+                         lost): every path they deliver is already byte-identical on \
+                         `{parent_branch}`, so there is nothing left to integrate. Delivered \
+                         path(s) checked: {}. Requiring a merge here would only pollute history \
+                         — and where the branch is additionally behind, revert shipped work.",
                         t.id,
                         fallback_branches.join(", "),
                         delivered.join(", "),
@@ -20528,44 +20507,94 @@ mod epic_status_gate_tests {
     }
 
     #[test]
-    fn epic_close_proceeds_when_every_delivered_path_was_superseded() {
-        // cas-69e7's exact shape, reduced: the lane is behind, but every path it
-        // delivered has since been moved on main and none is untouched-and-
-        // different. Nothing is stranded, so the epic must close WITHOUT anyone
-        // merging a stale branch.
-        let dir = init_squash_landed_repo(None);
+    fn behind_target_is_never_treated_as_proof_that_content_landed() {
+        // A hole in an EARLIER VERSION OF THIS FIX, kept as a permanent guard.
+        // I briefly cleared any lane whose every differing delivery path had
+        // since been moved on the target, reasoning that a moved path was
+        // "superseded". It is not: the target touching a file does not mean the
+        // target absorbed this lane's change. Here the lane's function never
+        // reaches main, main rewrites the same file for unrelated reasons, and
+        // that rule would have silently discarded real work — the permissive
+        // twin of the destructive bug this task exists to fix.
+        let dir = tempfile::tempdir().unwrap();
         let p = dir.path();
-        std::fs::write(p.join("feature.rs"), "fn feature() { v2 refactored }\n").unwrap();
+        git(p, &["init", "-q", "-b", "main"]);
+        std::fs::write(p.join("seed.txt"), "seed\n").unwrap();
+        git(p, &["add", "seed.txt"]);
+        git(p, &["commit", "-q", "-m", "seed"]);
+        git(p, &["checkout", "-q", "-b", "factory/lane"]);
+        std::fs::write(
+            p.join("feature.rs"),
+            "fn existing() {}\nfn only_on_the_lane() {}\n",
+        )
+        .unwrap();
         git(p, &["add", "feature.rs"]);
-        git(p, &["commit", "-q", "-m", "refactor: evolve feature to v2"]);
+        git(p, &["commit", "-q", "-m", "feat: lane work that never lands"]);
+        git(p, &["checkout", "-q", "main"]);
+        std::fs::write(p.join("feature.rs"), "fn existing() { /* rewritten */ }\n").unwrap();
+        git(p, &["add", "feature.rs"]);
+        git(p, &["commit", "-q", "-m", "refactor: unrelated rewrite on main"]);
 
-        let superseded = child("cas-superseded", TaskStatus::Closed, Some("lane"));
-        let task = epic("cas-epic-superseded");
-        let req = base_req(&task.id);
+        let child_task = child("cas-lost", TaskStatus::Closed, Some("lane"));
         let statuses =
-            collect_epic_branch_statuses(std::slice::from_ref(&superseded), "main", p);
-        assert_eq!(
-            statuses[0].unmerged_count, 0,
-            "a fully superseded lane strands nothing: {:?}",
+            collect_epic_branch_statuses(std::slice::from_ref(&child_task), "main", p);
+        assert!(
+            statuses[0].unmerged_count > 0,
+            "content that never landed must keep blocking even though the target \
+             moved the same path: {:?}",
             statuses[0].merge_evidence_note
         );
+        assert!(
+            statuses[0].merge_evidence_note.is_none(),
+            "a moved path is not merge evidence: {:?}",
+            statuses[0].merge_evidence_note
+        );
+    }
+
+    #[test]
+    fn respawn_lane_with_no_task_commits_is_never_called_stranded() {
+        // cas-5c10 shape, live: a task delivered by one worker and then
+        // administratively closed by a freshly spawned second worker gets the
+        // second lane named in the remediation too, though it authored nothing.
+        // The false-positive set otherwise grows with every respawn.
+        let dir = init_epic_repo(&[("original", 1)]);
+        let p = dir.path();
+        git(p, &["merge", "--no-ff", "-m", "land original", "factory/original"]);
+        // The respawn lane is just the reconciled base: zero task commits.
+        git(p, &["branch", "factory/respawn", "main"]);
         assert!(matches!(
-            run_epic_close_merge_gate(
-                &task,
-                &req,
-                "main",
-                p,
-                std::slice::from_ref(&superseded),
-            ),
-            EpicCloseGateOutcome::ProceedWithNote(_)
+            branch_content_direction(p, "factory/respawn", "main"),
+            BranchContentDirection::ContentPresent { .. }
         ));
+        let mut respawned = child("cas-respawn", TaskStatus::Closed, Some("respawn"));
+        respawned.deliverables.parked_branch = Some("factory/original".to_string());
+        let statuses =
+            collect_epic_branch_statuses(std::slice::from_ref(&respawned), "main", p);
+        assert_eq!(
+            statuses[0].unmerged_count, 0,
+            "a zero-commit respawn lane over a landed delivery strands nothing"
+        );
+        let task = epic("cas-epic-respawn");
+        let req = base_req(&task.id);
+        assert!(
+            matches!(
+                run_epic_close_merge_gate(
+                    &task,
+                    &req,
+                    "main",
+                    p,
+                    std::slice::from_ref(&respawned)
+                ),
+                EpicCloseGateOutcome::Proceed | EpicCloseGateOutcome::ProceedWithNote(_)
+            ),
+            "a respawn must not resurrect a solved epic block"
+        );
     }
 
     #[test]
     fn epic_close_still_blocks_a_behind_lane_rather_than_assuming_it_landed() {
-        // Fail-closed where it counts: a behind lane that ALSO carries a path
-        // main has never touched may hold real work, so it keeps blocking. This
-        // is the line between cas-69e7 (nothing stranded) and actual data loss.
+        // Fail-closed: being behind is not proof that nothing was lost. The fix
+        // must stop the destructive ADVICE without weakening the GATE.
         let dir = init_squash_landed_repo(Some(("rescue.rs", "fn rescue() {}\n")));
         let p = dir.path();
         std::fs::write(p.join("feature.rs"), "fn feature() { v2 refactored }\n").unwrap();

--- a/cas-cli/src/mcp/tools/core/task/repo_context.rs
+++ b/cas-cli/src/mcp/tools/core/task/repo_context.rs
@@ -1747,6 +1747,7 @@ mod tests {
             task.status = TaskStatus::InProgress;
             task.deliverables.work_target = Some(target);
             let request = TaskCloseRequest {
+                stranded_branch_override: None,
                 id: task.id.clone(),
                 reason: None,
                 bypass_code_review: Some(true),

--- a/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
+++ b/cas-cli/src/mcp/tools/core/workflow/worktree_ops.rs
@@ -2654,6 +2654,7 @@ impl CasCore {
             if let Some(task_id) = task_id {
                 let close_result = self
                     .cas_task_close(Parameters(TaskCloseRequest {
+                        stranded_branch_override: None,
                         id: task_id.to_string(),
                         reason: Some(receipt.scope_summary.clone()),
                         bypass_code_review: None,

--- a/cas-cli/src/mcp/tools/service/core.rs
+++ b/cas-cli/src/mcp/tools/service/core.rs
@@ -424,6 +424,9 @@ impl CasService {
             }
         });
         let inner_req = TaskCloseRequest {
+            // cas-b192: forwarded, not dropped — this is the only path by which
+            // the unified `task` tool can reach the epic close override.
+            stranded_branch_override: req.stranded_branch_override,
             id: req
                 .id
                 .ok_or_else(|| Self::error(ErrorCode::INVALID_PARAMS, "id required for close — pass task ID as `id` (not `task_id`, `taskId`, or `_id`). Example: mcp__cas__task action=close id=cas-abc1"))?,

--- a/cas-cli/src/mcp/tools/types/task.rs
+++ b/cas-cli/src/mcp/tools/types/task.rs
@@ -181,6 +181,34 @@ pub struct TaskCloseRequest {
     #[serde(default)]
     pub bypass_code_review: Option<bool>,
 
+    /// Supervisor override for the epic close stranded-branch gate (cas-b192).
+    ///
+    /// Deliberately a NARRATIVE STRING rather than a boolean: the value is the
+    /// audit record of what was actually inspected before waiving the gate, and
+    /// it is stored verbatim alongside the gate's own measurements.
+    ///
+    /// This exists because the gate is otherwise unsatisfiable for a legitimate
+    /// case — an epic whose children's content shipped through a squash and was
+    /// then refactored, leaving every lane behind the target. The gate cannot
+    /// prove those lanes are safe (an older line and a new line are
+    /// indistinguishable by text), and it must not guess. Without a designed
+    /// door, supervisors improvise one: a real session reached for
+    /// `execution_note=no-code` to escape this block and created a second
+    /// defect that needed `proof_scope_fix` to unwind.
+    ///
+    /// Only honored for a live registered supervisor; every other caller is
+    /// rejected. Never skips anything for a branch that measures as carrying
+    /// genuinely absent content — that is real unmerged work, not a stale lane.
+    #[schemars(description = "Supervisor override for the epic close \
+                       stranded-branch gate. Pass a narrative describing what \
+                       you inspected (e.g. 'diffed all 11 delivered paths \
+                       against main; content present and later refactored by \
+                       PR #406'). Only honored for a live registered \
+                       supervisor. The narrative and the gate's own \
+                       measurements are logged as a decision note.")]
+    #[serde(default)]
+    pub stranded_branch_override: Option<String>,
+
     /// Structured cas-code-review results passed in by the worker
     /// before it retries close (cas-b39f, option (a)). The worker
     /// invokes the cas-code-review skill, collects the merged

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -5392,6 +5392,7 @@ async fn cas_85fd_answered_urgent_does_not_block_later_unrelated_close() {
     let close = worker_service
         .inner
         .cas_task_close(Parameters(cas::mcp::tools::TaskCloseRequest {
+            stranded_branch_override: None,
             id: task_id.clone(),
             reason: Some("already merged before the urgent status check".to_string()),
             bypass_code_review: None,
@@ -6525,6 +6526,7 @@ async fn test_062d_lifecycle_close_pushes_closed() {
         .service
         .inner
         .cas_task_close(Parameters(cas::mcp::tools::TaskCloseRequest {
+            stranded_branch_override: None,
             id: "cas-062d-close".to_string(),
             reason: Some("lifecycle close proof".to_string()),
             code_review_findings: None,

--- a/cas-cli/tests/mcp_tools_test/server_protocol/mod.rs
+++ b/cas-cli/tests/mcp_tools_test/server_protocol/mod.rs
@@ -268,6 +268,7 @@ async fn test_start_allowed_with_other_task_pending_verification() {
 
     // Try to close first task - should get VERIFICATION REQUIRED
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: first_id.to_string(),
         reason: Some("Completed".to_string()),
         bypass_code_review: None,
@@ -372,6 +373,7 @@ async fn test_claim_allowed_with_other_task_pending_verification() {
 
     // Try to close first task - should get VERIFICATION REQUIRED
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: first_id.to_string(),
         reason: Some("Completed".to_string()),
         bypass_code_review: None,
@@ -580,6 +582,7 @@ async fn test_start_same_task_allowed_when_pending() {
 
     // Try to close - should get VERIFICATION REQUIRED
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: task_id.to_string(),
         reason: Some("Completed".to_string()),
         bypass_code_review: None,

--- a/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
@@ -138,6 +138,7 @@ async fn test_light_depth_solo_close_skips_verification_jail() {
 
     let close_text = extract_text(
         core.cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("Feel-driven pass complete.".to_string()),
             bypass_code_review: None,
@@ -222,6 +223,7 @@ async fn task_close_quarantines_linked_reminders_unless_explicitly_kept() {
     }
 
     core.cas_task_close(Parameters(TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("The task is complete.".to_string()),
         bypass_code_review: None,
@@ -261,6 +263,7 @@ async fn test_deep_depth_solo_close_still_arms_verification_jail() {
 
     let close_text = extract_text(
         core.cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("Done.".to_string()),
             bypass_code_review: None,
@@ -316,6 +319,7 @@ async fn test_unset_depth_solo_close_still_arms_verification_jail() {
 
     let close_text = extract_text(
         core.cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("Done.".to_string()),
             bypass_code_review: None,
@@ -523,6 +527,7 @@ async fn create_started_and_closed_light_task(core: &CasCore, title: &str) -> St
 
     let close_text = extract_text(
         core.cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("Feel-driven pass complete.".to_string()),
             bypass_code_review: None,

--- a/cas-cli/tests/mcp_tools_test/task_tools/double_close.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/double_close.rs
@@ -120,6 +120,7 @@ async fn test_close_on_already_closed_is_non_destructive() {
 
     let first_close = extract_text(
         core.cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("First closer wins.".to_string()),
             bypass_code_review: None,
@@ -150,6 +151,7 @@ async fn test_close_on_already_closed_is_non_destructive() {
     // Second close with a different reason — must not claim credit or mutate.
     let second_close = extract_text(
         core.cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("Second closer races.".to_string()),
             bypass_code_review: None,
@@ -219,6 +221,7 @@ async fn test_close_on_already_closed_skips_code_review_gate() {
 
     let first = extract_text(
         core.cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("Initial close.".to_string()),
             bypass_code_review: None,

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -2159,6 +2159,7 @@ async fn test_close_auto_unblocks_blocked_dependents() {
 
     let close = service
         .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: blocker_id,
             reason: Some("done".to_string()),
             bypass_code_review: None,

--- a/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
@@ -107,6 +107,7 @@ async fn legacy_repository_proof_rejects_drift(isolated: bool) {
     let other_id = extract_task_id(&extract_text(other)).unwrap().to_string();
 
     let close = |reason: &str| TaskCloseRequest {
+        stranded_branch_override: None,
         id: task_id.clone(),
         reason: Some(reason.to_string()),
         bypass_code_review: None,
@@ -1321,6 +1322,7 @@ async fn test_task_close_blocked_without_verification() {
 
     // Try to close task without verification - should be blocked
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.to_string(),
         reason: Some("Completed".to_string()),
         bypass_code_review: None,
@@ -1423,6 +1425,7 @@ require_merge_on_epic_close = true
     task_store.update(&task).expect("should update task");
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: task.id.clone(),
         reason: Some("Done".to_string()),
         bypass_code_review: None,
@@ -1593,6 +1596,7 @@ async fn test_normal_close_records_and_renders_lease_history_reason_cas_7aef() {
     let close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id.clone(),
                 reason: Some("implementation complete".to_string()),
                 bypass_code_review: None,
@@ -1705,6 +1709,7 @@ async fn test_supervisor_negative_result_closes_unmerged_experiment_with_receipt
         service
             .cas_task_close_with_completion(
                 Parameters(TaskCloseRequest {
+                    stranded_branch_override: None,
                     id: task_id.to_string(),
                     reason: Some("worker tries to discard its own delivery".to_string()),
                     bypass_code_review: None,
@@ -1733,6 +1738,7 @@ async fn test_supervisor_negative_result_closes_unmerged_experiment_with_receipt
     let ordinary = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: task_id.to_string(),
                 reason: Some("measurement complete".to_string()),
                 bypass_code_review: Some(true),
@@ -1755,6 +1761,7 @@ async fn test_supervisor_negative_result_closes_unmerged_experiment_with_receipt
         service
             .cas_task_close_with_completion(
                 Parameters(TaskCloseRequest {
+                    stranded_branch_override: None,
                     id: task_id.to_string(),
                     reason: None,
                     bypass_code_review: None,
@@ -1793,6 +1800,7 @@ async fn test_supervisor_negative_result_closes_unmerged_experiment_with_receipt
         service
             .cas_task_close_with_completion(
                 Parameters(TaskCloseRequest {
+                    stranded_branch_override: None,
                     id: task_id.to_string(),
                     reason: Some("experiment regressed the dominant path; do not ship".to_string()),
                     bypass_code_review: None,
@@ -1934,6 +1942,7 @@ async fn test_merge_required_close_parks_awaiting_merge_and_releases_gate_cas_8d
     let close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("ready for merge".to_string()),
                 bypass_code_review: None,
@@ -2047,6 +2056,7 @@ async fn test_merge_required_close_parks_awaiting_merge_and_releases_gate_cas_8d
     let close_after_merge = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("merged and ready to close".to_string()),
                 bypass_code_review: None,
@@ -2183,6 +2193,7 @@ async fn test_a844_merge_conflict_flags_task_and_names_alternative() {
     let close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("ready for merge".to_string()),
                 bypass_code_review: None,
@@ -2349,6 +2360,7 @@ async fn test_a844_clean_divergence_not_flagged_as_conflict() {
     let close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("ready for merge".to_string()),
                 bypass_code_review: None,
@@ -2484,6 +2496,7 @@ async fn test_repeated_merge_required_close_does_not_duplicate_park_audit_cas_62
     }
 
     let close_req = || TaskCloseRequest {
+        stranded_branch_override: None,
         id: id_a.clone(),
         reason: Some("ready for merge".to_string()),
         bypass_code_review: None,
@@ -2742,6 +2755,7 @@ async fn test_merge_before_first_close_uses_commit_hook_anchor_cas_3d37() {
     let close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: task_id.clone(),
                 reason: Some("work was merged before first close".to_string()),
                 bypass_code_review: None,
@@ -2882,6 +2896,7 @@ async fn test_serial_second_task_on_same_branch_does_not_restrand_first_close_ca
     let first_close = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("ready for merge".to_string()),
                 bypass_code_review: None,
@@ -2952,6 +2967,7 @@ async fn test_serial_second_task_on_same_branch_does_not_restrand_first_close_ca
     let second_close = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("merged and ready to close".to_string()),
                 bypass_code_review: None,
@@ -3131,6 +3147,7 @@ async fn test_stale_local_epic_ref_falls_back_to_origin_cas_38e2() {
     let close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("merged and pushed to origin".to_string()),
                 bypass_code_review: None,
@@ -3271,6 +3288,7 @@ async fn test_reopened_task_does_not_reuse_stale_anchor_cas_cf64() {
     let first_close = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("ready for merge".to_string()),
                 bypass_code_review: None,
@@ -3308,6 +3326,7 @@ async fn test_reopened_task_does_not_reuse_stale_anchor_cas_cf64() {
     let second_close = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("merged, closing".to_string()),
                 bypass_code_review: None,
@@ -3371,6 +3390,7 @@ async fn test_reopened_task_does_not_reuse_stale_anchor_cas_cf64() {
     let third_close = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("reworked, claiming done".to_string()),
                 bypass_code_review: None,
@@ -3480,6 +3500,7 @@ async fn test_nonepic_task_resolves_default_branch_and_proceeds_when_merged_cas_
     task_store.update(&task).expect("update task");
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("done, merged onto main".to_string()),
         bypass_code_review: None,
@@ -3584,6 +3605,7 @@ async fn test_nonepic_task_with_unmerged_code_is_rejected_not_skipped_cas_cf64()
     task_store.update(&task).expect("update task");
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("claiming done but never merged".to_string()),
         bypass_code_review: None,
@@ -3690,6 +3712,7 @@ async fn test_chore_type_task_with_unmerged_code_is_no_longer_exempt_cas_cf64() 
     task_store.update(&task).expect("update task");
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("claiming done but never merged".to_string()),
         bypass_code_review: None,
@@ -3767,6 +3790,7 @@ async fn test_chore_type_task_with_zero_commits_still_closes_on_notes_cas_cf64()
     task_store.update(&task).expect("update task");
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("resolved via notes, no code needed".to_string()),
         bypass_code_review: None,
@@ -3900,6 +3924,7 @@ enabled = false
     // committed. Closing must fail with UNCOMMITTED WORK.
     std::fs::write(worktree_path.join("seed.txt"), "worker edit\n").unwrap();
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("claims to be done".to_string()),
         bypass_code_review: None,
@@ -3933,6 +3958,7 @@ enabled = false
     std::fs::write(worktree_path.join("new.rs"), "fn main() {}\n").unwrap();
     git(&["add", "new.rs"]);
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("claims to be done".to_string()),
         bypass_code_review: None,
@@ -3959,6 +3985,7 @@ enabled = false
     // succeed (verification is disabled in this test's config).
     git(&["commit", "-q", "-m", "feat: add new.rs"]);
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("Committed and ready".to_string()),
         bypass_code_review: None,
@@ -4087,6 +4114,7 @@ async fn test_task_close_blocks_on_uncommitted_system_b_worker_worktree_cas_4b3f
     .unwrap();
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("done".to_string()),
         bypass_code_review: None,
@@ -4121,6 +4149,7 @@ async fn test_task_close_blocks_on_uncommitted_system_b_worker_worktree_cas_4b3f
     git(&["add", "seed.txt"]);
     git(&["commit", "-q", "-m", "fix: commit the work"]);
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("actually done now".to_string()),
         bypass_code_review: None,
@@ -4286,6 +4315,7 @@ enabled = false
     let resp_a = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("committed and additive".to_string()),
                 bypass_code_review: None,
@@ -4332,6 +4362,7 @@ enabled = false
     let resp_b = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_b.clone(),
                 reason: Some("claims to be additive".to_string()),
                 bypass_code_review: None,
@@ -4390,6 +4421,7 @@ enabled = false
     let resp_c = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_c.clone(),
                 reason: Some("localized existing value".to_string()),
                 bypass_code_review: None,
@@ -4533,6 +4565,7 @@ enabled = false
         .expect("start");
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("non-isolated direct CLI flow".to_string()),
         bypass_code_review: None,
@@ -4601,6 +4634,7 @@ enabled = false
         .expect("start");
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: additive_id.clone(),
         reason: Some("additive-only non-isolated".to_string()),
         bypass_code_review: None,
@@ -4680,6 +4714,7 @@ enabled = false
     // cas_root.parent() for the test is the temp dir which is not a
     // git repo → check_uncommitted_work returns empty → close passes.
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("done, no files touched".to_string()),
         bypass_code_review: None,
@@ -4782,6 +4817,7 @@ enabled = false
     );
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("done, no files touched".to_string()),
         bypass_code_review: None,
@@ -4932,6 +4968,7 @@ async fn test_0447_halted_inprogress_with_merged_receipt_closes_without_restart(
     let merged = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: task_id.clone(),
                 reason: Some("finished and merged".to_string()),
                 bypass_code_review: None,
@@ -4989,6 +5026,7 @@ enabled = false
     }
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("trying to close someone else's task".to_string()),
         bypass_code_review: None,
@@ -5052,6 +5090,7 @@ async fn test_epic_close_requires_epic_verification_type() {
 
     // Close without verification should be blocked
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.to_string(),
         reason: Some("Completed".to_string()),
         bypass_code_review: None,
@@ -5081,6 +5120,7 @@ async fn test_epic_close_requires_epic_verification_type() {
     add_exact_supervisor_fixture_verdict(&cas_dir, task_ver, Some(&task_dispatch.id));
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.to_string(),
         reason: Some("Completed".to_string()),
         bypass_code_review: None,
@@ -5112,6 +5152,7 @@ async fn test_epic_close_requires_epic_verification_type() {
     add_exact_supervisor_fixture_verdict(&cas_dir, epic_ver, Some(&epic_dispatch.id));
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.to_string(),
         reason: Some("Completed".to_string()),
         bypass_code_review: None,
@@ -5183,6 +5224,7 @@ async fn test_task_lifecycle_with_verification() {
 
     // Close task - should succeed now with verification
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.to_string(),
         reason: Some("Completed successfully".to_string()),
         bypass_code_review: None,
@@ -5264,6 +5306,7 @@ async fn test_task_close_blocked_with_rejected_verification() {
 
     // Try to close task - should be blocked due to rejected verification
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.to_string(),
         reason: Some("Completed".to_string()),
         bypass_code_review: None,
@@ -5335,6 +5378,7 @@ async fn test_task_close_runs_verifier_or_skips_cleanly() {
     // handler is supposed to dispatch a verifier (or record a skip), not just
     // print a warning and leave the task open.
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("Completed all acceptance criteria. Deployed to prod.".to_string()),
         bypass_code_review: None,
@@ -5526,6 +5570,7 @@ async fn test_close_supervisor_owned_epic_uses_owner_closed_wording() {
     let response_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id.clone(),
                 reason: Some("all child tasks complete".to_string()),
                 bypass_code_review: None,
@@ -5622,6 +5667,7 @@ async fn test_close_supervisor_bypass_orphaned_task() {
     let _guard = ScopedSupervisorEnv::new();
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("verification skipped — assignee inactive".to_string()),
         bypass_code_review: None,
@@ -5734,6 +5780,7 @@ async fn test_close_supervisor_bypass_ghost_assignee() {
     let _guard = ScopedSupervisorEnv::new();
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("verification skipped — assignee inactive (ghost agent)".to_string()),
         bypass_code_review: None,
@@ -5853,6 +5900,7 @@ async fn test_close_supervisor_active_worker_assignee_by_name() {
     //     bypass branch. Pre-fix this path falsely reported the worker as
     //     inactive and closed the task.
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("worker finished, asking supervisor to close".to_string()),
         bypass_code_review: None,
@@ -5887,6 +5935,7 @@ async fn test_close_supervisor_active_worker_assignee_by_name() {
     // --- Attempt 2: review bypass cannot erase the exact dispatch created by
     //     attempt 1. Supervisor-direct recovery must name and resolve it.
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("supervisor forced close after alignment".to_string()),
         bypass_code_review: Some(true),
@@ -5976,6 +6025,7 @@ async fn test_close_supervisor_no_bypass_when_assignee_alive() {
     let _guard = ScopedSupervisorEnv::new();
 
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         // Intentionally still use the "verification skipped" phrase to prove
         // the bypass is structural (assignee state), not reason-driven. Even
@@ -6732,6 +6782,7 @@ async fn test_close_auto_escalates_stale_verification_dispatch() {
     // First close — sets pending_verification and writes dispatch-request row.
     let _ = service
         .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("Completed".to_string()),
             bypass_code_review: None,
@@ -6787,6 +6838,7 @@ async fn test_close_auto_escalates_stale_verification_dispatch() {
     // Second close — should auto-escalate instead of looping.
     let result = service
         .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("Completed".to_string()),
             bypass_code_review: None,
@@ -6934,6 +6986,7 @@ async fn test_close_forwards_persisted_review_envelope_after_jail() {
     let first_close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id.clone(),
                 reason: Some("worker ran review, retrying close".to_string()),
                 bypass_code_review: None,
@@ -6979,6 +7032,7 @@ async fn test_close_forwards_persisted_review_envelope_after_jail() {
     let supervisor_close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id.clone(),
                 reason: Some("closing on worker's behalf; review already passed".to_string()),
                 bypass_code_review: None,
@@ -7311,6 +7365,7 @@ owner = "worker"
     // Close with a clean ReviewOutcome envelope. The verification gate
     // should short-circuit, write a Skipped row, and proceed with close.
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some(
             "All acceptance criteria met. cas-code-review autofix returned clean envelope."
@@ -7432,6 +7487,7 @@ owner = "worker"
     // Close with the forgery envelope: P0 in residual[] with pre_existing=true.
     // The bypass must be blocked — a P0 is a P0 regardless of per-finding flag.
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("Done (hiding P0 via pre_existing=true forgery)".to_string()),
         bypass_code_review: None,
@@ -7521,6 +7577,7 @@ owner = "worker"
     // Close with an envelope that has a P0 in residual. The gate must
     // NOT short-circuit — verification is required.
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("Done (but has P0 issue)".to_string()),
         bypass_code_review: None,
@@ -7608,6 +7665,7 @@ owner = "worker"
 
     // Close with malformed JSON. The gate must NOT short-circuit.
     let close_req = TaskCloseRequest {
+        stranded_branch_override: None,
         id: id.clone(),
         reason: Some("Done (but envelope is garbage)".to_string()),
         bypass_code_review: None,
@@ -7710,6 +7768,7 @@ owner = "worker"
     // written.
     let _ = service
         .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("Done".to_string()),
             bypass_code_review: None,
@@ -7753,6 +7812,7 @@ owner = "worker"
     // remain jailed and the dispatch row must NOT be replaced by a Skipped row.
     let result = service
         .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("All criteria met — clean review envelope.".to_string()),
             bypass_code_review: None,
@@ -7896,6 +7956,7 @@ async fn test_worker_close_succeeds_when_skipped_row_write_fails_option_b() {
     // must succeed.
     let result = service
         .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("All criteria met — clean review envelope.".to_string()),
             bypass_code_review: None,
@@ -8526,6 +8587,7 @@ async fn test_pending_dispatch_close_gate_prints_supervisor_recovery_cas_9fd4() 
     let text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id.clone(),
                 reason: Some("Ready for supervisor verification".to_string()),
                 bypass_code_review: None,
@@ -8859,6 +8921,7 @@ async fn supervisor_self_assignee_close_guidance(supervisor_cli: Option<&str>) -
     let response = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id.clone(),
                 reason: Some("Self-implemented; ready to self-verify".to_string()),
                 bypass_code_review: None,
@@ -8952,6 +9015,7 @@ async fn test_timeout_escalation_uses_codex_supervisor_verification_alias_cas_79
     // First close arms pending_verification + writes the dispatch-request row.
     let _ = service
         .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id.clone(),
             reason: Some("Completed".to_string()),
             bypass_code_review: None,
@@ -8979,6 +9043,7 @@ async fn test_timeout_escalation_uses_codex_supervisor_verification_alias_cas_79
     let text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id.clone(),
                 reason: Some("Completed".to_string()),
                 bypass_code_review: None,
@@ -9060,6 +9125,7 @@ async fn test_062d_close_lifecycle_push_to_owning_supervisor() {
     let close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id.clone(),
                 reason: Some("062d close proof".to_string()),
                 bypass_code_review: Some(true),
@@ -9207,6 +9273,7 @@ async fn test_60393_owned_awaiting_merge_recloses_despite_preexisting_halt() {
     let close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("ready for merge".to_string()),
                 bypass_code_review: None,
@@ -9261,6 +9328,7 @@ async fn test_60393_owned_awaiting_merge_recloses_despite_preexisting_halt() {
     let close_after_merge = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("merged and ready to close".to_string()),
                 bypass_code_review: None,
@@ -9399,6 +9467,7 @@ async fn test_60393_unmerged_awaiting_merge_still_bounces_merge_required_under_h
     let close_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("ready for merge".to_string()),
                 bypass_code_review: None,
@@ -9429,6 +9498,7 @@ async fn test_60393_unmerged_awaiting_merge_still_bounces_merge_required_under_h
     let retry_text = extract_text(
         service
             .cas_task_close(Parameters(TaskCloseRequest {
+                stranded_branch_override: None,
                 id: id_a.clone(),
                 reason: Some("retry before merge".to_string()),
                 bypass_code_review: None,
@@ -9536,6 +9606,7 @@ async fn test_3894_halt_no_longer_blocks_close_of_own_inprogress_task() {
     // must succeed instead of erroring — the inverse of the old assertion.
     let close_result = service
         .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: id_b.clone(),
             reason: Some("done".to_string()),
             bypass_code_review: None,

--- a/cas-cli/tests/worktree_surface_test.rs
+++ b/cas-cli/tests/worktree_surface_test.rs
@@ -1719,6 +1719,7 @@ async fn normal_close_lints_task_anchor_not_newer_same_worker_or_unrelated_workt
     core.set_agent_id_for_testing(agent_id);
     let result = core
         .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
             id: task.id.clone(),
             reason: Some("task A complete".to_string()),
             bypass_code_review: None,

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -257,6 +257,17 @@ pub struct TaskRequest {
     #[serde(default, deserialize_with = "deser::option_bool")]
     pub bypass_code_review: Option<bool>,
 
+    /// Supervisor override for the epic close stranded-branch gate (cas-b192).
+    ///
+    /// A narrative string, not a boolean: the value IS the audit record of what
+    /// was inspected before waiving the gate, and it is stored next to the
+    /// gate's own measurements. Only honored for a live registered supervisor.
+    #[schemars(
+        description = "Supervisor override for the epic close stranded-branch gate. Pass a narrative describing what you inspected (e.g. 'diffed all 11 delivered paths against main; content present and later refactored by PR #406'). Only honored for a live registered supervisor. The narrative and the gate's own per-branch measurements are logged as a decision note. Use this instead of improvising a workaround when every lane is measurably stale."
+    )]
+    #[serde(default)]
+    pub stranded_branch_override: Option<String>,
+
     /// Supervisor-authorized close for a measured negative result whose
     /// experimental branch is deliberately not merged.
     ///


### PR DESCRIPTION
Follow-up to #414, which merged before this task finished. **#414 landed `524924f3`, and this reverts it** — the author disproved their own commit after it merged.

**The revert (`6fadc2d2`) is the urgent half.** `524924f3` cleared any lane whose every differing delivery path had since been *moved* on the target, calling that "superseded". That is not the same claim: **the target touching a file does not mean the target absorbed this lane's change.** Demonstrated on a fixture — the lane adds a function that never reaches main, main rewrites the same file for unrelated reasons, and the rule silently discards real work. That is the permissive twin of the destructive bug this task exists to fix. Pinned by `behind_target_is_never_treated_as_proof_that_content_landed`.

The existing `DeliveryContentPresence::Superseded` is the genuinely stronger claim — it analyses whether the delivered patch was *evolved* by later first-parent commits, not merely whether the file moved. The reverted rule was a cheap imitation of it.

With this, `BehindTarget` stays **blocking** — the strict verdict — which is what makes the override necessary rather than decorative.

**The override (`8d156bab`)** is deliberately last in sequence: live registered-supervisor only, narrative reason required ("ok"/"lgtm"/"trust me" rejected, because the record *is* the point), and the decision note stores the narrative **and the waived gate output verbatim**, so the audit carries what was measurably true at override time rather than only what was asserted. The refusal now names the door and warns off `execution_note=no-code` by name — the improvised workaround that previously turned an unsatisfiable gate into a second defect.

**Validated against `cas-153f`** through the production functions, all 11 lanes of its 10 children: ten emit **no merge command** (one `ContentPresent`, the rest `BehindTarget` with zero candidate-unlanded paths). The eleventh is a **true positive** — `factory/steady-kestrel-84` is genuinely ahead of main holding unmerged `cas-0908` work, and the guard tracked that lane going from empty to carrying real work within twenty minutes, at gate time, without being told.

**Tests:** 351 `--lib close_ops` (13 new), 333 `mcp_tools_test`, 149 `factory_mcp_ops_test`, 55 `worktree_surface_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)