### PR TITLE
Enforce receipted external delegation in cas serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- **External expertise now crosses one enforced, receipted gateway.** `cas serve` replaces the proxy's compatibility default with an exact configured `(server, tool)` allowlist at boot and reload, denies every external call when that list is empty, and refuses paid verification routes outside the registered-supervisor gateway. The first production flow reserves a durable budget receipt before `ask_viktor`, resumes timed-out runs by their stored run ID, and returns only the fail-closed external-production-verification verdict; configuration and route/budget defaults are documented in `crates/cas-mcp-proxy/README.md`.
+
 ## [2.71.0] - 2026-08-16
 
 ### Added

--- a/cas-cli/src/mcp/daemon.rs
+++ b/cas-cli/src/mcp/daemon.rs
@@ -452,8 +452,18 @@ impl EmbeddedDaemon {
             Ok(cfg) => {
                 let server_count = cfg.servers.len();
                 let snapshot_config = cfg.clone();
+                // Close the dispatch gate before mutating upstreams. Reload may
+                // await connection setup, and a removed route must not remain
+                // usable during that window. A failed reload deliberately
+                // leaves the proxy deny-all until a valid snapshot arrives.
+                proxy
+                    .set_policy(std::sync::Arc::new(
+                        cmcp_core::ExternalToolAllowlistPolicy::default(),
+                    ))
+                    .await;
                 match proxy.reload(cfg.servers).await {
                     Ok(()) => {
+                        crate::mcp::server::install_proxy_policy(&proxy, &snapshot_config).await;
                         let tool_count = proxy.tool_count().await;
                         eprintln!(
                             "[CAS] Proxy reloaded ({server_count} server(s), {tool_count} tools)"

--- a/cas-cli/src/mcp/server/mod.rs
+++ b/cas-cli/src/mcp/server/mod.rs
@@ -889,6 +889,8 @@ mod prompts;
 mod resources;
 mod runtime;
 
+#[cfg(feature = "mcp-proxy")]
+pub(crate) use runtime::install_proxy_policy;
 pub use runtime::run_server;
 #[cfg(feature = "mcp-proxy")]
 pub use runtime::{

--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -325,6 +325,7 @@ async fn run_server_impl() -> anyhow::Result<()> {
                 let snapshot_config = cfg.clone();
                 match cmcp_core::ProxyEngine::from_configs(cfg.servers).await {
                     Ok(engine) => {
+                        install_proxy_policy(&engine, &snapshot_config).await;
                         let count = engine.tool_count().await;
                         eprintln!("[CAS] MCP proxy ready ({count} upstream tools)");
                         if let Err(error) = write_proxy_snapshot_cache_for_config(
@@ -446,6 +447,39 @@ async fn run_server_impl() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Install the production external dispatch policy from parsed configuration.
+/// This is unconditional: an empty allowlist deliberately replaces the proxy
+/// crate's compatibility default with a fail-closed policy.
+#[cfg(feature = "mcp-proxy")]
+pub(crate) async fn install_proxy_policy(
+    engine: &cmcp_core::ProxyEngine,
+    config: &cmcp_core::config::Config,
+) {
+    let routes = config
+        .allowlist
+        .iter()
+        .map(|route| cmcp_core::ExternalToolRoute::new(route.server.clone(), route.tool.clone()));
+    let delegation_routes = config
+        .delegation
+        .external_production_verification
+        .iter()
+        .flat_map(|gateway| {
+            [
+                cmcp_core::ExternalToolRoute::new(
+                    gateway.server.clone(),
+                    gateway.start_tool.clone(),
+                ),
+                cmcp_core::ExternalToolRoute::new(
+                    gateway.server.clone(),
+                    gateway.wait_tool.clone(),
+                ),
+            ]
+        });
+    let policy = cmcp_core::ExternalToolAllowlistPolicy::new(routes)
+        .with_supervisor_delegation_routes(delegation_routes);
+    engine.set_policy(std::sync::Arc::new(policy)).await;
 }
 
 /// Total time budget for the eager store-init phase before `cas serve` aborts.
@@ -1198,6 +1232,84 @@ mod tests {
     use crate::types::{Entry, Task};
     use std::sync::Arc;
     use tempfile::TempDir;
+
+    #[cfg(feature = "mcp-proxy")]
+    #[tokio::test]
+    async fn boot_policy_is_fail_closed_exact_and_gateway_bound() {
+        use cmcp_core::config::{
+            Config as ProxyConfig, ExternalProductionVerificationConfig, ExternalToolConfig,
+        };
+
+        let engine = cmcp_core::ProxyEngine::from_configs(Default::default())
+            .await
+            .unwrap();
+        let mut config = ProxyConfig::default();
+        config.allowlist = vec![
+            ExternalToolConfig {
+                server: "github".to_string(),
+                tool: "list_issues".to_string(),
+            },
+            ExternalToolConfig {
+                server: "viktor".to_string(),
+                tool: "ask_viktor".to_string(),
+            },
+            ExternalToolConfig {
+                server: "viktor".to_string(),
+                tool: "wait_for_run".to_string(),
+            },
+        ];
+        config.delegation.external_production_verification =
+            Some(ExternalProductionVerificationConfig {
+                server: "viktor".to_string(),
+                start_tool: "ask_viktor".to_string(),
+                wait_tool: "wait_for_run".to_string(),
+                reserved_amount: 1,
+                max_per_run: 1,
+                max_active_per_factory_session: 4,
+                max_active_per_epic: 2,
+                timeout_seconds: 120,
+            });
+        super::install_proxy_policy(&engine, &config).await;
+        let caller = cmcp_core::ProxyCaller {
+            agent_id: "supervisor".to_string(),
+            role: crate::types::AgentRole::Supervisor,
+            session_id: "supervisor".to_string(),
+            factory_session: Some("factory-1".to_string()),
+            active_task_ids: Vec::new(),
+        };
+
+        let foreign = engine
+            .call_tool(&caller, "viktor-shadow", "ask_viktor", None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(foreign.contains("external tool is not explicitly allowlisted"));
+        let direct_delegation = engine
+            .call_tool(&caller, "viktor", "ask_viktor", None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(direct_delegation.contains("requires the registered supervisor gateway"));
+
+        let ordinary = engine
+            .call_tool(&caller, "github", "list_issues", None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(ordinary.contains("server 'github' not connected"));
+        assert!(!ordinary.contains("proxy policy denied"));
+        let delegated = engine
+            .call_external_production_verification_tool(&caller, "viktor", "ask_viktor", None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(delegated.contains("server 'viktor' not connected"));
+        assert!(!delegated.contains("proxy policy denied"));
+
+        let audit = engine.policy_audit();
+        assert_eq!(audit.iter().filter(|entry| entry.allowed).count(), 2);
+        assert_eq!(audit.iter().filter(|entry| !entry.allowed).count(), 2);
+    }
 
     fn make_m233_pending(cas_root: &std::path::Path, wrong_ledger_identity: bool) {
         let conn = rusqlite::Connection::open(cas_root.join("cas.db")).unwrap();

--- a/cas-cli/src/mcp/tools/service/external_verification.rs
+++ b/cas-cli/src/mcp/tools/service/external_verification.rs
@@ -1,0 +1,609 @@
+use rmcp::model::{CallToolResult, ErrorCode};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+
+use super::{CasService, McpError, VerificationRequest};
+use cas_store::{
+    DelegationBudget, DelegationReceipt, DelegationReceiptState, DelegationReserveOutcome,
+    DelegationReserveRequest, DelegationVerdict, EXTERNAL_PRODUCTION_VERIFICATION_GATE,
+    ExternalVerificationOutcome, ExternalVerificationRequest, RequiredCheck,
+    SqliteDelegationReceiptStore, assess_response, assessment_for_outcome, authorize_request,
+    record_assessment,
+};
+
+impl CasService {
+    pub(super) async fn verification_external(
+        &self,
+        req: VerificationRequest,
+    ) -> Result<CallToolResult, McpError> {
+        let proxy = self.proxy.as_ref().ok_or_else(|| {
+            Self::error(
+                ErrorCode::INVALID_REQUEST,
+                "External verification requires a configured MCP proxy.",
+            )
+        })?;
+        let task_id = required(req.task_id, "task_id")?;
+        let message = required(req.message, "message")?;
+        let local_proof_reference = required(req.local_proof_reference, "local_proof_reference")?;
+        let required_checks: Vec<RequiredCheck> =
+            serde_json::from_str(required(req.required_checks, "required_checks")?.as_str())
+                .map_err(|_| {
+                    Self::error(
+                        ErrorCode::INVALID_PARAMS,
+                        "required_checks must be a JSON array of {name, expected} objects",
+                    )
+                })?;
+
+        let caller = self.proxy_caller()?;
+        let gate_request = ExternalVerificationRequest {
+            caller_role: caller.role,
+            local_proof_reference: local_proof_reference.clone(),
+            required_checks: required_checks.clone(),
+        };
+        authorize_request(&gate_request).map_err(|error| {
+            Self::error(
+                ErrorCode::INVALID_REQUEST,
+                format!("External verification denied: {error}"),
+            )
+        })?;
+        let factory_session_id = caller.factory_session.clone().ok_or_else(|| {
+            Self::error(
+                ErrorCode::INVALID_REQUEST,
+                "External verification requires a registered factory supervisor session.",
+            )
+        })?;
+
+        let task_store = self.inner.open_task_store()?;
+        let task = task_store.get(&task_id).map_err(|error| {
+            Self::error(
+                ErrorCode::INVALID_PARAMS,
+                format!("External verification task not found: {error}"),
+            )
+        })?;
+        let epic_id = if task.task_type == crate::types::TaskType::Epic {
+            task.id.clone()
+        } else {
+            task_store
+                .get_parent_epic(&task_id)
+                .map_err(|error| {
+                    Self::error(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to resolve delegation epic: {error}"),
+                    )
+                })?
+                .map(|epic| epic.id)
+                .ok_or_else(|| {
+                    Self::error(
+                        ErrorCode::INVALID_REQUEST,
+                        "External verification requires a task attached to an epic.",
+                    )
+                })?
+        };
+
+        let config = load_proxy_config(&self.inner.cas_root)?;
+        let gateway = config
+            .delegation
+            .external_production_verification
+            .ok_or_else(|| {
+                Self::error(
+                    ErrorCode::INVALID_REQUEST,
+                    "External production verification is not configured.",
+                )
+            })?;
+        for tool in [&gateway.start_tool, &gateway.wait_tool] {
+            if !config
+                .allowlist
+                .iter()
+                .any(|route| route.server == gateway.server && route.tool == *tool)
+            {
+                return Err(Self::error(
+                    ErrorCode::INVALID_REQUEST,
+                    format!(
+                        "External verification route {}.{} is not explicitly allowlisted.",
+                        gateway.server, tool
+                    ),
+                ));
+            }
+        }
+
+        let canonical = json!({
+            "gate": EXTERNAL_PRODUCTION_VERIFICATION_GATE,
+            "task_id": task_id,
+            "message": message,
+            "local_proof_reference": local_proof_reference,
+            "required_checks": required_checks,
+        });
+        let request_digest = format!("{:x}", Sha256::digest(canonical.to_string().as_bytes()));
+        let store = SqliteDelegationReceiptStore::open(&self.inner.cas_root).map_err(|error| {
+            Self::error(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to open delegation receipt store: {error}"),
+            )
+        })?;
+        let budget = DelegationBudget {
+            max_per_run: gateway.max_per_run,
+            max_active_per_factory_session: gateway.max_active_per_factory_session,
+            max_active_per_epic: gateway.max_active_per_epic,
+        };
+        let reservation = DelegationReserveRequest {
+            factory_session_id,
+            epic_id,
+            task_id: task_id.clone(),
+            gate_kind: EXTERNAL_PRODUCTION_VERIFICATION_GATE.to_string(),
+            request_digest,
+            reserved_amount: gateway.reserved_amount,
+        };
+        let outcome = store
+            .reserve_or_resume(&reservation, &budget)
+            .map_err(|error| {
+                Self::error(
+                    ErrorCode::INVALID_REQUEST,
+                    format!("External verification reservation denied: {error}"),
+                )
+            })?;
+        let receipt = match &outcome {
+            DelegationReserveOutcome::Created(receipt)
+            | DelegationReserveOutcome::Existing(receipt)
+            | DelegationReserveOutcome::Resume(receipt) => receipt.clone(),
+        };
+        if receipt.state == DelegationReceiptState::Completed {
+            return Ok(render_receipt(&receipt));
+        }
+
+        let (tool, arguments) = match outcome {
+            DelegationReserveOutcome::Resume(receipt) => {
+                let run_id = store.resume_run(&receipt.id).map_err(|error| {
+                    Self::error(
+                        ErrorCode::INVALID_REQUEST,
+                        format!("External verification cannot resume: {error}"),
+                    )
+                })?;
+                let mut args = Map::new();
+                args.insert("run_id".to_string(), Value::String(run_id));
+                args.insert(
+                    "timeout_seconds".to_string(),
+                    Value::Number(gateway.timeout_seconds.into()),
+                );
+                (gateway.wait_tool.clone(), args)
+            }
+            DelegationReserveOutcome::Created(receipt)
+            | DelegationReserveOutcome::Existing(receipt) => {
+                let mut args = Map::new();
+                args.insert(
+                    "message".to_string(),
+                    Value::String(provider_message(
+                        &message,
+                        &local_proof_reference,
+                        &required_checks,
+                    )),
+                );
+                args.insert("speed".to_string(), Value::String("smarter".to_string()));
+                args.insert(
+                    "timeout_seconds".to_string(),
+                    Value::Number(gateway.timeout_seconds.into()),
+                );
+                args.insert(
+                    "idempotency_key".to_string(),
+                    Value::String(receipt.idempotency_key),
+                );
+                args.insert("response_format".to_string(), response_format());
+                (gateway.start_tool.clone(), args)
+            }
+        };
+
+        let raw = match proxy
+            .call_external_production_verification_tool(
+                &caller,
+                &gateway.server,
+                &tool,
+                Some(arguments),
+            )
+            .await
+        {
+            Ok(raw) => raw,
+            Err(error) => {
+                let assessment =
+                    assessment_for_outcome(ExternalVerificationOutcome::TransportFailure);
+                let terminal = record_assessment(
+                    &store,
+                    &receipt.id,
+                    &assessment,
+                    receipt.reserved_amount,
+                    &format!("delegation://receipt/{}", receipt.id),
+                )
+                .map_err(|store_error| {
+                    Self::error(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to record transport failure: {store_error}"),
+                    )
+                })?;
+                tracing::warn!(receipt_id = %receipt.id, error = %error, "external verification transport failed closed");
+                return Ok(render_receipt(&terminal));
+            }
+        };
+
+        let payload = extract_tool_payload(&raw);
+        let run_id = find_string(&payload, &["run_id"]).or_else(|| {
+            find_pointer_string(&payload, &["/run/id", "/result/run_id", "/result/run/id"])
+        });
+        if let Some(run_id) = run_id.as_deref() {
+            store.record_run_id(&receipt.id, run_id).map_err(|error| {
+                Self::error(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to record delegated run id: {error}"),
+                )
+            })?;
+        }
+        if payload
+            .get("wait_timed_out")
+            .or_else(|| payload.pointer("/result/wait_timed_out"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            let run_id = run_id.ok_or_else(|| {
+                Self::error(
+                    ErrorCode::INTERNAL_ERROR,
+                    "External verifier timed out without a resumable run_id; refusing to start another run.",
+                )
+            })?;
+            let timed_out = store
+                .record_timeout(&receipt.id, &run_id)
+                .map_err(|error| {
+                    Self::error(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to persist timed-out delegation: {error}"),
+                    )
+                })?;
+            return Ok(render_receipt(&timed_out));
+        }
+
+        let outcome = provider_outcome(&payload);
+        let assessment = match outcome {
+            ExternalVerificationOutcome::Response => {
+                let response = payload
+                    .get("json")
+                    .or_else(|| payload.pointer("/result/json"))
+                    .cloned()
+                    .unwrap_or(payload.clone());
+                assess_response(&gate_request, response)
+            }
+            other => assessment_for_outcome(other),
+        };
+        let evidence_reference = run_id
+            .as_deref()
+            .map(|run_id| format!("viktor://run/{run_id}"))
+            .unwrap_or_else(|| format!("delegation://receipt/{}", receipt.id));
+        let terminal = record_assessment(
+            &store,
+            &receipt.id,
+            &assessment,
+            receipt.reserved_amount,
+            &evidence_reference,
+        )
+        .map_err(|error| {
+            Self::error(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to persist external verification verdict: {error}"),
+            )
+        })?;
+        Ok(render_receipt(&terminal))
+    }
+}
+
+fn required(value: Option<String>, field: &str) -> Result<String, McpError> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            CasService::error(
+                ErrorCode::INVALID_PARAMS,
+                format!("{field} required for external_verify"),
+            )
+        })
+}
+
+fn load_proxy_config(root: &std::path::Path) -> Result<cmcp_core::config::Config, McpError> {
+    let path = root.join("proxy.toml");
+    cmcp_core::config::Config::load_merged(path.exists().then_some(path.as_path())).map_err(
+        |error| {
+            CasService::error(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to load external verification config: {error}"),
+            )
+        },
+    )
+}
+
+fn provider_message(message: &str, local_proof: &str, checks: &[RequiredCheck]) -> String {
+    let checks = checks
+        .iter()
+        .map(|check| format!("- {}: {}", check.name, check.expected))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "Read-only external production verification. Do not mutate, submit, approve, or authenticate with write capability.\n\nRequest: {message}\nLocal proof: {local_proof}\nRequired checks:\n{checks}"
+    )
+}
+
+fn response_format() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["verdict", "checks", "limitations"],
+        "properties": {
+            "verdict": {"enum": ["pass", "fail", "inconclusive"]},
+            "checks": {"type": "array", "minItems": 1, "items": {
+                "type": "object", "additionalProperties": false,
+                "required": ["name", "expected", "observed", "evidence"],
+                "properties": {
+                    "name": {"type": "string"}, "expected": {"type": "string"},
+                    "observed": {"type": "string"}, "evidence": {"type": "string"}
+                }
+            }},
+            "limitations": {"type": "array", "items": {"type": "string"}}
+        }
+    })
+}
+
+fn extract_tool_payload(raw: &Value) -> Value {
+    if let Some(structured) = raw
+        .get("structuredContent")
+        .filter(|structured| !structured.is_null())
+    {
+        return structured.clone();
+    }
+    raw.pointer("/content/0/text")
+        .and_then(Value::as_str)
+        .and_then(|text| serde_json::from_str(text).ok())
+        .unwrap_or_else(|| json!({"error": "malformed"}))
+}
+
+fn find_string(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn find_pointer_string(value: &Value, pointers: &[&str]) -> Option<String> {
+    pointers
+        .iter()
+        .find_map(|pointer| value.pointer(pointer).and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn provider_outcome(payload: &Value) -> ExternalVerificationOutcome {
+    let code = find_string(payload, &["error", "status", "verdict"])
+        .or_else(|| {
+            find_pointer_string(
+                payload,
+                &[
+                    "/detail/error",
+                    "/result/error",
+                    "/result/status",
+                    "/run/status",
+                ],
+            )
+        })
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    match code.as_str() {
+        "requires_action" => ExternalVerificationOutcome::RequiresAction,
+        "thread_busy" => ExternalVerificationOutcome::ThreadBusy,
+        "insufficient_scope" => ExternalVerificationOutcome::InsufficientScope,
+        "rate_limited" | "rate_limit_exceeded" => ExternalVerificationOutcome::RateLimited,
+        "cancelled" => ExternalVerificationOutcome::Cancelled,
+        "transport_failure" => ExternalVerificationOutcome::TransportFailure,
+        _ => ExternalVerificationOutcome::Response,
+    }
+}
+
+fn render_receipt(receipt: &DelegationReceipt) -> CallToolResult {
+    let verdict = receipt.terminal_verdict.map(|verdict| verdict.to_string());
+    let passing = receipt.terminal_verdict == Some(DelegationVerdict::Pass);
+    CasService::success(
+        serde_json::to_string_pretty(&json!({
+            "receipt_id": receipt.id,
+            "task_id": receipt.task_id,
+            "state": receipt.state.to_string(),
+            "run_id": receipt.run_id,
+            "verdict": verdict,
+            "passing": passing,
+            "evidence_reference": receipt.evidence_reference,
+        }))
+        .unwrap_or_else(|_| "{\"passing\":false,\"verdict\":\"malformed\"}".to_string()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::server::CasCore;
+    use crate::store::{init_cas_dir, open_task_store};
+    use crate::types::{AgentRole, Task, TaskType};
+    use cmcp_core::config::{
+        Config as ProxyConfig, ExternalProductionVerificationConfig, ExternalToolConfig,
+        ServerConfig,
+    };
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn supervisor_flow_reserves_live_store_and_fails_closed_on_transport() {
+        let temp = tempfile::tempdir().unwrap();
+        let cas_root = init_cas_dir(temp.path()).unwrap();
+        let core = CasCore::with_daemon(cas_root.clone(), None, None);
+        core.register_agent(
+            "supervisor-session".to_string(),
+            "supervisor".to_string(),
+            None,
+        )
+        .unwrap();
+        let agent_store = core.open_agent_store().unwrap();
+        let mut agent = agent_store.get("supervisor-session").unwrap();
+        agent.role = AgentRole::Supervisor;
+        agent.factory_session = Some("factory-live".to_string());
+        agent_store.update(&agent).unwrap();
+
+        let task_store = open_task_store(&cas_root).unwrap();
+        let mut epic = Task::new("cas-gate-epic".to_string(), "epic".to_string());
+        epic.task_type = TaskType::Epic;
+        task_store.add(&epic).unwrap();
+        let task = Task::new("cas-gate-task".to_string(), "task".to_string());
+        task_store
+            .create_atomic(&task, &[], Some(&epic.id), Some(&agent.id))
+            .unwrap();
+
+        let mut config = ProxyConfig::default();
+        config.allowlist = vec![
+            ExternalToolConfig {
+                server: "viktor".to_string(),
+                tool: "ask_viktor".to_string(),
+            },
+            ExternalToolConfig {
+                server: "viktor".to_string(),
+                tool: "wait_for_run".to_string(),
+            },
+        ];
+        config.delegation.external_production_verification =
+            Some(ExternalProductionVerificationConfig {
+                server: "viktor".to_string(),
+                start_tool: "ask_viktor".to_string(),
+                wait_tool: "wait_for_run".to_string(),
+                reserved_amount: 1,
+                max_per_run: 1,
+                max_active_per_factory_session: 4,
+                max_active_per_epic: 2,
+                timeout_seconds: 30,
+            });
+        config.save_to(&cas_root.join("proxy.toml")).unwrap();
+        let engine = cmcp_core::ProxyEngine::from_configs(Default::default())
+            .await
+            .unwrap();
+        crate::mcp::server::install_proxy_policy(&engine, &config).await;
+        let service = CasService::new(core, Some(std::sync::Arc::new(engine)));
+        let req: VerificationRequest = serde_json::from_value(json!({
+            "action": "external_verify",
+            "task_id": task.id,
+            "message": "Confirm the public health endpoint returns ready",
+            "local_proof_reference": "local://scoped-test",
+            "required_checks": "[{\"name\":\"health\",\"expected\":\"ready\"}]"
+        }))
+        .unwrap();
+
+        let result = service.verification_external(req).await.unwrap();
+        let encoded = serde_json::to_value(result).unwrap();
+        let body: Value = serde_json::from_str(
+            encoded["content"][0]["text"]
+                .as_str()
+                .expect("receipt result text"),
+        )
+        .unwrap();
+        assert_eq!(body["verdict"], "transport_failure");
+        assert_eq!(body["passing"], false);
+        let receipt_id = body["receipt_id"].as_str().unwrap();
+        let receipt = SqliteDelegationReceiptStore::open(&cas_root)
+            .unwrap()
+            .get(receipt_id)
+            .unwrap();
+        assert_eq!(receipt.state, DelegationReceiptState::Completed);
+        assert_eq!(
+            receipt.terminal_verdict,
+            Some(DelegationVerdict::TransportFailure)
+        );
+        assert_eq!(receipt.factory_session_id, "factory-live");
+        assert_eq!(receipt.epic_id, epic.id);
+    }
+
+    #[tokio::test]
+    async fn supervisor_flow_records_real_upstream_run_and_passing_gate_verdict() {
+        let temp = tempfile::tempdir().unwrap();
+        let cas_root = init_cas_dir(temp.path()).unwrap();
+        let core = CasCore::with_daemon(cas_root.clone(), None, None);
+        core.register_agent(
+            "supervisor-session".to_string(),
+            "supervisor".to_string(),
+            None,
+        )
+        .unwrap();
+        let agent_store = core.open_agent_store().unwrap();
+        let mut agent = agent_store.get("supervisor-session").unwrap();
+        agent.role = AgentRole::Supervisor;
+        agent.factory_session = Some("factory-live".to_string());
+        agent_store.update(&agent).unwrap();
+
+        let task_store = open_task_store(&cas_root).unwrap();
+        let mut epic = Task::new("cas-gate-epic".to_string(), "epic".to_string());
+        epic.task_type = TaskType::Epic;
+        task_store.add(&epic).unwrap();
+        let task = Task::new("cas-gate-task".to_string(), "task".to_string());
+        task_store
+            .create_atomic(&task, &[], Some(&epic.id), Some(&agent.id))
+            .unwrap();
+
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/mock_mcp_viktor_server.py");
+        let upstream = ServerConfig::Stdio {
+            command: "python3".to_string(),
+            args: vec![fixture.to_string_lossy().into_owned()],
+            env: HashMap::new(),
+        };
+        let mut config = ProxyConfig::default();
+        config.add_server("viktor".to_string(), upstream.clone());
+        config.allowlist = vec![
+            ExternalToolConfig {
+                server: "viktor".to_string(),
+                tool: "ask_viktor".to_string(),
+            },
+            ExternalToolConfig {
+                server: "viktor".to_string(),
+                tool: "wait_for_run".to_string(),
+            },
+        ];
+        config.delegation.external_production_verification =
+            Some(ExternalProductionVerificationConfig {
+                server: "viktor".to_string(),
+                start_tool: "ask_viktor".to_string(),
+                wait_tool: "wait_for_run".to_string(),
+                reserved_amount: 1,
+                max_per_run: 1,
+                max_active_per_factory_session: 4,
+                max_active_per_epic: 2,
+                timeout_seconds: 30,
+            });
+        config.save_to(&cas_root.join("proxy.toml")).unwrap();
+        let engine =
+            cmcp_core::ProxyEngine::from_configs(HashMap::from([("viktor".to_string(), upstream)]))
+                .await
+                .unwrap();
+        crate::mcp::server::install_proxy_policy(&engine, &config).await;
+        let service = CasService::new(core, Some(std::sync::Arc::new(engine)));
+        let req: VerificationRequest = serde_json::from_value(json!({
+            "action": "external_verify",
+            "task_id": task.id,
+            "message": "Confirm the public health endpoint returns ready",
+            "local_proof_reference": "local://scoped-test",
+            "required_checks": "[{\"name\":\"health\",\"expected\":\"ready\"}]"
+        }))
+        .unwrap();
+
+        let result = service.verification_external(req).await.unwrap();
+        let encoded = serde_json::to_value(result).unwrap();
+        let body: Value = serde_json::from_str(
+            encoded["content"][0]["text"]
+                .as_str()
+                .expect("receipt result text"),
+        )
+        .unwrap();
+        assert_eq!(body["verdict"], "pass");
+        assert_eq!(body["passing"], true);
+        assert_eq!(body["run_id"], "run-fixture-1");
+        let receipt = SqliteDelegationReceiptStore::open(&cas_root)
+            .unwrap()
+            .get(body["receipt_id"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(receipt.state, DelegationReceiptState::Completed);
+        assert_eq!(receipt.terminal_verdict, Some(DelegationVerdict::Pass));
+        assert_eq!(
+            receipt.evidence_reference.as_deref(),
+            Some("viktor://run/run-fixture-1")
+        );
+    }
+}

--- a/cas-cli/src/mcp/tools/service/mod.rs
+++ b/cas-cli/src/mcp/tools/service/mod.rs
@@ -897,7 +897,7 @@ impl CasService {
     // ========================================================================
 
     #[tool(
-        description = "Verification operations (task quality gates). Actions: add (record verification result), show (verification details), list (verifications for task), latest (most recent for task)."
+        description = "Verification operations (task quality gates). Actions: add (record verification result), show (verification details), list (verifications for task), latest (most recent for task), external_verify (registered-supervisor-only receipted external production verification)."
     )]
     pub async fn verification(
         &self,
@@ -911,11 +911,18 @@ impl CasService {
                 "show" => this.verification_show(req).await,
                 "list" => this.verification_list(req).await,
                 "latest" => this.verification_latest(req).await,
+                #[cfg(feature = "mcp-proxy")]
+                "external_verify" => this.verification_external(req).await,
                 _ => Err(Self::error(
                     ErrorCode::INVALID_PARAMS,
                     format!(
-                        "Unknown verification action: {}. Valid: add, show, list, latest",
-                        req.action
+                        "Unknown verification action: {}. Valid: add, show, list, latest{}",
+                        req.action,
+                        if cfg!(feature = "mcp-proxy") {
+                            ", external_verify"
+                        } else {
+                            ""
+                        }
                     ),
                 )),
             };
@@ -1120,17 +1127,8 @@ impl CasService {
     // mcp_search - Search across all connected MCP servers
     // ========================================================================
 
-    #[cfg_attr(
-        feature = "mcp-proxy",
-        tool(
-            description = "Search across all tools from all connected MCP servers. Pass a keyword query to filter by tool name and description (case-insensitive). Use 'server:name' prefix to filter by server. Examples: 'screenshot', 'server:github issue', 'file read'."
-        )
-    )]
-    #[cfg_attr(
-        not(feature = "mcp-proxy"),
-        tool(
-            description = "Search across all tools from all connected MCP servers. Write TypeScript code to filter the tool catalog. A typed `tools` array is available with { server, name, description, input_schema } fields."
-        )
+    #[tool(
+        description = "Search across all tools from connected MCP servers. Pass a keyword query to filter by tool name and description (case-insensitive); use 'server:name' to filter by server. Builds without mcp-proxy return a rebuild instruction."
     )]
     pub async fn mcp_search(
         &self,
@@ -1172,17 +1170,8 @@ impl CasService {
     // mcp_execute - Execute tool calls across connected MCP servers
     // ========================================================================
 
-    #[cfg_attr(
-        feature = "mcp-proxy",
-        tool(
-            description = "Execute tool calls across all connected MCP servers. Use JSON dispatch: {\"server\": \"name\", \"tool\": \"tool_name\", \"args\": {...}} or an array for parallel calls. Also supports dot-call syntax: server.tool_name({\"param\": \"value\"})."
-        )
-    )]
-    #[cfg_attr(
-        not(feature = "mcp-proxy"),
-        tool(
-            description = "Execute TypeScript code that calls tools across all connected MCP servers. Each server is a typed global object (e.g. `canva`, `figma`) where every tool is an async function with typed parameters: `await server.tool_name({ param: value })`. Chain calls sequentially or run them in parallel with Promise.all across different servers."
-        )
+    #[tool(
+        description = "Execute calls across connected MCP servers after registered-caller policy enforcement. Use JSON dispatch: {\"server\":\"name\",\"tool\":\"tool_name\",\"args\":{...}} or dot-call syntax. Builds without mcp-proxy return a rebuild instruction."
     )]
     pub async fn mcp_execute(
         &self,
@@ -1293,6 +1282,8 @@ impl CasService {
 pub(crate) mod agent_liveness;
 pub(crate) mod agent_search_system;
 mod core;
+#[cfg(feature = "mcp-proxy")]
+mod external_verification;
 pub(crate) mod factory_ops;
 mod factory_remind;
 pub(crate) mod harness_observation;

--- a/cas-cli/tests/fixtures/mock_mcp_viktor_server.py
+++ b/cas-cli/tests/fixtures/mock_mcp_viktor_server.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Minimal stdio MCP fixture for the receipted Viktor gateway integration test."""
+
+import json
+import sys
+
+
+def respond(request_id, result):
+    sys.stdout.write(
+        json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}) + "\n"
+    )
+    sys.stdout.flush()
+
+
+def main():
+    for line in sys.stdin:
+        request = json.loads(line)
+        request_id = request.get("id")
+        if request_id is None:
+            continue
+        method = request.get("method")
+        if method == "initialize":
+            respond(
+                request_id,
+                {
+                    "protocolVersion": request.get("params", {}).get(
+                        "protocolVersion", "2024-11-05"
+                    ),
+                    "capabilities": {"tools": {"listChanged": False}},
+                    "serverInfo": {"name": "mock-viktor", "version": "0.0.1"},
+                },
+            )
+        elif method == "tools/list":
+            respond(
+                request_id,
+                {
+                    "tools": [
+                        {
+                            "name": "ask_viktor",
+                            "description": "Fixture run starter",
+                            "inputSchema": {"type": "object"},
+                        },
+                        {
+                            "name": "wait_for_run",
+                            "description": "Fixture run waiter",
+                            "inputSchema": {"type": "object"},
+                        },
+                    ]
+                },
+            )
+        elif method == "tools/call":
+            check = {
+                "name": "health",
+                "expected": "ready",
+                "observed": "ready",
+                "evidence": "fixture://health",
+            }
+            payload = {
+                "run_id": "run-fixture-1",
+                "json": {"verdict": "pass", "checks": [check], "limitations": []},
+            }
+            respond(
+                request_id,
+                {"content": [{"type": "text", "text": json.dumps(payload)}]},
+            )
+        elif method in ("ping", "shutdown", "exit"):
+            respond(request_id, {})
+        else:
+            respond(
+                request_id,
+                {"content": [{"type": "text", "text": '{"error":"unsupported"}'}]},
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/cas-cli/tests/mcp_proxy_test.rs
+++ b/cas-cli/tests/mcp_proxy_test.rs
@@ -156,6 +156,71 @@ fn session_start_output(sandbox: &CasSandbox) -> String {
     String::from_utf8(output.stdout).unwrap()
 }
 
+#[test]
+fn cas_serve_boot_installs_fail_closed_exact_allowlist_policy() {
+    let sandbox = CasSandbox::new();
+    std::fs::write(
+        sandbox.cas_root().join("proxy.toml"),
+        r#"
+[servers.github]
+transport = "stdio"
+command = "cas-f7ac-intentionally-missing-upstream"
+
+[[allowlist]]
+server = "github"
+tool = "list_issues"
+"#,
+    )
+    .unwrap();
+    let mut client = McpClient::spawn(&sandbox);
+    client.initialize();
+    let listed = client.request("tools/list", json!({}));
+    assert!(
+        listed["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|tool| tool["name"] == "mcp_execute"),
+        "mcp_execute missing after configured proxy boot: {listed}"
+    );
+    client.request(
+        "tools/call",
+        json!({
+            "name": "coordination",
+            "arguments": {
+                "action": "register",
+                "session_id": "proxy-boot-policy-test",
+                "name": "proxy boot policy test",
+                "agent_type": "standard"
+            }
+        }),
+    );
+
+    let denied = client.request_raw(
+        "tools/call",
+        json!({
+            "name": "mcp_execute",
+            "arguments": {"code": json!({"server":"github-shadow","tool":"list_issues","args":{}}).to_string()}
+        }),
+    );
+    let denied_message = denied["error"]["message"].as_str().unwrap();
+    assert!(
+        denied_message.contains("external tool is not explicitly allowlisted"),
+        "unexpected denied response: {denied}"
+    );
+
+    let admitted = client.request_raw(
+        "tools/call",
+        json!({
+            "name": "mcp_execute",
+            "arguments": {"code": json!({"server":"github","tool":"list_issues","args":{}}).to_string()}
+        }),
+    );
+    let admitted_message = admitted["error"]["message"].as_str().unwrap();
+    assert!(admitted_message.contains("server 'github' not connected"));
+    assert!(!admitted_message.contains("proxy policy denied"));
+}
+
 // ── Config round-trip ────────────────────────────────────────────────
 
 #[test]

--- a/crates/cas-mcp-proxy/README.md
+++ b/crates/cas-mcp-proxy/README.md
@@ -32,6 +32,57 @@ transport = "sse"
 url = "https://example.com/sse"
 ```
 
+### External dispatch policy
+
+`cas serve` installs an exact `(server, tool)` allowlist at startup and on hot
+reload. The default is fail-closed: configuring a server makes its catalog
+searchable, but an empty or omitted `allowlist` forwards no external calls.
+
+```toml
+[[allowlist]]
+server = "github"
+tool = "list_issues"
+```
+
+When `.cas/proxy.toml` exists its allowlist and delegation sections replace the
+user-scoped values rather than unioning them. This prevents a broader personal
+configuration from silently widening a project's external dispatch policy.
+
+### Supervisor external verification gateway
+
+The first receipted delegation flow is `verification action=external_verify`.
+It is available only to a registered factory supervisor, requires a task in an
+epic plus a non-secret local proof reference, and writes a budget reservation
+to the project's `cas.db` before starting the upstream run. A timed-out run is
+resumed by its recorded run ID; the gateway never starts a replacement run.
+
+Both gateway tools must also appear in the exact allowlist:
+
+```toml
+[[allowlist]]
+server = "viktor"
+tool = "ask_viktor"
+
+[[allowlist]]
+server = "viktor"
+tool = "wait_for_run"
+
+[delegation.external_production_verification]
+server = "viktor"
+start_tool = "ask_viktor"
+wait_tool = "wait_for_run"
+reserved_amount = 1
+max_per_run = 1
+max_active_per_factory_session = 4
+max_active_per_epic = 2
+timeout_seconds = 120
+```
+
+The run-starting and wait routes cannot be called through generic
+`mcp_execute`; the proxy admits them only when CAS marks the request as the
+registered-supervisor gateway path. The provider credential remains in proxy
+configuration and is never copied into tool arguments or model context.
+
 ## Search
 
 `ProxyEngine::search(query, max_length)` filters the tool catalog:
@@ -49,8 +100,9 @@ request, the engine evaluates its `ProxyPolicy` hook and records a
 request-free allow/deny audit entry. A denial is returned without forwarding
 the request.
 
-The default policy allows calls for backwards-compatible installations. A
-protected integration installs a `ProxyPolicy` with `set_policy`; policies can
+The proxy crate's standalone engine retains an allow-all compatibility default,
+but `cas serve` always replaces it with the configured fail-closed policy.
+Policies can
 inspect the registered caller and arguments to enforce server/tool or
 resource-specific rules without retaining arguments in the audit trail. Policy
 deny reasons must be safe for the operator audit and MCP error; they must not
@@ -78,7 +130,11 @@ github.list_issues({"repo": "myorg/app"})
 
 ## Hot-reload
 
-The daemon watches `.cas/proxy.toml` for changes. On config change, `ProxyEngine::reload()` compares stored configs against new ones, disconnects removed servers, reconnects changed ones, and leaves unchanged servers connected.
+The daemon watches `.cas/proxy.toml` for changes. On config change,
+`ProxyEngine::reload()` compares stored configs against new ones, disconnects
+removed servers, reconnects changed ones, and leaves unchanged servers
+connected. It then replaces the route/delegation policy from the same parsed
+snapshot, so removing an allowlist entry takes effect without a restart.
 
 ## Feature flag
 

--- a/crates/cas-mcp-proxy/src/config.rs
+++ b/crates/cas-mcp-proxy/src/config.rs
@@ -9,6 +9,75 @@ use serde::{Deserialize, Serialize};
 pub struct Config {
     #[serde(default)]
     pub servers: HashMap<String, ServerConfig>,
+    /// Exact external routes admitted by the production proxy policy.
+    ///
+    /// An empty list is intentionally fail-closed: configured upstreams may
+    /// connect and advertise tools, but no call is forwarded until its parsed
+    /// `(server, tool)` pair appears here.
+    #[serde(default)]
+    pub allowlist: Vec<ExternalToolConfig>,
+    /// Optional supervisor-owned delegation gateways.
+    #[serde(default)]
+    pub delegation: DelegationConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExternalToolConfig {
+    pub server: String,
+    pub tool: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DelegationConfig {
+    #[serde(default)]
+    pub external_production_verification: Option<ExternalProductionVerificationConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExternalProductionVerificationConfig {
+    pub server: String,
+    #[serde(default = "default_start_tool")]
+    pub start_tool: String,
+    #[serde(default = "default_wait_tool")]
+    pub wait_tool: String,
+    #[serde(default = "default_reserved_amount")]
+    pub reserved_amount: u64,
+    #[serde(default = "default_max_per_run")]
+    pub max_per_run: u64,
+    #[serde(default = "default_max_active_per_factory_session")]
+    pub max_active_per_factory_session: u64,
+    #[serde(default = "default_max_active_per_epic")]
+    pub max_active_per_epic: u64,
+    #[serde(default = "default_timeout_seconds")]
+    pub timeout_seconds: u64,
+}
+
+fn default_start_tool() -> String {
+    "ask_viktor".to_string()
+}
+
+fn default_wait_tool() -> String {
+    "wait_for_run".to_string()
+}
+
+fn default_reserved_amount() -> u64 {
+    1
+}
+
+fn default_max_per_run() -> u64 {
+    1
+}
+
+fn default_max_active_per_factory_session() -> u64 {
+    4
+}
+
+fn default_max_active_per_epic() -> u64 {
+    2
+}
+
+fn default_timeout_seconds() -> u64 {
+    120
 }
 
 /// Configuration for a single upstream MCP server.
@@ -108,6 +177,11 @@ impl Config {
             for (name, server) in project.servers {
                 merged.servers.insert(name, server);
             }
+            // Security policy is not union-merged. When a project config is
+            // present it is authoritative, including an omitted/empty list;
+            // a broader user config must not silently widen project dispatch.
+            merged.allowlist = project.allowlist;
+            merged.delegation = project.delegation;
         }
 
         Ok(merged)
@@ -146,6 +220,21 @@ mod tests {
     #[test]
     fn config_round_trip() {
         let mut config = Config::default();
+        config.allowlist.push(ExternalToolConfig {
+            server: "test-http".to_string(),
+            tool: "inspect".to_string(),
+        });
+        config.delegation.external_production_verification =
+            Some(ExternalProductionVerificationConfig {
+                server: "test-http".to_string(),
+                start_tool: "inspect".to_string(),
+                wait_tool: "wait".to_string(),
+                reserved_amount: 1,
+                max_per_run: 1,
+                max_active_per_factory_session: 4,
+                max_active_per_epic: 2,
+                timeout_seconds: 30,
+            });
         config.add_server(
             "test-stdio".to_string(),
             ServerConfig::Stdio {
@@ -186,6 +275,8 @@ mod tests {
     fn load_missing_file_returns_empty() {
         let config = Config::load_from(Path::new("/nonexistent/config.toml")).unwrap();
         assert!(config.servers.is_empty());
+        assert!(config.allowlist.is_empty());
+        assert!(config.delegation.external_production_verification.is_none());
     }
 
     #[test]
@@ -203,6 +294,44 @@ mod tests {
 
         let error = Config::load_merged_from(Some(&malformed), None).unwrap_err();
         assert!(error.to_string().contains("failed to parse"));
+    }
+
+    #[test]
+    fn project_security_policy_replaces_instead_of_widens_user_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let user = dir.path().join("user.toml");
+        let project = dir.path().join("project.toml");
+        std::fs::write(
+            &user,
+            r#"
+[[allowlist]]
+server = "personal"
+tool = "write_everything"
+
+[delegation.external_production_verification]
+server = "personal"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            &project,
+            r#"
+[[allowlist]]
+server = "viktor"
+tool = "ask_viktor"
+"#,
+        )
+        .unwrap();
+
+        let merged = Config::load_merged_from(Some(&user), Some(&project)).unwrap();
+        assert_eq!(
+            merged.allowlist,
+            vec![ExternalToolConfig {
+                server: "viktor".to_string(),
+                tool: "ask_viktor".to_string(),
+            }]
+        );
+        assert!(merged.delegation.external_production_verification.is_none());
     }
 
     #[test]

--- a/crates/cas-mcp-proxy/src/lib.rs
+++ b/crates/cas-mcp-proxy/src/lib.rs
@@ -81,6 +81,15 @@ pub struct ProxyPolicyRequest<'a> {
     pub server: &'a str,
     pub tool: &'a str,
     pub arguments: &'a Option<serde_json::Map<String, Value>>,
+    pub dispatch_kind: ProxyDispatchKind,
+}
+
+/// Server-selected dispatch path. This value is never decoded from tool
+/// arguments, so a direct caller cannot nominate the receipted gateway path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProxyDispatchKind {
+    Direct,
+    ExternalProductionVerification,
 }
 
 /// A single external MCP tool, identified by its parsed server and tool names.
@@ -156,6 +165,7 @@ impl ProxyPolicy for AllowAllProxyPolicy {
 #[derive(Debug, Default)]
 pub struct ExternalToolAllowlistPolicy {
     allowed_routes: BTreeSet<ExternalToolRoute>,
+    supervisor_delegation_routes: BTreeSet<ExternalToolRoute>,
 }
 
 impl ExternalToolAllowlistPolicy {
@@ -163,7 +173,18 @@ impl ExternalToolAllowlistPolicy {
     pub fn new(routes: impl IntoIterator<Item = ExternalToolRoute>) -> Self {
         Self {
             allowed_routes: routes.into_iter().collect(),
+            supervisor_delegation_routes: BTreeSet::new(),
         }
+    }
+
+    /// Require selected allowlisted routes to enter through the registered
+    /// supervisor delegation gateway rather than generic proxy execution.
+    pub fn with_supervisor_delegation_routes(
+        mut self,
+        routes: impl IntoIterator<Item = ExternalToolRoute>,
+    ) -> Self {
+        self.supervisor_delegation_routes = routes.into_iter().collect();
+        self
     }
 
     /// Whether an upstream route is in this exact allowlist.
@@ -175,13 +196,22 @@ impl ExternalToolAllowlistPolicy {
 
 impl ProxyPolicy for ExternalToolAllowlistPolicy {
     fn decide(&self, request: &ProxyPolicyRequest<'_>) -> ProxyPolicyDecision {
-        if self.allows(request.server, request.tool) {
-            ProxyPolicyDecision::Allow
-        } else {
-            ProxyPolicyDecision::Deny {
+        if !self.allows(request.server, request.tool) {
+            return ProxyPolicyDecision::Deny {
                 reason: "external tool is not explicitly allowlisted".to_string(),
-            }
+            };
         }
+        let route = ExternalToolRoute::new(request.server, request.tool);
+        if self.supervisor_delegation_routes.contains(&route)
+            && (request.dispatch_kind != ProxyDispatchKind::ExternalProductionVerification
+                || request.caller.role != cas_types::AgentRole::Supervisor)
+        {
+            return ProxyPolicyDecision::Deny {
+                reason: "external delegation route requires the registered supervisor gateway"
+                    .to_string(),
+            };
+        }
+        ProxyPolicyDecision::Allow
     }
 }
 
@@ -569,14 +599,28 @@ impl ProxyEngine {
         if calls.len() == 1 {
             let call = &calls[0];
             let result = self
-                .call_tool_raw(caller, &call.server, &call.tool, call.args.clone())
+                .call_tool_raw(
+                    caller,
+                    ProxyDispatchKind::Direct,
+                    &call.server,
+                    &call.tool,
+                    call.args.clone(),
+                )
                 .await?;
             collect_result(&result, &mut text_parts, &mut images);
         } else {
             // Execute in parallel
             let futures: Vec<_> = calls
                 .iter()
-                .map(|call| self.call_tool_raw(caller, &call.server, &call.tool, call.args.clone()))
+                .map(|call| {
+                    self.call_tool_raw(
+                        caller,
+                        ProxyDispatchKind::Direct,
+                        &call.server,
+                        &call.tool,
+                        call.args.clone(),
+                    )
+                })
                 .collect();
 
             let results = futures::future::join_all(futures).await;
@@ -722,23 +766,51 @@ impl ProxyEngine {
         arguments: Option<serde_json::Map<String, Value>>,
     ) -> Result<Value> {
         let result = self
-            .call_tool_raw(caller, server_name, tool_name, arguments)
+            .call_tool_raw(
+                caller,
+                ProxyDispatchKind::Direct,
+                server_name,
+                tool_name,
+                arguments,
+            )
             .await?;
 
         serde_json::to_value(result).context("failed to serialize tool result")
+    }
+
+    /// Call one tool through the receipted external-production verification
+    /// path. Only the CAS service should select this dispatch kind.
+    pub async fn call_external_production_verification_tool(
+        &self,
+        caller: &ProxyCaller,
+        server_name: &str,
+        tool_name: &str,
+        arguments: Option<serde_json::Map<String, Value>>,
+    ) -> Result<Value> {
+        let result = self
+            .call_tool_raw(
+                caller,
+                ProxyDispatchKind::ExternalProductionVerification,
+                server_name,
+                tool_name,
+                arguments,
+            )
+            .await?;
+        serde_json::to_value(result).context("failed to serialize delegated tool result")
     }
 
     /// Call a tool and return the raw rmcp result (for internal use by execute).
     async fn call_tool_raw(
         &self,
         caller: &ProxyCaller,
+        dispatch_kind: ProxyDispatchKind,
         server_name: &str,
         tool_name: &str,
         arguments: Option<serde_json::Map<String, Value>>,
     ) -> Result<rmcp::model::CallToolResult> {
         use rmcp::model::CallToolRequestParams;
 
-        self.authorize(caller, server_name, tool_name, &arguments)
+        self.authorize(caller, dispatch_kind, server_name, tool_name, &arguments)
             .await?;
 
         self.call_upstream(
@@ -756,6 +828,7 @@ impl ProxyEngine {
     async fn authorize(
         &self,
         caller: &ProxyCaller,
+        dispatch_kind: ProxyDispatchKind,
         server_name: &str,
         tool_name: &str,
         arguments: &Option<serde_json::Map<String, Value>>,
@@ -766,6 +839,7 @@ impl ProxyEngine {
             server: server_name,
             tool: tool_name,
             arguments,
+            dispatch_kind,
         };
         let decision = policy.decide(&request);
         let (allowed, reason) = match decision {
@@ -1480,6 +1554,7 @@ mod tests {
                 server,
                 tool,
                 arguments: &arguments,
+                dispatch_kind: ProxyDispatchKind::Direct,
             })
         };
 
@@ -1500,6 +1575,49 @@ mod tests {
                 "allowlist must compare parsed components exactly for {server}.{tool}"
             );
         }
+    }
+
+    #[test]
+    fn delegation_routes_require_internal_supervisor_dispatch_kind() {
+        let policy = ExternalToolAllowlistPolicy::new([
+            ExternalToolRoute::new("viktor", "ask_viktor"),
+            ExternalToolRoute::new("github", "list_issues"),
+        ])
+        .with_supervisor_delegation_routes([ExternalToolRoute::new("viktor", "ask_viktor")]);
+        let arguments = None;
+        let mut caller = registered_worker_caller();
+        let decide = |caller: &ProxyCaller, dispatch_kind, server, tool| {
+            policy.decide(&ProxyPolicyRequest {
+                caller,
+                server,
+                tool,
+                arguments: &arguments,
+                dispatch_kind,
+            })
+        };
+
+        assert_eq!(
+            decide(&caller, ProxyDispatchKind::Direct, "viktor", "ask_viktor"),
+            ProxyPolicyDecision::Deny {
+                reason: "external delegation route requires the registered supervisor gateway"
+                    .to_string()
+            }
+        );
+        caller.role = cas_types::AgentRole::Supervisor;
+        assert_eq!(
+            decide(
+                &caller,
+                ProxyDispatchKind::ExternalProductionVerification,
+                "viktor",
+                "ask_viktor"
+            ),
+            ProxyPolicyDecision::Allow
+        );
+        assert_eq!(
+            decide(&caller, ProxyDispatchKind::Direct, "github", "list_issues"),
+            ProxyPolicyDecision::Allow,
+            "ordinary allowlisted routes remain available through generic execution"
+        );
     }
 
     #[tokio::test]

--- a/crates/cas-mcp/src/types/ops_secondary.rs
+++ b/crates/cas-mcp/src/types/ops_secondary.rs
@@ -349,7 +349,7 @@ pub struct SystemRequest {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct VerificationRequest {
     /// Action to perform
-    #[schemars(description = "Action: 'add', 'show', 'list', 'latest'")]
+    #[schemars(description = "Action: 'add', 'show', 'list', 'latest', 'external_verify'")]
     pub action: String,
 
     /// Verification ID (for show)
@@ -414,6 +414,21 @@ pub struct VerificationRequest {
     #[schemars(description = "Exact durable verification dispatch ID")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dispatch_id: Option<String>,
+
+    /// Supervisor-owned external verification prompt.
+    #[schemars(description = "external_verify: bounded read-only verification request")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    /// Durable local proof that must exist before external delegation.
+    #[schemars(description = "external_verify: non-secret local proof reference")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_proof_reference: Option<String>,
+
+    /// Exact checks the structured external response must satisfy.
+    #[schemars(description = "external_verify: JSON array of {name, expected} check objects")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_checks: Option<String>,
 }
 
 /// Unified distilled-knowledge (project wiki) operations request.

--- a/crates/cas-store/src/external_verification_gate.rs
+++ b/crates/cas-store/src/external_verification_gate.rs
@@ -8,7 +8,7 @@
 use std::collections::HashSet;
 
 use cas_types::AgentRole;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
@@ -17,7 +17,8 @@ use crate::{
 
 pub const EXTERNAL_PRODUCTION_VERIFICATION_GATE: &str = "external_production_verification";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct RequiredCheck {
     pub name: String,
     pub expected: String,


### PR DESCRIPTION
Wires the shipped Viktor gateway contract into production: exact fail-closed external route policy at boot and reload, registered-supervisor receipted verification through the live SQLite store, run resume and structured fail-closed verdicts, plus documented configuration.\n\nProof: 5 production-path tests passed with committed-diff surface validation; all 41 proxy library tests passed; all 21 delegation receipt and external gate tests passed; cargo check -p cas --lib --tests passed.\n\nTask: cas-f7ac. Main requires protected checks, so this PR is the delivery path.