### PR TITLE
Release v2.71.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.71.0] - 2026-08-16
+
+### Added
+- **External expertise is now a governed capability, not a loose key.** The Viktor delegation gateway attributes every external MCP call to a registered caller, passes it through a pre-dispatch policy check with a redacted audit trail, and admits tools only by exactly-parsed (server, tool) pairs — lookalike or foreign routes are refused before anything leaves the machine. Every delegation gets a durable receipt with duplicate-call protection, budget reservations that deny over-cap requests locally, and resumption of timed-out runs; a verifier that could not answer — timeout, malformed output, insufficient scope, transport failure, or any other enumerated non-answer — records a durable non-pass and never reads as approval.
+
+### Changed
+- **Message status tells the truth.** Activity that merely suggests a recipient saw a message shows as its own weaker state instead of "confirmed", a message repeatedly blocked by a busy recipient is flagged undelivered instead of silently waiting, and only an explicit acknowledgment of the exact message discharges an urgent halt.
+- **One authority decides which branch work belongs on.** Worker spawn bases, merge destinations, and newly created or newly linked epic children all resolve through the same declared-work-target precedence chain; an epic branch that has cleanly fallen behind its parent is fast-forwarded before any worker is cut from it.
+- **Finished work is recognized as finished.** Epic close reconciles deliveries that were squash-merged and later improved, measures against live branch state instead of stored counts, and keeps unproven anchors fail-closed.
+- **Memory keeps instructions, not chatter.** Machine-to-machine relay turns are no longer captured as durable context, while genuine operator instructions are captured again — discriminated by typed delivery provenance instead of text parsing.
+
+### Fixed
+- **Commander is finished work on both surfaces.** A polish pass and a UX pass fixed the unreachable phone message button, empty worker panes, the drawer crushing the terminal, dead connection colours, the keyboard closing mid-word, drafts destroyed by the live refresh, sends without feedback, vanishing confirmations, unexplained disabled controls, duplicate alert cards, stale data posing as live, a dead-end first run, and alert cards missing their ticket.
+- **Sharp edges removed.** Ending a session no longer risks a nested-runtime panic; requesting an isolated worktree no longer gets a false refusal with invalid TOML instructions; the supervisor checklist no longer instructs an action that severs its own tools; a leak test no longer scatters orphan processes through CI cleanup; and memory list filters (tags, tier, scope) actually filter, with counts that match the rows.
+
 ## [2.70.0] - 2026-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.70.0"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.70.0"
+version = "2.71.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.70.0"
+version = "2.71.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.70.0"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.70.0"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.70.0"
+version = "2.71.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.70.0"
+version = "2.71.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.70.0"
+version = "2.71.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.70.0"
+version = "2.71.0"
 edition = "2024"
 rust-version = "1.85"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.70.0"
+version = "2.71.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.70.0"
+version = "2.71.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.70.0"
+version = "2.71.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-16-commander-ux-pass-slack.md
+++ b/docs/release-notes/2026-08-16-commander-ux-pass-slack.md
@@ -1,0 +1,38 @@
+# Slack draft — Commander UX pass (PR #437 → main, 7fac2f32)
+
+Channel: #cas-internal (C0B44GUKDK2)
+Order: user top-level → user reply (threaded) → dev top-level → dev reply (threaded)
+
+=== MESSAGE 1 (user top-level) ===
+**Live on production — User:** You can now actually finish typing a message to your supervisor on the phone — drafts survive the live refresh, sends confirm themselves, and stale data admits it's stale.
+
+=== MESSAGE 2 (user reply, thread of message 1) ===
+Was → Now:
+• The message you were typing was wiped every few seconds by the live refresh — a 41-character draft measured gone after 8 seconds. Now your draft, cursor, and focus all survive.
+• Sending gave no feedback and left the text sitting there, so success looked exactly like failure. Now it clears, confirms, and refuses an empty send with a reason.
+• Confirmations could be deleted by the next refresh moments after appearing. Now they stay until you've seen them.
+• Greyed-out controls (Take control, Interrupt) only explained themselves on mouse hover — nothing on touch. Now they tell you why on tap.
+• One outage produced six-plus identical alert cards. Now they group into one card with a ×N count.
+• Workers & tasks kept rendering as if live during an outage. Now they're labelled stale, aged from the last live moment, and dimmed.
+• First run was a dead end pointing at a button on the wrong machine. Now an unpaired Commander offers "Pair a machine", the pairing code has a copy button, and the next step is written out.
+
+=== MESSAGE 3 (dev top-level) ===
+**Live on production — Dev:** Heuristic UX pass over hub-web: heartbeat-render draft destruction fixed, toasts moved to a body-level overlay, attention fingerprint coalescing, stale-state labelling, and first-run/pairing affordances (PR #437).
+
+=== MESSAGE 4 (dev reply, thread of message 3) ===
+Was → Now:
+• Composer state lived inside the re-rendered shell: every ~5s heartbeat destroyed the draft and dropped focus to <body> → draft, caret, and focus preserved across renders, verified over 9s of live heartbeats at 390px and 1440px.
+• Toasts were children of the re-rendered tree → body-level overlay outside the render root.
+• Attention cards had no identity, so repeated events stacked duplicates → stable fingerprints coalesce with ×N counts.
+• No liveness signal on Workers & Tasks → stale sections labelled and aged from last live data; lease loss announced with the stale controller identity cleared.
+• Disabled controls relied on title/sr-only → spoken reason on tap; empty send refused with a reason; pairing success confirmed; Copy command on the pairing code.
+• Proof: 140/140 hub-web tests (7 new invariants), tsc clean, dist rebuilt once, byte-identical on clean rebuild. Bundle +3,340 B raw (+0.17% of payload), declared and accepted — no new request, dependency, font, or startup step. Full heuristic evaluation with 20 screenshots in the task artifacts. (PR #437)
+
+## POSTED
+
+- UTC: 2026-08-16T12:29:07Z
+- Channel: #cas-internal (C0B44GUKDK2)
+- Message 1 (user top-level): https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786883324402059
+- Message 2 (user reply): https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786883331739589?thread_ts=1786883324.402059&cid=C0B44GUKDK2
+- Message 3 (dev top-level): https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786883335834349
+- Message 4 (dev reply): https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786883343413109?thread_ts=1786883335.834349&cid=C0B44GUKDK2

--- a/docs/release-notes/2026-08-16-v19-burn-down-slack.md
+++ b/docs/release-notes/2026-08-16-v19-burn-down-slack.md
@@ -1,0 +1,37 @@
+# Slack draft — issue burn-down v19 batch (PR #438 → main, bf75cce2)
+
+Channel: #cas-internal (C0B44GUKDK2)
+Order: user top-level → user reply (threaded) → dev top-level → dev reply (threaded)
+
+=== MESSAGE 1 (user top-level) ===
+**Live on production — User:** Eleven long-standing reliability complaints fixed in one landing — honest message delivery status, workers that always start on fresh code, memory search filters that actually filter, and epics that close cleanly when the work shipped.
+
+=== MESSAGE 2 (user reply, thread of message 1) ===
+Was → Now:
+• A message to a busy worker could show "confirmed" while the worker provably never read it. Now unread-but-active shows as its own weaker state, and a message that can't get through gets escalated instead of silently waiting.
+• Workers could start on weeks-old code and waste their first hour rediscovering fixes. Now a stale starting branch is refreshed automatically before the worker is created.
+• Searching memories by tag silently returned everything. Now tag, tier, and scope filters actually narrow results, and the count matches what you see.
+• Machine-to-machine chatter was being saved as durable memory, drowning out real instructions. Now only genuine operator instructions are captured.
+• Finished projects could refuse to close with false "unmerged work" warnings. Now shipped-then-improved work is recognized as shipped.
+• Ending a session could crash the server; asking for an isolated workspace got a refusal with broken instructions; and following the standard upgrade steps could cut off your own tools. All three fixed.
+
+=== MESSAGE 3 (dev top-level) ===
+**Live on production — Dev:** v19 burn-down batch: truthful message_status staging with wake-decline escalation, WorkTarget-precedence branch resolution end to end, epic-close content reconciliation for squash-then-evolved deliveries, provenance-envelope prompt capture, and async-safe session_end (PR #438).
+
+=== MESSAGE 4 (dev reply, thread of message 3) ===
+Was → Now:
+• inferred_from_reply granted top-line confirmed on unrelated activity → assumed_seen as a distinct stage; three durable wake-gate declines flag undelivered_after_wake_declines; explicit exact-message ack is what discharges an urgent halt.
+• Spawn base derived an epic branch from the epic title slug, worktree_merge read a legacy branch field, and children defaulted to trunk → one WorkTarget precedence chain (task-WT > live epic branch > epic-WT > trunk) across spawn, merge, create-with-epic, and dep_add parent-link; stale-but-clean bases fast-forward and push before the worktree is cut.
+• Epic close compared recorded anchors byte-for-byte and stored commit counts → live lane refs, squash re-anchoring, and the child-level hunk-survival checker, with unproven anchors retained fail-closed.
+• Prompt capture parsed rendered text for provenance → delivery registers a typed one-shot envelope consumed by hook dispatch; operator capture restored, relay capture gone.
+• session_end ran block_on inside the async dispatcher and panicked → synchronous hook work moved off-dispatcher.
+• Plus: target_lock test reaps its sleeps (clean CI teardown), worktree_create tells the truth and prints valid TOML, supervisor-checklist mirrors sequence the binary rebuild safely, and a reconciliation pass fixed two real cross-lane regressions the scoped proofs missed. (PR #438)
+
+## POSTED
+
+- UTC timestamp: 2026-08-16T13:19:23Z
+- Channel: #cas-internal (C0B44GUKDK2)
+- Message 1: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786886336799609
+- Message 2: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786886345369039?thread_ts=1786886336.799609&cid=C0B44GUKDK2
+- Message 3: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786886349668379
+- Message 4: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786886359313259?thread_ts=1786886349.668379&cid=C0B44GUKDK2

--- a/docs/release-notes/2026-08-16-v2.71.0-slack.md
+++ b/docs/release-notes/2026-08-16-v2.71.0-slack.md
@@ -1,0 +1,53 @@
+# Slack draft — CAS vX.Y.Z runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — {{USER_IMPACT_PUNCH}}
+
+**Reply (Was → Now):**
+- Was: {{USER_WAS}} Now: {{USER_NOW}}
+- Install: use `cas update` for an existing installation, or download the
+  vX.Y.Z archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — {{DEV_IMPACT_PUNCH}}
+
+**Reply (Was → Now):**
+- Was: {{DEV_WAS}} Now: {{DEV_NOW}}
+- Validation and artifact: {{VALIDATION_SUMMARY}} The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |

--- a/docs/release-notes/2026-08-16-viktor-gateway-slack.md
+++ b/docs/release-notes/2026-08-16-viktor-gateway-slack.md
@@ -1,0 +1,49 @@
+# Slack draft — Viktor delegation gateway v1 (PR #439 → main, 61fcaebf) + attention ticket fix (PR #441 → main, 368c3909)
+
+Channel: #cas-internal (C0B44GUKDK2)
+Order: messages 1–2 = Viktor user thread, 3–4 = Viktor dev thread, 5–6 = ticket-fix user thread, 7–8 = ticket-fix dev thread.
+
+=== MESSAGE 1 (user top-level) ===
+**Live on production — User:** Agents can now safely ask an outside expert service to verify their work — every answer comes back as hard evidence, an expert who couldn't answer never counts as a pass, and only the supervisor holds the paid account.
+
+=== MESSAGE 2 (user reply, thread of message 1) ===
+Was → Now:
+• There was no controlled way for the team to use the external expert service — the account key would have granted anyone unlimited paid calls with nothing able to say no. Now every external call carries who is asking and passes a policy check before it goes anywhere, with an audit trail.
+• A misspelled or lookalike service name could have slipped through a naive filter. Now only exactly-approved (service, tool) pairs are allowed; everything else is refused before leaving the building.
+• Paid calls could have been double-charged on retries or blown past budgets. Now every delegation gets a receipt with duplicate-call protection, budget reservations that deny over-cap requests locally, and the ability to resume a timed-out run instead of paying again.
+• An external check that timed out, answered vaguely, or failed to connect could have been mistaken for approval. Now every one of those outcomes is recorded as a durable non-pass — an expert who could not answer never reads as a yes.
+
+=== MESSAGE 3 (dev top-level) ===
+**Live on production — Dev:** Viktor delegation gateway v1: registered caller identity + pre-dispatch policy hook in the MCP proxy, exact parsed (server, tool) allowlisting, a delegation receipt store with budget reservations and run resumption, and a fail-closed verdict contract (PR #439).
+
+=== MESSAGE 4 (dev reply, thread of message 3) ===
+Was → Now:
+• The MCP proxy carried no caller identity and had no policy decision point → every external dispatch is attributed to a registered caller and passes a pre-dispatch policy hook with redacted audit.
+• External tool admission would have been a raw mcp__ prefix match → exact parsed (server, tool) routing; lookalike servers and foreign tools deny before upstream; prompt/PTY parity preserves external names across Claude/Codex/Grok harnesses.
+• No persistence for delegations → receipt store (migration 236): backend-generated idempotency keys, budget reservations with local cap denial, timeout run-id persistence and resumption, terminal evidence/verdict fields.
+• No verdict discipline → gate passes only on a schema-valid pass meeting policy; fail, inconclusive, wait_timed_out, requires_action, thread_busy, insufficient scope, rate limit, cancellation, malformed output, and transport failure each produce a durable non-passing receipt (one test per outcome); requires_action never auto-continues. (PR #439)
+
+=== MESSAGE 5 (user top-level) ===
+**Live on production — User:** Alert cards now always show which ticket they belong to, wherever the alert came from.
+
+=== MESSAGE 6 (user reply, thread of message 5) ===
+Was → Now: alerts arriving through the live event stream displayed without their ticket number, so you couldn't tell which piece of work an alert was about without digging. Now every alert card names its ticket regardless of how it arrived.
+
+=== MESSAGE 7 (dev top-level) ===
+**Live on production — Dev:** hub-web renderCard read card.latest.ticketId, which is unset for cards derived from the hub event stream — it now reads the derived card.content.ticketId, with an invariant test for that path (PR #441).
+
+=== MESSAGE 8 (dev reply, thread of message 7) ===
+Was → Now: event-stream-derived attention cards carried their ticket on card.content.ticketId while the renderer read card.latest.ticketId, so the ticket rendered only for locally-built cards → renderer reads the derived content field; test covers an event-stream card with a ticket; dist rebuilt once (+2 bytes). (PR #441)
+
+## POSTED
+
+- UTC: 2026-08-16T13:39:53Z
+- Channel: #cas-internal (C0B44GUKDK2)
+- Message 1: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786887549245609
+- Message 2: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786887557741749?thread_ts=1786887549.245609&cid=C0B44GUKDK2
+- Message 3: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786887561921689
+- Message 4: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786887568936739?thread_ts=1786887561.921689&cid=C0B44GUKDK2
+- Message 5: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786887572299709
+- Message 6: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786887579021429?thread_ts=1786887572.299709&cid=C0B44GUKDK2
+- Message 7: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786887583481139
+- Message 8: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786887587662399?thread_ts=1786887583.481139&cid=C0B44GUKDK2


### PR DESCRIPTION
Version bump to 2.71.0 across the six workspace crates, CHANGELOG entry, release-note draft, and the PR-announcement receipts for #437/#438/#439/#441.

Covers tonight's landings: Viktor delegation gateway v1 (PR #439), issue burn-down v19 (PR #438), Commander polish (PR #436) + UX pass (PR #437) + attention ticket fix (PR #441).

After merge: tag the landed origin/main commit v2.71.0 and run ./scripts/release.sh --publish-tag; announcement follows the published-assets receipt per docs/RELEASE_SLACK_RUBRIC.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)