### PR TITLE
docs: v2.72.0 runtime-release Slack record

### DIFF
--- a/docs/release-notes/2026-08-17-v2.72.0-slack.md
+++ b/docs/release-notes/2026-08-17-v2.72.0-slack.md
@@ -1,0 +1,43 @@
+# Slack draft — CAS v2.72.0 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Receipt-verified from published assets; posting.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — CAS v2.72.0 is out: your task board can no longer be silently corrupted by a cloud sync, the web Commander tells you when a machine just needs re-pairing instead of playing dead, and `cas --help` finally matches reality.
+
+**Reply (Was → Now):**
+- Was: a cloud sync could quietly reopen tasks you closed weeks ago, and a permanently rejected push retried forever in a wall of error spam. Now: closed work stays closed unless there is a genuine reopen on record — with a note saying exactly which sync touched what — and rejected pushes park once with a single concise reason line.
+- Was: a machine whose pairing had expired looked offline in the Commander, with no way forward. Now: it shows "Machine needs pairing" with a Re-pair button; genuinely offline machines still show offline.
+- Was: `cas --help` hid the cloud commands and described others wrong. Now: help matches what commands actually do and `cas cloud sync` is discoverable.
+- Install: use `cas update` for an existing installation, or download the
+  v2.72.0 archive for Linux x86_64 (SHA-256 `8b26b64fd3fa7e92cc4e7081ce041595177b8b97a0f0aca36fb2757d5347167c`) or macOS ARM64
+  (SHA-256 `b4693b3c6213620b8e32fd63755b3dd1bae3b795561c4596709210d4722e865e`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v2.72.0 hardens the trust boundaries: pull-side sync gets a terminal-status guard with provenance-tagged transitions, push-side parks permanent rejections, and external MCP delegation is now enforced at the proxy — an empty allowlist means deny.
+
+**Reply (Was → Now):**
+- Was: the MCP proxy booted with an allow-all policy and the delegation gateway contract existed only in tests. Now: `cas serve` installs an exact `(server, tool)` allowlist at boot and reload (empty = deny all external dispatch), paid delegation routes additionally require the registered supervisor gateway path, and every delegated run reserves a durable budget receipt with a fail-closed verdict.
+- Was: pull apply was last-writer-wins in personal and team paths, so stale remote rows could regress terminal task states invisibly. Now: terminal states reopen only on an explicit newer reopen event; every applied transition carries a machine-tagged provenance note and the CLI prints per-project from→to receipts.
+- Also in this release: repo home is `Richards-LLC/cassy` across install/update/release paths; declared MSRV corrected to 1.88; spawn briefs warn about out-of-contract artifact paths; an Actions-outage release runbook; PTY test deflake; hosted-Commander health CORS + needs-pairing UX.
+- Validation and artifact: release PR landed through required Fast Validation + macOS lanes; receipt verified by fresh downloads. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `8b26b64fd3fa7e92cc4e7081ce041595177b8b97a0f0aca36fb2757d5347167c`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `b4693b3c6213620b8e32fd63755b3dd1bae3b795561c4596709210d4722e865e`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-17 20:19 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786997969376249 |
+| User reply (Was → Now) | 2026-08-17 20:19 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786997977030639 |
+| Dev top-level | 2026-08-17 20:19 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786997992884069 |
+| Dev reply (Was → Now) | 2026-08-17 20:20 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1786998001067239 |


### PR DESCRIPTION
POSTED receipt for the v2.72.0 runtime-release announcements in #cas-internal (receipt-verified checksums from published assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)