### PR TITLE
ci: shrink the suite archive and stop superseded runs holding runners (cas-59d3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,20 @@ jobs:
       actions: read
       # Read-only PR metadata for the dedupe gate below. Nothing writes.
       pull-requests: read
+    # cas-59d3: key on the PULL REQUEST (falling back to the branch ref for
+    # push events) and cancel superseded runs. Keying on the head SHA put every
+    # push in its own group, so a rapid second push left the first run's full
+    # validation consuming runners for work that could never be merged —
+    # measured on PR #482, where macOS Check sat queued ~5min and the suite
+    # archive build ~8min behind superseded runs of the same PR. Cancelling is
+    # safe for required checks: merging requires the checks on the PR's CURRENT
+    # head, which the newest run supplies, and a cancelled run always belonged
+    # to a head that can no longer be merged. Keying by ref for pushes means a
+    # factory branch only ever cancels its own older commit, never another
+    # branch's.
     concurrency:
-      group: scoped-validation-${{ github.event.pull_request.head.sha || github.sha }}
-      cancel-in-progress: false
+      group: scoped-validation-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -283,10 +294,27 @@ jobs:
         if: steps.classify-diff.outputs.rust-unaffected != 'true'
         uses: taiki-e/install-action@nextest
 
+      # Debug info is stripped from the archived test binaries (cas-59d3).
+      # Every shard downloads this whole artifact, so its size is multiplied by
+      # the shard count and lands directly on the PR critical path: measured at
+      # 4034 MB, the three shards spent 404s, 257s and 63s downloading it to
+      # run 108s, 105s and 101s of tests. The shards were never skewed — the
+      # download was. Stripping debug info measured 65% smaller binaries on
+      # this workspace (1344 MB of test binaries -> 476 MB with
+      # `strip --strip-debug`).
+      #
+      # The cost is that a CI failure's backtrace loses line numbers; the test
+      # name and assertion message are unaffected, and anyone who needs a
+      # symbolised trace reproduces locally, where the normal `dev` profile
+      # (debug = 1) still applies. This override is scoped to this job only.
       - name: Build full suite archive
         if: steps.classify-diff.outputs.rust-unaffected != 'true'
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
+          CARGO_PROFILE_DEV_STRIP: debuginfo
+          CARGO_PROFILE_TEST_STRIP: debuginfo
         run: cargo nextest archive --workspace --archive-file fast-validation-suite.tar.zst
 
       # The archive carries test executables, but integration tests that spawn
@@ -477,9 +505,20 @@ jobs:
       - fast-validation-preflight
       - fast-validation-suite
       - fast-validation-docs
+    # cas-59d3: key on the PULL REQUEST (falling back to the branch ref for
+    # push events) and cancel superseded runs. Keying on the head SHA put every
+    # push in its own group, so a rapid second push left the first run's full
+    # validation consuming runners for work that could never be merged —
+    # measured on PR #482, where macOS Check sat queued ~5min and the suite
+    # archive build ~8min behind superseded runs of the same PR. Cancelling is
+    # safe for required checks: merging requires the checks on the PR's CURRENT
+    # head, which the newest run supplies, and a cancelled run always belonged
+    # to a head that can no longer be merged. Keying by ref for pushes means a
+    # factory branch only ever cancels its own older commit, never another
+    # branch's.
     concurrency:
-      group: fast-validation-${{ github.event.pull_request.head.sha || github.sha }}
-      cancel-in-progress: false
+      group: fast-validation-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Require every Fast Validation lane to pass
@@ -554,9 +593,20 @@ jobs:
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/')))
+    # cas-59d3: key on the PULL REQUEST (falling back to the branch ref for
+    # push events) and cancel superseded runs. Keying on the head SHA put every
+    # push in its own group, so a rapid second push left the first run's full
+    # validation consuming runners for work that could never be merged —
+    # measured on PR #482, where macOS Check sat queued ~5min and the suite
+    # archive build ~8min behind superseded runs of the same PR. Cancelling is
+    # safe for required checks: merging requires the checks on the PR's CURRENT
+    # head, which the newest run supplies, and a cancelled run always belonged
+    # to a head that can no longer be merged. Keying by ref for pushes means a
+    # factory branch only ever cancels its own older commit, never another
+    # branch's.
     concurrency:
-      group: macos-check-${{ github.event.pull_request.head.sha || github.sha }}
-      cancel-in-progress: false
+      group: macos-check-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     # Zig 0.15.2 cannot link its build runner with the Xcode 26.6 / macOS 26.5
     # SDK that macos-latest selected in 2026-07. Keep the known-good Xcode 26.3
     # / macOS 26.2 SDK explicit until Zig is upgraded and verified against it.

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -104,8 +104,8 @@ require_text "$scoped" "steps.classify-diff.outputs.rust-unaffected != 'true'" '
 require_text "$scoped" 'id: pr-dedupe' 'scoped lane checks for a PR event on the same head SHA'
 require_text "$scoped" 'scripts/check-ci-pr-event-coverage.sh' 'scoped lane uses the shared fail-closed PR coverage guard'
 require_text "$scoped" "steps.pr-dedupe.outputs.covered != 'true'" 'scoped lane gates expensive work on the dedupe verdict'
-require_text "$scoped" 'scoped-validation-${{ github.event.pull_request.head.sha || github.sha }}' 'scoped lane groups duplicate runs by head SHA'
-require_text "$scoped" 'cancel-in-progress: false' 'scoped lane queues duplicate runs instead of cancelling validation'
+require_text "$scoped" 'scoped-validation-${{ github.event.pull_request.number || github.ref }}' 'scoped lane groups runs by pull request, falling back to the branch ref'
+require_text "$scoped" 'cancel-in-progress: true' 'scoped lane cancels its own superseded runs'
 require_text "$scoped" 'pull-requests: read' 'scoped lane reads PR metadata without write access'
 
 # The dedupe may only ever silence the PUSH copy. If the pull-request event
@@ -289,8 +289,8 @@ for job in "${required_pr_jobs[@]}"; do
     block="$(job_block "$job")"
     require_text "$block" "github.event_name == 'pull_request'" "$job runs for pull requests"
     require_text "$block" 'github.base_ref == github.event.repository.default_branch' "$job targets the default PR base"
-    require_text "$block" 'github.event.pull_request.head.sha || github.sha' "$job deduplicates push/PR runs by head SHA"
-    require_text "$block" 'cancel-in-progress: false' "$job queues duplicate required-check runs without cancellation"
+    require_text "$block" 'github.event.pull_request.number || github.ref' "$job groups runs by pull request rather than by head SHA"
+    require_text "$block" 'cancel-in-progress: true' "$job releases runners held by its own superseded runs"
 done
 
 preflight="$(job_block fast-validation-preflight)"
@@ -303,6 +303,22 @@ require_text "$suite_shards" 'shard: [1, 2, 3]' 'suite uses three nextest shards
 require_text "$suite_shards" 'fail-fast: false' 'suite keeps running other shards after a failure'
 require_text "$suite_build" 'cargo nextest archive --workspace --archive-file fast-validation-suite.tar.zst' 'suite compiles the workspace test graph once into an archive'
 require_text "$suite_build" 'actions/upload-artifact@v4' 'suite build publishes the shared nextest archive'
+
+# Archive payload is on the PR critical path (cas-59d3). Every shard downloads
+# the whole artifact, so its size is multiplied by the shard count. Measured at
+# 4034 MB: the three shards spent 404s / 257s / 63s downloading it in order to
+# run 108s / 105s / 101s of tests, i.e. the apparent "shard skew" was download
+# variance, not partition imbalance. Stripping debug info measured 65% smaller
+# binaries on this workspace. Keep the override, and keep it scoped to the
+# archive build so local and other lanes keep their normal debug info.
+require_text "$suite_build" 'CARGO_PROFILE_DEV_DEBUG: "0"' 'suite archive drops dev debug info'
+require_text "$suite_build" 'CARGO_PROFILE_TEST_DEBUG: "0"' 'suite archive drops test debug info'
+require_text "$suite_build" 'CARGO_PROFILE_DEV_STRIP: debuginfo' 'suite archive strips dev debug sections'
+require_text "$suite_build" 'CARGO_PROFILE_TEST_STRIP: debuginfo' 'suite archive strips test debug sections'
+require_absent "$ci_text" 'CARGO_PROFILE_DEV_STRIP: symbols' 'archive keeps symbol names for readable panics'
+for job in fast-validation-preflight fast-validation-docs clippy test-compile-guard; do
+    require_absent "$(job_block "$job")" 'CARGO_PROFILE_DEV_DEBUG' "$job keeps normal debug info: $job"
+done
 require_text "$suite_build" 'tar -czf fast-validation-suite-runner.tar.gz target/debug/cas' 'suite packages the executable CLI runner with its mode bits'
 require_text "$suite_shards" 'needs: fast-validation-suite-build' 'shards wait for the shared test archive'
 require_text "$suite_shards" 'actions/download-artifact@v4' 'shards download the shared nextest archive'


### PR DESCRIPTION
## The shards were never skewed

Step-level timings from run 32146014087 on current main:

| Job | Total | Download | Test |
|---|---|---|---|
| archive build | 469s | — | build 338s, upload 61s |
| shard 1/3 | 526s | **404s** | 108s |
| shard 2/3 | 381s | **257s** | 105s |
| shard 3/3 | 175s | **63s** | 101s |

Test execution is 108 / 105 / 101s — a **1.07× spread**, already inside the target. nextest's own summary on shard 1 reads `Summary [46.155s] 2712 tests run`. The 3× spread in *job* time is entirely `Download full suite archive`.

So re-partitioning (hash vs count, test-groups, more shards) would have moved seconds around, and **a fourth shard would have made it worse** by adding a fourth download.

## What actually costs the time

`fast-validation-suite-archive` is **4034 MB**, and every shard downloads all of it — roughly **12 GB of transfer per run to execute five minutes of tests**. Effective throughput ranged 10 MB/s to 64 MB/s; that variance is GitHub's artifact service, so the only lever we hold is the payload size.

The archive is unstripped debug test binaries. Measured with `strip --strip-debug` over this workspace's three largest test binaries: **1344 MB → 476 MB, 65% smaller**. The archive build now sets `debug = 0` and `strip = "debuginfo"`, scoped to that one job so local builds and every other lane keep their normal debug info.

Cost: a CI backtrace loses line numbers. Test names and assertion messages are unaffected, and anyone needing a symbolised trace reproduces locally.

## Superseded runs holding runners

The required lanes keyed concurrency on the head SHA with `cancel-in-progress: false`, so every push formed its own group and a superseded run kept consuming runners for work that could never be merged. On PR #482 that left macOS Check queued ~5min and the archive build ~8min behind that branch's own stale runs.

All three lanes now key on the **pull request number**, falling back to the **branch ref** for pushes, and cancel in progress. Cancelling is safe for required checks: merging needs the checks on the PR's *current* head, which the newest run supplies, and a cancelled run always belonged to a head that can no longer be merged. Keying by ref means a factory branch only ever cancels its own older commit, never another branch's.

## Testing

Tier contract **292 → 301 assertions, 0 failing**. Mutation-checked — each turns it red:

| Mutation | Result |
|---|---|
| `cancel-in-progress` back to `false` | FAIL |
| Re-key a group to the head SHA | FAIL |
| Drop the strip override | FAIL |

Before/after artifact size and per-shard download times will be recorded from this PR's own run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)