### PR TITLE
Ben's macOS field report: cloud sync registers or fails loud, auto team default, user-level login, guide + init guard (epic cas-e0d9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+- **Your team is picked up automatically — no setup command to discover.** When you are logged in and CAS can tell which team you are on, `cas cloud sync` scopes the project to that team and registers it, instead of syncing in personal scope until you happen to run a team command. It says which team it adopted and how to undo it; `cas cloud team auto off` keeps a project personal for good, `cas cloud team set` still pins a specific team, and if you belong to several teams with no default CAS asks you to pick rather than guessing.
+
 ### Fixed
 - **A successful cloud sync now means your project really is connected to your team.** `cas cloud sync` confirms the project is registered with the active team before reporting success, registers it when it is missing, and stops with the actual reason — including the exact server exchange that failed — instead of printing green checkmarks over a project the team never received. Previously a machine with nothing queued to send registered nothing, so `cas cloud team-memories` answered "this project hasn't been synced to the team yet" right after a clean sync. That message now names the project, team, and endpoint involved instead of repeating the command that just ran.
 - **`cas cloud team show` and `cas cloud team auto` agree on which team you are on.** Both resolve the team slug from your cached memberships, so a team set by UUID no longer displays as `<not resolved>` in one command while the other names it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- **`cas init` stops scaffolding your home directory by accident.** Run in `$HOME` (or at the filesystem root) it now names what it would create and asks before writing anything; non-interactive runs refuse outright and point at `--allow-non-project` for automation that means it. Project directories, including non-git ones, are unaffected.
+
+### Changed
+- **Signing in to the cloud is a once-per-machine act.** Credentials live in `~/.cas/cloud.json`, so `cas login` works from any directory and every project on the machine is signed in; `cas logout` signs all of them out.
+- **Browser login no longer produces a broken approval link,** and ordinary polling survives a rate limit instead of ending the login with a server-error message.
+
 ## [2.72.0] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- **A successful cloud sync now means your project really is connected to your team.** `cas cloud sync` confirms the project is registered with the active team before reporting success, registers it when it is missing, and stops with the actual reason — including the exact server exchange that failed — instead of printing green checkmarks over a project the team never received. Previously a machine with nothing queued to send registered nothing, so `cas cloud team-memories` answered "this project hasn't been synced to the team yet" right after a clean sync. That message now names the project, team, and endpoint involved instead of repeating the command that just ran.
+- **`cas cloud team show` and `cas cloud team auto` agree on which team you are on.** Both resolve the team slug from your cached memberships, so a team set by UUID no longer displays as `<not resolved>` in one command while the other names it.
+
 ## [2.72.0] - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -282,10 +282,13 @@ Deeper material: [ARCHITECTURE.md](cas-cli/docs/ARCHITECTURE.md) (crates, stores
 CAS is fully usable offline; the cloud adds sync across machines, semantic search and team sharing.
 
 ```bash
-cas login
-cas cloud status      # what is pending, what is embedded
-cas cloud sync        # push then pull
+cas login                        # browser device flow
+cas login --token <API-TOKEN>    # or a token, from any directory
+cas cloud status                 # what is pending, what is embedded
+cas cloud sync                   # push then pull
 ```
+
+Log in once per machine, not once per project. Credentials live at user level in `~/.cas/cloud.json`, so every project you `cas init` afterwards is already authenticated, `cas login` and `cas whoami` work outside a project too, and `cas logout` signs the machine out. Each project keeps its own `.cas/cloud.json` for project state (team link, sync watermarks) and a cached copy of the credential.
 
 Sync is project-scoped: a push or pull that cannot determine which project it is running in refuses to make the request rather than sending or asking for everything. Personal pushes are incremental: `cas cloud push` consumes the current project's pending `sync_queue` rows, removing successful rows while leaving failures retryable. `--dry-run` previews the next bounded queue batch; `--entries-only` and `--tasks-only` narrow both that plan and the real push. `cas doctor` tells you which bucket a project resolves to; `cas cloud project set` pins it explicitly.
 

--- a/cas-cli/src/cli/auth.rs
+++ b/cas-cli/src/cli/auth.rs
@@ -880,6 +880,8 @@ fn execute_login_with_token(token: &str, endpoint: &str, cli: &Cli) -> anyhow::R
         let mut fmt = Formatter::stdout(&mut out, theme);
         fmt.write_raw("  ")?;
         fmt.success("Logged in to CAS Cloud")?;
+        fmt.write_muted("  Scope: this machine — every CAS project here is signed in")?;
+        fmt.newline()?;
     }
 
     Ok(())
@@ -1172,6 +1174,8 @@ fn print_login_success(fmt: &mut Formatter, email: Option<&str>) -> io::Result<(
         fmt.write_primary(email)?;
         fmt.newline()?;
     }
+    fmt.write_muted("  Scope:  this machine — every CAS project here is signed in")?;
+    fmt.newline()?;
 
     fmt.newline()?;
     fmt.write_muted("  Quick start:")?;

--- a/cas-cli/src/cli/auth.rs
+++ b/cas-cli/src/cli/auth.rs
@@ -12,8 +12,8 @@ use crate::cli::cloud::{
     select_cached_team_after_login,
 };
 use crate::cloud::{
-    CloudConfig, FetchTeamsOutcome, default_endpoint, fetch_and_cache_teams, is_acceptable_endpoint,
-    maybe_apply_team_backfill,
+    CloudConfig, FetchTeamsOutcome, clear_login_credentials, default_endpoint, fetch_and_cache_teams,
+    is_acceptable_endpoint, maybe_apply_team_backfill, store_login_credentials,
 };
 use crate::ui::components::{
     Component, Formatter, Spinner, SpinnerMsg, clear_inline, render_inline_view, rerender_inline,
@@ -78,10 +78,315 @@ fn parse_endpoint(s: &str) -> Result<String, String> {
     }
 }
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// DEVICE-FLOW PURE HELPERS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Build the URL that opens the device-authorization page in a browser.
+///
+/// The `/device/code` response may already carry the user code — either as
+/// RFC 8628's `verification_uri_complete`, or (as CAS Cloud does today) baked
+/// into `verification_uri` itself. Appending `?code=` unconditionally produced
+/// `…/device?code=FEUE-NMWQ?code=FEUE-NMWQ`, and the page then read the whole
+/// blob as the code and failed (cas-046d).
+///
+/// Rules, in order:
+///  1. an explicit `verification_uri_complete` is used verbatim;
+///  2. a `verification_uri` that already has a `code` query parameter is left
+///     alone;
+///  3. otherwise the code is appended with the correct separator and
+///     percent-encoded.
+pub(crate) fn build_verification_url(
+    verification_uri: &str,
+    verification_uri_complete: Option<&str>,
+    user_code: &str,
+) -> String {
+    if let Some(complete) = verification_uri_complete
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return complete.to_string();
+    }
+
+    let base = verification_uri.trim();
+    if user_code.is_empty() || has_code_param(base) {
+        return base.to_string();
+    }
+
+    let separator = if base.contains('?') { '&' } else { '?' };
+    format!(
+        "{base}{separator}code={}",
+        urlencoding::encode(user_code.trim())
+    )
+}
+
+/// True when `url`'s query string already contains a `code` parameter.
+fn has_code_param(url: &str) -> bool {
+    let Some((_, query)) = url.split_once('?') else {
+        return false;
+    };
+    let query = query.split('#').next().unwrap_or(query);
+    query.split('&').any(|pair| {
+        let name = pair.split_once('=').map(|(name, _)| name).unwrap_or(pair);
+        name.eq_ignore_ascii_case("code")
+    })
+}
+
+/// What the CLI should do after one `/device/token` poll.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PollDecision {
+    /// Nobody has approved the code yet — keep waiting at the current cadence.
+    Pending,
+    /// The server asked us to slow down: RFC 8628 `slow_down`, or HTTP 429.
+    SlowDown { retry_after: Option<u64> },
+    /// Transient failure (5xx, timeout, dropped connection) — retry, backed off.
+    Transient,
+    /// The user rejected the request.
+    Denied,
+    /// The device code is no longer valid.
+    Expired,
+    /// Unrecoverable: stop and report the HTTP status.
+    Fatal { http_status: u16 },
+}
+
+/// Map one poll result to the next action.
+///
+/// `body_status` is the `status` (or `error`) field of the response body;
+/// `retry_after` is the parsed `Retry-After` header, when the server sent one.
+///
+/// The rate-limit case is the point of this function: a 429 during ordinary
+/// login polling used to abort the whole login with "Server error (429)"
+/// (cas-046d / Ben #7). It is a throttle, not a failure.
+pub(crate) fn classify_poll_status(
+    http_status: u16,
+    body_status: &str,
+    retry_after: Option<u64>,
+) -> PollDecision {
+    match body_status {
+        "authorization_pending" | "pending" => return PollDecision::Pending,
+        "slow_down" => return PollDecision::SlowDown { retry_after },
+        "access_denied" => return PollDecision::Denied,
+        "expired_token" | "expired" => return PollDecision::Expired,
+        _ => {}
+    }
+
+    match http_status {
+        429 => PollDecision::SlowDown { retry_after },
+        200 | 202 => PollDecision::Pending,
+        408 | 425 | 500..=599 => PollDecision::Transient,
+        other => PollDecision::Fatal { http_status: other },
+    }
+}
+
+/// Longest gap the client will wait between polls, however hard the server
+/// throttles. Keeps a slow-down storm from silently parking the login.
+const MAX_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Next polling interval after a throttle or transient failure.
+///
+/// `Retry-After` (delta-seconds) wins when the server sent one; otherwise the
+/// interval grows by 5 seconds, per RFC 8628 §3.5. The result never shrinks
+/// below the current interval and never exceeds [`MAX_POLL_INTERVAL`].
+pub(crate) fn backoff_interval(
+    current: std::time::Duration,
+    retry_after: Option<u64>,
+) -> std::time::Duration {
+    use std::time::Duration;
+
+    let proposed = match retry_after {
+        Some(secs) if secs > 0 => Duration::from_secs(secs),
+        _ => current.saturating_add(Duration::from_secs(5)),
+    };
+    let floor = current.min(MAX_POLL_INTERVAL);
+    proposed.max(floor).min(MAX_POLL_INTERVAL)
+}
+
+/// Parse a `Retry-After` header value expressed in delta-seconds.
+///
+/// The HTTP-date form is deliberately unsupported: it returns `None`, and the
+/// caller falls back to the RFC 8628 `+5s` rule rather than guessing a clock
+/// skew.
+pub(crate) fn parse_retry_after(header: Option<&str>) -> Option<u64> {
+    let value = header.map(str::trim).filter(|value| !value.is_empty())?;
+    value.parse::<u64>().ok().filter(|secs| *secs > 0)
+}
+
+/// The status field of a device-token response, tolerating both the CAS Cloud
+/// `status` spelling and RFC 8628's `error`.
+fn body_status(body: &serde_json::Value) -> &str {
+    body["status"]
+        .as_str()
+        .or_else(|| body["error"].as_str())
+        .unwrap_or("")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_support::TestEnvGuard;
+    use std::time::Duration;
+
+    #[test]
+    fn verification_url_does_not_double_append_code() {
+        // The exact shape Ben hit: the server's verification_uri already
+        // carries the code, so appending another one broke the page.
+        let url = build_verification_url(
+            "https://petra-stella-cloud.vercel.app/device?code=FEUE-NMWQ",
+            None,
+            "FEUE-NMWQ",
+        );
+        assert_eq!(
+            url, "https://petra-stella-cloud.vercel.app/device?code=FEUE-NMWQ",
+            "a verification_uri that already carries the code must be used as-is"
+        );
+        assert_eq!(url.matches("code=").count(), 1, "exactly one code parameter");
+    }
+
+    #[test]
+    fn verification_url_appends_code_when_absent() {
+        assert_eq!(
+            build_verification_url("https://cloud.example/device", None, "ABCD-EFGH"),
+            "https://cloud.example/device?code=ABCD-EFGH"
+        );
+    }
+
+    #[test]
+    fn verification_url_uses_ampersand_with_existing_query() {
+        let url = build_verification_url("https://cloud.example/device?next=/home", None, "AB-CD");
+        assert_eq!(url, "https://cloud.example/device?next=/home&code=AB-CD");
+        assert_eq!(url.matches("code=").count(), 1);
+    }
+
+    #[test]
+    fn verification_url_prefers_uri_complete() {
+        let url = build_verification_url(
+            "https://cloud.example/device",
+            Some("https://cloud.example/device?user_code=AB-CD&code=AB-CD"),
+            "AB-CD",
+        );
+        assert_eq!(
+            url, "https://cloud.example/device?user_code=AB-CD&code=AB-CD",
+            "RFC 8628 verification_uri_complete wins verbatim"
+        );
+    }
+
+    #[test]
+    fn verification_url_percent_encodes_the_code() {
+        let url = build_verification_url("https://cloud.example/device", None, "A B&C");
+        assert_eq!(url, "https://cloud.example/device?code=A%20B%26C");
+    }
+
+    #[test]
+    fn verification_url_ignores_a_code_prefixed_param() {
+        // `codex=` must not be mistaken for `code=`.
+        let url = build_verification_url("https://cloud.example/device?codex=1", None, "AB-CD");
+        assert_eq!(url, "https://cloud.example/device?codex=1&code=AB-CD");
+    }
+
+    #[test]
+    fn rate_limit_backs_off_instead_of_aborting_login() {
+        assert_eq!(
+            classify_poll_status(429, "", None),
+            PollDecision::SlowDown { retry_after: None },
+            "429 during ordinary polling is a throttle, not a login failure"
+        );
+        assert_eq!(
+            classify_poll_status(429, "", Some(30)),
+            PollDecision::SlowDown {
+                retry_after: Some(30)
+            }
+        );
+    }
+
+    #[test]
+    fn poll_classification_covers_the_device_flow_states() {
+        assert_eq!(
+            classify_poll_status(400, "authorization_pending", None),
+            PollDecision::Pending
+        );
+        assert_eq!(
+            classify_poll_status(400, "slow_down", None),
+            PollDecision::SlowDown { retry_after: None }
+        );
+        assert_eq!(
+            classify_poll_status(400, "access_denied", None),
+            PollDecision::Denied
+        );
+        assert_eq!(
+            classify_poll_status(400, "expired_token", None),
+            PollDecision::Expired
+        );
+        assert_eq!(classify_poll_status(502, "", None), PollDecision::Transient);
+        assert_eq!(
+            classify_poll_status(403, "", None),
+            PollDecision::Fatal { http_status: 403 }
+        );
+        assert_eq!(classify_poll_status(200, "", None), PollDecision::Pending);
+    }
+
+    #[test]
+    fn backoff_grows_by_five_seconds_without_retry_after() {
+        assert_eq!(
+            backoff_interval(Duration::from_secs(5), None),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            backoff_interval(Duration::from_secs(10), None),
+            Duration::from_secs(15)
+        );
+    }
+
+    #[test]
+    fn backoff_honours_retry_after_and_never_speeds_up() {
+        assert_eq!(
+            backoff_interval(Duration::from_secs(5), Some(30)),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            backoff_interval(Duration::from_secs(20), Some(2)),
+            Duration::from_secs(20),
+            "a shorter Retry-After must not make the client poll faster"
+        );
+    }
+
+    #[test]
+    fn backoff_is_capped() {
+        assert_eq!(
+            backoff_interval(Duration::from_secs(58), None),
+            MAX_POLL_INTERVAL
+        );
+        assert_eq!(
+            backoff_interval(Duration::from_secs(30), Some(3600)),
+            MAX_POLL_INTERVAL
+        );
+    }
+
+    #[test]
+    fn retry_after_parses_delta_seconds_only() {
+        assert_eq!(parse_retry_after(Some("30")), Some(30));
+        assert_eq!(parse_retry_after(Some("  30 ")), Some(30));
+        assert_eq!(parse_retry_after(Some("0")), None);
+        assert_eq!(parse_retry_after(Some("")), None);
+        assert_eq!(parse_retry_after(None), None);
+        assert_eq!(
+            parse_retry_after(Some("Wed, 21 Oct 2026 07:28:00 GMT")),
+            None,
+            "HTTP-date form falls back to the RFC 8628 +5s rule"
+        );
+    }
+
+    #[test]
+    fn body_status_accepts_both_spellings() {
+        assert_eq!(
+            body_status(&serde_json::json!({"status": "slow_down"})),
+            "slow_down"
+        );
+        assert_eq!(
+            body_status(&serde_json::json!({"error": "authorization_pending"})),
+            "authorization_pending"
+        );
+        assert_eq!(body_status(&serde_json::json!({})), "");
+    }
 
     #[test]
     fn login_args_default_uses_default_endpoint() {
@@ -160,8 +465,10 @@ fn execute_device_flow_login(args: &LoginArgs, cli: &Cli) -> anyhow::Result<()> 
 
     use crate::cloud::CloudConfig;
 
-    // Check if already logged in
-    if let Ok(config) = CloudConfig::load() {
+    // Check if already logged in. `load_effective` so a machine-wide login is
+    // recognised from any project — and from outside a project entirely.
+    {
+        let config = CloudConfig::load_effective();
         if config.is_logged_in() {
             if cli.json {
                 let output = serde_json::json!({
@@ -231,25 +538,28 @@ fn execute_device_flow_login(args: &LoginArgs, cli: &Cli) -> anyhow::Result<()> 
     let verification_uri = device_response["verification_uri"]
         .as_str()
         .unwrap_or(&default_verification_uri);
+    let verification_uri_complete = device_response["verification_uri_complete"].as_str();
     let expires_in = device_response["expires_in"].as_u64().unwrap_or(900);
     let interval = device_response["interval"].as_u64().unwrap_or(5);
 
+    // One code parameter, whether the server pre-baked it or not (cas-046d).
+    let browser_url = build_verification_url(verification_uri, verification_uri_complete, user_code);
+
     if cli.json {
         println!(
-            r#"{{"status":"pending","user_code":"{user_code}","verification_uri":"{verification_uri}"}}"#
+            r#"{{"status":"pending","user_code":"{user_code}","verification_uri":"{browser_url}"}}"#
         );
     } else {
         let mut out = io::stdout();
         let theme = ActiveTheme::default();
         let mut fmt = Formatter::stdout(&mut out, theme);
 
-        // Display the code prominently
-        print_device_code(&mut fmt, user_code, verification_uri)?;
+        // Display the code prominently — the same URL the browser will open.
+        print_device_code(&mut fmt, user_code, &browser_url)?;
 
         // Open browser if not disabled
         if !args.no_browser {
-            let url_with_code = format!("{verification_uri}?code={user_code}");
-            if open_browser(&url_with_code).is_ok() {
+            if open_browser(&browser_url).is_ok() {
                 fmt.write_raw("  ")?;
                 fmt.write_accent(&format!("{} ", Icons::ARROW_RIGHT))?;
                 fmt.write_raw("Opening browser...")?;
@@ -269,12 +579,25 @@ fn execute_device_flow_login(args: &LoginArgs, cli: &Cli) -> anyhow::Result<()> 
             fmt.newline()?;
             fmt.newline()?;
         }
+
+        print_token_fallback_hint(&mut fmt)?;
     }
 
-    // Step 2: Poll for authorization
+    // Step 2: Poll for authorization.
+    //
+    // Cadence is server-driven (cas-046d / Ben #7): the interval starts at the
+    // server's advertised value and only ever grows — on `slow_down`, on HTTP
+    // 429 (honouring `Retry-After`), and on transient 5xx/network errors. The
+    // loop is bounded by the code's own expiry rather than a precomputed
+    // attempt count, so backing off shortens the number of requests instead of
+    // extending the wait past `expires_in`.
     let token_url = format!("{}/device/token", args.endpoint);
-    let poll_interval = Duration::from_secs(interval);
-    let max_attempts = (expires_in / interval) as usize;
+    let mut poll_interval = Duration::from_secs(interval.clamp(1, MAX_POLL_INTERVAL.as_secs()));
+    let deadline = std::time::Instant::now() + Duration::from_secs(expires_in);
+    let mut consecutive_transient: u32 = 0;
+    let mut last_transport_error: Option<String> = None;
+    /// Consecutive transport/5xx failures tolerated before giving up.
+    const MAX_CONSECUTIVE_TRANSIENT: u32 = 5;
     let theme = ActiveTheme::default();
 
     let mut spinner = Spinner::new("Waiting for authorization...");
@@ -284,18 +607,24 @@ fn execute_device_flow_login(args: &LoginArgs, cli: &Cli) -> anyhow::Result<()> 
         0
     };
 
-    for attempt in 0..max_attempts {
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let wait = poll_interval.min(remaining);
+
         // Animate spinner during sleep interval
         if !cli.json {
             let tick_interval = Duration::from_millis(80);
-            let num_ticks = poll_interval.as_millis() / tick_interval.as_millis();
-            for _ in 0..num_ticks {
+            let wait_started = std::time::Instant::now();
+            while wait_started.elapsed() < wait {
                 spinner.update(SpinnerMsg::Tick);
                 prev_lines = rerender_inline(&spinner, prev_lines, &theme)?;
                 std::thread::sleep(tick_interval);
             }
         } else {
-            std::thread::sleep(poll_interval);
+            std::thread::sleep(wait);
         }
 
         let poll_response = ureq::post(&token_url)
@@ -304,188 +633,159 @@ fn execute_device_flow_login(args: &LoginArgs, cli: &Cli) -> anyhow::Result<()> 
                 "device_code": device_code
             }));
 
-        match poll_response {
+        let decision = match poll_response {
             Ok(resp) => {
                 let body: serde_json::Value = resp.into_json()?;
-                let status = body["status"].as_str().unwrap_or("");
+                let status = body_status(&body).to_string();
 
-                match status {
-                    "authorized" => {
-                        if !cli.json {
-                            clear_inline(prev_lines)?;
-                        }
-
-                        let access_token = body["access_token"]
-                            .as_str()
-                            .ok_or_else(|| anyhow::anyhow!("No access token in response"))?;
-                        let email = body["user"]["email"].as_str();
-                        let plan = body["user"]["plan"].as_str();
-
-                        // Save config
-                        {
-                            let mut config = CloudConfig::load().unwrap_or_default();
-                            config.endpoint = args.endpoint.clone();
-                            config.token = Some(access_token.to_string());
-                            config.email = email.map(String::from);
-                            config.plan = plan.map(String::from);
-                            config.save()?;
-                        }
-
-                        // Best-effort: fetch team membership from /api/me and
-                        // cache into ~/.cas/cloud.json so T3's resolution chain
-                        // works offline immediately after login.
-                        let membership_outcome =
-                            fetch_and_cache_teams(&args.endpoint, access_token);
-                        match &membership_outcome {
-                            FetchTeamsOutcome::Updated { team_count } => {
-                                tracing::debug!(
-                                    team_count,
-                                    "fetched and cached team membership from /api/me"
-                                );
-                            }
-                            FetchTeamsOutcome::Empty => {
-                                tracing::debug!("logged in but /api/me returned zero team memberships");
-                            }
-                            FetchTeamsOutcome::AuthFailed => {
-                                eprintln!(
-                                    "warning: could not fetch team membership (/api/me returned 401). \
-                                     Run `cas cloud login` again to refresh."
-                                );
-                            }
-                            FetchTeamsOutcome::NetworkError(msg) => {
-                                eprintln!(
-                                    "warning: could not fetch team membership: {msg}. \
-                                     Team auto-scope will work after the next `cas cloud sync`."
-                                );
-                            }
-                        }
-
-                        if matches!(
-                            membership_outcome,
-                            FetchTeamsOutcome::Updated { .. } | FetchTeamsOutcome::Empty
-                        ) {
-                            apply_login_team_selection(cli);
-                        }
-
-                        // T6: first-run backfill — auto-promote to team scope on first
-                        // login when the user has exactly one team (or the server already
-                        // set a default).  Best-effort; errors in the write are ignored.
-                        let backfill_outcome = maybe_apply_team_backfill();
-                        print_backfill_notice(cli, &backfill_outcome);
-
-                        if cli.json {
-                            println!(r#"{{"status":"ok","email":"{}"}}"#, email.unwrap_or(""));
-                        } else {
-                            let mut out = io::stdout();
-                            let mut fmt = Formatter::stdout(&mut out, theme.clone());
-                            print_login_success(&mut fmt, email)?;
-                        }
-
-                        return Ok(());
+                if status == "authorized" {
+                    if !cli.json {
+                        clear_inline(prev_lines)?;
                     }
-                    "authorization_pending" => {
-                        if !cli.json {
-                            let remaining = expires_in - (attempt as u64 * interval);
-                            spinner.update(SpinnerMsg::SetMessage(format!(
-                                "Waiting for authorization... ({remaining}s remaining)"
-                            )));
-                        }
+
+                    let access_token = body["access_token"]
+                        .as_str()
+                        .ok_or_else(|| anyhow::anyhow!("No access token in response"))?;
+                    let email = body["user"]["email"].as_str();
+                    let plan = body["user"]["plan"].as_str();
+
+                    // Credentials are user-level: one login serves every
+                    // project on the machine (cas-046d).
+                    store_login_credentials(&args.endpoint, access_token, email, plan)?;
+
+                    // Best-effort: fetch team membership from /api/me and
+                    // cache into ~/.cas/cloud.json so T3's resolution chain
+                    // works offline immediately after login.
+                    let membership_outcome = fetch_and_cache_teams(&args.endpoint, access_token);
+                    report_membership_outcome(&membership_outcome);
+
+                    if matches!(
+                        membership_outcome,
+                        FetchTeamsOutcome::Updated { .. } | FetchTeamsOutcome::Empty
+                    ) {
+                        apply_login_team_selection(cli);
                     }
-                    "access_denied" => {
-                        if !cli.json {
-                            clear_inline(prev_lines)?;
-                        }
-                        if cli.json {
-                            println!(r#"{{"status":"denied","message":"Authorization denied"}}"#);
-                        } else {
-                            let mut err = io::stderr();
-                            let mut fmt = Formatter::stdout(&mut err, theme.clone());
-                            fmt.newline()?;
-                            fmt.write_raw("  ")?;
-                            fmt.error("Authorization denied")?;
-                        }
-                        return Ok(());
+
+                    // T6: first-run backfill — auto-promote to team scope on first
+                    // login when the user has exactly one team (or the server already
+                    // set a default).  Best-effort; errors in the write are ignored.
+                    let backfill_outcome = maybe_apply_team_backfill();
+                    print_backfill_notice(cli, &backfill_outcome);
+
+                    if cli.json {
+                        println!(r#"{{"status":"ok","email":"{}"}}"#, email.unwrap_or(""));
+                    } else {
+                        let mut out = io::stdout();
+                        let mut fmt = Formatter::stdout(&mut out, theme.clone());
+                        print_login_success(&mut fmt, email)?;
                     }
-                    "expired_token" => {
-                        if !cli.json {
-                            clear_inline(prev_lines)?;
-                        }
-                        if cli.json {
-                            println!(r#"{{"status":"expired","message":"Code expired"}}"#);
-                        } else {
-                            let mut err = io::stderr();
-                            let mut fmt = Formatter::stdout(&mut err, theme.clone());
-                            fmt.newline()?;
-                            fmt.write_raw("  ")?;
-                            fmt.error("Code expired. Please try again.")?;
-                        }
-                        return Ok(());
-                    }
-                    _ => {}
+
+                    return Ok(());
                 }
+
+                classify_poll_status(200, &status, None)
             }
-            Err(ureq::Error::Status(202, _)) => {
-                // Still pending, continue
-            }
+            Err(ureq::Error::Status(202, _)) => PollDecision::Pending,
             Err(ureq::Error::Status(code, resp)) => {
-                if !cli.json {
-                    clear_inline(prev_lines)?;
-                }
+                let retry_after = parse_retry_after(resp.header("Retry-After"));
                 let body: serde_json::Value = resp.into_json().unwrap_or_default();
-                let status = body["status"].as_str().unwrap_or("");
+                classify_poll_status(code, body_status(&body), retry_after)
+            }
+            Err(error) => {
+                last_transport_error = Some(error.to_string());
+                PollDecision::Transient
+            }
+        };
 
-                match status {
-                    "authorization_pending" => continue,
-                    "access_denied" => {
-                        if cli.json {
-                            println!(r#"{{"status":"denied"}}"#);
-                        } else {
-                            let mut err = io::stderr();
-                            let mut fmt = Formatter::stdout(&mut err, theme.clone());
-                            fmt.newline()?;
-                            fmt.write_raw("  ")?;
-                            fmt.error("Authorization denied")?;
-                        }
-                        return Ok(());
-                    }
-                    "expired_token" => {
-                        if cli.json {
-                            println!(r#"{{"status":"expired"}}"#);
-                        } else {
-                            let mut err = io::stderr();
-                            let mut fmt = Formatter::stdout(&mut err, theme.clone());
-                            fmt.newline()?;
-                            fmt.write_raw("  ")?;
-                            fmt.error("Code expired")?;
-                        }
-                        return Ok(());
-                    }
-                    _ => {
-                        if cli.json {
-                            println!(r#"{{"status":"error","code":{code}}}"#);
-                        } else {
-                            let mut err = io::stderr();
-                            let mut fmt = Formatter::stdout(&mut err, theme.clone());
-                            fmt.newline()?;
-                            fmt.write_raw("  ")?;
-                            fmt.error(&format!("Server error ({code})"))?;
-                        }
-                        return Ok(());
-                    }
+        let remaining_secs = deadline
+            .saturating_duration_since(std::time::Instant::now())
+            .as_secs();
+
+        match decision {
+            PollDecision::Pending => {
+                consecutive_transient = 0;
+                if !cli.json {
+                    spinner.update(SpinnerMsg::SetMessage(format!(
+                        "Waiting for authorization... ({remaining_secs}s remaining)"
+                    )));
                 }
             }
-            Err(e) => {
+            PollDecision::SlowDown { retry_after } => {
+                consecutive_transient = 0;
+                poll_interval = backoff_interval(poll_interval, retry_after);
+                if !cli.json {
+                    spinner.update(SpinnerMsg::SetMessage(format!(
+                        "Waiting for authorization... (server busy; retrying every {}s, {remaining_secs}s remaining)",
+                        poll_interval.as_secs()
+                    )));
+                }
+            }
+            PollDecision::Transient => {
+                consecutive_transient += 1;
+                if consecutive_transient >= MAX_CONSECUTIVE_TRANSIENT {
+                    if !cli.json {
+                        clear_inline(prev_lines)?;
+                    }
+                    let detail = last_transport_error
+                        .clone()
+                        .unwrap_or_else(|| "the server is not responding".to_string());
+                    if cli.json {
+                        println!(r#"{{"status":"error","message":"Connection lost"}}"#);
+                    } else {
+                        let mut err = io::stderr();
+                        let mut fmt = Formatter::stdout(&mut err, theme.clone());
+                        fmt.newline()?;
+                        fmt.write_raw("  ")?;
+                        fmt.error(&format!("Connection lost: {detail}"))?;
+                    }
+                    return Ok(());
+                }
+                poll_interval = backoff_interval(poll_interval, None);
+            }
+            PollDecision::Denied => {
                 if !cli.json {
                     clear_inline(prev_lines)?;
                 }
                 if cli.json {
-                    println!(r#"{{"status":"error","message":"Connection lost"}}"#);
+                    println!(r#"{{"status":"denied","message":"Authorization denied"}}"#);
                 } else {
                     let mut err = io::stderr();
                     let mut fmt = Formatter::stdout(&mut err, theme.clone());
                     fmt.newline()?;
                     fmt.write_raw("  ")?;
-                    fmt.error(&format!("Connection lost: {e}"))?;
+                    fmt.error("Authorization denied")?;
+                }
+                return Ok(());
+            }
+            PollDecision::Expired => {
+                if !cli.json {
+                    clear_inline(prev_lines)?;
+                }
+                if cli.json {
+                    println!(r#"{{"status":"expired","message":"Code expired"}}"#);
+                } else {
+                    let mut err = io::stderr();
+                    let mut fmt = Formatter::stdout(&mut err, theme.clone());
+                    fmt.newline()?;
+                    fmt.write_raw("  ")?;
+                    fmt.error("Code expired. Please try again.")?;
+                }
+                return Ok(());
+            }
+            PollDecision::Fatal { http_status } => {
+                if !cli.json {
+                    clear_inline(prev_lines)?;
+                }
+                if cli.json {
+                    println!(r#"{{"status":"error","code":{http_status}}}"#);
+                } else {
+                    let mut err = io::stderr();
+                    let mut fmt = Formatter::stdout(&mut err, theme.clone());
+                    fmt.newline()?;
+                    fmt.write_raw("  ")?;
+                    fmt.error(&format!("Server error ({http_status})"))?;
+                    fmt.newline()?;
+                    print_token_fallback_hint(&mut fmt)?;
                 }
                 return Ok(());
             }
@@ -534,15 +834,10 @@ fn execute_login_with_token(token: &str, endpoint: &str, cli: &Cli) -> anyhow::R
         }
     }
 
-    // Save config
-    {
-        use crate::cloud::CloudConfig;
-
-        let mut config = CloudConfig::load().unwrap_or_default();
-        config.endpoint = endpoint.to_string();
-        config.token = Some(token.to_string());
-        config.save()?;
-    }
+    // Credentials live at user level (`~/.cas/cloud.json`), so this works from
+    // any directory — including outside a CAS project — and logs the whole
+    // machine in once (cas-046d / Ben #3, #4).
+    store_login_credentials(endpoint, token, None, None)?;
 
     // Best-effort: fetch team membership from /api/me and cache into
     // ~/.cas/cloud.json so T3's resolution chain works immediately.
@@ -590,6 +885,51 @@ fn execute_login_with_token(token: &str, endpoint: &str, cli: &Cli) -> anyhow::R
     Ok(())
 }
 
+/// Report the best-effort `/api/me` membership refresh that follows a login.
+fn report_membership_outcome(outcome: &FetchTeamsOutcome) {
+    match outcome {
+        FetchTeamsOutcome::Updated { team_count } => {
+            tracing::debug!(
+                team_count,
+                "fetched and cached team membership from /api/me"
+            );
+        }
+        FetchTeamsOutcome::Empty => {
+            tracing::debug!("logged in but /api/me returned zero team memberships");
+        }
+        FetchTeamsOutcome::AuthFailed => {
+            eprintln!(
+                "warning: could not fetch team membership (/api/me returned 401). \
+                 Run `cas login` again to refresh."
+            );
+        }
+        FetchTeamsOutcome::NetworkError(msg) => {
+            eprintln!(
+                "warning: could not fetch team membership: {msg}. \
+                 Team auto-scope will work after the next `cas cloud sync`."
+            );
+        }
+    }
+}
+
+/// Point at the token path, which does not depend on the device-approval page.
+///
+/// The hosted `/device` page currently rejects an otherwise valid code with
+/// "Missing or invalid Authorization header" even for a signed-in session
+/// (cas-046d, server-side; see `docs/reports/2026-08-18-cloud-device-login-server-defect.md`).
+/// Until that is fixed, browser approval can fail through no fault of the CLI,
+/// so every device-flow screen names the working alternative.
+fn print_token_fallback_hint(fmt: &mut Formatter) -> io::Result<()> {
+    fmt.write_muted("  If the approval page reports an authorization error, use a token instead:")?;
+    fmt.newline()?;
+    fmt.write_raw("    ")?;
+    fmt.write_accent("cas login --token <API-TOKEN>")?;
+    fmt.newline()?;
+    fmt.write_muted("  It works from any directory and logs in every project on this machine.")?;
+    fmt.newline()?;
+    fmt.newline()
+}
+
 /// Use the cached-membership resolver behind `cas cloud team set` to make a
 /// sole team membership active for the project that just logged in. Failures
 /// remain non-fatal, matching the surrounding best-effort membership refresh.
@@ -626,7 +966,9 @@ fn execute_logout(cli: &Cli) -> anyhow::Result<()> {
     {
         use crate::cloud::CloudConfig;
 
-        let mut config = CloudConfig::load().unwrap_or_default();
+        // `load_effective` + `clear_login_credentials`: logging out is a
+        // machine-wide act, and it must work from outside a project too.
+        let config = CloudConfig::load_effective();
 
         if !config.is_logged_in() {
             if cli.json {
@@ -646,8 +988,7 @@ fn execute_logout(cli: &Cli) -> anyhow::Result<()> {
         }
 
         let email = config.email.clone().unwrap_or_else(|| "user".to_string());
-        config.logout();
-        config.save()?;
+        clear_login_credentials()?;
 
         if cli.json {
             let output = serde_json::json!({
@@ -674,7 +1015,9 @@ fn execute_whoami(cli: &Cli) -> anyhow::Result<()> {
     {
         use crate::cloud::CloudConfig;
 
-        let config = CloudConfig::load().unwrap_or_default();
+        // Machine-wide credentials, so `cas whoami` answers the same question
+        // in every directory (cas-046d).
+        let config = CloudConfig::load_effective();
 
         if config.is_logged_in() {
             if cli.json {

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -976,6 +976,66 @@ fn print_personal_scope_notice(cli: &Cli, notice: &PersonalScopeNotice) {
     }
 }
 
+/// Report the automatic team-scope adoption (cas-c117).
+///
+/// Adoption promotes this project's memories, tasks, rules and skills from
+/// personal to team scope, so it is never silent: the user is told which team
+/// was adopted and how to undo it. The quiet outcomes (already scoped, opted
+/// out, not logged in) print nothing — routine syncs keep their output.
+fn print_team_scope_adoption(cli: &Cli, adoption: &crate::cloud::TeamScopeAdoption) {
+    use crate::cloud::TeamScopeAdoption;
+
+    match adoption {
+        TeamScopeAdoption::Adopted(team) => {
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "team_scope_adoption": {
+                            "status": "adopted",
+                            "team_id": team.team_id,
+                            "team_slug": team.team_slug,
+                            "team_name": team.team_name,
+                        }
+                    })
+                );
+            } else {
+                eprintln!(
+                    "  \u{2713} Team scope enabled for this project: {} ({})\n    \
+                     This project's memories, tasks and skills now sync to your team. \
+                     Run `cas cloud team auto off` to keep it personal.",
+                    team.team_name, team.team_slug
+                );
+            }
+        }
+        TeamScopeAdoption::NoResolvableTeam { membership_count } if *membership_count > 1 => {
+            // Genuinely ambiguous: CAS will not guess which of several teams a
+            // project belongs to, and silence here would reproduce exactly the
+            // "why is nothing shared?" confusion this task exists to remove.
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "team_scope_adoption": {
+                            "status": "ambiguous",
+                            "membership_count": membership_count,
+                        }
+                    })
+                );
+            } else {
+                eprintln!(
+                    "  \u{25CF} This project is personal: you belong to {membership_count} teams \
+                     and no default is set.\n    Run `cas cloud team default <slug>` to pick one, \
+                     or `cas cloud team auto off` to silence this."
+                );
+            }
+        }
+        other => {
+            tracing::debug!(outcome = ?other, "team scope adoption made no change");
+        }
+    }
+}
+
 /// Outcome of the eager slug-resolution flow run by `cas cloud team set`
 /// (cas-1ced).
 ///
@@ -1250,6 +1310,13 @@ fn execute_team_clear(cli: &Cli) -> anyhow::Result<()> {
         } else {
             "No team was configured"
         })?;
+        fmt.newline()?;
+        // cas-c117: sync now adopts a resolvable team automatically, so
+        // clearing alone is not "make this project personal" — say so rather
+        // than letting the next sync silently re-adopt.
+        fmt.write_muted(
+            "  The next sync re-adopts your default team. Run `cas cloud team auto off` to keep this project personal.",
+        )?;
         fmt.newline()?;
     }
     Ok(())
@@ -2429,6 +2496,21 @@ pub fn execute_sync(args: &CloudSyncArgs, cli: &Cli, cas_root: &Path) -> anyhow:
     if !args.dry_run {
         let outcome = maybe_apply_team_backfill();
         print_backfill_notice(cli, &outcome);
+
+        // cas-c117 (operator directive): the team identity is already known
+        // locally by this point — `/api/me` filled `teams[]` and the backfill
+        // above set `default_team_id` — so a logged-in user must not have to
+        // run `cas cloud team set` / `team auto on` before their project is
+        // scoped to their team. Adopt it here, BEFORE the personal-scope
+        // notice (which then correctly says nothing) and before execute_push
+        // opens the syncing stores that read `active_team_id()`.
+        match crate::cloud::maybe_adopt_team_scope(cas_root) {
+            Ok(adoption) => print_team_scope_adoption(cli, &adoption),
+            Err(e) => {
+                tracing::warn!(error = %e, "could not adopt the resolvable team scope");
+            }
+        }
+
         match maybe_mark_personal_scope_notice(cas_root) {
             Ok(Some(notice)) => print_personal_scope_notice(cli, &notice),
             Ok(None) => {}

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -1085,11 +1085,59 @@ pub(crate) fn check_bucket_ambiguity(
 fn team_show_json(cas_root: &Path) -> anyhow::Result<serde_json::Value> {
     let config = CloudConfig::load_from_cas_dir(cas_root)?;
     let canonical_id = crate::cloud::resolve_canonical_id(cas_root);
+    let team = resolve_team_display_for_show(&config);
     Ok(serde_json::json!({
-        "team_id": config.team_id,
-        "team_slug": config.team_slug,
+        "team_id": team.team_id,
+        "team_slug": team.team_slug,
+        "team_name": team.team_name,
         "canonical_id": canonical_id,
     }))
+}
+
+/// The team identity `cas cloud team show` displays, resolved exactly the
+/// way `cas cloud team auto` resolves it (cas-c117, field-report finding #6).
+struct ResolvedTeamDisplay {
+    team_id: Option<String>,
+    team_slug: Option<String>,
+    team_name: Option<String>,
+}
+
+/// Resolve the displayed team identity from the project config first and the
+/// user-level membership cache second.
+///
+/// Before this, `team show` printed only `config.team_slug`, which
+/// `cas cloud team set <uuid>` leaves as `None` (a raw UUID carries no slug —
+/// see `execute_team_set`). The result was `Team slug: <not resolved>`
+/// immediately after `cas cloud team auto on` had printed
+/// "Effective team: Petra Stella (petra-stella)" for the very same UUID,
+/// because `team auto` resolves through [`find_team_display`] and the
+/// user-level `teams[]` cache. Both surfaces now share that resolution.
+///
+/// The project-level `team_id` still wins over the user-level effective team
+/// so an explicit `cas cloud team set` is never hidden by the auto-promotion
+/// kill switch.
+fn resolve_team_display_for_show(config: &CloudConfig) -> ResolvedTeamDisplay {
+    let user_config = load_user_cloud_config_or_default();
+    let team_id = config
+        .team_id
+        .clone()
+        .or_else(|| config.active_team_id_with_user_config(Some(&user_config)));
+
+    match team_id {
+        Some(id) => {
+            let (slug, name) = find_team_display(&id, config, &user_config);
+            ResolvedTeamDisplay {
+                team_slug: slug.map(ToString::to_string),
+                team_name: name.map(ToString::to_string),
+                team_id: Some(id),
+            }
+        }
+        None => ResolvedTeamDisplay {
+            team_id: None,
+            team_slug: None,
+            team_name: None,
+        },
+    }
 }
 
 /// Test-only entrypoint that returns the rendered JSON string. `pub` so
@@ -1104,8 +1152,12 @@ pub fn execute_team_show_for_test(_cli: &Cli, cas_root: &Path) -> anyhow::Result
 
 fn execute_team_show(cli: &Cli, cas_root: &Path) -> anyhow::Result<()> {
     let config = CloudConfig::load_from_cas_dir(cas_root)?;
+    // cas-c117 finding #6: resolve the slug the same way `team auto` does —
+    // project config first, user-level membership cache second — so the two
+    // commands can never disagree about the same UUID.
+    let resolved = resolve_team_display_for_show(&config);
 
-    match (&config.team_id, &config.team_slug) {
+    match (&resolved.team_id, &resolved.team_slug) {
         (Some(id), slug) => {
             // cas-f07a (AC2): use the full resolution chain so the slug is
             // never shown as "<not resolved>" for an active project.  The
@@ -1118,6 +1170,7 @@ fn execute_team_show(cli: &Cli, cas_root: &Path) -> anyhow::Result<()> {
                 let out = serde_json::json!({
                     "team_id": id,
                     "team_slug": slug,
+                    "team_name": resolved.team_name,
                     "canonical_id": canonical_id,
                 });
                 println!("{}", out);
@@ -1130,7 +1183,21 @@ fn execute_team_show(cli: &Cli, cas_root: &Path) -> anyhow::Result<()> {
                 fmt.write_raw(id)?;
                 fmt.newline()?;
                 fmt.write_muted("  Team slug:    ")?;
-                fmt.write_raw(slug.as_deref().unwrap_or("<not resolved>"))?;
+                match (slug.as_deref(), resolved.team_name.as_deref()) {
+                    (Some(slug), Some(name)) => {
+                        fmt.write_raw(slug)?;
+                        fmt.write_raw(" (")?;
+                        fmt.write_raw(name)?;
+                        fmt.write_raw(")")?;
+                    }
+                    (Some(slug), None) => fmt.write_raw(slug)?,
+                    // Unresolved now means the membership cache is stale, not
+                    // that the team is unknown — say so instead of leaving a
+                    // bare sentinel the user cannot act on.
+                    (None, _) => fmt.write_raw(
+                        "<not resolved — run `cas cloud login` to refresh team memberships>",
+                    )?,
+                }
                 fmt.newline()?;
                 fmt.write_muted("  Project slug: ")?;
                 fmt.write_raw(canonical_id.as_deref().unwrap_or("<not resolved>"))?;
@@ -2374,6 +2441,18 @@ pub fn execute_sync(args: &CloudSyncArgs, cli: &Cli, cas_root: &Path) -> anyhow:
         }
     }
 
+    // cas-c117: make the project↔team registration explicit and verified
+    // BEFORE anything prints "✓ Push complete". Registration used to be a
+    // side effect of a non-empty team push, so a machine with nothing queued
+    // synced "successfully" while the server never learned about the project,
+    // and `cas cloud team-memories` then told the user to run the sync they
+    // had just run. This step either confirms the registration or fails the
+    // whole command with the real reason.
+    if !args.dry_run {
+        let cloud_config = CloudConfig::load()?;
+        ensure_team_project_registration(&cloud_config, cas_root, cli, args.full)?;
+    }
+
     execute_push(
         &CloudPushArgs {
             entries_only: false,
@@ -2422,6 +2501,166 @@ pub fn execute_sync(args: &CloudSyncArgs, cli: &Cli, cas_root: &Path) -> anyhow:
         }
     }
 
+    Ok(())
+}
+
+/// Metadata key recording a confirmed project↔team registration, so the
+/// steady-state sync pays no extra round-trip. Scoped by team AND canonical
+/// id: re-homing the project or switching teams must re-verify.
+fn team_registration_metadata_key(team_id: &str, canonical_id: &str) -> String {
+    format!("team_project_registered_{team_id}_{canonical_id}")
+}
+
+/// Ensure this project is registered with the active team before the sync
+/// reports success (cas-c117).
+///
+/// No-op when no team is configured, when the user is not logged in (the
+/// personal push that follows reports that far more clearly), or when a
+/// previous sync already confirmed the registration — unless `force` (i.e.
+/// `cas cloud sync --full`) asks for a fresh verification.
+///
+/// Contract, and the whole point of the task: this returns `Err` — failing
+/// the entire `cas cloud sync` with a non-zero exit — whenever the server
+/// does not end up listing the project. A green sync now implies the project
+/// is genuinely registered.
+///
+/// `pub` + `#[doc(hidden)]` so `cas-cli/tests/team_registration_test.rs` can
+/// drive it against a wiremock server. Not intended for external use.
+#[doc(hidden)]
+pub fn ensure_team_project_registration(
+    cloud_config: &CloudConfig,
+    cas_root: &Path,
+    cli: &Cli,
+    force: bool,
+) -> anyhow::Result<()> {
+    let Some(team_id) = cloud_config.active_team_id() else {
+        return Ok(());
+    };
+    let team_id = team_id.to_string();
+
+    let Some(token) = cloud_config.token.as_deref() else {
+        // Not logged in: `execute_push` reports this immediately after us with
+        // the canonical message. Registering is impossible either way, and
+        // duplicating the login error here would only be noise.
+        return Ok(());
+    };
+
+    // Same resolver the team push uses (`cloud/syncer/team_push.rs`), so the
+    // bucket we register is exactly the bucket rows are pushed into.
+    let canonical_id = crate::cloud::get_project_canonical_id().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Cannot register this project with team {team_id}: no canonical project id could \
+             be resolved. Run `cas cloud project set <canonical-id>` (see `cas cloud projects`)."
+        )
+    })?;
+
+    // Best-effort cache. A queue that cannot be opened just means we verify
+    // over the network every sync — correctness never depends on the cache.
+    let queue = SyncQueue::open(cas_root).ok().and_then(|q| {
+        // `init()` is idempotent; without it a brand-new root has no
+        // sync_metadata table to read.
+        if let Err(e) = q.init() {
+            tracing::warn!(error = %e, "team registration: sync queue init failed; skipping cache");
+            return None;
+        }
+        Some(q)
+    });
+    let cache_key = team_registration_metadata_key(&team_id, &canonical_id);
+    if !force {
+        if let Some(q) = queue.as_ref() {
+            if matches!(q.get_metadata(&cache_key), Ok(Some(_))) {
+                return Ok(());
+            }
+        }
+    }
+
+    // cas-8ca5 contract §5 — same remote the team push sends, so the server's
+    // resolver maps us onto the team's existing bucket rather than forking a
+    // new one.
+    let git_remote = crate::store::find_cas_root()
+        .ok()
+        .and_then(|root| crate::cloud::normalized_git_remote_for_push(&root));
+
+    let registration = crate::cloud::TeamRegistration::new(
+        &cloud_config.endpoint,
+        token,
+        &team_id,
+        &canonical_id,
+    )
+    .with_git_remote(git_remote.as_deref());
+
+    match registration.ensure() {
+        Ok(outcome) => {
+            if let Some(q) = queue.as_ref() {
+                let _ = q.set_metadata(&cache_key, &chrono::Utc::now().to_rfc3339());
+            }
+            report_team_registration(cli, &team_id, &canonical_id, &outcome)?;
+            Ok(())
+        }
+        Err(failure) => {
+            tracing::error!(
+                team_id = %team_id,
+                canonical_id = %canonical_id,
+                interaction = %failure.interaction,
+                "project could not be registered with the team; failing the sync"
+            );
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "team_registration": {
+                            "team_id": team_id,
+                            "canonical_id": canonical_id,
+                            "registered": false,
+                            "reason": failure.reason,
+                            "interaction": failure.interaction,
+                        }
+                    })
+                );
+            }
+            Err(anyhow::anyhow!(
+                "Sync aborted: this project is not registered with your team, so team \
+                 memories and team pushes would silently do nothing.\n  {failure}"
+            ))
+        }
+    }
+}
+
+fn report_team_registration(
+    cli: &Cli,
+    team_id: &str,
+    canonical_id: &str,
+    outcome: &crate::cloud::RegistrationOutcome,
+) -> anyhow::Result<()> {
+    if cli.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "team_registration": {
+                    "team_id": team_id,
+                    "canonical_id": canonical_id,
+                    "registered": true,
+                    "newly_registered": outcome.newly_registered(),
+                    "project_uuid": outcome.project_uuid(),
+                }
+            })
+        );
+        return Ok(());
+    }
+
+    // Only the state change is worth a line; a project that was already
+    // registered stays quiet so routine syncs keep their current output.
+    if outcome.newly_registered() {
+        let theme = ActiveTheme::default();
+        let mut out = io::stdout();
+        let mut fmt = Formatter::stdout(&mut out, theme);
+        let success_color = fmt.theme().palette.status_success;
+        fmt.write_colored("  \u{2713} ", success_color)?;
+        fmt.write_raw(&format!(
+            "Registered project {canonical_id} with team {team_id}"
+        ))?;
+        fmt.newline()?;
+    }
     Ok(())
 }
 
@@ -3076,8 +3315,18 @@ fn execute_team_memories(
             if prev_lines > 0 {
                 clear_inline(prev_lines)?;
             }
+            // cas-c117: the old wording ("run `cas cloud sync` to register
+            // it") was circular — the user reaches this line precisely after
+            // a green sync. Sync now registers the project or fails loudly,
+            // so the only remaining explanation is a bucket mismatch: name
+            // the ids involved instead of repeating the instruction.
             anyhow::bail!(
-                "This project hasn't been synced to the team yet. Run `cas cloud sync` while a team is configured (see `cas cloud team set <uuid>`) to register it."
+                "Project '{canonical_id}' is not registered with team {team_id} on {}. \
+                 `cas cloud sync` registers it (and now fails loudly if the server refuses), \
+                 so if a sync just succeeded this project is most likely pinned to a different \
+                 bucket than the team's. Compare `cas cloud team show` with `cas cloud projects` \
+                 and pin the right one with `cas cloud project set <canonical-id>`.",
+                config.endpoint
             );
         }
     };

--- a/cas-cli/src/cli/init.rs
+++ b/cas-cli/src/cli/init.rs
@@ -115,6 +115,66 @@ pub struct InitArgs {
     /// Override the auto-detected GitHub `OWNER/REPO` (from `git remote -v`).
     #[arg(long, value_name = "OWNER/REPO")]
     pub github: Option<String>,
+
+    /// Initialize even when this directory is not a project directory (your
+    /// home directory or the filesystem root). For automation that really
+    /// means it; interactive runs are asked to confirm instead.
+    #[arg(long)]
+    pub allow_non_project: bool,
+}
+
+// ============================================================================
+// Non-project guard (cas-2962 / Ben #8b)
+// ============================================================================
+
+/// Why a directory looks like the wrong place to scaffold a project.
+///
+/// `cas init` writes `CLAUDE.md`, `.gitignore`, `.mcp.json`, `scripts/` and
+/// `.cas/` into the current directory. Run by accident in `$HOME` that litters
+/// the home directory with project files and no warning was given (Ben #8b).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NonProjectDir {
+    /// The user's home directory.
+    Home,
+    /// The filesystem root.
+    FilesystemRoot,
+}
+
+impl NonProjectDir {
+    /// One line naming what the directory is.
+    pub(crate) fn describe(self) -> &'static str {
+        match self {
+            NonProjectDir::Home => "your home directory",
+            NonProjectDir::FilesystemRoot => "the filesystem root",
+        }
+    }
+
+    /// The full warning shown before anything is written.
+    pub(crate) fn warning(self, cwd: &Path) -> String {
+        format!(
+            "{} is {}, not a project directory.\n\
+             `cas init` would create .cas/, CLAUDE.md, .gitignore, .mcp.json and scripts/ here.",
+            cwd.display(),
+            self.describe()
+        )
+    }
+}
+
+/// Classify the directory `cas init` was invoked in.
+///
+/// Deliberately narrow: only the home directory and the filesystem root are
+/// refused. "Not a git repository" is NOT a signal — CAS supports non-git
+/// projects and derives a canonical id from the folder name, so refusing there
+/// would reject legitimate setups.
+pub(crate) fn classify_init_dir(cwd: &Path, home: Option<&Path>) -> Option<NonProjectDir> {
+    if cwd.parent().is_none() {
+        return Some(NonProjectDir::FilesystemRoot);
+    }
+    let home = home?;
+    // Compare canonicalized paths so `/home/me`, `/home/me/.`, and a symlinked
+    // spelling of the same directory all resolve alike.
+    let same = cwd.canonicalize().ok()? == home.canonicalize().ok()?;
+    same.then_some(NonProjectDir::Home)
 }
 
 // ============================================================================
@@ -268,6 +328,30 @@ impl WizardConfig {
 
 pub fn execute(args: &InitArgs, cli: &Cli) -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
+
+    // Ben #8b: refuse to litter $HOME (or /) with project scaffolding without
+    // saying so first. Interactive runs get a confirmation; non-interactive
+    // runs must opt in with --allow-non-project.
+    if !args.allow_non_project
+        && let Some(kind) = classify_init_dir(&cwd, dirs::home_dir().as_deref())
+    {
+        let non_interactive = cli.json || args.yes;
+        if non_interactive {
+            anyhow::bail!(
+                "{}\n\nRefusing to initialize here. `cd` into your project first, \
+                 or pass --allow-non-project if this is really what you want.",
+                kind.warning(&cwd)
+            );
+        }
+
+        println!();
+        print_colored(&format!("  ⚠  {}", kind.warning(&cwd)), colors::ORANGE)?;
+        println!();
+        if !interactive::confirm("  Initialize CAS here anyway", false)? {
+            println!("\n  Nothing was written. `cd` into your project and run `cas init` there.");
+            return Ok(());
+        }
+    }
 
     spawn_init_watchdog();
     info!(
@@ -1165,6 +1249,7 @@ mod integration_flag_tests {
             vercel: Some("prj_abc".to_string()),
             neon: Some("np_xyz".to_string()),
             github: Some("acme/widgets".to_string()),
+            allow_non_project: false,
         };
         let flags = integration_flags_from(&args);
         assert!(flags.disabled);
@@ -1234,5 +1319,95 @@ mod grok_agent_selection_tests {
         let selection = detect_agent_defaults(temp.path());
         assert!(!selection.grok);
         assert!(selection.claude);
+    }
+}
+
+#[cfg(test)]
+mod non_project_guard_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn home_directory_is_refused() {
+        // Ben #8b: `cas init` in $HOME scaffolded CLAUDE.md/.gitignore/
+        // .mcp.json/scripts/ with no warning at all.
+        let home = TempDir::new().unwrap();
+
+        assert_eq!(
+            classify_init_dir(home.path(), Some(home.path())),
+            Some(NonProjectDir::Home)
+        );
+    }
+
+    #[test]
+    fn a_project_under_home_is_allowed() {
+        let home = TempDir::new().unwrap();
+        let project = home.path().join("code").join("some-project");
+        std::fs::create_dir_all(&project).unwrap();
+
+        assert_eq!(
+            classify_init_dir(&project, Some(home.path())),
+            None,
+            "only $HOME itself is refused, not everything inside it"
+        );
+    }
+
+    #[test]
+    fn a_non_git_project_directory_is_allowed() {
+        // CAS supports non-git projects (canonical id falls back to the folder
+        // name), so "no git repo" must not be treated as "not a project".
+        let home = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        assert!(!project.path().join(".git").exists());
+
+        assert_eq!(classify_init_dir(project.path(), Some(home.path())), None);
+    }
+
+    #[test]
+    fn filesystem_root_is_refused() {
+        let home = TempDir::new().unwrap();
+
+        assert_eq!(
+            classify_init_dir(Path::new("/"), Some(home.path())),
+            Some(NonProjectDir::FilesystemRoot)
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_home_does_not_block_init() {
+        let project = TempDir::new().unwrap();
+
+        assert_eq!(
+            classify_init_dir(project.path(), None),
+            None,
+            "a machine with no resolvable home must still be able to init"
+        );
+    }
+
+    #[test]
+    fn a_symlinked_spelling_of_home_is_still_home() {
+        let temp = TempDir::new().unwrap();
+        let real_home = temp.path().join("real-home");
+        std::fs::create_dir_all(&real_home).unwrap();
+        let link = temp.path().join("linked-home");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_home, &link).unwrap();
+
+        #[cfg(unix)]
+        assert_eq!(
+            classify_init_dir(&link, Some(&real_home)),
+            Some(NonProjectDir::Home),
+            "a symlinked path to $HOME must not slip past the guard"
+        );
+    }
+
+    #[test]
+    fn the_warning_names_the_directory_and_what_would_be_written() {
+        let warning = NonProjectDir::Home.warning(Path::new("/Users/ben"));
+
+        assert!(warning.contains("/Users/ben"), "names the directory");
+        assert!(warning.contains("home directory"), "names what it is");
+        assert!(warning.contains("CLAUDE.md"), "names what would be created");
+        assert!(warning.contains(".cas/"));
     }
 }

--- a/cas-cli/src/cli/mod.rs
+++ b/cas-cli/src/cli/mod.rs
@@ -376,7 +376,10 @@ fn auth_requirement(command: &Option<Commands>) -> AuthRequirement {
 /// Ensure the user is authenticated before running a command
 fn ensure_authenticated() -> anyhow::Result<()> {
     {
-        let config = crate::cloud::CloudConfig::load().unwrap_or_default();
+        // `load_effective`: the login is machine-wide (cas-046d), so this gate
+        // must not report "not logged in" merely because the current directory
+        // is not a CAS project.
+        let config = crate::cloud::CloudConfig::load_effective();
         if config.token.is_some() {
             return Ok(());
         }

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -855,6 +855,92 @@ where
     Ok(notice)
 }
 
+/// Outcome of the automatic team-scope adoption `cas cloud sync` performs
+/// (cas-c117, operator directive 2026-08-18).
+///
+/// # Why this exists
+///
+/// The team identity is already known locally — `/api/me` populates
+/// `teams[]` and `maybe_apply_team_backfill` sets `default_team_id` — but
+/// [`CloudConfig::active_team_id_with_user_config`] refuses to use it unless
+/// the project opted in with `cas cloud team set` or `cas cloud team auto on`
+/// (the cas-f8e3 guard). A new clone therefore synced in personal scope and
+/// registered nothing with the team until the user ran a command they had no
+/// reason to know about. Sync now adopts the resolvable team for the project
+/// itself; explicit configuration remains an override, not a prerequisite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TeamScopeAdoption {
+    /// The project had no team scope and one team resolved — the project is
+    /// now opted in (`team_auto_promote = Some(true)`).
+    Adopted(PersonalScopeNotice),
+    /// The project already resolves a team (explicit `team_id` or a prior
+    /// adoption). Nothing changed.
+    AlreadyScoped { team_id: String },
+    /// `cas cloud team auto off` — the hard kill-switch. Never re-adopted.
+    OptedOut,
+    /// No token in this project's cloud config; nothing can be resolved.
+    NotLoggedIn,
+    /// No single team identity resolves. `membership_count` is 0 (no teams)
+    /// or ≥ 2 with no user-level default (genuinely ambiguous — CAS refuses
+    /// to guess which team a project belongs to).
+    NoResolvableTeam { membership_count: usize },
+}
+
+/// Adopt the user's resolvable team for this project. Pure — mutates
+/// `project_cfg` in memory only, so the decision table is unit-testable.
+///
+/// Precedence, highest first:
+///  1. not logged in → nothing to resolve;
+///  2. `team_auto_promote = Some(false)` → user said personal, forever;
+///  3. project already resolves a team → leave it alone (this is what makes
+///     `cas cloud team set` an override rather than a competitor);
+///  4. exactly one resolvable team (user `default_team_id`, else a sole
+///     membership) → opt the project in;
+///  5. otherwise → stay personal and report why.
+pub fn adopt_team_scope_for_configs(
+    project_cfg: &mut CloudConfig,
+    user_cfg: &CloudConfig,
+) -> TeamScopeAdoption {
+    if !project_cfg.is_logged_in() {
+        return TeamScopeAdoption::NotLoggedIn;
+    }
+    if matches!(project_cfg.team_auto_promote, Some(false)) {
+        return TeamScopeAdoption::OptedOut;
+    }
+    if let Some(team_id) = project_cfg.active_team_id_with_user_config(Some(user_cfg)) {
+        return TeamScopeAdoption::AlreadyScoped { team_id };
+    }
+
+    match usable_team_from_user_config(user_cfg) {
+        Some(team) => {
+            // The same knob `cas cloud team auto on` sets — so adoption is
+            // indistinguishable from the user having opted in by hand, and
+            // `cas cloud team auto off` reverses it.
+            project_cfg.team_auto_promote = Some(true);
+            TeamScopeAdoption::Adopted(team)
+        }
+        None => TeamScopeAdoption::NoResolvableTeam {
+            membership_count: user_cfg.teams.len(),
+        },
+    }
+}
+
+/// Disk-backed [`adopt_team_scope_for_configs`]: reads the project config at
+/// `cas_root` and the user-level config, and persists the project config only
+/// when adoption actually changed it.
+pub fn maybe_adopt_team_scope(cas_root: &Path) -> Result<TeamScopeAdoption, CasError> {
+    let mut project_cfg = CloudConfig::load_from_cas_dir(cas_root)?;
+    let user_cfg = user_level_cloud_json_path()
+        .and_then(|p| CloudConfig::load_from(&p).ok())
+        .unwrap_or_default();
+
+    let outcome = adopt_team_scope_for_configs(&mut project_cfg, &user_cfg);
+    if matches!(outcome, TeamScopeAdoption::Adopted(_)) {
+        project_cfg.save_to_cas_dir(cas_root)?;
+    }
+    Ok(outcome)
+}
+
 impl CloudConfig {
     /// Return the path to the user-level `~/.cas/cloud.json`.
     ///
@@ -1321,6 +1407,192 @@ mod tests {
                 .as_deref(),
             Some("solo-team-id"),
         );
+    }
+
+    // ── cas-c117: automatic team-scope adoption ────────────────────────────
+    //
+    // Operator directive: a logged-in user whose team identity is already
+    // resolvable must not have to run `cas cloud team set` / `team auto on`
+    // before their project is team-scoped. These lock the decision table.
+
+    fn logged_in_project() -> CloudConfig {
+        let mut cfg = CloudConfig::default();
+        cfg.token = Some("test-token".to_string());
+        cfg
+    }
+
+    fn user_with_teams(teams: &[(&str, &str, &str)], default_team_id: Option<&str>) -> CloudConfig {
+        let mut cfg = CloudConfig::default();
+        cfg.teams = teams
+            .iter()
+            .map(|(id, slug, name)| TeamInfo {
+                id: (*id).to_string(),
+                slug: (*slug).to_string(),
+                name: (*name).to_string(),
+                role: "member".to_string(),
+            })
+            .collect();
+        cfg.default_team_id = default_team_id.map(ToString::to_string);
+        cfg
+    }
+
+    #[test]
+    fn adoption_opts_a_fresh_project_into_the_sole_team() {
+        let _guard = TestEnvGuard::new();
+        let mut project = logged_in_project();
+        let user = user_with_teams(&[("solo-team-id", "solo", "Solo Team")], None);
+
+        let outcome = adopt_team_scope_for_configs(&mut project, &user);
+
+        match outcome {
+            TeamScopeAdoption::Adopted(team) => {
+                assert_eq!(team.team_id, "solo-team-id");
+                assert_eq!(team.team_slug, "solo");
+                assert_eq!(team.team_name, "Solo Team");
+            }
+            other => panic!("expected adoption of the sole membership, got {other:?}"),
+        }
+        assert_eq!(project.team_auto_promote, Some(true));
+        assert_eq!(
+            project
+                .active_team_id_with_user_config(Some(&user))
+                .as_deref(),
+            Some("solo-team-id"),
+            "adoption must make the team actually effective, not just recorded"
+        );
+    }
+
+    #[test]
+    fn adoption_prefers_the_user_default_over_membership_order() {
+        let _guard = TestEnvGuard::new();
+        let mut project = logged_in_project();
+        let user = user_with_teams(
+            &[
+                ("team-a", "alpha", "Alpha"),
+                ("team-b", "beta", "Beta"),
+            ],
+            Some("team-b"),
+        );
+
+        match adopt_team_scope_for_configs(&mut project, &user) {
+            TeamScopeAdoption::Adopted(team) => assert_eq!(team.team_id, "team-b"),
+            other => panic!("expected the user default to be adopted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn adoption_never_overrides_an_explicit_team_set() {
+        let _guard = TestEnvGuard::new();
+        let mut project = logged_in_project();
+        project.set_team("pinned-team", "pinned");
+        let user = user_with_teams(&[("other-team", "other", "Other")], Some("other-team"));
+
+        assert_eq!(
+            adopt_team_scope_for_configs(&mut project, &user),
+            TeamScopeAdoption::AlreadyScoped {
+                team_id: "pinned-team".to_string()
+            },
+            "`cas cloud team set` must remain an override, not a competitor"
+        );
+        assert_eq!(project.team_id.as_deref(), Some("pinned-team"));
+    }
+
+    #[test]
+    fn adoption_respects_the_auto_off_kill_switch() {
+        let _guard = TestEnvGuard::new();
+        let mut project = logged_in_project();
+        project.team_auto_promote = Some(false);
+        let user = user_with_teams(&[("solo-team-id", "solo", "Solo")], None);
+
+        assert_eq!(
+            adopt_team_scope_for_configs(&mut project, &user),
+            TeamScopeAdoption::OptedOut,
+            "`cas cloud team auto off` must never be undone by adoption"
+        );
+        assert_eq!(project.team_auto_promote, Some(false));
+    }
+
+    #[test]
+    fn adoption_refuses_to_guess_between_several_teams() {
+        let _guard = TestEnvGuard::new();
+        let mut project = logged_in_project();
+        let user = user_with_teams(
+            &[("team-a", "alpha", "Alpha"), ("team-b", "beta", "Beta")],
+            None,
+        );
+
+        assert_eq!(
+            adopt_team_scope_for_configs(&mut project, &user),
+            TeamScopeAdoption::NoResolvableTeam {
+                membership_count: 2
+            }
+        );
+        assert_eq!(project.team_auto_promote, None);
+    }
+
+    #[test]
+    fn adoption_is_inert_without_a_token_or_membership() {
+        let _guard = TestEnvGuard::new();
+        let mut anonymous = CloudConfig::default();
+        let user = user_with_teams(&[("solo-team-id", "solo", "Solo")], None);
+        assert_eq!(
+            adopt_team_scope_for_configs(&mut anonymous, &user),
+            TeamScopeAdoption::NotLoggedIn
+        );
+        assert_eq!(anonymous.team_auto_promote, None);
+
+        let mut project = logged_in_project();
+        let no_teams = CloudConfig::default();
+        assert_eq!(
+            adopt_team_scope_for_configs(&mut project, &no_teams),
+            TeamScopeAdoption::NoResolvableTeam {
+                membership_count: 0
+            }
+        );
+        assert_eq!(project.team_auto_promote, None);
+    }
+
+    #[test]
+    fn adoption_persists_only_when_it_changed_something() {
+        let _guard = TestEnvGuard::new();
+        let project_dir = TempDir::new().unwrap();
+        let user_dir = TempDir::new().unwrap();
+
+        let user = user_with_teams(&[("solo-team-id", "solo", "Solo")], None);
+        user.save_to_cas_dir(user_dir.path()).unwrap();
+        // SAFETY: TestEnvGuard serializes env mutation for this test.
+        unsafe {
+            std::env::set_var(
+                "CAS_USER_CLOUD_JSON",
+                user_dir.path().join("cloud.json").to_str().unwrap(),
+            );
+        }
+
+        logged_in_project()
+            .save_to_cas_dir(project_dir.path())
+            .unwrap();
+
+        let first = maybe_adopt_team_scope(project_dir.path()).unwrap();
+        assert!(matches!(first, TeamScopeAdoption::Adopted(_)));
+        let persisted = CloudConfig::load_from_cas_dir(project_dir.path()).unwrap();
+        assert_eq!(
+            persisted.team_auto_promote,
+            Some(true),
+            "adoption must survive the process that made it"
+        );
+
+        // Second run: already scoped, nothing to write.
+        let second = maybe_adopt_team_scope(project_dir.path()).unwrap();
+        assert_eq!(
+            second,
+            TeamScopeAdoption::AlreadyScoped {
+                team_id: "solo-team-id".to_string()
+            }
+        );
+
+        unsafe {
+            std::env::remove_var("CAS_USER_CLOUD_JSON");
+        }
     }
 
     #[test]

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -746,6 +746,81 @@ pub(crate) fn user_level_cloud_json_path() -> Option<std::path::PathBuf> {
     dirs::home_dir().map(|h| h.join(".cas").join("cloud.json"))
 }
 
+/// Compare two config paths for identity, tolerating different spellings of
+/// the same file (`..`, symlinks) when both exist.
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    if a == b {
+        return true;
+    }
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
+}
+
+/// Persist a successful login at user level (`~/.cas/cloud.json`) so every
+/// project on the machine is logged in (cas-046d / Ben #3).
+///
+/// The project-level `.cas/cloud.json` is refreshed too when the caller is
+/// inside a project, because the MCP daemon and background syncers read that
+/// file directly; it is a cache of the user-level truth, and the write is
+/// best-effort so `cas login --token` still succeeds from `$HOME` (Ben #4).
+///
+/// Returns the project path that was also updated, if any.
+pub fn store_login_credentials(
+    endpoint: &str,
+    token: &str,
+    email: Option<&str>,
+    plan: Option<&str>,
+) -> Result<Option<PathBuf>, CasError> {
+    let mut user_config = CloudConfig::load_user().unwrap_or_default();
+    user_config.endpoint = endpoint.to_string();
+    user_config.token = Some(token.to_string());
+    user_config.email = email.map(String::from);
+    user_config.plan = plan.map(String::from);
+    user_config.save_user()?;
+
+    let Ok(project_path) = CloudConfig::config_path() else {
+        return Ok(None);
+    };
+    if user_level_cloud_json_path().is_some_and(|user| paths_equal(&user, &project_path)) {
+        return Ok(None);
+    }
+    let mut project_config = CloudConfig::load_from(&project_path).unwrap_or_default();
+    project_config.endpoint = endpoint.to_string();
+    project_config.token = Some(token.to_string());
+    project_config.email = email.map(String::from);
+    project_config.plan = plan.map(String::from);
+    match project_config.save_to(&project_path) {
+        Ok(()) => Ok(Some(project_path)),
+        Err(error) => {
+            tracing::debug!(%error, "logged in, but could not cache credentials in the project cloud.json");
+            Ok(None)
+        }
+    }
+}
+
+/// Clear credentials from `~/.cas/cloud.json` and, when inside a project, from
+/// that project's cached copy. Non-credential state (teams, sync timestamps)
+/// is preserved.
+pub fn clear_login_credentials() -> Result<(), CasError> {
+    let mut user_config = CloudConfig::load_user().unwrap_or_default();
+    user_config.logout();
+    user_config.save_user()?;
+
+    if let Ok(project_path) = CloudConfig::config_path()
+        && !user_level_cloud_json_path().is_some_and(|user| paths_equal(&user, &project_path))
+        && project_path.exists()
+        && let Ok(mut project_config) = CloudConfig::load_from(&project_path)
+    {
+        project_config.logout();
+        if let Err(error) = project_config.save_to(&project_path) {
+            tracing::debug!(%error, "could not clear project-level cloud credentials");
+        }
+    }
+    Ok(())
+}
+
 impl Default for CloudConfig {
     fn default() -> Self {
         Self {
@@ -858,10 +933,14 @@ where
 impl CloudConfig {
     /// Return the path to the user-level `~/.cas/cloud.json`.
     ///
+    /// Delegates to [`user_level_cloud_json_path`] so reads (`load_user`) and
+    /// writes (`save_user`) always agree, including under the
+    /// `CAS_USER_CLOUD_JSON` test seam.
+    ///
     /// Returns `None` only when `dirs::home_dir()` fails — practically
     /// unreachable on any supported platform (Linux/macOS).
     pub fn user_config_path() -> Option<PathBuf> {
-        dirs::home_dir().map(|h| h.join(".cas").join("cloud.json"))
+        user_level_cloud_json_path()
     }
 
     /// Load the user-level cloud config from `~/.cas/cloud.json`.
@@ -889,10 +968,81 @@ impl CloudConfig {
         self.save_to(&path)
     }
 
-    /// Load cloud config from .cas/cloud.json
+    /// Load cloud config from `.cas/cloud.json` for the current project,
+    /// inheriting the machine-wide login from `~/.cas/cloud.json`.
+    ///
+    /// Credentials are user-level (cas-046d): `cas login` stores the token in
+    /// `~/.cas/cloud.json`, so a project that has never been logged in to picks
+    /// it up here instead of reporting "not logged in". When the inheritance
+    /// fires inside a real project the credentials are also written through to
+    /// the project file, so the direct-file readers
+    /// ([`load_from_cas_dir`][Self::load_from_cas_dir] — the MCP daemon and
+    /// background syncers) converge without a second `cas login`. That
+    /// write-through is best-effort: a read-only checkout still returns the
+    /// inherited credentials in memory.
     pub fn load() -> Result<Self, CasError> {
         let path = Self::config_path()?;
-        Self::load_from(&path)
+        let mut config = Self::load_from(&path)?;
+        if config.inherit_credentials_from_user_level(&path) {
+            // Cache fill only — never fatal.
+            if let Err(error) = config.save_to(&path) {
+                tracing::debug!(%error, "could not cache user-level credentials into project cloud.json");
+            }
+        }
+        Ok(config)
+    }
+
+    /// The config governing the current context, never failing.
+    ///
+    /// Inside a CAS project this is [`load`][Self::load]; outside one (for
+    /// example `cas login --token` run from `$HOME`) it is the user-level
+    /// `~/.cas/cloud.json` alone. Auth commands use this so they work
+    /// everywhere: credentials do not live in a project.
+    pub fn load_effective() -> Self {
+        match Self::load() {
+            Ok(config) => config,
+            Err(_) => Self::load_user().unwrap_or_default(),
+        }
+    }
+
+    /// Copy the machine-wide login into this (project) config when the project
+    /// has none of its own. Returns whether anything changed.
+    ///
+    /// `self_path` is the file `self` was read from; when it *is* the
+    /// user-level file there is nothing to inherit.
+    fn inherit_credentials_from_user_level(&mut self, self_path: &Path) -> bool {
+        let Some(user_path) = user_level_cloud_json_path() else {
+            return false;
+        };
+        if paths_equal(&user_path, self_path) {
+            return false;
+        }
+        let Ok(user_config) = Self::load_from(&user_path) else {
+            return false;
+        };
+        self.inherit_credentials_from(&user_config)
+    }
+
+    /// Adopt `user`'s credentials when `self` is not logged in. Returns whether
+    /// anything changed. Pure — unit-testable without touching disk.
+    pub fn inherit_credentials_from(&mut self, user: &Self) -> bool {
+        if self.is_logged_in() || !user.is_logged_in() {
+            return false;
+        }
+        self.token = user.token.clone();
+        if self.email.is_none() {
+            self.email = user.email.clone();
+        }
+        if self.plan.is_none() {
+            self.plan = user.plan.clone();
+        }
+        // Only override an endpoint the project never chose for itself.
+        if (self.endpoint.trim().is_empty() || self.endpoint == default_endpoint())
+            && !user.endpoint.trim().is_empty()
+        {
+            self.endpoint = user.endpoint.clone();
+        }
+        true
     }
 
     /// Load cloud config from a specific path
@@ -1140,6 +1290,188 @@ mod tests {
         assert_eq!(loaded.token, Some("test_token".to_string()));
         assert_eq!(loaded.email, Some("test@example.com".to_string()));
         assert!(loaded.is_logged_in());
+    }
+
+    /// Wire up a fake machine: a user-level `~/.cas/cloud.json` (via the
+    /// `CAS_USER_CLOUD_JSON` seam) and a project `.cas/` (via `CAS_ROOT`).
+    /// Returns the guard plus both paths.
+    fn machine_fixture() -> (TestEnvGuard, TempDir, PathBuf, PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let user_path = temp.path().join("home-cas").join("cloud.json");
+        std::fs::create_dir_all(user_path.parent().unwrap()).unwrap();
+        let project_cas = temp.path().join("project-b").join(".cas");
+        std::fs::create_dir_all(&project_cas).unwrap();
+
+        let mut guard = TestEnvGuard::new();
+        guard.set("CAS_USER_CLOUD_JSON", &user_path);
+        guard.set("CAS_ROOT", &project_cas);
+        let project_path = project_cas.join("cloud.json");
+        (guard, temp, user_path, project_path)
+    }
+
+    #[test]
+    fn login_is_machine_wide_so_a_second_project_is_already_logged_in() {
+        // Ben #3 (cas-046d): after `cas login` in one project, a freshly
+        // `cas init`-ed second project reported "not logged in".
+        let (_guard, _temp, user_path, project_path) = machine_fixture();
+        CloudConfig {
+            token: Some("user-level-token".to_string()),
+            email: Some("ben@example.com".to_string()),
+            ..Default::default()
+        }
+        .save_to(&user_path)
+        .unwrap();
+        assert!(
+            !project_path.exists(),
+            "second project has never been logged in to"
+        );
+
+        let loaded = CloudConfig::load().unwrap();
+
+        assert!(
+            loaded.is_logged_in(),
+            "a machine-wide login must serve every project"
+        );
+        assert_eq!(loaded.token.as_deref(), Some("user-level-token"));
+        assert_eq!(loaded.email.as_deref(), Some("ben@example.com"));
+
+        // Write-through so the direct-file readers (MCP daemon, syncers)
+        // converge without a second login.
+        let cached = CloudConfig::load_from(&project_path).unwrap();
+        assert_eq!(cached.token.as_deref(), Some("user-level-token"));
+    }
+
+    #[test]
+    fn project_credentials_win_over_the_user_level_login() {
+        let (_guard, _temp, user_path, project_path) = machine_fixture();
+        CloudConfig {
+            token: Some("user-level-token".to_string()),
+            ..Default::default()
+        }
+        .save_to(&user_path)
+        .unwrap();
+        CloudConfig {
+            token: Some("project-token".to_string()),
+            ..Default::default()
+        }
+        .save_to(&project_path)
+        .unwrap();
+
+        let loaded = CloudConfig::load().unwrap();
+
+        assert_eq!(
+            loaded.token.as_deref(),
+            Some("project-token"),
+            "an explicit project credential must not be overwritten"
+        );
+    }
+
+    #[test]
+    fn inheritance_keeps_an_endpoint_the_project_chose_for_itself() {
+        let mut project = CloudConfig {
+            endpoint: "https://staging.example.com".to_string(),
+            ..Default::default()
+        };
+        let user = CloudConfig {
+            endpoint: "https://petra-stella-cloud.vercel.app".to_string(),
+            token: Some("t".to_string()),
+            ..Default::default()
+        };
+
+        assert!(project.inherit_credentials_from(&user));
+
+        assert_eq!(project.token.as_deref(), Some("t"));
+        assert_eq!(
+            project.endpoint, "https://staging.example.com",
+            "a non-default project endpoint survives credential inheritance"
+        );
+    }
+
+    #[test]
+    fn store_login_credentials_writes_user_level_and_project_cache() {
+        let (_guard, _temp, user_path, project_path) = machine_fixture();
+
+        let cached = store_login_credentials(
+            "https://petra-stella-cloud.vercel.app",
+            "fresh-token",
+            Some("ben@example.com"),
+            Some("pro"),
+        )
+        .unwrap();
+
+        assert_eq!(cached.as_deref(), Some(project_path.as_path()));
+        let user = CloudConfig::load_from(&user_path).unwrap();
+        assert_eq!(
+            user.token.as_deref(),
+            Some("fresh-token"),
+            "the login must land in ~/.cas/cloud.json"
+        );
+        assert_eq!(user.email.as_deref(), Some("ben@example.com"));
+        assert_eq!(user.plan.as_deref(), Some("pro"));
+        let project = CloudConfig::load_from(&project_path).unwrap();
+        assert_eq!(project.token.as_deref(), Some("fresh-token"));
+    }
+
+    #[test]
+    fn store_login_credentials_works_outside_a_project() {
+        // Ben #4 (cas-046d): `cas login --token` from $HOME died with
+        // "CAS not initialized — run cas init".
+        let temp = TempDir::new().unwrap();
+        let user_path = temp.path().join("home-cas").join("cloud.json");
+        std::fs::create_dir_all(user_path.parent().unwrap()).unwrap();
+        let outside = temp.path().join("not-a-cas-project");
+        std::fs::create_dir_all(&outside).unwrap();
+
+        let mut guard = TestEnvGuard::new();
+        guard.set("CAS_USER_CLOUD_JSON", &user_path);
+        guard.remove("CAS_ROOT");
+        guard.set_current_dir(&outside);
+
+        let cached = store_login_credentials(
+            "https://petra-stella-cloud.vercel.app",
+            "fresh-token",
+            None,
+            None,
+        )
+        .expect("logging in outside a project must succeed");
+
+        assert!(cached.is_none(), "there is no project cache to write");
+        let user = CloudConfig::load_from(&user_path).unwrap();
+        assert_eq!(user.token.as_deref(), Some("fresh-token"));
+        assert!(CloudConfig::load_effective().is_logged_in());
+    }
+
+    #[test]
+    fn clear_login_credentials_clears_user_level_and_project() {
+        let (_guard, _temp, user_path, project_path) = machine_fixture();
+        CloudConfig {
+            token: Some("t".to_string()),
+            team_id: Some("team-123".to_string()),
+            ..Default::default()
+        }
+        .save_to(&user_path)
+        .unwrap();
+        CloudConfig {
+            token: Some("t".to_string()),
+            team_id: Some("team-123".to_string()),
+            ..Default::default()
+        }
+        .save_to(&project_path)
+        .unwrap();
+
+        clear_login_credentials().unwrap();
+
+        let user = CloudConfig::load_from(&user_path).unwrap();
+        assert!(!user.is_logged_in(), "logout is machine-wide");
+        let project = CloudConfig::load_from(&project_path).unwrap();
+        assert!(
+            !project.is_logged_in(),
+            "the project credential cache must not outlive logout"
+        );
+        assert!(
+            !CloudConfig::load().unwrap().is_logged_in(),
+            "nothing re-inherits a cleared credential"
+        );
     }
 
     #[test]

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -972,11 +972,16 @@ pub enum TeamScopeAdoption {
 ///  4. exactly one resolvable team (user `default_team_id`, else a sole
 ///     membership) → opt the project in;
 ///  5. otherwise → stay personal and report why.
+///
+/// "Logged in" is machine-wide (cas-046d): a project whose own `cloud.json`
+/// has no token still counts when `~/.cas/cloud.json` does, because that is
+/// exactly the fresh-clone case this adoption exists for — checking only the
+/// project copy would make adoption miss the users who need it most.
 pub fn adopt_team_scope_for_configs(
     project_cfg: &mut CloudConfig,
     user_cfg: &CloudConfig,
 ) -> TeamScopeAdoption {
-    if !project_cfg.is_logged_in() {
+    if !project_cfg.is_logged_in() && !user_cfg.is_logged_in() {
         return TeamScopeAdoption::NotLoggedIn;
     }
     if matches!(project_cfg.team_auto_promote, Some(false)) {
@@ -1247,6 +1252,19 @@ impl CloudConfig {
         // auto-pick must NOT apply, otherwise personal workspaces would be
         // silently promoted to team scope whenever the user has a team
         // configured for their main project.
+        //
+        // cas-c117 — CONSTRAINT ON THIS GUARD, read before "simplifying" it:
+        // the operator reversed the *default* (a logged-in user's project must
+        // land in their team without them discovering `cas cloud team set`),
+        // but deliberately NOT this guard. `cas cloud sync` calls
+        // [`adopt_team_scope_for_configs`], which writes
+        // `team_auto_promote = Some(true)` into the project config and prints
+        // what it did, so the opt-in still exists as a durable, inspectable,
+        // reversible fact on disk. Do not "fix" the UX by making this function
+        // fall through to the user-level default on its own: that would make
+        // team scope an invisible property of the ambient environment, apply
+        // to every non-sync caller (stores, MCP, daemon) with no notice and no
+        // record, and remove the `team auto off` kill switch's only anchor.
         if !matches!(self.team_auto_promote, Some(true)) {
             return None;
         }
@@ -1863,10 +1881,29 @@ mod tests {
     }
 
     #[test]
+    fn adoption_accepts_the_machine_wide_login_of_a_fresh_clone() {
+        let _guard = TestEnvGuard::new();
+        // cas-046d: `cas login` stores the token in `~/.cas/cloud.json`, so a
+        // freshly cloned project has no token of its own. That is precisely
+        // the case adoption exists for — it must not read as "not logged in".
+        let mut project = CloudConfig::default();
+        assert!(!project.is_logged_in());
+        let mut user = user_with_teams(&[("solo-team-id", "solo", "Solo")], None);
+        user.token = Some("machine-wide-token".to_string());
+
+        match adopt_team_scope_for_configs(&mut project, &user) {
+            TeamScopeAdoption::Adopted(team) => assert_eq!(team.team_id, "solo-team-id"),
+            other => panic!("a machine-wide login must enable adoption, got {other:?}"),
+        }
+        assert_eq!(project.team_auto_promote, Some(true));
+    }
+
+    #[test]
     fn adoption_is_inert_without_a_token_or_membership() {
         let _guard = TestEnvGuard::new();
         let mut anonymous = CloudConfig::default();
         let user = user_with_teams(&[("solo-team-id", "solo", "Solo")], None);
+        assert!(!user.is_logged_in(), "neither config holds a token");
         assert_eq!(
             adopt_team_scope_for_configs(&mut anonymous, &user),
             TeamScopeAdoption::NotLoggedIn

--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -38,9 +38,10 @@ pub mod team_registration;
 pub use backfill::{BackfillOutcome, maybe_apply_team_backfill, maybe_apply_team_backfill_inner};
 pub use config::{
     CanonicalIdCollision, CanonicalIdSource, CloudConfig, LocalRootIdentity, PersonalScopeNotice,
-    TeamInfo, canonical_id_from_cas_root, canonical_id_from_config_toml,
-    derive_canonical_id_from_git_remote, detect_canonical_id_collisions, get_project_canonical_id,
-    invalidate_cached_project_id, maybe_mark_personal_scope_notice, normalize_project_canonical_id,
+    TeamInfo, TeamScopeAdoption, adopt_team_scope_for_configs, canonical_id_from_cas_root,
+    canonical_id_from_config_toml, derive_canonical_id_from_git_remote,
+    detect_canonical_id_collisions, get_project_canonical_id, invalidate_cached_project_id,
+    maybe_adopt_team_scope, maybe_mark_personal_scope_notice, normalize_project_canonical_id,
     normalized_git_remote_for_push, personal_scope_notice_for_configs, resolve_canonical_id,
     resolve_canonical_id_with_source, set_canonical_id_in_config_toml, should_adopt_canonical_id,
 };

--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -31,6 +31,8 @@ pub(crate) mod me;
 mod sync_queue;
 mod syncer;
 pub mod task_proposals;
+// cas-c117: explicit, verified project↔team registration for `cas cloud sync`.
+pub mod team_registration;
 
 // T6: first-run backfill — `pub` so integration tests can call the inner seam.
 pub use backfill::{BackfillOutcome, maybe_apply_team_backfill, maybe_apply_team_backfill_inner};
@@ -57,6 +59,9 @@ pub use me::{
     FetchTeamsOutcome, fetch_and_cache_teams, fetch_and_cache_teams_inner, teams_cache_stale,
 };
 pub use sync_queue::{EntityType, QueueHealth, QueuedSync, SyncOperation, SyncQueue};
+pub use team_registration::{
+    REGISTRATION_TIMEOUT, RegistrationFailure, RegistrationOutcome, TeamRegistration,
+};
 pub(crate) use syncer::entity_matches_project;
 pub use syncer::{
     CloudSyncer, CloudSyncerConfig, ConflictAction, ConflictResolution, KNOWLEDGE_ENTITY,

--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -36,11 +36,12 @@ pub mod task_proposals;
 pub use backfill::{BackfillOutcome, maybe_apply_team_backfill, maybe_apply_team_backfill_inner};
 pub use config::{
     CanonicalIdCollision, CanonicalIdSource, CloudConfig, LocalRootIdentity, PersonalScopeNotice,
-    TeamInfo, canonical_id_from_cas_root, canonical_id_from_config_toml,
+    TeamInfo, canonical_id_from_cas_root, canonical_id_from_config_toml, clear_login_credentials,
     derive_canonical_id_from_git_remote, detect_canonical_id_collisions, get_project_canonical_id,
     invalidate_cached_project_id, maybe_mark_personal_scope_notice, normalize_project_canonical_id,
     normalized_git_remote_for_push, personal_scope_notice_for_configs, resolve_canonical_id,
     resolve_canonical_id_with_source, set_canonical_id_in_config_toml, should_adopt_canonical_id,
+    store_login_credentials,
 };
 pub(crate) use config::{
     default_endpoint, is_acceptable_endpoint, normalize_git_remote_url, user_level_cloud_json_path,

--- a/cas-cli/src/cloud/team_registration.rs
+++ b/cas-cli/src/cloud/team_registration.rs
@@ -1,0 +1,396 @@
+//! Explicit team↔project registration for `cas cloud sync` (cas-c117).
+//!
+//! # Why this module exists
+//!
+//! The server only learns that a project belongs to a team as a *side effect*
+//! of `POST /api/teams/{teamId}/sync/push`: the route upserts the project row
+//! (`INSERT … ON CONFLICT DO NOTHING`) from the `project_canonical_id` field of
+//! the push payload. The client, however, only issues that POST when the team
+//! sync queue has rows to send — [`CloudSyncer::push_team`] returns early with
+//! an empty [`SyncResult`] when `pending_for_team` is empty
+//! (`cloud/syncer/team_push.rs`).
+//!
+//! Team rows are enqueued at *write* time (`store/syncing_*.rs`), so a clean
+//! install, a fresh clone, or any machine that simply hasn't written anything
+//! since the team was configured has an empty team queue. `cas cloud sync` then
+//! prints "✓ Push complete / ✓ Pull complete", exits 0, and the project is
+//! still unknown to the team — after which `cas cloud team-memories` reports
+//! "This project hasn't been synced to the team yet. Run `cas cloud sync`",
+//! which is exactly what the user just did. Ben hit this on a macOS
+//! clean install (cas-c117, EPIC cas-e0d9).
+//!
+//! # What this module does
+//!
+//! [`TeamRegistration::ensure`] makes registration explicit and *verified*:
+//!
+//! 1. `GET /api/teams/{teamId}/projects` — is the canonical id already listed?
+//! 2. If not, `POST /api/teams/{teamId}/sync/push` carrying only
+//!    `project_canonical_id` (+ `git_remote`) and an empty `entries` array —
+//!    the same request shape a normal push uses, minus the rows. That is the
+//!    server's registration path.
+//! 3. `GET /api/teams/{teamId}/projects` again — the registration is only
+//!    "done" when the server itself lists the project.
+//!
+//! Every failure is returned as a [`RegistrationFailure`] carrying both a
+//! human reason and the exact HTTP interaction that failed, so the caller can
+//! exit non-zero with a real explanation instead of a green checkmark.
+
+use std::fmt;
+use std::time::Duration;
+
+use crate::cloud::{CloudSyncer, TeamProjectsResponse};
+
+/// Timeout for both the lookup and the registration request. Matches the
+/// 30 s used by the other interactive team endpoints in `cli/cloud.rs`.
+pub const REGISTRATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Successful outcome of [`TeamRegistration::ensure`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistrationOutcome {
+    /// The server already listed the project for this team — no write needed.
+    AlreadyRegistered { project_uuid: String },
+    /// The project was missing and the server accepted + confirmed it.
+    Registered { project_uuid: String },
+}
+
+impl RegistrationOutcome {
+    /// Server-side UUID of the team project.
+    pub fn project_uuid(&self) -> &str {
+        match self {
+            Self::AlreadyRegistered { project_uuid } | Self::Registered { project_uuid } => {
+                project_uuid
+            }
+        }
+    }
+
+    /// `true` when this run created the registration (worth telling the user).
+    pub fn newly_registered(&self) -> bool {
+        matches!(self, Self::Registered { .. })
+    }
+}
+
+/// A registration attempt that did not end with the server listing the
+/// project. Carries an operator-facing `reason` and the precise
+/// `interaction` (method, URL, status, body excerpt) for escalation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistrationFailure {
+    /// Human, actionable statement of what went wrong.
+    pub reason: String,
+    /// The exact request/response that failed — for bug reports against the
+    /// cloud server, which lives in a separate repository.
+    pub interaction: String,
+}
+
+impl fmt::Display for RegistrationFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}\n  Failing interaction: {}", self.reason, self.interaction)
+    }
+}
+
+impl std::error::Error for RegistrationFailure {}
+
+/// Trim a server body for inclusion in an error message. Bodies can be large
+/// HTML error pages; the first 300 characters are enough to identify them.
+fn body_excerpt(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "<empty body>".to_string();
+    }
+    if trimmed.chars().count() <= 300 {
+        return trimmed.replace('\n', " ");
+    }
+    let head: String = trimmed.chars().take(300).collect();
+    format!("{}…", head.replace('\n', " "))
+}
+
+/// One project↔team registration check, parameterized so integration tests can
+/// point it at a wiremock server.
+pub struct TeamRegistration<'a> {
+    endpoint: &'a str,
+    token: &'a str,
+    team_id: &'a str,
+    canonical_id: &'a str,
+    git_remote: Option<&'a str>,
+    timeout: Duration,
+}
+
+impl<'a> TeamRegistration<'a> {
+    /// Build a registration for `canonical_id` against `team_id`.
+    pub fn new(
+        endpoint: &'a str,
+        token: &'a str,
+        team_id: &'a str,
+        canonical_id: &'a str,
+    ) -> Self {
+        Self {
+            endpoint,
+            token,
+            team_id,
+            canonical_id,
+            git_remote: None,
+            timeout: REGISTRATION_TIMEOUT,
+        }
+    }
+
+    /// Attach the normalized git remote so the server's project resolver can
+    /// map this machine onto the team's existing bucket (cas-8ca5 contract §5)
+    /// instead of creating a second one.
+    pub fn with_git_remote(mut self, git_remote: Option<&'a str>) -> Self {
+        self.git_remote = git_remote;
+        self
+    }
+
+    /// Override the HTTP timeout (tests use a short one).
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    fn projects_url(&self) -> String {
+        format!("{}/api/teams/{}/projects", self.endpoint, self.team_id)
+    }
+
+    fn push_url(&self) -> String {
+        format!("{}/api/teams/{}/sync/push", self.endpoint, self.team_id)
+    }
+
+    /// Verify (and if necessary create) the project↔team registration.
+    ///
+    /// Returns `Ok` only when the *server* lists the project — a 2xx on the
+    /// registration write is not treated as proof on its own.
+    pub fn ensure(&self) -> Result<RegistrationOutcome, RegistrationFailure> {
+        if let Some(project_uuid) = self.lookup()? {
+            return Ok(RegistrationOutcome::AlreadyRegistered { project_uuid });
+        }
+
+        let register_status = self.register()?;
+
+        match self.lookup()? {
+            Some(project_uuid) => Ok(RegistrationOutcome::Registered { project_uuid }),
+            None => Err(RegistrationFailure {
+                reason: format!(
+                    "Project '{}' is still not registered with team {} on {} after the \
+                     registration request succeeded. The server accepted the write but does \
+                     not list the project, so team memories and team pushes for this project \
+                     cannot work. This is a server-side defect — report the interaction below.",
+                    self.canonical_id, self.team_id, self.endpoint
+                ),
+                interaction: format!(
+                    "POST {} (body: {{\"entries\":[],\"project_canonical_id\":\"{}\"{}}}) -> {}; \
+                     GET {} -> 200 but no project with canonical_id \"{}\"",
+                    self.push_url(),
+                    self.canonical_id,
+                    match self.git_remote {
+                        Some(remote) => format!(",\"git_remote\":\"{remote}\""),
+                        None => String::new(),
+                    },
+                    register_status,
+                    self.projects_url(),
+                    self.canonical_id,
+                ),
+            }),
+        }
+    }
+
+    /// `GET /api/teams/{teamId}/projects` → the project UUID when the team
+    /// already knows this canonical id.
+    fn lookup(&self) -> Result<Option<String>, RegistrationFailure> {
+        let url = self.projects_url();
+        let response = ureq::get(&url)
+            .set("Authorization", &format!("Bearer {}", self.token))
+            .timeout(self.timeout)
+            .call();
+
+        let resp = match response {
+            Ok(resp) => resp,
+            Err(ureq::Error::Status(401, resp)) => {
+                let body = resp.into_string().unwrap_or_default();
+                return Err(RegistrationFailure {
+                    reason: "Cloud session expired — could not confirm this project is \
+                             registered with your team. Run `cas login` to re-authenticate."
+                        .to_string(),
+                    interaction: format!("GET {url} -> 401 {}", body_excerpt(&body)),
+                });
+            }
+            Err(ureq::Error::Status(403, resp)) => {
+                let body = resp.into_string().unwrap_or_default();
+                return Err(RegistrationFailure {
+                    reason: format!(
+                        "Your account is not a member of team {} on {} — the project cannot \
+                         be registered. Run `cas cloud team set <uuid>` with a team you belong to.",
+                        self.team_id, self.endpoint
+                    ),
+                    interaction: format!("GET {url} -> 403 {}", body_excerpt(&body)),
+                });
+            }
+            Err(ureq::Error::Status(code, resp)) => {
+                let body = resp.into_string().unwrap_or_default();
+                return Err(RegistrationFailure {
+                    reason: format!(
+                        "Could not confirm this project is registered with team {}: the server \
+                         returned HTTP {code}.",
+                        self.team_id
+                    ),
+                    interaction: format!("GET {url} -> {code} {}", body_excerpt(&body)),
+                });
+            }
+            Err(ureq::Error::Transport(e)) => {
+                return Err(RegistrationFailure {
+                    reason: format!(
+                        "Could not reach {} to confirm this project is registered with your \
+                         team: {e}",
+                        self.endpoint
+                    ),
+                    interaction: format!("GET {url} -> transport error: {e}"),
+                });
+            }
+        };
+
+        let body = resp.into_string().unwrap_or_default();
+        let parsed: TeamProjectsResponse =
+            serde_json::from_str(&body).map_err(|e| RegistrationFailure {
+                reason: format!(
+                    "Could not confirm this project is registered with team {}: the server's \
+                     project list could not be parsed ({e}).",
+                    self.team_id
+                ),
+                interaction: format!("GET {url} -> 200 {}", body_excerpt(&body)),
+            })?;
+
+        Ok(parsed
+            .projects
+            .into_iter()
+            .find(|p| p.canonical_id == self.canonical_id)
+            .map(|p| p.id))
+    }
+
+    /// `POST /api/teams/{teamId}/sync/push` with no rows — the server's
+    /// project-registration path. Returns the accepted status code.
+    fn register(&self) -> Result<u16, RegistrationFailure> {
+        let url = self.push_url();
+
+        let mut payload = serde_json::Map::new();
+        // An empty `entries` array keeps the request shape identical to a
+        // normal team push (which the server already accepts) while writing
+        // no rows — only the project registration.
+        payload.insert("entries".to_string(), serde_json::json!([]));
+        payload.insert(
+            "project_canonical_id".to_string(),
+            serde_json::json!(self.canonical_id),
+        );
+        if let Some(remote) = self.git_remote {
+            payload.insert("git_remote".to_string(), serde_json::json!(remote));
+        }
+        CloudSyncer::insert_client_version(&mut payload);
+
+        let json_bytes = serde_json::to_vec(&payload).map_err(|e| RegistrationFailure {
+            reason: format!("Could not build the team registration request: {e}"),
+            interaction: format!("POST {url} (payload serialization failed)"),
+        })?;
+        let compressed = CloudSyncer::gzip_json(&json_bytes).map_err(|e| RegistrationFailure {
+            reason: format!("Could not compress the team registration request: {e}"),
+            interaction: format!("POST {url} (gzip failed)"),
+        })?;
+
+        let response = ureq::post(&url)
+            .set("Authorization", &format!("Bearer {}", self.token))
+            .set("Content-Type", "application/json")
+            .set("Content-Encoding", "gzip")
+            .timeout(self.timeout)
+            .send_bytes(&compressed);
+
+        match response {
+            Ok(resp) => {
+                let status = resp.status();
+                if (200..300).contains(&status) {
+                    return Ok(status);
+                }
+                let body = resp.into_string().unwrap_or_default();
+                Err(self.register_failure(&url, status, &body))
+            }
+            Err(ureq::Error::Status(code, resp)) => {
+                let body = resp.into_string().unwrap_or_default();
+                Err(self.register_failure(&url, code, &body))
+            }
+            Err(ureq::Error::Transport(e)) => Err(RegistrationFailure {
+                reason: format!(
+                    "Could not reach {} to register this project with your team: {e}",
+                    self.endpoint
+                ),
+                interaction: format!("POST {url} -> transport error: {e}"),
+            }),
+        }
+    }
+
+    fn register_failure(&self, url: &str, status: u16, body: &str) -> RegistrationFailure {
+        let reason = match status {
+            401 => "Cloud session expired — could not register this project with your team. \
+                    Run `cas login` to re-authenticate."
+                .to_string(),
+            403 => format!(
+                "Your account is not allowed to register projects for team {} on {}.",
+                self.team_id, self.endpoint
+            ),
+            _ => format!(
+                "Could not register project '{}' with team {} on {}: the server returned \
+                 HTTP {status}.",
+                self.canonical_id, self.team_id, self.endpoint
+            ),
+        };
+        RegistrationFailure {
+            reason,
+            interaction: format!(
+                "POST {url} (body: {{\"entries\":[],\"project_canonical_id\":\"{}\"}}) -> \
+                 {status} {}",
+                self.canonical_id,
+                body_excerpt(body)
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_excerpt_reports_empty_bodies_explicitly() {
+        assert_eq!(body_excerpt("   \n "), "<empty body>");
+    }
+
+    #[test]
+    fn body_excerpt_flattens_and_truncates() {
+        let long = "x".repeat(500);
+        let out = body_excerpt(&long);
+        assert!(out.ends_with('…'));
+        assert_eq!(out.chars().count(), 301);
+
+        assert_eq!(body_excerpt("a\nb"), "a b");
+    }
+
+    #[test]
+    fn failure_display_includes_reason_and_interaction() {
+        let failure = RegistrationFailure {
+            reason: "nope".to_string(),
+            interaction: "GET /x -> 500".to_string(),
+        };
+        let rendered = failure.to_string();
+        assert!(rendered.contains("nope"));
+        assert!(rendered.contains("GET /x -> 500"));
+    }
+
+    #[test]
+    fn outcome_reports_uuid_and_novelty() {
+        let already = RegistrationOutcome::AlreadyRegistered {
+            project_uuid: "p-1".to_string(),
+        };
+        assert_eq!(already.project_uuid(), "p-1");
+        assert!(!already.newly_registered());
+
+        let fresh = RegistrationOutcome::Registered {
+            project_uuid: "p-2".to_string(),
+        };
+        assert_eq!(fresh.project_uuid(), "p-2");
+        assert!(fresh.newly_registered());
+    }
+}

--- a/cas-cli/tests/cloud_login_scope_test.rs
+++ b/cas-cli/tests/cloud_login_scope_test.rs
@@ -1,0 +1,159 @@
+//! End-to-end scope tests for `cas login` (cas-046d, Ben's field report #3/#4).
+//!
+//! Two behaviours are pinned by driving the real binary:
+//!
+//!  1. `cas login --token` works from a directory that is not a CAS project.
+//!     It used to abort with "CAS not initialized — run cas init", because the
+//!     credential was written to `<project>/.cas/cloud.json`.
+//!  2. That one login serves every project on the machine: a second, freshly
+//!     created project reports the user as logged in without logging in again.
+//!
+//! The cloud is stood up as a one-thread canned HTTP server so the test never
+//! touches the network and never depends on a live endpoint.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+/// Serve canned `200 {"teams":[]}` responses until the returned handle is
+/// dropped. Returns the bound `http://127.0.0.1:<port>` base URL.
+fn spawn_canned_cloud() -> (String, std::thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind canned cloud");
+    let endpoint = format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port());
+
+    let handle = std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { break };
+            if !serve_one(stream) {
+                break;
+            }
+        }
+    });
+
+    (endpoint, handle)
+}
+
+/// Answer one request. Returns false once the shutdown request is seen.
+fn serve_one(mut stream: TcpStream) -> bool {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).is_err() {
+        return true;
+    }
+    // Drain headers so the client sees a complete exchange.
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) if line == "\r\n" || line == "\n" => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+
+    let body = r#"{"teams":[],"default_team_id":null}"#;
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+    !request_line.contains("/__shutdown")
+}
+
+fn stop_canned_cloud(endpoint: &str, handle: std::thread::JoinHandle<()>) {
+    let addr = endpoint.trim_start_matches("http://");
+    if let Ok(mut stream) = TcpStream::connect(addr) {
+        let _ = stream.write_all(b"GET /__shutdown HTTP/1.1\r\nHost: x\r\n\r\n");
+        let _ = stream.flush();
+    }
+    let _ = handle.join();
+}
+
+/// A `cas` invocation confined to `home`: no real `~/.cas`, no ambient
+/// `CAS_ROOT`, and cwd under the caller's control.
+fn cas_command(home: &Path, cwd: &Path) -> Command {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cas"));
+    cmd.current_dir(cwd)
+        .env("HOME", home)
+        .env("CAS_USER_CLOUD_JSON", home.join(".cas").join("cloud.json"))
+        .env_remove("CAS_ROOT")
+        .env_remove("CAS_CLOUD_TOKEN")
+        .env_remove("CAS_CLOUD_ENDPOINT");
+    cmd
+}
+
+#[test]
+fn token_login_outside_a_project_succeeds_and_serves_every_project() {
+    let (endpoint, server) = spawn_canned_cloud();
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let outside = temp.path().join("outside-any-project");
+    let project_b = temp.path().join("project-b");
+    std::fs::create_dir_all(home.join(".cas")).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::create_dir_all(project_b.join(".cas")).unwrap();
+
+    // 1. Log in from a directory that is not a CAS project.
+    let login = cas_command(&home, &outside)
+        .args(["login", "--token", "test-token", "--endpoint", &endpoint])
+        .output()
+        .expect("run cas login");
+
+    let stderr = String::from_utf8_lossy(&login.stderr).to_string();
+    assert!(
+        login.status.success(),
+        "`cas login --token` outside a project must succeed; stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("not initialized"),
+        "login must not demand `cas init` when credentials are user-level; stderr: {stderr}"
+    );
+
+    let user_config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(home.join(".cas").join("cloud.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        user_config["token"].as_str(),
+        Some("test-token"),
+        "the credential belongs in ~/.cas/cloud.json"
+    );
+
+    // 2. A different project, never logged in to, is already authenticated.
+    let whoami = cas_command(&home, &project_b)
+        .arg("whoami")
+        .output()
+        .expect("run cas whoami");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&whoami.stdout),
+        String::from_utf8_lossy(&whoami.stderr)
+    );
+    assert!(
+        whoami.status.success(),
+        "a second project must inherit the machine-wide login; output: {combined}"
+    );
+    assert!(
+        !combined.contains("Not logged in"),
+        "a second project must not be asked to log in again; output: {combined}"
+    );
+
+    // 3. Logout is machine-wide too.
+    let logout = cas_command(&home, &project_b)
+        .arg("logout")
+        .output()
+        .expect("run cas logout");
+    assert!(logout.status.success());
+    let after: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(home.join(".cas").join("cloud.json")).unwrap())
+            .unwrap();
+    assert!(
+        after["token"].is_null(),
+        "logout must clear the user-level credential, got {after}"
+    );
+
+    stop_canned_cloud(&endpoint, server);
+}

--- a/cas-cli/tests/init_non_project_guard_test.rs
+++ b/cas-cli/tests/init_non_project_guard_test.rs
@@ -1,0 +1,77 @@
+//! `cas init` must not scaffold a project into the home directory (cas-2962,
+//! Ben's field report #8b: init in `$HOME` created CLAUDE.md, .gitignore,
+//! .mcp.json and scripts/ loose in the home directory with no warning).
+//!
+//! The classification itself is unit-tested in `cli::init::non_project_guard_tests`;
+//! this drives the real binary to prove the guard is wired in, that nothing is
+//! written when it fires, and that automation can still opt in.
+//!
+//! The "allowed" direction needs no test of its own here: every other
+//! integration test in this suite runs `cas init` in a temp directory, so a
+//! false positive would fail the suite loudly.
+
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn cas_init_in(home: &Path, cwd: &Path, extra: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cas"));
+    cmd.current_dir(cwd)
+        .env("HOME", home)
+        .env_remove("CAS_ROOT")
+        .arg("init")
+        .arg("-y")
+        .args(extra);
+    cmd.output().expect("run cas init")
+}
+
+#[test]
+fn init_in_home_refuses_and_writes_nothing() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+
+    let output = cas_init_in(&home, &home, &[]);
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert!(
+        !output.status.success(),
+        "init in $HOME must fail, not silently scaffold; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("home directory"),
+        "the refusal must say what the directory is; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("--allow-non-project"),
+        "the refusal must name the escape hatch; stderr: {stderr}"
+    );
+
+    let leftovers: Vec<String> = std::fs::read_dir(&home)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "nothing may be written to $HOME when the guard fires, found: {leftovers:?}"
+    );
+}
+
+#[test]
+fn allow_non_project_lets_automation_through() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+
+    let output = cas_init_in(&home, &home, &["--allow-non-project"]);
+
+    assert!(
+        output.status.success(),
+        "--allow-non-project must bypass the guard; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        home.join(".cas").exists(),
+        "the bypass must actually initialize"
+    );
+}

--- a/cas-cli/tests/team_pull_wiring_test.rs
+++ b/cas-cli/tests/team_pull_wiring_test.rs
@@ -69,16 +69,29 @@ static ENV_LOCK: Mutex<()> = Mutex::new(());
 /// caveats, which we handle with `ENV_LOCK`.
 struct CasRootGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
-    prev: Option<std::ffi::OsString>,
+    prev: Vec<(&'static str, Option<std::ffi::OsString>)>,
 }
 
 impl CasRootGuard {
     fn set(cas_root: &Path) -> Self {
+        Self::set_with(cas_root, &[])
+    }
+
+    /// Set `CAS_ROOT` plus `extra` vars under a SINGLE `ENV_LOCK`
+    /// acquisition. Two separate guards cannot be combined: `std::sync::Mutex`
+    /// is not reentrant, so holding `CasRootGuard` and `ScopedEnvVar` at once
+    /// would deadlock the test thread.
+    fn set_with(cas_root: &Path, extra: &[(&'static str, &str)]) -> Self {
         let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let prev = std::env::var_os("CAS_ROOT");
+        let mut prev = vec![("CAS_ROOT", std::env::var_os("CAS_ROOT"))];
         // SAFETY: env mutation on an integration-test process, guarded by
         // ENV_LOCK so no other test can race the var concurrently.
         unsafe { std::env::set_var("CAS_ROOT", cas_root) };
+        for (key, value) in extra {
+            prev.push((*key, std::env::var_os(key)));
+            // SAFETY: as above.
+            unsafe { std::env::set_var(key, value) };
+        }
         Self { _lock: lock, prev }
     }
 }
@@ -87,9 +100,11 @@ impl Drop for CasRootGuard {
     fn drop(&mut self) {
         // SAFETY: same as `set` — ENV_LOCK held for entire guard lifetime.
         unsafe {
-            match &self.prev {
-                Some(v) => std::env::set_var("CAS_ROOT", v),
-                None => std::env::remove_var("CAS_ROOT"),
+            for (key, prev) in &self.prev {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
             }
         }
     }
@@ -660,7 +675,19 @@ async fn execute_sync_does_not_hit_team_pull_when_no_team_configured() {
     cfg.token = Some("test-token".to_string());
     cfg.save_to_cas_dir(&cas_root).unwrap();
 
-    let _env = CasRootGuard::set(&cas_root);
+    // Isolate from `~/.cas/cloud.json`: since cas-c117, `execute_sync` adopts
+    // a resolvable team automatically, so a developer machine with a real
+    // membership would legitimately turn this "no team anywhere" project into
+    // a team project and hit the endpoints this test asserts are silent.
+    // Pointing the user config at a nonexistent path is what makes "no team
+    // configured" true for the whole resolution chain.
+    let _env = CasRootGuard::set_with(
+        &cas_root,
+        &[(
+            "CAS_USER_CLOUD_JSON",
+            "/nonexistent/cas-test-isolation/cloud.json",
+        )],
+    );
 
     let args = CloudSyncArgs {
         dry_run: false,

--- a/cas-cli/tests/team_pull_wiring_test.rs
+++ b/cas-cli/tests/team_pull_wiring_test.rs
@@ -443,6 +443,25 @@ async fn mount_knowledge_pull(server: &MockServer) {
 }
 
 async fn mount_full_sync_mocks(server: &MockServer, team_entry_id: &str) {
+    // Project↔team registration check (cas-c117): `execute_sync` now verifies
+    // with the server that this project is registered before it reports any
+    // success. Answer "already registered" so these tests keep exercising the
+    // pull wiring rather than the registration write.
+    Mock::given(method("GET"))
+        .and(path(format!("/api/teams/{TEST_TEAM}/projects")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "projects": [{
+                "id": "project-uuid-1",
+                "canonical_id": get_project_canonical_id()
+                    .unwrap_or_else(|| "cas-src".to_string()),
+                "name": "CAS",
+                "contributor_count": 1,
+                "memory_count": 0,
+            }]
+        })))
+        .mount(server)
+        .await;
+
     // Personal push: any payload, success. Empty stores still produce 1 batch.
     Mock::given(method("POST"))
         .and(path("/api/sync/push"))

--- a/cas-cli/tests/team_registration_test.rs
+++ b/cas-cli/tests/team_registration_test.rs
@@ -1,0 +1,404 @@
+//! Regression tests for the sync-reports-success-but-unregistered defect
+//! (cas-c117, EPIC cas-e0d9 — Ben's macOS clean-install field report).
+//!
+//! # The bug these lock down
+//!
+//! The server only learned about a project as a side effect of a *non-empty*
+//! team push: `CloudSyncer::push_team` returns early when the team queue has
+//! no rows (`cloud/syncer/team_push.rs`), so a clean install — nothing written
+//! since the team was configured — issued no `POST /api/teams/{id}/sync/push`
+//! at all. `cas cloud sync` printed "✓ Push complete / ✓ Pull complete" and
+//! exited 0 while the project stayed unknown to the team, after which
+//! `cas cloud team-memories` told the user to run the sync they had just run.
+//!
+//! After the fix, `cas cloud sync` verifies the registration against the
+//! server, creates it when missing, and fails the whole command (non-zero)
+//! when the server still does not list the project.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+mod common;
+use common::{TEST_TEAM, make_cli_json, make_cloud_config};
+
+use cas::cli::cloud::{CloudSyncArgs, ensure_team_project_registration, execute_sync};
+use cas::cloud::{CloudConfig, SyncQueue, get_project_canonical_id};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Process-global lock for CAS_ROOT mutations — same rationale as
+/// `team_pull_wiring_test.rs`: `cargo test` runs every `#[tokio::test]` in
+/// one process, and the env var is shared.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct CasRootGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    prev: Option<std::ffi::OsString>,
+}
+
+impl CasRootGuard {
+    fn set(cas_root: &Path) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var_os("CAS_ROOT");
+        // SAFETY: env mutation in an integration-test process, serialized by
+        // ENV_LOCK for the guard's whole lifetime.
+        unsafe { std::env::set_var("CAS_ROOT", cas_root) };
+        Self { _lock: lock, prev }
+    }
+}
+
+impl Drop for CasRootGuard {
+    fn drop(&mut self) {
+        // SAFETY: ENV_LOCK held for the entire guard lifetime.
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var("CAS_ROOT", v),
+                None => std::env::remove_var("CAS_ROOT"),
+            }
+        }
+    }
+}
+
+fn make_cas_root() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let queue = SyncQueue::open(tmp.path()).unwrap();
+    queue.init().unwrap();
+    tmp
+}
+
+/// The canonical id the production path resolves — the same
+/// `get_project_canonical_id()` used by `ensure_team_project_registration`
+/// and by the team push, so mock and product always agree.
+fn project_id() -> String {
+    get_project_canonical_id().expect("canonical project id must resolve in tests")
+}
+
+fn projects_path() -> String {
+    format!("/api/teams/{TEST_TEAM}/projects")
+}
+
+fn team_push_path() -> String {
+    format!("/api/teams/{TEST_TEAM}/sync/push")
+}
+
+fn project_list_body(canonical_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "projects": [{
+            "id": "project-uuid-1",
+            "canonical_id": canonical_id,
+            "name": "Gabber Studio",
+            "contributor_count": 1,
+            "memory_count": 0,
+        }]
+    })
+}
+
+fn empty_project_list_body() -> serde_json::Value {
+    serde_json::json!({ "projects": [] })
+}
+
+fn team_push_ok_body() -> serde_json::Value {
+    serde_json::json!({
+        "synced": {
+            "entries": 0, "tasks": 0, "rules": 0, "skills": 0,
+            "sessions": 0, "verifications": 0, "events": 0,
+            "prompts": 0, "file_changes": 0, "commit_links": 0,
+            "agents": 0, "worktrees": 0,
+        }
+    })
+}
+
+/// THE regression test for the reported defect: the server accepts everything
+/// but never lists the project. Before the fix this was a green, exit-0 sync;
+/// now `execute_sync` fails with a non-zero exit and names the real reason.
+///
+/// The `.expect(0)` on the personal push is load-bearing: it proves the
+/// failure happens *before* anything can print "✓ Push complete", so a green
+/// push line always implies a registered project.
+#[tokio::test]
+async fn sync_fails_loud_when_server_never_registers_the_project() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_project_list_body()))
+        // Once before the registration write, once to verify it.
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(team_push_ok_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/push"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = make_cas_root();
+    let cas_root = tmp.path().to_path_buf();
+    make_cloud_config(server.uri())
+        .save_to_cas_dir(&cas_root)
+        .unwrap();
+    let _env = CasRootGuard::set(&cas_root);
+
+    let expected_id = project_id();
+    let args = CloudSyncArgs {
+        dry_run: false,
+        rehome: false,
+        full: false,
+    };
+    let cli = make_cli_json();
+    let cas_root_owned = cas_root.clone();
+    let result = tokio::task::spawn_blocking(move || execute_sync(&args, &cli, &cas_root_owned))
+        .await
+        .unwrap();
+
+    let err = result.expect_err(
+        "sync must fail when the project is not registered with the team — a silent \
+         exit-0 here is the exact reported bug",
+    );
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains(&expected_id),
+        "failure must name the canonical project id, got:\n{msg}"
+    );
+    assert!(
+        msg.contains(TEST_TEAM),
+        "failure must name the team, got:\n{msg}"
+    );
+    assert!(
+        msg.contains("not registered"),
+        "failure must state the real reason, got:\n{msg}"
+    );
+    assert!(
+        msg.contains(&projects_path()) && msg.contains(&team_push_path()),
+        "failure must document the exact failing interaction for escalation, got:\n{msg}"
+    );
+
+    // The registration must NOT be cached as successful — the next sync has
+    // to try again rather than inherit a false "already registered".
+    let queue = SyncQueue::open(&cas_root).unwrap();
+    assert_eq!(
+        queue
+            .get_metadata(&format!("team_project_registered_{TEST_TEAM}_{expected_id}"))
+            .unwrap(),
+        None,
+        "a failed registration must never be recorded as confirmed"
+    );
+}
+
+/// Positive path for the clean-install case: nothing queued, project unknown
+/// to the team → the sync registers it explicitly and the server confirms.
+#[tokio::test]
+async fn registration_creates_the_project_when_the_team_does_not_know_it() {
+    let server = MockServer::start().await;
+    let expected_id = project_id();
+
+    // First lookup: unknown. `up_to_n_times(1)` retires this mock so the
+    // post-write verification falls through to the registered response.
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_project_list_body()))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(team_push_ok_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_list_body(&expected_id)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = make_cas_root();
+    let cas_root = tmp.path().to_path_buf();
+    let config = make_cloud_config(server.uri());
+    config.save_to_cas_dir(&cas_root).unwrap();
+    let _env = CasRootGuard::set(&cas_root);
+
+    let cli = make_cli_json();
+    let cas_root_owned = cas_root.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        ensure_team_project_registration(&config, &cas_root_owned, &cli, false)
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        result.is_ok(),
+        "registration must succeed once the server lists the project; got {result:?}"
+    );
+
+    let queue = SyncQueue::open(&cas_root).unwrap();
+    assert!(
+        queue
+            .get_metadata(&format!("team_project_registered_{TEST_TEAM}_{expected_id}"))
+            .unwrap()
+            .is_some(),
+        "a confirmed registration must be cached so steady-state syncs stay cheap"
+    );
+}
+
+/// An already-registered project must not be written again, and the confirmed
+/// state must be cached so routine syncs pay no extra round-trip.
+#[tokio::test]
+async fn already_registered_project_is_verified_once_then_cached() {
+    let server = MockServer::start().await;
+    let expected_id = project_id();
+
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_list_body(&expected_id)))
+        // Exactly one lookup across BOTH calls: the second is served from the
+        // local cache.
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = make_cas_root();
+    let cas_root = tmp.path().to_path_buf();
+    let config = make_cloud_config(server.uri());
+    config.save_to_cas_dir(&cas_root).unwrap();
+    let _env = CasRootGuard::set(&cas_root);
+
+    let cli = make_cli_json();
+    let cas_root_owned = cas_root.clone();
+    let (first, second) = tokio::task::spawn_blocking(move || {
+        let first = ensure_team_project_registration(&config, &cas_root_owned, &cli, false);
+        let second = ensure_team_project_registration(&config, &cas_root_owned, &cli, false);
+        (first, second)
+    })
+    .await
+    .unwrap();
+
+    assert!(first.is_ok(), "first verification must pass: {first:?}");
+    assert!(second.is_ok(), "cached verification must pass: {second:?}");
+}
+
+/// `cas cloud sync --full` re-verifies rather than trusting the cache — the
+/// escape hatch when a project was deleted server-side or re-homed.
+#[tokio::test]
+async fn full_sync_reverifies_registration_instead_of_trusting_the_cache() {
+    let server = MockServer::start().await;
+    let expected_id = project_id();
+
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_list_body(&expected_id)))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let tmp = make_cas_root();
+    let cas_root = tmp.path().to_path_buf();
+    let config = make_cloud_config(server.uri());
+    config.save_to_cas_dir(&cas_root).unwrap();
+    let _env = CasRootGuard::set(&cas_root);
+
+    let cli = make_cli_json();
+    let cas_root_owned = cas_root.clone();
+    tokio::task::spawn_blocking(move || {
+        ensure_team_project_registration(&config, &cas_root_owned, &cli, false)
+            .expect("first verification");
+        ensure_team_project_registration(&config, &cas_root_owned, &cli, true)
+            .expect("forced re-verification");
+    })
+    .await
+    .unwrap();
+}
+
+/// An expired session must be reported as an expired session — not as a
+/// mystery, and not as a green sync.
+#[tokio::test]
+async fn expired_session_fails_registration_with_a_login_instruction() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(401).set_body_string("{\"error\":\"unauthorized\"}"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = make_cas_root();
+    let cas_root = tmp.path().to_path_buf();
+    let config = make_cloud_config(server.uri());
+    config.save_to_cas_dir(&cas_root).unwrap();
+    let _env = CasRootGuard::set(&cas_root);
+
+    let cli = make_cli_json();
+    let cas_root_owned = cas_root.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        ensure_team_project_registration(&config, &cas_root_owned, &cli, false)
+    })
+    .await
+    .unwrap();
+
+    let msg = format!("{:#}", result.expect_err("401 must fail the sync"));
+    assert!(
+        msg.contains("cas login"),
+        "an expired session must tell the user to log in, got:\n{msg}"
+    );
+    assert!(
+        msg.contains("401"),
+        "the failing interaction must carry the status code, got:\n{msg}"
+    );
+}
+
+/// Personal-only users must not pay for any of this: no team, no traffic.
+#[tokio::test]
+async fn registration_is_a_no_op_without_a_configured_team() {
+    let server = MockServer::start().await;
+    // Any request at all fails the test.
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = make_cas_root();
+    let cas_root = tmp.path().to_path_buf();
+    let mut config = CloudConfig::default();
+    config.endpoint = server.uri();
+    config.token = Some("test-token".to_string());
+    config.save_to_cas_dir(&cas_root).unwrap();
+    let _env = CasRootGuard::set(&cas_root);
+
+    let cli = make_cli_json();
+    let cas_root_owned = cas_root.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        ensure_team_project_registration(&config, &cas_root_owned, &cli, false)
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        result.is_ok(),
+        "no team configured must be a silent no-op; got {result:?}"
+    );
+}

--- a/cas-cli/tests/team_registration_test.rs
+++ b/cas-cli/tests/team_registration_test.rs
@@ -22,7 +22,11 @@ mod common;
 use common::{TEST_TEAM, make_cli_json, make_cloud_config};
 
 use cas::cli::cloud::{CloudSyncArgs, ensure_team_project_registration, execute_sync};
-use cas::cloud::{CloudConfig, SyncQueue, get_project_canonical_id};
+use cas::cloud::{CloudConfig, SyncQueue, TeamInfo, get_project_canonical_id};
+use cas::store::{
+    open_commit_link_store, open_event_store, open_file_change_store, open_prompt_store,
+    open_rule_store, open_skill_store, open_spec_store, open_store, open_task_store,
+};
 use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -32,29 +36,43 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 /// one process, and the env var is shared.
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-struct CasRootGuard {
+/// Sets one or more env vars for the duration of a test under a single
+/// ENV_LOCK acquisition. One guard for all of them is required, not stylistic:
+/// `std::sync::Mutex` is not reentrant, so two guards that each take ENV_LOCK
+/// would deadlock the moment a test needs both `CAS_ROOT` and
+/// `CAS_USER_CLOUD_JSON`.
+struct ScopedEnv {
     _lock: std::sync::MutexGuard<'static, ()>,
-    prev: Option<std::ffi::OsString>,
+    prev: Vec<(&'static str, Option<std::ffi::OsString>)>,
 }
 
-impl CasRootGuard {
-    fn set(cas_root: &Path) -> Self {
+impl ScopedEnv {
+    fn set(vars: &[(&'static str, &str)]) -> Self {
         let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let prev = std::env::var_os("CAS_ROOT");
-        // SAFETY: env mutation in an integration-test process, serialized by
-        // ENV_LOCK for the guard's whole lifetime.
-        unsafe { std::env::set_var("CAS_ROOT", cas_root) };
+        let mut prev = Vec::with_capacity(vars.len());
+        for (key, value) in vars {
+            prev.push((*key, std::env::var_os(key)));
+            // SAFETY: env mutation in an integration-test process, serialized
+            // by ENV_LOCK for the guard's whole lifetime.
+            unsafe { std::env::set_var(key, value) };
+        }
         Self { _lock: lock, prev }
+    }
+
+    fn cas_root(cas_root: &Path) -> Self {
+        Self::set(&[("CAS_ROOT", &cas_root.to_string_lossy())])
     }
 }
 
-impl Drop for CasRootGuard {
+impl Drop for ScopedEnv {
     fn drop(&mut self) {
         // SAFETY: ENV_LOCK held for the entire guard lifetime.
         unsafe {
-            match &self.prev {
-                Some(v) => std::env::set_var("CAS_ROOT", v),
-                None => std::env::remove_var("CAS_ROOT"),
+            for (key, prev) in &self.prev {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
             }
         }
     }
@@ -65,6 +83,20 @@ fn make_cas_root() -> TempDir {
     let queue = SyncQueue::open(tmp.path()).unwrap();
     queue.init().unwrap();
     tmp
+}
+
+/// Create every SQLite store `execute_sync` opens, so a full-sync test
+/// exercises the sync itself rather than store creation.
+fn init_all_stores_at(cas_root: &Path) {
+    let _ = open_store(cas_root).unwrap();
+    let _ = open_task_store(cas_root).unwrap();
+    let _ = open_rule_store(cas_root).unwrap();
+    let _ = open_skill_store(cas_root).unwrap();
+    let _ = open_spec_store(cas_root).unwrap();
+    let _ = open_event_store(cas_root).unwrap();
+    let _ = open_prompt_store(cas_root).unwrap();
+    let _ = open_file_change_store(cas_root).unwrap();
+    let _ = open_commit_link_store(cas_root).unwrap();
 }
 
 /// The canonical id the production path resolves — the same
@@ -145,7 +177,7 @@ async fn sync_fails_loud_when_server_never_registers_the_project() {
     make_cloud_config(server.uri())
         .save_to_cas_dir(&cas_root)
         .unwrap();
-    let _env = CasRootGuard::set(&cas_root);
+    let _env = ScopedEnv::cas_root(&cas_root);
 
     let expected_id = project_id();
     let args = CloudSyncArgs {
@@ -226,7 +258,7 @@ async fn registration_creates_the_project_when_the_team_does_not_know_it() {
     let cas_root = tmp.path().to_path_buf();
     let config = make_cloud_config(server.uri());
     config.save_to_cas_dir(&cas_root).unwrap();
-    let _env = CasRootGuard::set(&cas_root);
+    let _env = ScopedEnv::cas_root(&cas_root);
 
     let cli = make_cli_json();
     let cas_root_owned = cas_root.clone();
@@ -277,7 +309,7 @@ async fn already_registered_project_is_verified_once_then_cached() {
     let cas_root = tmp.path().to_path_buf();
     let config = make_cloud_config(server.uri());
     config.save_to_cas_dir(&cas_root).unwrap();
-    let _env = CasRootGuard::set(&cas_root);
+    let _env = ScopedEnv::cas_root(&cas_root);
 
     let cli = make_cli_json();
     let cas_root_owned = cas_root.clone();
@@ -311,7 +343,7 @@ async fn full_sync_reverifies_registration_instead_of_trusting_the_cache() {
     let cas_root = tmp.path().to_path_buf();
     let config = make_cloud_config(server.uri());
     config.save_to_cas_dir(&cas_root).unwrap();
-    let _env = CasRootGuard::set(&cas_root);
+    let _env = ScopedEnv::cas_root(&cas_root);
 
     let cli = make_cli_json();
     let cas_root_owned = cas_root.clone();
@@ -342,7 +374,7 @@ async fn expired_session_fails_registration_with_a_login_instruction() {
     let cas_root = tmp.path().to_path_buf();
     let config = make_cloud_config(server.uri());
     config.save_to_cas_dir(&cas_root).unwrap();
-    let _env = CasRootGuard::set(&cas_root);
+    let _env = ScopedEnv::cas_root(&cas_root);
 
     let cli = make_cli_json();
     let cas_root_owned = cas_root.clone();
@@ -360,6 +392,215 @@ async fn expired_session_fails_registration_with_a_login_instruction() {
     assert!(
         msg.contains("401"),
         "the failing interaction must carry the status code, got:\n{msg}"
+    );
+}
+
+/// Operator directive (cas-c117 amendment): a logged-in user whose team
+/// identity is already resolvable must NOT have to run `cas cloud team set`
+/// or `cas cloud team auto on` first. `cas cloud sync` adopts the team for the
+/// project and registers it — the whole flow Ben had to drive by hand.
+///
+/// The project config here has no team at all; only the user-level
+/// `cloud.json` knows about the membership, exactly as it does after `cas
+/// login` / the `/api/me` refresh.
+#[tokio::test]
+async fn sync_adopts_the_resolvable_team_without_any_manual_team_command() {
+    let server = MockServer::start().await;
+    let expected_id = project_id();
+
+    // Registration: unknown first, listed after the registration write.
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_project_list_body()))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_list_body(&expected_id)))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Registration write + the (empty) team drain later in the same sync.
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(team_push_ok_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/api/teams/{TEST_TEAM}/sync/pull")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": [], "tasks": [], "rules": [], "skills": [],
+            "pulled_at": "2026-08-18T00:00:00Z",
+            "team_id": TEST_TEAM,
+            "status": "ok",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/push"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/sync/pull"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": [], "tasks": [], "rules": [], "skills": [],
+            "specs": [], "events": [], "prompts": [],
+            "file_changes": [], "commit_links": [],
+            "knowledge_pages": [],
+            "pulled_at": "2026-08-18T00:00:00Z",
+        })))
+        .mount(&server)
+        .await;
+
+    let tmp = make_cas_root();
+    let cas_root = tmp.path().to_path_buf();
+    init_all_stores_at(&cas_root);
+
+    // Project config: logged in, NO team of any kind.
+    let mut project_cfg = CloudConfig::default();
+    project_cfg.endpoint = server.uri();
+    project_cfg.token = Some("test-token".to_string());
+    project_cfg.save_to_cas_dir(&cas_root).unwrap();
+    assert_eq!(project_cfg.team_id, None);
+    assert_eq!(project_cfg.team_auto_promote, None);
+
+    // User config: the membership the CLI already knows about.
+    let user_dir = TempDir::new().unwrap();
+    let mut user_cfg = CloudConfig::default();
+    user_cfg.endpoint = server.uri();
+    user_cfg.teams = vec![TeamInfo {
+        id: TEST_TEAM.to_string(),
+        slug: "petra-stella".to_string(),
+        name: "Petra Stella".to_string(),
+        role: "member".to_string(),
+    }];
+    user_cfg.default_team_id = Some(TEST_TEAM.to_string());
+    // Fresh cache + backfill already done, so the sync makes no /api/me call
+    // and this test measures adoption alone.
+    user_cfg.teams_fetched_at = Some(chrono::Utc::now());
+    user_cfg.team_backfill_notified = true;
+    user_cfg.save_to_cas_dir(user_dir.path()).unwrap();
+
+    let _env = ScopedEnv::set(&[
+        ("CAS_ROOT", &cas_root.to_string_lossy()),
+        (
+            "CAS_USER_CLOUD_JSON",
+            &user_dir.path().join("cloud.json").to_string_lossy(),
+        ),
+    ]);
+
+    let args = CloudSyncArgs {
+        dry_run: false,
+        rehome: false,
+        full: false,
+    };
+    let cli = make_cli_json();
+    let cas_root_owned = cas_root.clone();
+    let result = tokio::task::spawn_blocking(move || execute_sync(&args, &cli, &cas_root_owned))
+        .await
+        .unwrap();
+
+    assert!(
+        result.is_ok(),
+        "sync must adopt the resolvable team and register the project without any \
+         manual team command; got {result:?}"
+    );
+
+    // The project is now team-scoped and stays that way for later commands.
+    let saved = CloudConfig::load_from_cas_dir(&cas_root).unwrap();
+    assert_eq!(
+        saved.team_auto_promote,
+        Some(true),
+        "sync must persist the adopted team scope"
+    );
+    assert_eq!(
+        saved.active_team_id_with_user_config(Some(&user_cfg)).as_deref(),
+        Some(TEST_TEAM),
+        "the adopted scope must resolve to the user's team"
+    );
+
+    // And the registration actually happened for that team — the mocks'
+    // `.expect(1)` on the lookup pair and the registration write assert it on
+    // MockServer drop.
+    let queue = SyncQueue::open(&cas_root).unwrap();
+    assert!(
+        queue
+            .get_metadata(&format!("team_project_registered_{TEST_TEAM}_{expected_id}"))
+            .unwrap()
+            .is_some(),
+        "the adopted team must end the sync with a confirmed registration"
+    );
+}
+
+/// The kill switch outranks adoption: `cas cloud team auto off` keeps a
+/// project personal even when a team resolves, and no team endpoint is hit.
+#[tokio::test]
+async fn team_auto_off_keeps_a_project_personal_despite_a_resolvable_team() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = make_cas_root();
+    let cas_root = tmp.path().to_path_buf();
+
+    let mut project_cfg = CloudConfig::default();
+    project_cfg.endpoint = server.uri();
+    project_cfg.token = Some("test-token".to_string());
+    project_cfg.team_auto_promote = Some(false); // `cas cloud team auto off`
+    project_cfg.save_to_cas_dir(&cas_root).unwrap();
+
+    let user_dir = TempDir::new().unwrap();
+    let mut user_cfg = CloudConfig::default();
+    user_cfg.teams = vec![TeamInfo {
+        id: TEST_TEAM.to_string(),
+        slug: "petra-stella".to_string(),
+        name: "Petra Stella".to_string(),
+        role: "member".to_string(),
+    }];
+    user_cfg.default_team_id = Some(TEST_TEAM.to_string());
+    user_cfg.teams_fetched_at = Some(chrono::Utc::now());
+    user_cfg.team_backfill_notified = true;
+    user_cfg.save_to_cas_dir(user_dir.path()).unwrap();
+
+    let _env = ScopedEnv::set(&[
+        ("CAS_ROOT", &cas_root.to_string_lossy()),
+        (
+            "CAS_USER_CLOUD_JSON",
+            &user_dir.path().join("cloud.json").to_string_lossy(),
+        ),
+    ]);
+
+    let cli = make_cli_json();
+    let cas_root_owned = cas_root.clone();
+    let config = CloudConfig::load_from_cas_dir(&cas_root).unwrap();
+    tokio::task::spawn_blocking(move || {
+        cas::cloud::maybe_adopt_team_scope(&cas_root_owned).expect("adoption must not error");
+        ensure_team_project_registration(&config, &cas_root_owned, &cli, false)
+            .expect("a personal project must not fail the sync")
+    })
+    .await
+    .unwrap();
+
+    let saved = CloudConfig::load_from_cas_dir(&cas_root).unwrap();
+    assert_eq!(
+        saved.team_auto_promote,
+        Some(false),
+        "adoption must never undo the explicit kill switch"
     );
 }
 
@@ -387,7 +628,7 @@ async fn registration_is_a_no_op_without_a_configured_team() {
     config.endpoint = server.uri();
     config.token = Some("test-token".to_string());
     config.save_to_cas_dir(&cas_root).unwrap();
-    let _env = CasRootGuard::set(&cas_root);
+    let _env = ScopedEnv::cas_root(&cas_root);
 
     let cli = make_cli_json();
     let cas_root_owned = cas_root.clone();

--- a/cas-cli/tests/team_registration_test.rs
+++ b/cas-cli/tests/team_registration_test.rs
@@ -460,18 +460,22 @@ async fn sync_adopts_the_resolvable_team_without_any_manual_team_command() {
     let cas_root = tmp.path().to_path_buf();
     init_all_stores_at(&cas_root);
 
-    // Project config: logged in, NO team of any kind.
+    // Project config: a fresh clone. NO team of any kind, and — per cas-046d,
+    // where `cas login` stores credentials machine-wide — no token of its own
+    // either. This is Ben's actual starting state.
     let mut project_cfg = CloudConfig::default();
     project_cfg.endpoint = server.uri();
-    project_cfg.token = Some("test-token".to_string());
     project_cfg.save_to_cas_dir(&cas_root).unwrap();
     assert_eq!(project_cfg.team_id, None);
     assert_eq!(project_cfg.team_auto_promote, None);
+    assert!(!project_cfg.is_logged_in());
 
-    // User config: the membership the CLI already knows about.
+    // User config: the machine-wide login plus the membership the CLI already
+    // knows about.
     let user_dir = TempDir::new().unwrap();
     let mut user_cfg = CloudConfig::default();
     user_cfg.endpoint = server.uri();
+    user_cfg.token = Some("test-token".to_string());
     user_cfg.teams = vec![TeamInfo {
         id: TEST_TEAM.to_string(),
         slug: "petra-stella".to_string(),

--- a/docs/onboarding/2026-08-17-mac-setup-petra-stella.md
+++ b/docs/onboarding/2026-08-17-mac-setup-petra-stella.md
@@ -80,6 +80,10 @@ cas cloud team     # confirm/select the Petra Stella team scope
 cas cloud status   # confirm: logged in, team set, auto-sync on
 ```
 
+**Once per machine, not once per project.** The credential is stored at user level in `~/.cas/cloud.json`, so you can run `cas login` from anywhere — including outside a CAS project — and every project you set up afterwards is already signed in. `cas logout` signs the whole machine out.
+
+**Prefer the token over `cas login`'s browser flow for now.** The hosted device-approval page currently rejects a valid code with "Missing or invalid Authorization header"; that is a server-side defect (written up in [docs/reports/2026-08-18-cloud-device-login-server-defect.md](../reports/2026-08-18-cloud-device-login-server-defect.md)). `cas login --token` does not use that page at all.
+
 **When to sync: normally never by hand.** Auto-sync is on by default (`cloud.auto_sync = true`) and runs every 60 seconds while you are logged in. Manual commands exist for exactly three situations:
 
 | Situation | Command |

--- a/docs/onboarding/2026-08-17-mac-setup-petra-stella.md
+++ b/docs/onboarding/2026-08-17-mac-setup-petra-stella.md
@@ -1,6 +1,6 @@
 # CAS on a Mac from zero — Petra Stella team member guide
 
-Date: 2026-08-17 · Verified against: CAS v2.72.0 (released 2026-08-17), `cas` CLI help on a live install · Audience: a new Petra Stella team member with an Apple Silicon Mac and terminal comfort.
+Date: 2026-08-17 · Revised 2026-08-18 after a clean-install run found the step order, `cas cloud team`, and `cas update --user` claims wrong · Verified against: CAS v2.72.0 (released 2026-08-17), `cas` CLI help and measured command behaviour on a live install · Audience: a new Petra Stella team member with an Apple Silicon Mac and terminal comfort.
 
 **Time: about 15 minutes**, none of it compiling. This uses the published release binary, not a source build. (The older `docs/onboarding/macbook-from-zero.md` is the source-build path for people hacking on CAS itself; it predates current releases — see Known gaps.)
 
@@ -13,7 +13,8 @@ Apple Silicon (M1–M4). Check: `uname -m` → `arm64`.
 ```bash
 # Homebrew (skip if `brew --version` works)
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+grep -qxF 'eval "$(/opt/homebrew/bin/brew shellenv)"' ~/.zprofile 2>/dev/null \
+  || echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
 # Git + Node, then Claude Code
@@ -22,6 +23,8 @@ npm install -g @anthropic-ai/claude-code
 ```
 
 Claude Code ≥ 2.1.126 is required (earlier 2.1.117–2.1.125 had a factory-mode rendering crash); a fresh install today is far past that.
+
+Steps 1 and 2 are safe to paste twice: each `~/.zprofile` line is appended only when it is not already present, so a re-run cannot duplicate it.
 
 ## 2. Install the CAS binary
 
@@ -34,17 +37,24 @@ curl -fsSL -o cas.tar.gz \
 tar -xzf cas.tar.gz
 mv cas ~/.local/bin/cas && chmod +x ~/.local/bin/cas
 xattr -d com.apple.quarantine ~/.local/bin/cas 2>/dev/null || true  # Gatekeeper
-echo 'export PATH=$HOME/.local/bin:$PATH' >> ~/.zprofile
-exec zsh -l
-cas --version   # expect: cas 2.72.0 (or newer)
+grep -qxF 'export PATH=$HOME/.local/bin:$PATH' ~/.zprofile 2>/dev/null \
+  || echo 'export PATH=$HOME/.local/bin:$PATH' >> ~/.zprofile
+export PATH=$HOME/.local/bin:$PATH   # this shell; ~/.zprofile covers new ones
+cas --version                        # expect: cas 2.72.0 (or newer)
 ```
+
+The block used to end with `exec zsh -l`, which replaced the shell mid-paste so the lines after it never ran. `export PATH=…` does the same job for the current shell and lets the rest of the block finish. New terminals pick the PATH up from `~/.zprofile`.
 
 ## 3. One-time CAS setup
 
 ```bash
-cas update --user   # seeds ~/.claude with the built-in skills/agents/commands
-cas doctor          # green across the board before continuing
+mkdir -p ~/.claude   # opt this machine's Claude Code install into CAS built-ins
+cas update --user    # seeds the harness dirs that exist: ~/.claude, ~/.codex, ~/.grok
 ```
+
+`cas update --user` only writes into a harness directory that already exists — it will not materialize `~/.claude` for someone who does not use Claude Code. On a clean Mac that directory does not exist until Claude Code has run once, which is why the `mkdir -p` is there; without it the command prints `~/.claude does not exist — skipping (Claude Code not installed?)` and seeds only `~/.codex` / `~/.grok` if you happen to have them.
+
+Skip `cas doctor` for now — it reports on a *project*, and you do not have one yet. Step 7 runs it in the right place.
 
 From now on, upgrading is a single command — `cas update` — which fetches the latest release, replaces the binary, and runs schema migrations. Run it when release announcements land in #cas-internal; nothing else to maintain.
 
@@ -72,17 +82,20 @@ Pairings expire (90 days absolute, 30 days idle). Since v2.72.0 an expired pairi
 
 ## 5. CAS Cloud — set and forget
 
-The team runs the self-hosted **Petra Stella Cloud**; auth is a personal static API key, and the endpoint (`https://petra-stella-cloud.vercel.app`) is already the CLI's built-in default — no endpoint flag needed.
+The team runs the self-hosted **Petra Stella Cloud** at **`https://petra-stella-cloud.vercel.app`** — that is the domain you are authenticating against, and it is already the CLI's built-in default, so no endpoint flag is needed. Auth is a personal static API key.
 
 ```bash
 cas login --token <YOUR-PERSONAL-API-KEY>   # key comes from Daniel; one time
-cas cloud team     # confirm/select the Petra Stella team scope
-cas cloud status   # confirm: logged in, team set, auto-sync on
+cas whoami                                  # prints the endpoint you are signed in to
 ```
 
-**Once per machine, not once per project.** The credential is stored at user level in `~/.cas/cloud.json`, so you can run `cas login` from anywhere — including outside a CAS project — and every project you set up afterwards is already signed in. `cas logout` signs the whole machine out.
+`cas whoami` exits 0 when you are logged in and non-zero with "Not logged in" when you are not — that exit code is the check. It names your email only when the server supplied one; a token login does not carry an email, so seeing just the endpoint line is normal and correct.
 
-**Prefer the token over `cas login`'s browser flow for now.** The hosted device-approval page currently rejects a valid code with "Missing or invalid Authorization header"; that is a server-side defect (written up in [docs/reports/2026-08-18-cloud-device-login-server-defect.md](../reports/2026-08-18-cloud-device-login-server-defect.md)). `cas login --token` does not use that page at all.
+**Use the token, not the browser flow.** `cas login` with no arguments opens the device-approval page at `petra-stella-cloud.vercel.app/device`, and that page currently rejects a valid code with "Missing or invalid Authorization header" even in a signed-in browser. It is a server-side defect, written up in [docs/reports/2026-08-18-cloud-device-login-server-defect.md](../reports/2026-08-18-cloud-device-login-server-defect.md). `cas login --token` never touches that page.
+
+**Once per machine, not once per project.** The credential is stored at user level in `~/.cas/cloud.json`, so this step works from anywhere — including here, before any project exists — and every project you set up afterwards is already signed in. `cas logout` signs the whole machine out.
+
+Team scope and sync status are *project*-scoped, so they are confirmed in step 7, after you have a project. Running them here fails with `CAS not initialized`.
 
 **When to sync: normally never by hand.** Auto-sync is on by default (`cloud.auto_sync = true`) and runs every 60 seconds while you are logged in. Manual commands exist for exactly three situations:
 
@@ -104,16 +117,26 @@ Since v2.72.0 sync is also honest: it prints a summary of any task-status change
 
 ## 7. Per project
 
+Run this from inside the project, never from your home directory — `cas init` scaffolds `.cas/`, `CLAUDE.md`, `.gitignore`, `.mcp.json` and `scripts/` into whatever directory you are standing in. (After v2.72.0 it refuses to do that in `$HOME` and tells you to `cd` first; on 2.72.0 itself it does it silently.)
+
 ```bash
 cd ~/code/some-project
-cas init    # initialize CAS here (tasks/memories/knowledge wire up, cloud slug derives)
-cas         # bare `cas` launches the factory TUI with defaults
+cas init              # tasks/memories/knowledge wire up, cloud slug derives
+cas doctor            # green across the board for this project
+cas cloud team show   # confirm the Petra Stella team scope (bare `cas cloud team` only prints help)
+cas cloud status      # confirm: logged in, team set, auto-sync on
 ```
+
+If `cas cloud team show` reports no team, set it once for this project with `cas cloud team set <uuid>` or turn on inheritance of your user-level default with `cas cloud team auto on`.
+
+Then start working: bare `cas` launches the factory TUI with defaults.
 
 ## Troubleshooting
 
 - Binary killed instantly on first run → Gatekeeper: `xattr -d com.apple.quarantine ~/.local/bin/cas`.
-- `cas` not found → `~/.local/bin` missing from PATH; re-check the `~/.zprofile` line, `exec zsh -l`.
+- `cas` not found → `~/.local/bin` missing from PATH; re-check the `~/.zprofile` line, then open a new terminal (or `source ~/.zprofile`).
+- `CAS not initialized` from a cloud command → you are outside a project. `cas login`, `cas logout` and `cas whoami` work anywhere; `cas doctor`, `cas cloud status` and `cas cloud team show` need you to `cd` into a `cas init`-ed project.
+- `cas init` refuses with "is your home directory" → that is the guard working; `cd` into the project first.
 - Hub unreachable from hub.petrastella.io → `cas hub service status`; confirm Tailscale is connected; re-pair if the Commander shows "Machine needs pairing".
 - Anything else → `cas doctor` first, then ask in #cas-internal.
 
@@ -121,8 +144,8 @@ cas         # bare `cas` launches the factory TUI with defaults
 
 - **[#469](https://github.com/Richards-LLC/cassy/issues/469)** `cas-install.sh` rejects macOS — the reason this guide hand-downloads the release asset. When fixed, step 2 collapses to one curl|bash line.
 - **[#470](https://github.com/Richards-LLC/cassy/issues/470)** the older from-zero doc is source-build-only with stale claims about release channels; this guide supersedes it for non-contributors.
-- **[#471](https://github.com/Richards-LLC/cassy/issues/471)** there is no CLI or documented flow for the *admin* side of team invites — a Petra Stella admin must invite your account in the CAS Cloud web UI before `cas cloud team` will show the team.
+- **[#471](https://github.com/Richards-LLC/cassy/issues/471)** there is no CLI or documented flow for the *admin* side of team invites — a Petra Stella admin must invite your account in the CAS Cloud web UI before `cas cloud team show` will show the team.
 
 ---
 
-Provenance: commands and flags verified against `cas 2.71.0/2.72.0` `--help` output and `cas config` defaults on the machine `soundwave-linux` (2026-08-17); release asset names and checksums from the published v2.72.0 GitHub release; memory-sharing semantics from the CAS memory MCP contract and `cas memory`/`cas cloud team-memories` CLI. HTML companion: `2026-08-17-mac-setup-petra-stella.html`.
+Provenance: commands and flags verified against `cas 2.71.0/2.72.0` `--help` output and `cas config` defaults on the machine `soundwave-linux` (2026-08-17); release asset names and checksums from the published v2.72.0 GitHub release; memory-sharing semantics from the CAS memory MCP contract and `cas memory`/`cas cloud team-memories` CLI. The 2026-08-18 revision additionally measured each step's real behaviour outside and inside a project (`cas login --token`, `cas whoami`, `cas cloud team show`, `cas cloud status`, `cas doctor`, `cas init`) and read `sync_user_builtins` in `cas-cli/src/cli/update.rs` for the `--user` claim.

--- a/docs/onboarding/macbook-from-zero.md
+++ b/docs/onboarding/macbook-from-zero.md
@@ -348,7 +348,7 @@ You're on a custom Cargo profile that overrides `panic`. The MCP panic catcher r
 ## What this guide does NOT cover
 
 - **Legacy public install paths** (`install.sh`, Homebrew). They ship a much older binary; use this repository's build instead.
-- **CAS Cloud sync setup beyond the basics** — `cas login` + `cas cloud sync` are packaged commands; team scope auto-resolves from your `/api/me` membership. See the [README Team Memories section](../../README.md#team-memories-optional) for the full flow (`cas cloud team default <slug>` if you want to pin a team override).
+- **CAS Cloud sync setup beyond the basics** — `cas login` + `cas cloud sync` are packaged commands; team scope auto-resolves from your `/api/me` membership. Logging in is once per machine (the credential lives in `~/.cas/cloud.json`, so later projects are already signed in), and `cas login --token <API-TOKEN>` works from any directory. See the [README Team Memories section](../../README.md#team-memories-optional) for the full flow (`cas cloud team default <slug>` if you want to pin a team override).
 - **`cas-update` / `cas-refresh` orchestrator scripts** — author-specific wrappers in `~/.local/bin/`. See `docs/ideation/2026-04-30-cas-shell-helpers-distribution-ideation.md`.
 - **Multi-user setups**, shared `cas.db`, team collaboration patterns.
 - **Custom skill / agent authoring**.

--- a/docs/reports/2026-08-18-cloud-device-login-server-defect.md
+++ b/docs/reports/2026-08-18-cloud-device-login-server-defect.md
@@ -1,0 +1,85 @@
+# Server defect: `/device` approval page rejects a valid code with "Missing or invalid Authorization header"
+
+**Status:** open, **not fixable in this repository**. The CLI half is fixed (cas-046d);
+this document exists so the server half is escalated rather than silently dropped.
+
+**Component:** Petra Stella Cloud web app — the device-authorization page at
+`https://petra-stella-cloud.vercel.app/device` and the endpoint it posts to.
+That code lives in the cloud/Next.js project, not in `cas-src`.
+
+**Reported by:** Ben, macOS clean install, 2026-08-18 (field report finding #2).
+
+## Symptom
+
+With an active, signed-in browser session on the cloud app, opening the device
+page with a freshly issued code:
+
+```
+https://petra-stella-cloud.vercel.app/device?code=FEUE-NMWQ
+```
+
+fails with:
+
+```
+Missing or invalid Authorization header
+```
+
+The approval never completes, so the waiting `cas login` eventually times out.
+
+## Reproduction
+
+1. On a machine with the CAS CLI, run `cas login`.
+2. Note the `user_code` printed by the CLI (for example `FEUE-NMWQ`).
+3. In a browser already signed in to `https://petra-stella-cloud.vercel.app`,
+   open `https://petra-stella-cloud.vercel.app/device?code=<user_code>`.
+4. Observe the error text above instead of an approve/deny prompt.
+
+Reproduced with three separate codes in one session. The session was signed in
+throughout — a page reload of the dashboard in the same browser worked.
+
+## Scope: what is and is not the CLI
+
+Two defects were interleaved in the original report; only the first was ours.
+
+- **CLI defect (fixed here, cas-046d).** `cas login` built the browser URL by
+  appending `?code=<code>` to a `verification_uri` that already carried the
+  code, producing `…/device?code=FEUE-NMWQ?code=FEUE-NMWQ`. The page then read
+  the whole `FEUE-NMWQ?code=FEUE-NMWQ` blob as the code. Fixed in
+  `cas-cli/src/cli/auth.rs` (`build_verification_url`), with regression tests.
+- **Server defect (this document).** After hand-correcting the URL to a single
+  `?code=<code>`, the page still fails with "Missing or invalid Authorization
+  header". No CLI change can affect that: at this point the CLI is only polling
+  `POST /device/token`, and the browser is talking to the web app on its own
+  session cookie.
+
+## Likely shape of the server bug
+
+The message is an API-side auth rejection, which suggests the device page is
+calling its own approval API with a bearer-token expectation (`Authorization:
+Bearer …`) while the browser only has a session cookie — i.e. the page never
+attaches credentials, or attaches the wrong kind. Worth checking on the server:
+
+- the fetch the `/device` page makes when it loads or when the code is
+  submitted, and whether it forwards the session;
+- whether the approval route requires `Authorization` rather than accepting the
+  authenticated session;
+- whether the route is running on an edge/middleware path that strips cookies.
+
+## Mitigation shipped in the CLI
+
+Until the page is fixed, the device flow can fail through no fault of the CLI,
+so every device-flow screen (and the fatal-error path) now names the working
+alternative:
+
+```
+cas login --token <API-TOKEN>
+```
+
+That path does not touch the `/device` page at all: it verifies the token
+against `/api/sync/status` and stores it in `~/.cas/cloud.json`. It works from
+any directory and logs in every project on the machine.
+
+## Escalation
+
+Owner: the cloud web app maintainer. This file is the CAS-side record; the CLI
+work is complete and the remaining fix is a server change.

--- a/docs/requests/BUG-team-project-registration-requires-nonempty-push.md
+++ b/docs/requests/BUG-team-project-registration-requires-nonempty-push.md
@@ -1,0 +1,94 @@
+---
+to: Petra Stella Cloud team
+from: CAS CLI (cas-c117, EPIC cas-e0d9 — macOS clean-install field report)
+date: 2026-08-18
+priority: P1
+status: client-side fix shipped; one server behaviour needs confirmation
+---
+
+# Project↔team registration only happens as a side effect of a non-empty team push
+
+## What the user saw
+
+On a clean macOS install (cas 2.72.0, schema v236, endpoint
+`petra-stella-cloud.vercel.app`):
+
+1. `cas cloud team set 2a57bec9-5dfa-4a8f-b711-31f9aeb8d6cb` → success.
+2. `cas cloud sync` → `✓ Push complete`, `✓ Pull complete`, exit 0, 0 entries.
+3. `cas cloud team-memories --full` → "This project hasn't been synced to the
+   team yet. Run `cas cloud sync` while a team is configured" — the exact
+   command just run.
+
+Reproduced identically in a plain folder, with `team auto on`, with
+`cas cloud project set <canonical-id>`, and in a real clone of
+`github.com/Richards-LLC/gabber-studio`. `cas doctor` healthy throughout.
+
+## Client-side root cause (fixed here)
+
+The server learns about a project only through the `project_canonical_id`
+field of `POST /api/teams/{teamId}/sync/push` (the route upserts the project
+row — `INSERT … ON CONFLICT DO NOTHING`, previously reported in
+`completed/BUG-team-memories-never-populate.md`).
+
+The CLI only issued that POST when the team sync queue had rows:
+`CloudSyncer::push_team` returns early on an empty queue
+(`cas-cli/src/cloud/syncer/team_push.rs`). Team rows are enqueued at write
+time, so a clean install — nothing written since the team was configured —
+sent no team push at all, and the project was never registered. Everything
+downstream (team memories, team pull scoping) then silently had nothing to
+work with, while the sync reported success.
+
+**Fixed client-side (cas-c117):** `cas cloud sync` now performs an explicit,
+verified registration *before* it reports any success:
+
+1. `GET /api/teams/{teamId}/projects` — already registered?
+2. If not: `POST /api/teams/{teamId}/sync/push` with
+   `{"entries": [], "project_canonical_id": "<canonical>", "git_remote": "<normalized>", "client_version": …}`
+   (gzip, same shape as a normal push, no rows).
+3. `GET /api/teams/{teamId}/projects` again — the registration counts as done
+   only when the server itself lists the project.
+
+If step 3 still does not list the project, the CLI exits non-zero and prints
+the exact interaction instead of a green checkmark. A confirmed registration
+is cached locally so steady-state syncs cost no extra round-trip
+(`cas cloud sync --full` re-verifies).
+
+## What we need confirmed on the server
+
+**Does `POST /api/teams/{teamId}/sync/push` register the project when the
+payload carries `project_canonical_id` but no entity rows?**
+
+The client now depends on that being true (it is how a machine with nothing
+queued registers at all). We could not verify against production from the
+CLI repo — no credentials on the build machine, and the server lives in
+`petra-stella-cloud`, which is not checked out here.
+
+- If the route already upserts the project before it looks at the entity
+  arrays: nothing to do, the client fix is complete.
+- If the route short-circuits on an empty payload (e.g. returns early when
+  every entity array is empty), the entity-less registration write is a no-op
+  and users on a clean install will now get a loud, accurate failure instead
+  of a silent one — better, but still blocked. In that case please either
+  register before the empty-payload check, or expose a dedicated endpoint,
+  e.g. `POST /api/teams/{teamId}/projects` with
+  `{"canonical_id": …, "git_remote": …}` returning the project row. We will
+  switch the client to it.
+
+The exact request the client sends for registration:
+
+```
+POST /api/teams/{teamId}/sync/push
+Authorization: Bearer <token>
+Content-Type: application/json
+Content-Encoding: gzip
+{"entries":[],"project_canonical_id":"github.com/richards-llc/gabber-studio","git_remote":"github.com/richards-llc/gabber-studio","client_version":"…","client_build":"…"}
+```
+
+Expected: 2xx, and the project appears in `GET /api/teams/{teamId}/projects`.
+
+## Related
+
+- `completed/BUG-team-memories-never-populate.md` — the original report that
+  documented the server's auto-register-on-push behaviour.
+- `RESPONSE-cloud-open-decisions-and-git-remote-spec.md` §5 — `git_remote`
+  normalization used by the registration payload.


### PR DESCRIPTION
Assembled epic branch carrying all four lanes from Ben's 2026-08-18 clean-install field report, one CI run per batching policy:

- **cas-046d** — device-code URL fixed (no more `?code=X?code=X`), RFC 8628 polling backoff (429/slow_down are throttles, not failures), credentials now user-level in ~/.cas/cloud.json (one login per machine), login works outside a project. Server-side /device page defect escalated in docs/reports/2026-08-18-cloud-device-login-server-defect.md.
- **cas-c117** — root cause: project↔team registration only ever happened as a side effect of a non-empty team push, so clean installs never registered while sync printed green checkmarks. Sync now verifies registration with the server before reporting success and exits non-zero with the exact failing interaction otherwise. Plus (operator directive) sync auto-adopts the resolvable team default — no manual `team set` prerequisite; visible adoption notice, `team auto off` is a hard opt-out, multi-team users are asked, never guessed. Server-side registration question escalated in docs/requests/BUG-team-project-registration-requires-nonempty-push.md.
- **cas-2962** — Mac setup guide corrected against measured CLI behavior (step order, `cas cloud team show`, paste-safe shell block, real `cas update --user` seeding behavior, cloud domain named) and `cas init` now refuses to scaffold $HOME/root without confirmation (`--allow-non-project` for automation).

Test receipts across the combined branch (workers' scoped runs): 306 cloud lib, 8 team_registration (incl. e2e adopt+register with zero manual team commands), 22 cli::init incl. 7 guard tests, 18 cli::auth, 2 init_non_project_guard (real binary), 1 cloud_login_scope (real binary vs canned HTTP cloud), plus team_pull_wiring/team_scope_e2e/team_memories_e2e/active_team_id/team_default/team_backfill suites green.

Remaining for full end-to-end validation: Ben's team-memories back-fill on his Mac needs the next release build; two server-side defects need the cloud web-app owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)