### PR TITLE
CI: cut release publication wall with parallel thin-LTO builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ env:
   RUSTC_WRAPPER: sccache
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_GHA_VERSION: "cas-v2"
+  # Thin LTO preserves cross-crate optimization while allowing parallel codegen.
+  # The packaged binaries are explicitly stripped below, matching the shipped
+  # size behavior of the full release profile.
+  RELEASE_PROFILE: release-fast
+  RELEASE_DIR: release-fast
 
 jobs:
   verify:
@@ -63,7 +68,6 @@ jobs:
 
   build:
     name: Build Linux x86_64
-    needs: verify
     runs-on: ubuntu-latest
 
     steps:
@@ -114,18 +118,19 @@ jobs:
         run: |
           # The subsequent build-input audit must inspect this build, never a
           # stale BLAKE3 output restored from the target cache.
-          cargo clean -p blake3 --release --target x86_64-unknown-linux-gnu
-          cargo build -p cas --release --target x86_64-unknown-linux-gnu --locked
+          cargo clean -p blake3 --profile "$RELEASE_PROFILE" --target x86_64-unknown-linux-gnu
+          cargo build -p cas --profile "$RELEASE_PROFILE" --target x86_64-unknown-linux-gnu --locked
 
       - name: Stage package
         run: |
           mkdir -p package
-          cp target/x86_64-unknown-linux-gnu/release/cas package/
+          cp "target/x86_64-unknown-linux-gnu/$RELEASE_DIR/cas" package/
+          strip package/cas
           cp LICENSE package/
 
       - name: Audit exact packaged Linux executable
         run: |
-          ./scripts/check-blake3-no-avx512-build.sh target/x86_64-unknown-linux-gnu/release/build
+          ./scripts/check-blake3-no-avx512-build.sh "target/x86_64-unknown-linux-gnu/$RELEASE_DIR/build"
           ./scripts/test-check-portable-x86_64-isa.sh package/cas
 
       - name: Package
@@ -142,7 +147,6 @@ jobs:
 
   build-macos:
     name: Build macOS ARM64
-    needs: verify
     # Zig 0.15.2 needs the Xcode 26.3 / macOS 26.2 SDK; macos-latest uses an
     # incompatible newer SDK. Keep this aligned with ci.yml's macos-check.
     runs-on: macos-26
@@ -186,12 +190,13 @@ jobs:
       - name: Build
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: cargo build -p cas --release --target aarch64-apple-darwin --locked
+        run: cargo build -p cas --profile "$RELEASE_PROFILE" --target aarch64-apple-darwin --locked
 
       - name: Package
         run: |
           mkdir -p package
-          cp target/aarch64-apple-darwin/release/cas package/
+          cp "target/aarch64-apple-darwin/$RELEASE_DIR/cas" package/
+          strip package/cas
           cp LICENSE package/
           cd package
           tar -czvf cas-aarch64-apple-darwin.tar.gz cas LICENSE

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -57,6 +57,15 @@ job_block() {
     ' "$ci"
 }
 
+release_job_block() {
+    local job="$1"
+    awk -v header="  ${job}:" '
+        $0 == header { inside = 1; next }
+        inside && /^  [A-Za-z0-9_-]+:$/ { exit }
+        inside { print }
+    ' "$release"
+}
+
 ci_text="$(<"$ci")"
 mapfile -t required_contexts < <(
     grep -oE '"context": "[^"]+"' "$ruleset" | sed -E 's/"context": "(.*)"/\1/'
@@ -257,7 +266,22 @@ else
 fi
 require_text "$ci_text" 'SCCACHE_GHA_ENABLED: "true"' 'CI enables GitHub cache-v2 backend'
 require_text "$(<"$release")" 'SCCACHE_GHA_ENABLED: "true"' 'release enables GitHub cache-v2 backend'
-require_text "$(<"$release")" 'needs: [verify, build, build-macos]' 'release publication waits for both Linux and macOS builds'
+release_text="$(<"$release")"
+release_linux="$(release_job_block build)"
+release_macos="$(release_job_block build-macos)"
+release_publish="$(release_job_block release)"
+require_absent "$release_linux" 'needs: verify' 'Linux release build starts in parallel with input verification'
+require_absent "$release_macos" 'needs: verify' 'macOS release build starts in parallel with input verification'
+require_text "$release_publish" 'needs: [verify, build, build-macos]' 'release publication waits for verification and both platform builds'
+for platform_build in "$release_linux" "$release_macos"; do
+    require_text "$platform_build" '--profile "$RELEASE_PROFILE"' 'platform release build uses the thin-LTO profile'
+    require_text "$platform_build" 'strip package/cas' 'platform package strips symbols before publication'
+    require_text "$platform_build" '$RELEASE_DIR/cas' 'platform package selects the configured profile output'
+done
+require_text "$release_linux" 'check-blake3-no-avx512-build.sh "target/x86_64-unknown-linux-gnu/$RELEASE_DIR/build"' 'Linux release audits BLAKE3 inputs from the selected profile'
+require_text "$release_linux" 'test-check-portable-x86_64-isa.sh package/cas' 'Linux release audits the exact stripped executable'
+require_text "$release_linux" 'name: cas-x86_64-unknown-linux-gnu' 'Linux release asset remains required'
+require_text "$release_macos" 'name: cas-aarch64-apple-darwin' 'macOS release asset remains required'
 require_absent "$(<"$release")" 'gh release delete' 'release never replaces published assets after a receipt'
 require_text "$(<"$release")" 'refusing to replace its assets' 'release rerun with an existing release fails loudly'
 require_text "$(<"$release")" 'RELEASE_SLACK_RUBRIC.md#recovering-a-failed-or-partial-release' 'release rerun names its recovery procedure'


### PR DESCRIPTION
## Summary

- start release input verification, Linux build, and macOS build concurrently; publication still requires all three
- build shipped assets with the existing release-fast profile (thin LTO, 16 codegen units) and explicitly strip the exact packaged executables
- retain both platform assets, the exact Linux BLAKE3 and portable-ISA audits, immutable publication, and the published-receipt flow

## Measured baseline

Real v2.72.0 run 32062368898 took 26m27s tag to workflow completion. Verify was 5m03s (preflight 4m19s). Linux was 17m32s: build 15m20s, exact-byte audits 1m22s, upload 3s. macOS was the 21m03s long pole: build 20m00s, package 3s, upload 2s. Create Release took 11s.

Real v2.71.0 run 31954264753 took 21m07s. Verify was 3m27s; Linux build was 14m37s plus 1m25s audit; macOS build was 16m15s.

Concurrency alone projects v2.72.0 from 26m27s to about 21m14s, saving 5m13s (19.7%). On the same source generation, CI run 32062364891 measured the release-fast panic build/test at 11m27s versus 21m31s for full release, 46.8% faster. Applying that directional ratio to the v2.72 macOS build projects roughly 11m53s tag to assets, about 14m34s (55%) faster. The ratio is a projection, not a claimed release result.

A synthetic RC is unsafe: release preflight accepts only exact vX.Y.Z versions matching all release crates and CHANGELOG, and the workflow always creates a normal immutable release. The first real after measurement will therefore be the next legitimate release tag.

## Local artifact tradeoff

A clean, sccache-disabled Linux release-fast build at 1d54d282 completed in 3m03s (668% average CPU, 5.17 GB peak RSS). The unchanged BLAKE3 input audit and portable x86_64 audit both passed on the exact stripped artifact.

Against the published v2.72.0 Linux bytes, the stripped executable is 70,736,248 versus 56,849,112 bytes: +13,887,136 (+24.4%). The compressed asset is 27,270,257 versus 23,020,330 bytes: +4,249,927 (+18.5%). Five alternating 100-run cas --version samples averaged 3.557 ms for thin LTO versus 3.125 ms for the published full-LTO binary: +0.431 ms (+13.8%). The artifact comparison includes small post-v2.72 source changes, so it is an upper-bound directional profile comparison rather than a same-commit binary benchmark.

Tradeoff decision: accept a 4.25 MB download increase and a sub-millisecond trivial-command startup change for a projected 14.5-minute release-wall reduction. Exact before/after wall and same-release byte comparisons will be recorded on the next legitimate tag.

## Safety and contracts

- scripts/test-ci-test-tiers.sh: 165 passed, 0 failed
- scripts/test-release-published-receipt.sh: 5 passed, 0 failed
- scripts/test-check-portable-x86_64-isa.sh: 9 fixture checks plus the exact final artifact passed
- clean release-fast build: passed in 3m03s
- BLAKE3 input audit: passed against target/x86_64-unknown-linux-gnu/release-fast/build
- portable ISA audit: passed against the exact stripped artifact
- bash syntax and git diff check pass