### PR TITLE
ci: publish per-job sccache hit stats on every compiling Rust lane (cas-67a2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,19 @@ name: CI
 # jobs below are deliberately fanned out rather than chained inside one job.
 # The four release/benchmark workloads used to run in series in a single job
 # and cost ~51m; they are independent and now run concurrently.
+#
+# COMPILER CACHE CONTRACT (cas-67a2). Every job here that compiles Rust must:
+#   1. configure the GitHub cache-v2 sccache backend — the workflow-level env
+#      below does that for all of them, and only `build-benchmark` opts out; and
+#   2. end with a `Report sccache stats` step calling
+#      scripts/ci-sccache-summary.sh, so each job's hit rate is visible in its
+#      job summary instead of buried in a log nobody greps.
+# Warm lanes measured 90-92% hits while pre-cache-v2 lanes measured 0-6%; that
+# difference is worth minutes per run and used to be invisible. The stats step
+# is observability only — it always exits 0 and can never redden a lane.
+# `build-benchmark` is the one deliberately uncached compiling job: it measures
+# a cold compiler, so it gets neither the backend nor a stats step (see below).
+# scripts/test-ci-test-tiers.sh pins all of this.
 
 on:
   pull_request:
@@ -72,6 +85,10 @@ jobs:
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: scripts/run-scoped-tests.sh -p cas --lib --no-fail-fast
+
+      - name: Report sccache stats
+        if: always()
+        run: ./scripts/ci-sccache-summary.sh "Scoped Validation"
 
   # Required checks always start: path selection happens in steps, never with
   # job-level `paths` filters, so their exact ruleset contexts keep reporting.
@@ -138,6 +155,10 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo build -p cas --no-default-features
 
+      - name: Report sccache stats
+        if: always() && steps.classify-diff.outputs.rust-unaffected != 'true'
+        run: ./scripts/ci-sccache-summary.sh "Fast Validation — preflight"
+
   # Compile the workspace test graph once. The archive contains the binaries
   # and nextest metadata needed by the shard jobs below, avoiding three cold
   # runners rebuilding the same graph before their disjoint test partitions.
@@ -199,6 +220,12 @@ jobs:
             fast-validation-suite-runner.tar.gz
           retention-days: 1
           compression-level: 0
+
+      # This lane compiles the whole workspace test graph, so its hit rate is
+      # the single best predictor of the required critical path.
+      - name: Report sccache stats
+        if: always() && steps.classify-diff.outputs.rust-unaffected != 'true'
+        run: ./scripts/ci-sccache-summary.sh "Fast Validation — suite archive build"
 
   fast-validation-suite-shards:
     name: Fast Validation — suite shard ${{ matrix.shard }}/3
@@ -327,6 +354,10 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo test -p cas --doc
 
+      - name: Report sccache stats
+        if: always() && steps.classify-diff.outputs.rust-unaffected != 'true'
+        run: ./scripts/ci-sccache-summary.sh "Fast Validation — doctests"
+
   # The repository ruleset requires this exact check name. It reports success
   # only after preflight, all exhaustive nextest shards, and doctests pass.
   # Queue (rather than cancel) matching head-SHA checks per cas-9eaf; because
@@ -396,6 +427,10 @@ jobs:
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo clippy -p cas --all-targets
+
+      - name: Report sccache stats
+        if: always() && steps.tree-dedupe.outputs.run-heavy != 'false'
+        run: ./scripts/ci-sccache-summary.sh "Clippy"
 
   # Keep this compile-only: --all-targets catches Darwin-only type errors in
   # production, test, example, and benchmark code without duplicating the full
@@ -491,6 +526,10 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo check -p cas --no-default-features
 
+      - name: Report sccache stats
+        if: always() && steps.classify-diff.outputs.rust-unaffected != 'true'
+        run: ./scripts/ci-sccache-summary.sh "macOS Check"
+
   # A receipt is trustworthy only after every per-tree PR lane passes. The
   # artifact name is the checked-out Git tree, so a merge commit with identical
   # contents can reuse it even though the commit SHA changed.
@@ -577,6 +616,10 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo test -p cas --no-run
 
+      - name: Report sccache stats
+        if: always() && steps.tree-dedupe.outputs.run-heavy != 'false'
+        run: ./scripts/ci-sccache-summary.sh "Test Compile Guard"
+
   # EPIC cas-c351 / cas-9e02: run the A2/A3/B3 panic-isolation tests under the
   # release profiles to catch any future profile change that silently
   # re-introduces panic=abort, or any release-mode codegen that breaks the
@@ -612,6 +655,10 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: make -C cas-cli test-release-panic-release
 
+      - name: Report sccache stats
+        if: always()
+        run: ./scripts/ci-sccache-summary.sh "Panic Isolation — release profile"
+
   panic-isolation-release-fast:
     name: Panic Isolation — release-fast profile (named subset, not the suite)
     if: >-
@@ -634,6 +681,10 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: make -C cas-cli test-release-panic-release-fast
 
+      - name: Report sccache stats
+        if: always()
+        run: ./scripts/ci-sccache-summary.sh "Panic Isolation — release-fast profile"
+
   # Build-time measurement only. This job executes no tests.
   #
   # save-cache: false is load-bearing. scripts/benchmark-build.sh starts with
@@ -647,9 +698,14 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    # This job measures a genuinely cold compiler. Letting the repaired remote
-    # sccache serve objects after `cargo clean` would turn the benchmark into a
-    # cache benchmark and make its historical regression threshold meaningless.
+    # DELIBERATELY UNCACHED — the one compiling job exempt from the compiler
+    # cache contract at the top of this file. It measures a genuinely cold
+    # compiler; letting the remote sccache serve objects after `cargo clean`
+    # would turn the benchmark into a cache benchmark and make its historical
+    # regression threshold meaningless. Both overrides below are load-bearing,
+    # and this job intentionally has no `Report sccache stats` step: there is no
+    # cache to report on, and a 0% summary here would read as a regression.
+    # Do not "fix" this lane by enabling the cache.
     env:
       RUSTC_WRAPPER: ""
       SCCACHE_GHA_ENABLED: "false"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Fail fast on release inputs
         run: ./scripts/check-release-preflight.sh "${GITHUB_REF_NAME}"
 
+      # Same compiler cache contract as ci.yml: every compiling lane publishes
+      # its hit rate. Observability only — this step can never fail a release.
+      - name: Report sccache stats
+        if: always()
+        run: ./scripts/ci-sccache-summary.sh "Verify Release Inputs"
+
   build:
     name: Build Linux x86_64
     runs-on: ubuntu-latest
@@ -145,6 +151,10 @@ jobs:
           name: cas-x86_64-unknown-linux-gnu
           path: cas-x86_64-unknown-linux-gnu.tar.gz
 
+      - name: Report sccache stats
+        if: always()
+        run: ./scripts/ci-sccache-summary.sh "Build Linux x86_64"
+
   build-macos:
     name: Build macOS ARM64
     # Zig 0.15.2 needs the Xcode 26.3 / macOS 26.2 SDK; macos-latest uses an
@@ -207,6 +217,10 @@ jobs:
         with:
           name: cas-aarch64-apple-darwin
           path: cas-aarch64-apple-darwin.tar.gz
+
+      - name: Report sccache stats
+        if: always()
+        run: ./scripts/ci-sccache-summary.sh "Build macOS ARM64"
 
   release:
     name: Create Release

--- a/scripts/ci-sccache-summary.sh
+++ b/scripts/ci-sccache-summary.sh
@@ -11,6 +11,11 @@
 # `set -e` and always exits 0: a broken stats probe is a reporting bug, not a
 # reason to redden a lane that compiled and tested fine.
 #
+# sccache-action's own post hook emits a bare one-line notice annotation. This
+# is not that: it renders a table into the job summary, names the backend the
+# lane actually resolved, warns on a cold or unconfigured lane, and still says
+# something useful when sccache is missing or its stats are unreadable.
+#
 # Usage: scripts/ci-sccache-summary.sh "<lane label>"
 
 set -uo pipefail
@@ -27,6 +32,18 @@ emit() {
     printf '%s\n' "$1"
     if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
         printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+# A log line alone cannot distinguish "rendered into the job summary" from
+# "printed to stdout", so state which one happened. Every caller ends with this.
+report_destination() {
+    if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        echo "sccache stats printed to the log only: GITHUB_STEP_SUMMARY is unset."
+    elif [[ -s "${GITHUB_STEP_SUMMARY}" ]]; then
+        echo "sccache stats written to the job summary ($(wc -c <"$GITHUB_STEP_SUMMARY" | tr -d '[:space:]') bytes at $GITHUB_STEP_SUMMARY)."
+    else
+        echo "sccache stats could not be written to the job summary at $GITHUB_STEP_SUMMARY."
     fi
 }
 
@@ -47,6 +64,7 @@ report_unavailable() {
     emit ""
     emit "Backend: $(backend_label)"
     echo "::warning title=sccache stats unavailable::${lane}: $1 — this lane compiled without measured cache reuse."
+    report_destination
     exit 0
 }
 
@@ -143,4 +161,5 @@ elif [[ -n "$rate_value" && "$requests" != "?" ]] \
     echo "::warning title=sccache cold lane::${lane} hit rate ${rate} is below ${min_hit_rate}% over ${requests} compile requests; this lane paid a cold/seed compile penalty."
 fi
 
+report_destination
 exit 0

--- a/scripts/ci-sccache-summary.sh
+++ b/scripts/ci-sccache-summary.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Publish this job's sccache effectiveness to the GitHub job summary.
+#
+# Why (cas-67a2, rank-3 of docs/analysis/2026-08-17-ci-speed-spike.md): warm CI
+# lanes reach 90-92% compiler-cache hits, but that number is invisible unless a
+# human greps a job log, so a lane that silently regresses to the pre-cache-v2
+# 0-6% range — or pays a 43% cold/seed penalty — costs minutes with nobody
+# noticing. Every compiling Rust lane calls this at the end of the job.
+#
+# OBSERVABILITY MUST NEVER FAIL A BUILD. This script deliberately runs without
+# `set -e` and always exits 0: a broken stats probe is a reporting bug, not a
+# reason to redden a lane that compiled and tested fine.
+#
+# Usage: scripts/ci-sccache-summary.sh "<lane label>"
+
+set -uo pipefail
+
+lane="${1:-${GITHUB_JOB:-unknown lane}}"
+# A lane whose hit rate falls below this is cold or misconfigured; annotate it
+# so the cost is visible in the run's Annotations, not just in this summary.
+min_hit_rate="${CAS_SCCACHE_MIN_HIT_RATE:-50}"
+# Below this many compile requests the ratio is noise (a lane that short-circuited,
+# or one whose whole graph was already linked), so no warning is raised.
+min_requests_for_warning="${CAS_SCCACHE_MIN_REQUESTS:-10}"
+
+emit() {
+    printf '%s\n' "$1"
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        printf '%s\n' "$1" >>"$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+backend_label() {
+    if [[ "${SCCACHE_GHA_ENABLED:-}" == "true" || "${SCCACHE_GHA_ENABLED:-}" == "on" ]]; then
+        printf 'GitHub Actions cache v2 (namespace `%s`)' "${SCCACHE_GHA_VERSION:-<unset>}"
+    elif [[ -z "${SCCACHE_GHA_ENABLED:-}" ]]; then
+        printf '**not configured** — `SCCACHE_GHA_ENABLED` is unset, so this lane cannot reuse CI objects'
+    else
+        printf 'disabled (`SCCACHE_GHA_ENABLED=%s`)' "${SCCACHE_GHA_ENABLED}"
+    fi
+}
+
+report_unavailable() {
+    emit "### sccache — ${lane}"
+    emit ""
+    emit "Cache statistics unavailable: $1."
+    emit ""
+    emit "Backend: $(backend_label)"
+    echo "::warning title=sccache stats unavailable::${lane}: $1 — this lane compiled without measured cache reuse."
+    exit 0
+}
+
+# The shared setup's probe writes SCCACHE_GHA_ENABLED=false into GITHUB_ENV when
+# the action download or server start failed. In that state the wrapper is
+# already cleared and asking the binary for stats would just restart a server
+# that nothing used.
+if [[ "${SCCACHE_GHA_ENABLED:-}" == "false" ]]; then
+    report_unavailable "sccache backend was disabled for this job (build ran uncached)"
+fi
+
+if ! command -v sccache >/dev/null 2>&1; then
+    report_unavailable "the sccache executable is not on PATH"
+fi
+
+json="$(sccache --show-stats --stats-format=json 2>/dev/null)"
+text="$(sccache --show-stats 2>/dev/null)"
+
+hits=""
+misses=""
+requests=""
+executed=""
+errors=""
+writes=""
+
+if [[ -n "$json" ]] && command -v jq >/dev/null 2>&1 && jq -e . >/dev/null 2>&1 <<<"$json"; then
+    read -r requests executed hits misses errors writes < <(
+        jq -r '
+            def total: (.counts // {}) | to_entries | map(.value) | add // 0;
+            .stats
+            | [ (.compile_requests // 0),
+                (.requests_executed // 0),
+                (.cache_hits | total),
+                (.cache_misses | total),
+                (.cache_errors | total),
+                (.cache_writes // 0) ]
+            | @tsv
+        ' <<<"$json" | tr '\t' ' '
+    )
+elif [[ -n "$text" ]]; then
+    # Fallback for an sccache build whose JSON schema this script does not know.
+    field() { awk -v key="$1" 'index($0, key) == 1 { print $NF }' <<<"$text" | head -1; }
+    requests="$(field 'Compile requests ')"
+    executed="$(field 'Compile requests executed')"
+    hits="$(field 'Cache hits ')"
+    misses="$(field 'Cache misses ')"
+    errors="$(field 'Cache errors')"
+    writes="$(field 'Cache writes')"
+else
+    report_unavailable "sccache returned no statistics"
+fi
+
+# Any field the probe could not read stays visibly unknown rather than silently 0.
+numeric() { [[ "$1" =~ ^[0-9]+$ ]] && printf '%s' "$1" || printf '?'; }
+hits="$(numeric "${hits:-}")"
+misses="$(numeric "${misses:-}")"
+requests="$(numeric "${requests:-}")"
+executed="$(numeric "${executed:-}")"
+errors="$(numeric "${errors:-}")"
+writes="$(numeric "${writes:-}")"
+
+rate="n/a"
+rate_value=""
+if [[ "$hits" != "?" && "$misses" != "?" ]]; then
+    total=$((hits + misses))
+    if ((total > 0)); then
+        rate_value=$(((hits * 100) / total))
+        rate="${rate_value}%"
+    fi
+fi
+
+emit "### sccache — ${lane}"
+emit ""
+emit "**${hits} hits / ${misses} misses — hit rate ${rate}** (${executed} of ${requests} compile requests executed)"
+emit ""
+emit "| Metric | Value |"
+emit "| --- | --- |"
+emit "| Cache hits | ${hits} |"
+emit "| Cache misses | ${misses} |"
+emit "| Hit rate | ${rate} |"
+emit "| Compile requests | ${requests} |"
+emit "| Requests executed | ${executed} |"
+emit "| Cache writes | ${writes} |"
+emit "| Cache errors | ${errors} |"
+emit "| Backend | $(backend_label) |"
+emit ""
+
+echo "::notice title=sccache ${lane}::${hits} hits / ${misses} misses (hit rate ${rate}) across ${requests} compile requests."
+
+if [[ -z "${SCCACHE_GHA_ENABLED:-}" ]]; then
+    echo "::warning title=sccache backend unconfigured::${lane} compiled without SCCACHE_GHA_ENABLED; CI objects are not being shared."
+elif [[ -n "$rate_value" && "$requests" != "?" ]] \
+    && ((requests >= min_requests_for_warning)) && ((rate_value < min_hit_rate)); then
+    echo "::warning title=sccache cold lane::${lane} hit rate ${rate} is below ${min_hit_rate}% over ${requests} compile requests; this lane paid a cold/seed compile penalty."
+fi
+
+exit 0

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -466,6 +466,8 @@ EOF
     require_text "$summary_output" '47 hits / 4 misses' 'warm lane summary reports hits and misses'
     require_text "$summary_output" 'hit rate 92%' 'warm lane summary reports a hit rate'
     require_text "$summary_output" 'cache v2' 'warm lane summary names the configured backend'
+    require_text "$summary_output" 'written to the job summary' 'the lane states that its stats reached the job summary, not just the log'
+    require_text "$(<"$stats_tmp/summary.md")" '| Hit rate | 92% |' 'the job summary file itself carries the rendered table'
 
     run_summary cold "PATH=$stats_tmp/bin:$PATH" SCCACHE_GHA_ENABLED=true CAS_SCCACHE_MIN_HIT_RATE=95
     require_text "$summary_output" '::warning title=sccache cold lane::' 'a lane below the hit-rate floor is annotated, not failed'

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -381,6 +381,116 @@ else
     fail=$((fail + 1))
 fi
 
+# Compiler cache observability (cas-67a2). Warm lanes reach 90-92% sccache hits
+# and pre-cache-v2 lanes measured 0-6%; that gap is worth minutes per run and is
+# invisible unless each lane publishes its own hit rate. Pin both halves: every
+# compiling lane is cache-v2 configured, and every compiling lane reports.
+summary_script="$repo_root/scripts/ci-sccache-summary.sh"
+require_text "$ci_text" 'SCCACHE_GHA_VERSION: "cas-v2"' 'CI pins one shared cache-v2 object namespace'
+require_text "$release_text" 'SCCACHE_GHA_VERSION: "cas-v2"' 'release shares the CI cache-v2 object namespace'
+
+# Lane label must match the job so a summary is attributable to its job.
+declare -A compiling_lanes=(
+    [scoped-validation]='Scoped Validation'
+    [fast-validation-preflight]='Fast Validation — preflight'
+    [fast-validation-suite-build]='Fast Validation — suite archive build'
+    [fast-validation-docs]='Fast Validation — doctests'
+    [clippy]='Clippy'
+    [macos-check]='macOS Check'
+    [test-compile-guard]='Test Compile Guard'
+    [panic-isolation-release]='Panic Isolation — release profile'
+    [panic-isolation-release-fast]='Panic Isolation — release-fast profile'
+)
+for job in "${!compiling_lanes[@]}"; do
+    block="$(job_block "$job")"
+    require_text "$block" "./scripts/ci-sccache-summary.sh \"${compiling_lanes[$job]}\"" \
+        "$job publishes its own sccache hit stats"
+    require_text "$block" 'if: always()' "$job reports cache stats even when the lane fails"
+    require_absent "$block" 'SCCACHE_GHA_ENABLED: "false"' "$job keeps the cache-v2 backend enabled"
+done
+
+for job in build build-macos verify; do
+    block="$(release_job_block "$job")"
+    require_text "$block" './scripts/ci-sccache-summary.sh' "release $job publishes its own sccache hit stats"
+done
+
+# The single deliberate exemption. It measures a cold compiler, so a stats
+# summary there would report an alarming 0% for a lane that is working correctly.
+benchmark="$(job_block build-benchmark)"
+require_text "$benchmark" 'SCCACHE_GHA_ENABLED: "false"' 'Build Benchmark stays deliberately uncached'
+require_text "$benchmark" 'RUSTC_WRAPPER: ""' 'Build Benchmark clears the compiler wrapper'
+require_text "$benchmark" 'DELIBERATELY UNCACHED' 'Build Benchmark documents why it is exempt'
+require_absent "$benchmark" 'ci-sccache-summary.sh' 'Build Benchmark reports no cache stats'
+
+# Test-only lanes execute prebuilt binaries; a stats step there would report a
+# cache that never had a compile to serve.
+require_absent "$suite_shards" 'ci-sccache-summary.sh' 'suite shards compile nothing and report no cache stats'
+
+# Observability must not be able to fail a build. Exercise the real script
+# against a warm cache, a missing binary, and the probe's disabled-backend
+# state; every path must exit 0 and still say something useful.
+if [[ -x "$summary_script" ]]; then
+    printf 'ok   sccache summary script is executable\n'
+    pass=$((pass + 1))
+    stats_tmp="$(mktemp -d)"
+    mkdir -p "$stats_tmp/bin"
+    cat >"$stats_tmp/bin/sccache" <<'EOF'
+#!/usr/bin/env bash
+if [[ " $* " == *" --stats-format=json "* ]]; then
+    printf '%s\n' '{"stats":{"compile_requests":51,"requests_executed":51,"cache_errors":{"counts":{},"adv_counts":{}},"cache_hits":{"counts":{"Rust":47},"adv_counts":{}},"cache_misses":{"counts":{"Rust":4},"adv_counts":{}},"cache_writes":4}}'
+else
+    printf 'Compile requests                     51\nCompile requests executed            51\nCache hits                           47\nCache misses                          4\nCache writes                          4\nCache errors                          0\n'
+fi
+EOF
+    chmod +x "$stats_tmp/bin/sccache"
+
+    # Keep the exit-status assertion in this shell: running the probe inside a
+    # command substitution would swallow both its status and the counters.
+    summary_output=""
+    run_summary() {
+        local label="$1"
+        shift
+        local summary="$stats_tmp/summary.md" log="$stats_tmp/log"
+        : >"$summary"
+        if env "$@" GITHUB_STEP_SUMMARY="$summary" "$summary_script" 'Contract Lane' >"$log" 2>&1; then
+            printf 'ok   sccache summary exits 0 (%s)\n' "$label"
+            pass=$((pass + 1))
+        else
+            printf 'FAIL sccache summary must never fail a build (%s)\n' "$label"
+            fail=$((fail + 1))
+        fi
+        summary_output="$(cat "$summary" "$log")"
+    }
+
+    run_summary warm "PATH=$stats_tmp/bin:$PATH" SCCACHE_GHA_ENABLED=true SCCACHE_GHA_VERSION=cas-v2
+    require_text "$summary_output" '47 hits / 4 misses' 'warm lane summary reports hits and misses'
+    require_text "$summary_output" 'hit rate 92%' 'warm lane summary reports a hit rate'
+    require_text "$summary_output" 'cache v2' 'warm lane summary names the configured backend'
+
+    run_summary cold "PATH=$stats_tmp/bin:$PATH" SCCACHE_GHA_ENABLED=true CAS_SCCACHE_MIN_HIT_RATE=95
+    require_text "$summary_output" '::warning title=sccache cold lane::' 'a lane below the hit-rate floor is annotated, not failed'
+
+    # A PATH with no sccache but still a usable shell. If this host ships
+    # sccache in a system directory the case is unobservable, so say so rather
+    # than assert something the environment cannot demonstrate.
+    mkdir -p "$stats_tmp/empty"
+    if PATH="$stats_tmp/empty:/usr/bin:/bin" command -v sccache >/dev/null 2>&1; then
+        printf 'ok   (not observable here) system sccache shadows the missing-binary case\n'
+        pass=$((pass + 1))
+    else
+        run_summary missing "PATH=$stats_tmp/empty:/usr/bin:/bin" SCCACHE_GHA_ENABLED=true
+        require_text "$summary_output" 'Cache statistics unavailable' 'a missing sccache binary degrades to a visible note'
+    fi
+
+    run_summary disabled "PATH=$stats_tmp/bin:$PATH" SCCACHE_GHA_ENABLED=false
+    require_text "$summary_output" 'build ran uncached' 'the probe-disabled backend is reported as uncached'
+
+    rm -rf "$stats_tmp"
+else
+    printf 'FAIL sccache summary script must exist and be executable\n'
+    fail=$((fail + 1))
+fi
+
 printf '\ntest result: %s passed; %s failed\n' "$pass" "$fail"
 if [[ "$fail" -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
Rank-3 of the CI speed spike (`docs/analysis/2026-08-17-ci-speed-spike.md`). Warm CI lanes measured 90-92% compiler-cache hits while pre-cache-v2 lanes measured 0-6%, and a seeding run paid a 43% cold penalty. Those are minutes per run, and today they are invisible unless somebody greps a job log — so a lane that silently loses its cache costs time nobody attributes.

## What changes

- **`scripts/ci-sccache-summary.sh` (new).** Publishes hits, misses, hit rate, compile requests, cache writes/errors, and the resolved backend into the job's GitHub summary, plus a one-line `::notice::`. Raises a `::warning::` when a lane drops below a 50% hit rate over a meaningful number of requests, or compiles with no cache-v2 backend configured — the cold and misconfigured cases the spike found.
- **Every compiling Rust lane reports.** Nine jobs in `ci.yml` and three in `release.yml` end with a `Report sccache stats` step, gated on the same condition as their compile work and `if: always()` so a red lane still explains its cache.
- **The deliberate exemption is documented.** `build-benchmark` measures a genuinely cold compiler, so it keeps `RUSTC_WRAPPER: ""` / `SCCACHE_GHA_ENABLED: "false"` and gets no stats step; the job comment now says why and warns against "fixing" it. The suite-shard lane executes prebuilt archive binaries and installs neither the toolchain nor Zig, so it compiles nothing and reports nothing.
- **`scripts/test-ci-test-tiers.sh` pins the contract:** the lane-to-label mapping for each compiling job, cache-v2 configuration on every one of them, both exemptions, and four executions of the real script.

## Observability must never fail a build

The script runs without `set -e` and always exits 0. It degrades to a visible note when sccache is missing, when the shared setup's probe already disabled the backend, or when stats come back unparseable, and it prefers JSON via `jq` with a fallback that parses the human stats table. Both parse paths were checked to agree on the same fixture (47/4 = 92%). The tier test executes it warm, cold, with no binary on PATH, and with a disabled backend, asserting exit 0 each time.

No `continue-on-error:` was added, so the existing sccache fail-open counts in the tier contract are untouched.

## Verification

- `scripts/test-ci-test-tiers.sh` — 245 passed, 0 failed
- `make -C cas-cli test-ci-tiers` — green, 277 assertions
- Both workflows parse as YAML; lane coverage audited programmatically
- Script exercised against real sccache 0.10.0 plus fixtures for warm, cold, garbage output, nonzero exit, missing binary, and disabled backend

Based on `main` @ 657b70db, which already contains #467 — no conflict with that lane's workflow edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)