### PR TITLE
fix(worker-skill): Codex context occupancy is last_token_usage vs model window, never cumulative totals

### DIFF
--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -2964,9 +2964,11 @@ This is the body content."#;
                 "~2 minutes",
                 "gh run watch",
                 "action=remind",
-                "context headroom",
                 "Checkpoint, never compact",
                 "discipline.md",
+                "last_token_usage",
+                "model_context_window",
+                "total_token_usage",
             ] {
                 assert!(
                     skill_content.contains(required),
@@ -3017,6 +3019,9 @@ This is the body content."#;
                 "git push",
                 "respawn",
                 "auto-compaction",
+                "37,952",
+                "258,400",
+                "356,457",
             ] {
                 assert!(
                     ref_content.contains(required),

--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -69,8 +69,8 @@ Your scope is locked at assignment:
 - **Document important choices.** Use `mcp__cs__task action=notes note_type=decision` for non-obvious decisions.
 - **Keep durable discoveries deliberately.** Relays are attributed, not auto-saved; use `mcp__cs__memory action=remember` for cross-session facts.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
-- **Report context headroom** ("context: ~60% used") in every milestone progress note.
-- **Checkpoint, never compact.** When context is low: commit, push, leave a handoff note, and ask for respawn. Prefer small pushed commits. See [discipline.md](cas-worker/references/discipline.md).
+- Codex: checkpoint on last_token_usage/model_context_window, never total_token_usage; see discipline.md.
+- **Checkpoint, never compact.** When context is low: commit, push, hand off, and request a respawn. See [discipline.md](cas-worker/references/discipline.md).
 
 ## cas-src surface checklist — required before close
 

--- a/cas-cli/src/builtins/codex/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker/references/discipline.md
@@ -225,6 +225,18 @@ still an order, and a scope change you missed means your last hour needs redoing
 Context is a consumable the operator pays for. Auto-compaction is not a safety net — it is the
 expensive failure mode. Budget it the way you budget wall-clock.
 
+### Measure Codex live occupancy, never cumulative totals
+
+For Codex, calculate occupancy from the newest rollout `token_count` event:
+`last_token_usage.input_tokens / model_context_window`. `total_token_usage` is a cumulative,
+cache-heavy history counter, not current prompt occupancy and never a checkpoint trigger.
+
+Worked incident: `last_token_usage.input_tokens = 37,952` against
+`model_context_window = 258,400` is about **15% occupied** (about **85% headroom**). The same
+rollout reported `total_token_usage.input_tokens = 356,457`, including about 330k cached tokens;
+that total does **not** mean the worker is near exhaustion. Keep working unless the live
+occupancy or another real failure signal requires a checkpoint.
+
 ### Report headroom in every milestone note
 
 Every `note_type=progress` milestone note ends with your remaining context, plainly:

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -69,8 +69,8 @@ Your scope is locked at assignment:
 - **Document important choices.** Use `cas__task action=notes note_type=decision` for non-obvious decisions.
 - **Keep durable discoveries deliberately.** Relays are attributed, not auto-saved; use `cas__memory action=remember` for cross-session facts.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
-- **Report context headroom** ("context: ~60% used") in every milestone progress note.
-- **Checkpoint, never compact.** When context is low: commit, push, leave a handoff note, and ask for respawn. Prefer small pushed commits. See [discipline.md](cas-worker/references/discipline.md).
+- Codex: checkpoint on last_token_usage/model_context_window, never total_token_usage; see discipline.md.
+- **Checkpoint, never compact.** When context is low: commit, push, hand off, and request a respawn. See [discipline.md](cas-worker/references/discipline.md).
 
 ## cas-src surface checklist — required before close
 

--- a/cas-cli/src/builtins/grok/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker/references/discipline.md
@@ -225,6 +225,18 @@ still an order, and a scope change you missed means your last hour needs redoing
 Context is a consumable the operator pays for. Auto-compaction is not a safety net — it is the
 expensive failure mode. Budget it the way you budget wall-clock.
 
+### Measure Codex live occupancy, never cumulative totals
+
+For Codex, calculate occupancy from the newest rollout `token_count` event:
+`last_token_usage.input_tokens / model_context_window`. `total_token_usage` is a cumulative,
+cache-heavy history counter, not current prompt occupancy and never a checkpoint trigger.
+
+Worked incident: `last_token_usage.input_tokens = 37,952` against
+`model_context_window = 258,400` is about **15% occupied** (about **85% headroom**). The same
+rollout reported `total_token_usage.input_tokens = 356,457`, including about 330k cached tokens;
+that total does **not** mean the worker is near exhaustion. Keep working unless the live
+occupancy or another real failure signal requires a checkpoint.
+
 ### Report headroom in every milestone note
 
 Every `note_type=progress` milestone note ends with your remaining context, plainly:

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -69,8 +69,8 @@ Your scope is locked at assignment:
 - **Document important choices.** Use `mcp__cas__task action=notes note_type=decision` for non-obvious decisions.
 - **Keep durable discoveries deliberately.** Relays are attributed, not auto-saved; use `mcp__cas__memory action=remember` for cross-session facts.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
-- **Report context headroom** ("context: ~60% used") in every milestone progress note.
-- **Checkpoint, never compact.** When context is low: commit, push, leave a handoff note, and ask for respawn. Prefer small pushed commits. See [discipline.md](cas-worker/references/discipline.md).
+- Codex: checkpoint on last_token_usage/model_context_window, never total_token_usage; see discipline.md.
+- **Checkpoint, never compact.** When context is low: commit, push, hand off, and request a respawn. See [discipline.md](cas-worker/references/discipline.md).
 
 ## cas-src surface checklist — required before close
 

--- a/cas-cli/src/builtins/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/skills/cas-worker/references/discipline.md
@@ -225,6 +225,18 @@ still an order, and a scope change you missed means your last hour needs redoing
 Context is a consumable the operator pays for. Auto-compaction is not a safety net — it is the
 expensive failure mode. Budget it the way you budget wall-clock.
 
+### Measure Codex live occupancy, never cumulative totals
+
+For Codex, calculate occupancy from the newest rollout `token_count` event:
+`last_token_usage.input_tokens / model_context_window`. `total_token_usage` is a cumulative,
+cache-heavy history counter, not current prompt occupancy and never a checkpoint trigger.
+
+Worked incident: `last_token_usage.input_tokens = 37,952` against
+`model_context_window = 258,400` is about **15% occupied** (about **85% headroom**). The same
+rollout reported `total_token_usage.input_tokens = 356,457`, including about 330k cached tokens;
+that total does **not** mean the worker is near exhaustion. Keep working unless the live
+occupancy or another real failure signal requires a checkpoint.
+
 ### Report headroom in every milestone note
 
 Every `note_type=progress` milestone note ends with your remaining context, plainly:


### PR DESCRIPTION
Two Codex workers today self-checkpointed claiming near-exhaustion while holding ~85% real headroom — they read the cumulative, cache-heavy total_token_usage counter as prompt occupancy. Cost: an unnecessary worker recycle per false alarm (the fresh worker immediately re-alarms, since the cumulative counter never resets against the window).

- cas-worker skill (claude/codex/grok variants) + discipline.md reference: occupancy = latest token_count.last_token_usage.input_tokens / model_context_window; total_token_usage is never a checkpoint trigger
- Worked incident as the example: 37,952 / 258,400 ≈ 15% occupied while the cumulative counter read 356,457
- Companion to the supervisor-side gauge fix (cas-e05c, PR #426)

Task: cas-ecfb

🤖 Generated with [Claude Code](https://claude.com/claude-code)