### PR TITLE
Issue burn-down v20: the whole workspace suite runs in CI, base refresh survives push failure, receipts fail closed on empty runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,12 +166,13 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       # Keep --no-fail-fast so failures never mask later binaries. This runs
-      # every test binary; the doctest lane below covers what nextest cannot.
+      # every workspace test binary; the doctest lane below covers what
+      # nextest cannot.
       - name: Test full suite
         if: steps.classify-diff.outputs.fast-pass != 'true'
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: cargo nextest run -p cas --no-fail-fast
+        run: cargo nextest run --workspace --no-fail-fast
 
   fast-validation-docs:
     name: Fast Validation — doctests

--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -31,7 +31,7 @@ CARGO ?= cargo
 
 # Run all tests
 test:
-	$(CARGO) nextest run -p cas --no-fail-fast
+	$(CARGO) nextest run --workspace --no-fail-fast
 	$(CARGO) test -p cas --doc
 
 # Run full test matrix

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -895,40 +895,38 @@ fn fast_forward_epic_base_from_parent(
         ));
     }
 
-    // A local-only refresh merely defers the same stale-base incident to the
-    // next supervisor. Publish the exact ref update before allowing the spawn
-    // to proceed. If publishing fails, restore the old local tip so the
-    // caller can warn-and-cut from the unchanged (but explicitly diagnosed)
-    // base rather than silently leaving local and remote coordination lanes
-    // split.
+    // Publishing is best-effort. The local fast-forward is already the safe
+    // spawn base, so a remote-less checkout or rejected publication must not
+    // roll it back and reintroduce the stale-base worker cut this refresh just
+    // prevented.
+    let origin_configured = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(repo_root)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+    if !origin_configured {
+        return Ok(Some(format!(
+            "EPIC BASE FAST-FORWARDED (LOCAL-ONLY): epic base '{epic_branch}' ({}) advanced to its recorded parent '{parent_branch}' via '{parent_ref}' ({}); no origin remote is configured, so the refreshed local ref is unpublished and will be used to cut the worker worktree.",
+            &epic_sha[..epic_sha.len().min(8)],
+            &parent_sha[..parent_sha.len().min(8)],
+        )));
+    }
+
     let push = std::process::Command::new("git")
         .args(["push", "origin", &format!("{refname}:{refname}")])
         .current_dir(repo_root)
-        .output()
-        .map_err(|error| {
-            let _ = std::process::Command::new("git")
-                .args(["update-ref", &refname, &epic_sha, &parent_sha])
-                .current_dir(repo_root)
-                .output();
-            format!("could not push refreshed epic base '{epic_branch}' to origin: {error}")
-        })?;
-    if !push.status.success() {
-        let rollback = std::process::Command::new("git")
-            .args(["update-ref", &refname, &epic_sha, &parent_sha])
-            .current_dir(repo_root)
-            .output();
-        let rollback_detail = match rollback {
-            Ok(output) if output.status.success() => "local ref restored".to_string(),
-            Ok(output) => format!(
-                "local rollback failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            ),
-            Err(error) => format!("local rollback could not run: {error}"),
+        .output();
+    if !matches!(&push, Ok(output) if output.status.success()) {
+        let push_error = match push {
+            Ok(output) => String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            Err(error) => error.to_string(),
         };
-        return Err(format!(
-            "could not push refreshed epic base '{epic_branch}' to origin: {}; {rollback_detail}",
-            String::from_utf8_lossy(&push.stderr).trim()
-        ));
+        return Ok(Some(format!(
+            "EPIC BASE FAST-FORWARDED (UNPUBLISHED): epic base '{epic_branch}' ({}) advanced to its recorded parent '{parent_branch}' via '{parent_ref}' ({}), but push to origin failed: {push_error}. The refreshed local ref remains in effect and is unpublished; the worker worktree will be cut from the refreshed tip.",
+            &epic_sha[..epic_sha.len().min(8)],
+            &parent_sha[..parent_sha.len().min(8)],
+        )));
     }
 
     Ok(Some(format!(
@@ -3745,6 +3743,141 @@ mod spawn_base_tests {
         assert!(
             worker_path.join("parent-advance.txt").exists(),
             "the spawned worktree must include the parent branch advance"
+        );
+    }
+
+    #[test]
+    fn epic_base_refresh_without_origin_keeps_local_tip_and_cuts_worker_from_it() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        init_repo(&repo);
+        Command::new("git")
+            .args(["branch", "epic/behind", "main"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+
+        commit(&repo, "parent-advance.txt", "parent advanced locally");
+        let parent_tip = head_sha(&repo, "main");
+
+        let notice = fast_forward_epic_base_from_parent(&repo, "epic/behind", "main")
+            .expect("a remote-less checkout can still refresh its local epic base")
+            .expect("the local refresh must be reported");
+        assert!(notice.contains("LOCAL-ONLY"), "{notice}");
+        assert!(notice.contains("epic/behind"), "{notice}");
+        assert!(notice.contains("main"), "{notice}");
+        assert!(notice.contains("unpublished"), "{notice}");
+        assert_eq!(head_sha(&repo, "epic/behind"), parent_tip);
+
+        let worker_path = repo.join(".cas/worktrees/local-only-refreshed-worker");
+        WorkerSpawnPrep {
+            worker_name: "local-only-refreshed-worker".to_string(),
+            worktree_info: Some(WorktreePrep {
+                worktree_path: worker_path.clone(),
+                branch_name: "factory/local-only-refreshed-worker".to_string(),
+                parent_branch: "epic/behind".to_string(),
+                base_ref: None,
+                repo_root: repo.clone(),
+                cas_dir: repo.join(".cas"),
+            }),
+            warnings: Vec::new(),
+            base_provenance: None,
+        }
+        .run()
+        .expect("worker provisioning must use the retained local refresh");
+        assert!(
+            worker_path.join("parent-advance.txt").exists(),
+            "the worker must be cut from the refreshed local tip, not the stale base"
+        );
+    }
+
+    #[test]
+    fn epic_base_refresh_push_rejection_keeps_local_tip_and_cuts_worker_from_it() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let origin = tmp.path().join("origin");
+        std::fs::create_dir(&origin).unwrap();
+        init_repo(&origin);
+        Command::new("git")
+            .args(["branch", "epic/behind", "main"])
+            .current_dir(&origin)
+            .output()
+            .unwrap();
+        let reject_hook = origin.join(".git/hooks/pre-receive");
+        std::fs::write(
+            &reject_hook,
+            "#!/bin/sh\necho push rejected by test hook >&2\nexit 1\n",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&reject_hook).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&reject_hook, permissions).unwrap();
+
+        let repo = tmp.path().join("repo");
+        Command::new("git")
+            .args([
+                "clone",
+                "-q",
+                origin.to_str().unwrap(),
+                repo.to_str().unwrap(),
+            ])
+            .output()
+            .expect("git clone");
+        Command::new("git")
+            .args(["config", "user.email", "test@cas.test"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "CAS Test"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["branch", "epic/behind", "origin/epic/behind"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+
+        let remote_epic_tip = head_sha(&origin, "epic/behind");
+        commit(&origin, "parent-advance.txt", "parent advanced upstream");
+        let parent_tip = head_sha(&origin, "main");
+
+        let notice = fast_forward_epic_base_from_parent(&repo, "epic/behind", "main")
+            .expect("a rejected publish must retain the safe local refresh")
+            .expect("the unpublished refresh must be reported");
+        assert!(notice.contains("UNPUBLISHED"), "{notice}");
+        assert!(notice.contains("epic/behind"), "{notice}");
+        assert!(notice.contains("main"), "{notice}");
+        assert!(notice.contains("push rejected by test hook"), "{notice}");
+        assert_eq!(head_sha(&repo, "epic/behind"), parent_tip);
+        assert_eq!(
+            head_sha(&origin, "epic/behind"),
+            remote_epic_tip,
+            "a rejected publication must leave only the remote ref stale"
+        );
+
+        let worker_path = repo.join(".cas/worktrees/push-rejected-refreshed-worker");
+        WorkerSpawnPrep {
+            worker_name: "push-rejected-refreshed-worker".to_string(),
+            worktree_info: Some(WorktreePrep {
+                worktree_path: worker_path.clone(),
+                branch_name: "factory/push-rejected-refreshed-worker".to_string(),
+                parent_branch: "epic/behind".to_string(),
+                base_ref: None,
+                repo_root: repo.clone(),
+                cas_dir: repo.join(".cas"),
+            }),
+            warnings: Vec::new(),
+            base_provenance: None,
+        }
+        .run()
+        .expect("worker provisioning must use the retained local refresh");
+        assert!(
+            worker_path.join("parent-advance.txt").exists(),
+            "the worker must be cut from the refreshed local tip after a push rejection"
         );
     }
 

--- a/crates/cas-core/src/sync/agents_md.rs
+++ b/crates/cas-core/src/sync/agents_md.rs
@@ -183,8 +183,11 @@ mod tests {
     fn uncomments_fully_commented_codex_only_blocks() {
         let generated =
             transform_agents_md("<!-- codex-only:start\ncodex guidance\ncodex-only:end -->\n");
-        assert!(generated.contains("codex guidance\n"));
-        assert!(!generated.contains("<!--"));
+        assert_eq!(
+            generated,
+            format!("{GENERATED_HEADER}codex guidance\n"),
+            "the codex-only wrapper must be removed while the generated-file header remains"
+        );
     }
 
     #[test]

--- a/crates/cas-mux/src/mux.rs
+++ b/crates/cas-mux/src/mux.rs
@@ -358,8 +358,9 @@ impl Mux {
         result
     }
 
-    /// Create a multiplexer with factory configuration
-    pub fn factory(config: MuxConfig) -> Result<Self> {
+    /// Initialize the non-PTY state shared by factory construction and
+    /// dynamic-worker configuration previews.
+    fn configured_factory(config: &MuxConfig) -> Self {
         let mut mux = Self::new(config.rows, config.cols);
         mux.factory_session = config.factory_session.clone();
 
@@ -387,6 +388,23 @@ impl Mux {
                 mux.worker_specs.insert(name.clone(), spec.clone());
             }
         }
+
+        mux
+    }
+
+    /// Build factory configuration state without spawning panes.
+    ///
+    /// This is intentionally test-only: production callers must use
+    /// [`Self::factory`] so they cannot accidentally create a factory whose
+    /// supervisor and initial workers were never launched.
+    #[cfg(test)]
+    pub(crate) fn factory_state_for_test(config: &MuxConfig) -> Self {
+        Self::configured_factory(config)
+    }
+
+    /// Create a multiplexer with factory configuration
+    pub fn factory(config: MuxConfig) -> Result<Self> {
+        let mut mux = Self::configured_factory(&config);
 
         // Calculate pane sizes based on layout
         // Layout: [Workers] [Supervisor] [Director]

--- a/crates/cas-mux/src/mux_tests/tests.rs
+++ b/crates/cas-mux/src/mux_tests/tests.rs
@@ -2,7 +2,40 @@ use crate::harness::SupervisorCli;
 use crate::mux::*;
 use crate::pane::UserInputKind;
 use crate::spec::{Effort, WorkerSpec};
+use std::ffi::OsString;
 use std::path::PathBuf;
+use std::sync::Mutex;
+
+// cas-mux tests mutate these process-wide launch probes to make assertions
+// independent of the host's installed harness binaries.
+static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct RestoreEnv {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl RestoreEnv {
+    fn set(key: &'static str, value: impl Into<OsString>) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: callers hold `TEST_ENV_LOCK` for the lifetime of the guard,
+        // serializing process-wide test environment mutation in this binary.
+        unsafe { std::env::set_var(key, value.into()) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for RestoreEnv {
+    fn drop(&mut self) {
+        // SAFETY: this guard is only constructed while `TEST_ENV_LOCK` is held.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
 
 fn env_value<'a>(config: &'a crate::pty::PtyConfig, key: &str) -> Option<&'a str> {
     config
@@ -27,6 +60,8 @@ fn codex_factory_session_arg(config: &crate::pty::PtyConfig) -> Option<&str> {
 
 #[test]
 fn factory_pane_configs_supervisor_effort_reaches_pty_args() {
+    let _env_lock = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _effort_support = RestoreEnv::set("CAS_FACTORY_EFFORT_SUPPORTED", "1");
     let config = MuxConfig {
         cwd: PathBuf::from("/tmp/test"),
         workers: 1,
@@ -60,6 +95,8 @@ fn factory_pane_configs_supervisor_effort_reaches_pty_args() {
 
 #[test]
 fn factory_pane_configs_worker_effort_reaches_pty_args() {
+    let _env_lock = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _effort_support = RestoreEnv::set("CAS_FACTORY_EFFORT_SUPPORTED", "1");
     let config = MuxConfig {
         cwd: PathBuf::from("/tmp/test"),
         workers: 1,
@@ -165,7 +202,7 @@ fn factory_pane_configs_propagates_supervisor_name_to_codex_worker_mcp_env() {
 
 #[test]
 fn build_add_worker_config_propagates_factory_session_for_dynamic_spawns() {
-    let mut mux = Mux::factory(MuxConfig {
+    let config = MuxConfig {
         cwd: PathBuf::from("/tmp/test"),
         workers: 0,
         worker_names: vec![],
@@ -174,8 +211,8 @@ fn build_add_worker_config_propagates_factory_session_for_dynamic_spawns() {
         supervisor_cli: SupervisorCli::Claude,
         worker_cli: SupervisorCli::Codex,
         ..MuxConfig::default()
-    })
-    .expect("factory config should build");
+    };
+    let mut mux = Mux::factory_state_for_test(&config);
 
     mux.set_default_worker_spec(WorkerSpec::codex_default("dynamic-worker"));
     let pty_config = mux.build_add_worker_config(
@@ -515,8 +552,35 @@ fn effective_worker_spec_uses_worker_specs_map() {
 /// worker added to a Claude-default factory (the exact bug scenario) resolved back
 /// to the Claude default — and the entire routing fix would be inert, silently
 /// inboxing messages the codex process can never read.
+#[cfg(unix)]
 #[test]
 fn add_worker_persists_explicit_spec_so_effective_resolves_codex() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _env_lock = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let bin_dir =
+        std::env::temp_dir().join(format!("cas-mux-add-worker-test-{}", std::process::id()));
+    std::fs::create_dir_all(&bin_dir).expect("fake-bin directory must be creatable");
+    for binary in ["cas", "codex"] {
+        let path = bin_dir.join(binary);
+        std::fs::write(&path, b"#!/bin/sh\nexit 0\n").expect("fake worker binary must be writable");
+        let mut permissions = std::fs::metadata(&path)
+            .expect("fake worker binary metadata must be readable")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions)
+            .expect("fake worker binary must be executable");
+    }
+    // Keep system utilities such as the optional `nice` wrapper available;
+    // the fake directory remains first so the test never launches a real Codex.
+    let mut path_entries = vec![bin_dir.clone()];
+    if let Some(current_path) = std::env::var_os("PATH") {
+        path_entries.extend(std::env::split_paths(&current_path));
+    }
+    let test_path = std::env::join_paths(path_entries)
+        .expect("test PATH entries must be representable on this platform");
+    let _path = RestoreEnv::set("PATH", test_path);
+
     let mut mux = Mux::new(24, 80);
     // Session default is Claude — the explicit per-spawn spec must persist and win.
     mux.set_default_worker_spec(WorkerSpec {
@@ -550,6 +614,9 @@ fn add_worker_persists_explicit_spec_so_effective_resolves_codex() {
         "after add_worker, a later harness lookup must resolve the persisted Codex \
          spec — not fall back to the Claude default (cas-b68a)"
     );
+
+    drop(mux);
+    std::fs::remove_dir_all(bin_dir).expect("fake-bin directory must be removable");
 }
 
 // ── cas-35fe: custom worker_names branch ─────────────────────────────────────
@@ -600,6 +667,8 @@ fn add_worker_effort_propagates_to_pty_args() {
     // Uses the config-only build_add_worker_config helper (no PTY spawn).
     use crate::spec::Effort;
 
+    let _env_lock = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _effort_support = RestoreEnv::set("CAS_FACTORY_EFFORT_SUPPORTED", "1");
     let mut mux = Mux::new(24, 80);
     mux.set_default_worker_spec(crate::spec::WorkerSpec {
         name: None,

--- a/crates/cas-pty/src/pty.rs
+++ b/crates/cas-pty/src/pty.rs
@@ -3322,9 +3322,12 @@ mod tests {
                 None,
                 None,
             );
-            let before = env_value(&config.env, "CARGO_BUILD_JOBS")
-                .expect("worker config must carry CARGO_BUILD_JOBS")
-                .to_string();
+            // Simulate a stale duplicate from an older builder. On small CI
+            // hosts the constructor's default can already be "2", so proving
+            // replacement by comparing numeric values is not portable.
+            config
+                .env
+                .push(("CARGO_BUILD_JOBS".to_string(), "99".to_string()));
 
             config.apply_worker_build_concurrency(Some(64));
 
@@ -3341,10 +3344,6 @@ mod tests {
             );
             let after = entries[0].1.clone();
             assert_eq!(after, "2", "a 64-worker fleet floors at 2 jobs");
-            assert_ne!(
-                after, before,
-                "the fleet-aware value must actually replace the default"
-            );
         }
 
         #[test]

--- a/crates/cas-store/src/delegation_receipt_store.rs
+++ b/crates/cas-store/src/delegation_receipt_store.rs
@@ -288,7 +288,9 @@ impl SqliteDelegationReceiptStore {
         if let Some(receipt) = existing {
             tx.commit()?;
             return Ok(
-                if receipt.state == DelegationReceiptState::TimedOut && receipt.run_id.is_some() {
+                if receipt.state == DelegationReceiptState::TimedOut
+                    && receipt.run_id.as_deref().is_some_and(|run_id| !run_id.trim().is_empty())
+                {
                     DelegationReserveOutcome::Resume(receipt)
                 } else {
                     DelegationReserveOutcome::Existing(receipt)
@@ -337,7 +339,34 @@ impl SqliteDelegationReceiptStore {
         Self::get_with_conn(&conn, id)
     }
     pub fn record_timeout(&self, id: &str, run_id: &str) -> Result<DelegationReceipt> {
+        if run_id.trim().is_empty() {
+            return Err(StoreError::Parse(
+                "delegation run_id must be non-empty".to_string(),
+            ));
+        }
         let conn = self.conn.lock().map_err(lock_err)?;
+        let current = Self::get_with_conn(&conn, id)?;
+        if current.state == DelegationReceiptState::Completed {
+            return Err(StoreError::Parse(
+                "cannot time out a completed or missing delegation receipt".to_string(),
+            ));
+        }
+        if let Some(existing_run_id) = current
+            .run_id
+            .as_deref()
+            .filter(|existing_run_id| !existing_run_id.trim().is_empty())
+        {
+            if existing_run_id != run_id {
+                return Err(StoreError::Parse(
+                    "cannot replace an existing delegation run_id".to_string(),
+                ));
+            }
+            if current.state == DelegationReceiptState::TimedOut {
+                // Re-observing the same timed-out run is idempotent: it must
+                // never create or adopt a second upstream run.
+                return Ok(current);
+            }
+        }
         let now = Utc::now().to_rfc3339();
         let changed = conn.execute("UPDATE delegation_receipts SET state='timed_out', run_id=?2, terminal_verdict='wait_timed_out', updated_at=?3 WHERE id=?1 AND state != 'completed'", params![id, run_id, now])?;
         if changed == 0 {
@@ -356,7 +385,7 @@ impl SqliteDelegationReceiptStore {
                 "delegation receipt is not awaiting run resumption".to_string(),
             ));
         }
-        receipt.run_id.ok_or_else(|| {
+        receipt.run_id.filter(|run_id| !run_id.trim().is_empty()).ok_or_else(|| {
             StoreError::Parse("timed-out delegation receipt has no run_id; fail closed".to_string())
         })
     }
@@ -437,6 +466,90 @@ mod tests {
         assert_eq!(store.resume_run(&resumed.id).unwrap(), "run-42");
         assert_eq!(timed_out.run_id.as_deref(), Some("run-42"));
     }
+
+    #[test]
+    fn record_timeout_rejects_empty_run_ids_without_changing_the_receipt() {
+        let dir = TempDir::new().unwrap();
+        let store = SqliteDelegationReceiptStore::open(dir.path()).unwrap();
+        let receipt = match store
+            .reserve_or_resume(&request("digest-a", 4), &budget())
+            .unwrap()
+        {
+            DelegationReserveOutcome::Created(v) => v,
+            other => panic!("expected created, got {other:?}"),
+        };
+
+        for run_id in ["", " \t\n "] {
+            let error = store.record_timeout(&receipt.id, run_id).unwrap_err();
+            assert!(error.to_string().contains("run_id must be non-empty"));
+            assert_eq!(
+                store.get(&receipt.id).unwrap(),
+                receipt,
+                "invalid timeout input must leave the receipt unchanged"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_stored_run_id_fails_closed_for_resume_and_reconnect() {
+        let dir = TempDir::new().unwrap();
+        let store = SqliteDelegationReceiptStore::open(dir.path()).unwrap();
+        let receipt = match store
+            .reserve_or_resume(&request("digest-a", 4), &budget())
+            .unwrap()
+        {
+            DelegationReserveOutcome::Created(v) => v,
+            other => panic!("expected created, got {other:?}"),
+        };
+
+        // Simulate a legacy corrupt row written before record_timeout rejected
+        // empty IDs: both consumers must still fail closed on read.
+        store
+            .conn
+            .lock()
+            .unwrap()
+            .execute(
+                "UPDATE delegation_receipts SET state='timed_out', run_id='' WHERE id=?1",
+                [&receipt.id],
+            )
+            .unwrap();
+
+        let error = store.resume_run(&receipt.id).unwrap_err();
+        assert!(error.to_string().contains("has no run_id; fail closed"));
+        let reconnected = store
+            .reserve_or_resume(&request("digest-a", 4), &budget())
+            .unwrap();
+        match reconnected {
+            DelegationReserveOutcome::Existing(receipt) => {
+                assert_eq!(receipt.run_id.as_deref(), Some(""));
+            }
+            other => panic!("empty run_id must not resume, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_timeout_rejects_a_different_run_without_replacing_the_original() {
+        let dir = TempDir::new().unwrap();
+        let store = SqliteDelegationReceiptStore::open(dir.path()).unwrap();
+        let receipt = match store
+            .reserve_or_resume(&request("digest-a", 4), &budget())
+            .unwrap()
+        {
+            DelegationReserveOutcome::Created(v) => v,
+            other => panic!("expected created, got {other:?}"),
+        };
+        let timed_out = store.record_timeout(&receipt.id, "run-1").unwrap();
+
+        let error = store.record_timeout(&receipt.id, "run-2").unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("cannot replace an existing delegation run_id"));
+        assert_eq!(store.get(&receipt.id).unwrap(), timed_out);
+
+        // Re-observing the same timeout is explicitly idempotent.
+        assert_eq!(store.record_timeout(&receipt.id, "run-1").unwrap(), timed_out);
+    }
+
     #[test]
     fn exhausted_reservation_is_denied_and_never_queued() {
         let dir = TempDir::new().unwrap();

--- a/crates/cas-store/src/prompt_queue_store.rs
+++ b/crates/cas-store/src/prompt_queue_store.rs
@@ -5653,11 +5653,11 @@ mod tests {
         );
     }
 
-    /// cas-45c4 (GH #102): an ack inferred from a later reply must never be
-    /// reported the same way as the recipient's own acknowledgement. The
-    /// inference proves the recipient took a turn; it does not prove this
-    /// message's content was ever surfaced to it — and reporting both as
-    /// "confirmed" is what let status claim a confirmation nobody made.
+    /// cas-45c4 (GH #102): later recipient activity must never be reported
+    /// the same way as the recipient's own acknowledgement. It proves the
+    /// recipient took a turn; it does not prove this message's content entered
+    /// that later turn, so cas-dcf2 records only `AssumedSeen` rather than a
+    /// confirmation.
     #[test]
     fn confirmation_source_separates_an_explicit_ack_from_a_reply_inference() {
         let (_temp, store) = create_test_store();
@@ -5706,14 +5706,18 @@ mod tests {
             "the recipient acknowledged this message itself"
         );
 
-        assert_eq!(b.confirmation_source, ConfirmationSource::InferredFromReply);
+        // Preserve the original distinction: a reply after a surfacing receipt
+        // is useful evidence, but it is still not the recipient's claim about
+        // this particular message.
+        assert_eq!(b.stage, DeliveryStage::AssumedSeen);
+        assert_eq!(b.confirmation_source, ConfirmationSource::Unconfirmed);
+        assert_eq!(b.confirmed_at, None);
+        assert!(b.assumed_seen_at.is_some());
         assert!(
             !b.confirmation_source.is_recipient_claim(),
-            "a reply-inferred ack must not be presented as the recipient's claim about \
-             THIS message — it may never have been surfaced"
+            "later activity must not be presented as the recipient's claim about THIS message"
         );
-        // Both still read as legacy-confirmed, so older clients are unaffected.
-        assert!(a.confirmed_at.is_some() && b.confirmed_at.is_some());
+        assert!(a.confirmed_at.is_some());
     }
 
     /// cas-45c4: rows acked before provenance tracking existed must report
@@ -5918,7 +5922,7 @@ mod tests {
     }
 
     #[test]
-    fn recipient_response_confirms_only_delivered_counterparty_messages() {
+    fn recipient_response_marks_only_delivered_counterparty_messages_as_assumed_seen() {
         let (_temp, store) = create_test_store();
         let consumed = store
             .enqueue_with_session(
@@ -5948,7 +5952,7 @@ mod tests {
         // cas-99d2: reply-inference also needs a surfacing receipt for the row.
         record_seen(&store, consumed, "worker-1", Utc::now());
 
-        let confirmed = store
+        let assumed_seen = store
             .ack_delivered_for_recipient(
                 &["worker-1"],
                 &["supervisor", "display-supervisor"],
@@ -5956,14 +5960,23 @@ mod tests {
                 Utc::now(),
             )
             .unwrap();
-        assert_eq!(confirmed, 1);
+        assert_eq!(assumed_seen, 1);
+        // Preserve the original filter intent: only delivered messages to the
+        // responding counterparty advance. cas-dcf2 makes that advance the
+        // non-confirming `AssumedSeen` step.
         assert_eq!(
             store
                 .message_delivery_report(consumed)
                 .unwrap()
                 .unwrap()
                 .stage,
-            DeliveryStage::Confirmed
+            DeliveryStage::AssumedSeen
+        );
+        let consumed_report = store.message_delivery_report(consumed).unwrap().unwrap();
+        assert_eq!(consumed_report.confirmed_at, None);
+        assert_eq!(
+            consumed_report.confirmation_source,
+            ConfirmationSource::Unconfirmed
         );
         assert_eq!(
             store

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -8,6 +8,7 @@ release="$repo_root/.github/workflows/release.yml"
 setup="$repo_root/.github/actions/setup-rust-linux/action.yml"
 fallback="$repo_root/scripts/sccache-unavailable.sh"
 ruleset="$repo_root/docs/branch-protection/main-ruleset.json"
+makefile="$repo_root/cas-cli/Makefile"
 
 pass=0
 fail=0
@@ -157,8 +158,9 @@ preflight="$(job_block fast-validation-preflight)"
 suite="$(job_block fast-validation-suite)"
 docs="$(job_block fast-validation-docs)"
 fan_in="$(job_block fast-validation)"
-require_text "$suite" 'cargo nextest run -p cas --no-fail-fast' 'suite retains full nextest coverage'
+require_text "$suite" 'cargo nextest run --workspace --no-fail-fast' 'suite executes every workspace nextest binary'
 require_absent "$suite" '--partition' 'suite avoids duplicate test-graph compilation across runners'
+require_text "$(<"$makefile")" '$(CARGO) nextest run --workspace --no-fail-fast' 'local make test matches CI workspace nextest scope'
 require_text "$docs" 'cargo test -p cas --doc' 'doctest coverage remains in Fast Validation'
 require_text "$fan_in" 'fast-validation-preflight' 'required Fast Validation waits for preflight'
 require_text "$fan_in" 'fast-validation-suite' 'required Fast Validation waits for the full suite'


### PR DESCRIPTION
Assembled landing of the three v20 follow-up lanes (epic cas-9186), each with green lane CI at merge. Fixes #442, fixes #443, fixes #445.

- cas-store's suite is green AND executes: the two tests still asserting the pre-assumed_seen reply-inference contract move to the new ladder, Fast Validation and `make test` run the workspace suite (662+ previously-unrun cas-store tests included), and the CI-tier guard pins that scope (#442).
- Epic-base refresh keeps its local fast-forward when publication fails: no-origin repos skip the push with a local-only notice, rejected pushes retain the refreshed base and name the branch pair + error + unpublished status, divergent refusal unchanged — regression tests cover no-origin and push-rejected repos (#443).
- Delegation receipts fail closed on empty runs: record_timeout validates run_id like record_run_id, different-run re-timeouts are rejected (same-run stays idempotent), and resume/reservation classification treat an empty stored run id as no-run (#445).

NOTE: this is the first PR whose Fast Validation executes the full workspace suite — the widened net is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)