### PR TITLE
fix(hub): paired-origin CORS on /v1/health unblocks hosted Commander dialing

### DIFF
--- a/cas-cli/src/hub/server.rs
+++ b/cas-cli/src/hub/server.rs
@@ -98,7 +98,7 @@ pub fn router<R: SessionReadModel>(state: HubState<R>) -> Router {
             get(commander_ghostty_write_wasm),
         )
         .route("/commander/symbols.woff2", get(commander_symbols_font))
-        .route("/v1/health", get(health))
+        .route("/v1/health", get(health::<R>).options(preflight::<R>))
         .route(
             "/v1/auth/pairing/exchange",
             post(pairing_exchange::<R>).options(preflight::<R>),
@@ -320,8 +320,24 @@ fn valid_pairing_origin(origin: &str) -> bool {
     }
 }
 
-async fn health() -> Json<HealthResponse> {
-    Json(HealthResponse::ready())
+async fn health<R: SessionReadModel>(
+    State(state): State<HubState<R>>,
+    headers: HeaderMap,
+) -> Response {
+    let response = Json(HealthResponse::ready()).into_response();
+    // Health remains available to curl and local readiness checks. A browser
+    // may read it cross-origin only after that origin has been paired.
+    let paired_origin = origin(&headers).is_some_and(|origin| {
+        state.auth.as_ref().is_some_and(|auth| {
+            auth.is_paired_origin(&origin, chrono::Utc::now())
+                .unwrap_or(false)
+        })
+    });
+    if paired_origin {
+        with_cors(response, &headers)
+    } else {
+        response
+    }
 }
 
 #[derive(Serialize)]

--- a/cas-cli/src/hub/tests.rs
+++ b/cas-cli/src/hub/tests.rs
@@ -448,6 +448,7 @@ async fn h1_http_surface_is_real_and_origin_authorized() {
         .await
         .unwrap();
     assert_eq!(health.status(), StatusCode::OK);
+    assert!(!health.headers().contains_key("access-control-allow-origin"));
     let health: serde_json::Value =
         serde_json::from_slice(&to_bytes(health.into_body(), usize::MAX).await.unwrap()).unwrap();
     assert_eq!(
@@ -522,6 +523,36 @@ async fn h4_real_browser_safe_reads_derive_only_a_trusted_same_origin() {
         .with_effective_origin("http://127.0.0.1:4173"),
     );
     let authorization = format!("DPoP {}", credential.credential);
+    let health = app
+        .clone()
+        .oneshot(
+            Request::get("/v1/health")
+                .header("origin", "http://127.0.0.1:4173")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        health.headers()["access-control-allow-origin"],
+        "http://127.0.0.1:4173"
+    );
+    assert_eq!(health.headers()["vary"], "Origin");
+    let unpaired_health = app
+        .clone()
+        .oneshot(
+            Request::get("/v1/health")
+                .header("origin", "https://evil.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        !unpaired_health
+            .headers()
+            .contains_key("access-control-allow-origin")
+    );
     let proof = |method: &str, uri: &str| {
         sign_dpop(
             &signing,


### PR DESCRIPTION
The Commander modernization changed the client dial gate to a real CORS fetch of /v1/health (previously an opaque no-cors ping), but the hub never sent CORS headers on that route. From the hosted origin (hub.petrastella.io) the browser blocks the response, so every machine is stuck 'retrying dialing' with capabilities unavailable — a field-blocking regression only visible cross-origin.

Fix (server-only; the deployed hosted bundle needs no re-promotion):
- /v1/health now echoes Access-Control-Allow-Origin + Vary: Origin for paired origins only, matching the hub's exact-Origin posture
- unpaired origins and no-Origin (curl/CLI) requests are byte-identical to before
- .options(preflight) added for route uniformity
- Regression tests cover all three cases; scoped hub suite: 138/138 passed

Task: cas-8d7f

🤖 Generated with [Claude Code](https://claude.com/claude-code)