### PR TITLE
chore(release): prepare v2.72.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [2.72.0] - 2026-08-17
+
 ### Added
 - **External expertise now crosses one enforced, receipted gateway.** `cas serve` replaces the proxy's compatibility default with an exact configured `(server, tool)` allowlist at boot and reload, denies every external call when that list is empty, and refuses paid verification routes outside the registered-supervisor gateway. The first production flow reserves a durable budget receipt before `ask_viktor`, resumes timed-out runs by their stored run ID, and returns only the fail-closed external-production-verification verdict; configuration and route/budget defaults are documented in `crates/cas-mcp-proxy/README.md`.
+
+### Changed
+- **Cloud synchronization retains an auditable outcome.** Terminal task updates are guarded before they can regress, pull provenance and sync receipts surface the applied result, permanent push rejections are parked with concise errors, and canonical task identifiers remain normalized through the full sync path.
+- **Repository and release references now point at `Richards-LLC/cassy`.** Install, update, Homebrew, release, and API links follow the canonical repository home.
+- **Commander and CLI guidance better match live behavior.** Hosted Commander health checks admit the supported origin, reachable hubs clearly guide users through re-pairing, and command help exposes cloud operations while keeping internal maintenance tools out of the public surface.
+- **Supported Rust is now 1.88.** The declared MSRV and all workspace package requirements advance from 1.85 to 1.88.
+- **README documentation now explains the knowledge system.**
+
+### Fixed
+- **Factory workers see stale output instructions before acting on them.** Spawn briefs name each task's resolved durable artifact directory and warn when task prose prescribes an absolute or home-relative path outside the worktree or sanctioned artifact root.
+- **Release and test operations recover more predictably.** The repository includes an Actions-outage release fallback runbook, and PTY tests tolerate loaded runners without flaking.
 
 ## [2.71.0] - 2026-08-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "2.71.0"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "2.71.0"
+version = "2.72.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "2.71.0"
+version = "2.72.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "2.71.0"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "2.71.0"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "2.71.0"
+version = "2.72.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "2.71.0"
+version = "2.72.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "2.71.0"
+version = "2.72.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "2.71.0"
+version = "2.72.0"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "2.71.0"
+version = "2.72.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "2.71.0"
+version = "2.72.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "2.71.0"
+version = "2.72.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"


### PR DESCRIPTION
## Summary
- bump the six release-train crates and Cargo.lock to 2.72.0
- curate the 2026-08-17 v2.72.0 changelog from merged work
- leave tagging and publication to the post-merge release flow

## Verification
-  (exit 0)
-  intentionally not run: it requires an existing annotated tag, and this release-prep task must not create one.