### PR TITLE
CI: dedupe already validated main trees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_GHA_VERSION: "cas-v2"
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   # Factory pushes and PRs that do not target the protected default branch get
   # one cheap target-scoped lane. Main PRs use the full required lanes below;
@@ -248,6 +252,8 @@ jobs:
     name: Clippy (advisory, compiles only — no test suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
@@ -256,11 +262,23 @@ jobs:
         with:
           submodules: recursive
 
+      - id: tree-dedupe
+        name: Check for protected-PR validation of this tree
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/check-ci-tree-validation.sh
+
+      - name: Report deduplicated heavy validation
+        if: steps.tree-dedupe.outputs.run-heavy == 'false'
+        run: echo "Skipping Clippy; this tree was validated by ${{ steps.tree-dedupe.outputs.prior-run-url }}"
+
       - uses: ./.github/actions/setup-rust-linux
+        if: steps.tree-dedupe.outputs.run-heavy != 'false'
         with:
           cache-key: clippy
 
       - name: Clippy (report warnings)
+        if: steps.tree-dedupe.outputs.run-heavy != 'false'
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo clippy -p cas --all-targets
@@ -355,6 +373,44 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo check -p cas --no-default-features
 
+  # A receipt is trustworthy only after every per-tree PR lane passes. The
+  # artifact name is the checked-out Git tree, so a merge commit with identical
+  # contents can reuse it even though the commit SHA changed.
+  record-pr-validation:
+    name: Record protected PR tree validation
+    if: >-
+      github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch
+      && needs.fast-validation.result == 'success'
+      && needs.macos-check.result == 'success'
+      && needs.clippy.result == 'success'
+      && needs.test-compile-guard.result == 'success'
+    needs: [fast-validation, macos-check, clippy, test-compile-guard]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - id: tree
+        name: Compute validated tree receipt
+        run: |
+          tree_hash="$(git rev-parse 'HEAD^{tree}')"
+          echo "hash=$tree_hash" >> "$GITHUB_OUTPUT"
+          printf 'tree=%s\ncommit=%s\nrun=%s/actions/runs/%s\n' \
+            "$tree_hash" "${{ github.event.pull_request.head.sha }}" \
+            "${{ github.server_url }}/${{ github.repository }}" "${{ github.run_id }}" \
+            > pr-validation-receipt.txt
+
+      - name: Publish tree validation receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-validated-tree-${{ steps.tree.outputs.hash }}
+          path: pr-validation-receipt.txt
+          retention-days: 30
+          if-no-files-found: error
+
   # ┌───────────────────────────────────────────────────────────────────────┐
   # │ THIS JOB RUNS NO TESTS. Its green means "the test binaries still      │
   # │ compile" — nothing about whether they pass.                           │
@@ -370,6 +426,8 @@ jobs:
     name: Test Compile Guard (compile-only, executes nothing)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
@@ -378,13 +436,25 @@ jobs:
         with:
           submodules: recursive
 
+      - id: tree-dedupe
+        name: Check for protected-PR validation of this tree
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/check-ci-tree-validation.sh
+
+      - name: Report deduplicated heavy validation
+        if: steps.tree-dedupe.outputs.run-heavy == 'false'
+        run: echo "Skipping test compilation; this tree was validated by ${{ steps.tree-dedupe.outputs.prior-run-url }}"
+
       - uses: ./.github/actions/setup-rust-linux
+        if: steps.tree-dedupe.outputs.run-heavy != 'false'
         with:
           cache-key: test-compile-guard
 
       # --no-run COMPILES the test binaries and executes nothing. A green here
       # says the tests still build; it says nothing about whether they pass.
       - name: Compile tests only (--no-run, executes nothing)
+        if: steps.tree-dedupe.outputs.run-heavy != 'false'
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo test -p cas --no-run
@@ -406,8 +476,6 @@ jobs:
     name: Panic Isolation — release profile (named subset, not the suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'push'
-      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -430,8 +498,6 @@ jobs:
     name: Panic Isolation — release-fast profile (named subset, not the suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'push'
-      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -462,8 +528,6 @@ jobs:
     name: Build Benchmark & Timings (measurement only, no test suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'push'
-      && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     # This job measures a genuinely cold compiler. Letting the repaired remote
     # sccache serve objects after `cargo clean` would turn the benchmark into a

--- a/scripts/check-ci-tree-validation.sh
+++ b/scripts/check-ci-tree-validation.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Decide whether a main-push heavy CI job may reuse protected-PR validation.
+# Any missing or ambiguous evidence deliberately leaves run-heavy=true.
+set -euo pipefail
+
+output="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+event="${GITHUB_EVENT_NAME:-}"
+ref="${GITHUB_REF:-}"
+repository="${GITHUB_REPOSITORY:-}"
+
+printf 'run-heavy=true\n' >>"$output"
+
+if [[ "$event" != "push" || "$ref" != "refs/heads/main" ]]; then
+    echo "Tree dedupe applies only to main pushes; running heavy validation for ${event:-unknown} ${ref:-unknown}."
+    exit 0
+fi
+
+tree_hash="$(git rev-parse 'HEAD^{tree}')"
+printf 'tree-hash=%s\n' "$tree_hash" >>"$output"
+marker="pr-validated-tree-$tree_hash"
+
+if [[ -z "$repository" ]] || ! command -v gh >/dev/null || ! command -v jq >/dev/null; then
+    echo "::warning::Tree validation lookup prerequisites unavailable; running heavy validation."
+    exit 0
+fi
+
+if ! artifacts="$(gh api "/repos/$repository/actions/artifacts?name=$marker&per_page=100" 2>/dev/null)"; then
+    echo "::warning::Could not query prior tree validation; running heavy validation."
+    exit 0
+fi
+
+mapfile -t run_ids < <(jq -r '.artifacts[] | select(.expired == false) | .workflow_run.id // empty' <<<"$artifacts")
+for run_id in "${run_ids[@]}"; do
+    [[ "$run_id" =~ ^[0-9]+$ ]] || continue
+    if ! run="$(gh api "/repos/$repository/actions/runs/$run_id" 2>/dev/null)"; then
+        continue
+    fi
+    if jq -e '.event == "pull_request" and .status == "completed" and .conclusion == "success"' <<<"$run" >/dev/null; then
+        run_url="$(jq -r '.html_url' <<<"$run")"
+        [[ "$run_url" == https://* ]] || continue
+        printf 'run-heavy=false\nprior-run-url=%s\n' "$run_url" >>"$output"
+        echo "Tree $tree_hash already passed protected PR validation in $run_url; skipping duplicate main-push heavy work."
+        exit 0
+    fi
+done
+
+echo "No completed successful protected-PR receipt exists for tree $tree_hash; running heavy validation."

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -169,20 +169,82 @@ require_text "$fan_in" 'test "$PREFLIGHT" = success' 'required Fast Validation r
 require_text "$fan_in" 'test "$SUITE" = success' 'required Fast Validation rejects a failed full suite'
 require_text "$fan_in" 'test "$DOCS" = success' 'required Fast Validation rejects failed doctests'
 
-# Main PRs schedule only the required Fast Validation lanes and macOS Check.
-# The scoped subset is deliberately excluded, and advisory/release jobs remain
-# push/schedule-only, so a non-required job cannot consume a PR runner first.
+# Main PRs validate the reusable compile surfaces while the release-profile
+# panic probes and cold benchmark remain schedule/manual workloads.
 require_text "$scoped" 'github.base_ref != github.event.repository.default_branch' 'non-required scoped lane skips main PRs'
-for job in clippy test-compile-guard panic-isolation-release panic-isolation-release-fast build-benchmark; do
+for job in clippy test-compile-guard; do
     block="$(job_block "$job")"
     require_text "$block" "refs/heads/main" "$job runs on main"
     require_text "$block" "github.event_name == 'schedule'" "$job runs on schedule"
     require_text "$block" "github.event_name == 'workflow_dispatch'" "$job supports supervisor dispatch"
-    require_absent "$block" "github.event_name == 'pull_request'" "$job cannot run on PRs"
+    require_text "$block" "github.event_name == 'pull_request'" "$job validates protected PR trees"
+    require_text "$block" 'github.base_ref == github.event.repository.default_branch' "$job targets the protected PR base"
     require_absent "$block" 'refs/heads/epic/' "$job cannot run on epic pushes"
     require_absent "$block" 'refs/heads/factory/' "$job cannot run on factory pushes"
     require_absent "$block" 'refs/tags/' "$job cannot run on tag pushes"
+    require_text "$block" 'id: tree-dedupe' "$job checks for an identical PR-validated tree first"
+    require_text "$block" 'scripts/check-ci-tree-validation.sh' "$job uses the shared fail-closed tree guard"
+    require_text "$block" "steps.tree-dedupe.outputs.run-heavy != 'false'" "$job gates expensive work on the tree receipt"
+    require_text "$block" 'steps.tree-dedupe.outputs.prior-run-url' "$job logs the validating run URL when deduped"
 done
+
+for job in panic-isolation-release panic-isolation-release-fast build-benchmark; do
+    block="$(job_block "$job")"
+    require_text "$block" "github.event_name == 'schedule'" "$job runs on schedule"
+    require_text "$block" "github.event_name == 'workflow_dispatch'" "$job supports supervisor dispatch"
+    require_absent "$block" 'refs/heads/main' "$job does not consume runners on ordinary main pushes"
+    require_absent "$block" "github.event_name == 'pull_request'" "$job does not delay PR validation"
+done
+
+receipt_job="$(job_block record-pr-validation)"
+require_text "$ci_text" 'actions: read' 'CI may query validation receipt artifacts'
+require_text "$receipt_job" 'needs: [fast-validation, macos-check, clippy, test-compile-guard]' 'tree receipt waits for every per-tree validation lane'
+require_text "$receipt_job" "needs.fast-validation.result == 'success'" 'tree receipt requires successful Fast Validation'
+require_text "$receipt_job" "needs.macos-check.result == 'success'" 'tree receipt requires successful macOS Check'
+require_text "$receipt_job" "needs.clippy.result == 'success'" 'tree receipt requires successful Clippy'
+require_text "$receipt_job" "needs.test-compile-guard.result == 'success'" 'tree receipt requires successful test compilation'
+require_text "$receipt_job" "git rev-parse 'HEAD^{tree}'" 'tree receipt keys exact Git contents'
+require_text "$receipt_job" 'name: pr-validated-tree-${{ steps.tree.outputs.hash }}' 'tree receipt artifact is named by tree hash'
+
+tree_guard="$repo_root/scripts/check-ci-tree-validation.sh"
+guard_tmp="$(mktemp -d)"
+mkdir -p "$guard_tmp/bin"
+cat >"$guard_tmp/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${FAKE_GH_LOG:?}"
+case "${FAKE_GH_MODE:?}:$*" in
+  hit:*actions/artifacts*) printf '%s\n' '{"artifacts":[{"expired":false,"workflow_run":{"id":123}}]}' ;;
+  hit:*actions/runs/123*) printf '%s\n' '{"event":"pull_request","status":"completed","conclusion":"success","html_url":"https://example.test/actions/runs/123"}' ;;
+  wrong-event:*actions/artifacts*) printf '%s\n' '{"artifacts":[{"expired":false,"workflow_run":{"id":456}}]}' ;;
+  wrong-event:*actions/runs/456*) printf '%s\n' '{"event":"push","status":"completed","conclusion":"success","html_url":"https://example.test/actions/runs/456"}' ;;
+  miss:*actions/artifacts*) printf '%s\n' '{"artifacts":[]}' ;;
+  error:*) exit 1 ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod +x "$guard_tmp/bin/gh"
+
+guard_tree="$(git -C "$repo_root" rev-parse 'HEAD^{tree}')"
+run_guard() {
+    local mode="$1"
+    local output="$guard_tmp/$mode.output"
+    : >"$output"
+    GITHUB_OUTPUT="$output" GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main \
+        GITHUB_REPOSITORY=example/repo FAKE_GH_MODE="$mode" FAKE_GH_LOG="$guard_tmp/gh.log" \
+        PATH="$guard_tmp/bin:$PATH" "$tree_guard" >/dev/null
+    cat "$output"
+}
+
+hit_output="$(run_guard hit)"
+require_text "$hit_output" 'run-heavy=false' 'matching successful PR receipt skips heavy work'
+require_text "$hit_output" 'prior-run-url=https://example.test/actions/runs/123' 'matching receipt exposes the prior run URL'
+require_text "$(<"$guard_tmp/gh.log")" "pr-validated-tree-$guard_tree" 'tree lookup queries the exact current Git tree'
+for mode in miss wrong-event error; do
+    output_path="$(run_guard "$mode")"
+    require_text "$output_path" 'run-heavy=true' "$mode receipt evidence fails closed to heavy work"
+    require_absent "$output_path" 'run-heavy=false' "$mode receipt evidence never dedupes"
+done
+rm -rf "$guard_tmp"
 
 all_actions="$(<"$setup")$(<"$ci")$(<"$release")"
 require_text "$all_actions" 'mozilla-actions/sccache-action@v0.0.11' 'cache-v2-capable sccache action is pinned'


### PR DESCRIPTION
## Summary
- publish a Git-tree receipt only after every per-tree protected PR validation lane succeeds
- fail closed when main-push Clippy/test-compile cannot verify an exact receipt; otherwise skip loudly with the prior run URL
- move both release-profile panic probes and the cold benchmark to schedule/manual execution
- pin match, miss, wrong-event, and API-error behavior in the CI tier contract

## Verification
- `bash -n scripts/check-ci-tree-validation.sh scripts/test-ci-test-tiers.sh`
- `scripts/test-ci-test-tiers.sh` (153 assertions)
- `git diff --check`

## Measurement
Baseline main pushes: 21–23 minutes (panic release 22.3m, benchmark 15.5m, release-fast 12.3m, compile guard 5.4m, Clippy 2.6m). The post-merge exact-tree hit and <=3m wall-time receipt must be captured from the landing main run.