### PR TITLE
fix(hub): serve Commander favicon.svg from the hub binary

### DIFF
--- a/cas-cli/src/hub/server.rs
+++ b/cas-cli/src/hub/server.rs
@@ -92,6 +92,7 @@ pub fn router<R: SessionReadModel>(state: HubState<R>) -> Router {
         .route("/commander/", get(commander_index))
         .route("/commander/app.js", get(commander_javascript))
         .route("/commander/app.css", get(commander_stylesheet))
+        .route("/commander/favicon.svg", get(commander_favicon))
         .route("/commander/ghostty-vt.wasm", get(commander_ghostty_wasm))
         .route(
             "/commander/ghostty-write-pty.wasm",
@@ -169,6 +170,13 @@ async fn commander_stylesheet() -> Response {
     commander_asset(
         include_bytes!("../../../hub-web/dist/app.css"),
         "text/css; charset=utf-8",
+    )
+}
+
+async fn commander_favicon() -> Response {
+    commander_asset(
+        include_bytes!("../../../hub-web/dist/favicon.svg"),
+        "image/svg+xml",
     )
 }
 

--- a/cas-cli/src/hub/tests.rs
+++ b/cas-cli/src/hub/tests.rs
@@ -456,6 +456,24 @@ async fn h1_http_surface_is_real_and_origin_authorized() {
         serde_json::json!({"schema_version": 1, "ready": true})
     );
 
+    let favicon = app
+        .clone()
+        .oneshot(
+            Request::get("/commander/favicon.svg")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(favicon.status(), StatusCode::OK);
+    assert_eq!(favicon.headers()["content-type"], "image/svg+xml");
+    assert!(
+        to_bytes(favicon.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .starts_with(b"<svg")
+    );
+
     let denied = app
         .clone()
         .oneshot(Request::get("/v1/sessions").body(Body::empty()).unwrap())


### PR DESCRIPTION
The polish batch added favicon.svg to hub-web and linked it from index.html, but the hub router only serves explicitly-listed assets — the tailnet origin returned 405 for /commander/favicon.svg, logging a boot console error. Adds the route + include_bytes! handler (image/svg+xml) matching the existing asset pattern, with h1 surface coverage (200, content type, SVG bytes).

Task: cas-d4b9

🤖 Generated with [Claude Code](https://claude.com/claude-code)