### PR TITLE
prompts: pay for the conciseness contract in bytes (cas-0e4a follow-up)

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -52,20 +52,18 @@ Null means use judgment; other values are invalid.
 
 ## Rules of Engagement
 
-Your scope is locked at assignment:
-
 - **Cross-team routing.** Report CAS defects to `Richards-LLC/cassy`; file Richards-LLC team requests on its issue board, not its checkout. Save a memory receipt (URL, ask, date); `docs/requests` is legacy-only.
 
 - **Never self-dispatch.** Start only a task assigned by `action=mine` or named explicitly by the supervisor. `ready`/`available` are backlog *visibility*, never authorization to `start` a task yourself. Idle means wait.
 - **One task at a time.** Complete the current task before taking another.
 - **Scope is frozen.** Build exactly the spec; note related improvements without implementing them.
 - **Honor non-goals and layer boundaries.** Modify only assigned files/modules.
-- **Match existing patterns.** Follow established conventions; don't introduce new ones without asking.
+- **Match existing patterns.** Don't introduce new conventions without asking.
 - **Stow/install only from the main checkout, never a worktree.** Persistent symlinks otherwise break when the worktree is cleaned.
 - **No config surprises.** Don't hardcode values that should be configurable. Don't add config that wasn't requested.
 - **Recover from workspace denials; never retry the denied target.** Route source/build output to the worktree, durable proof to `[factory] artifacts_root/<task-id>/`, and ephemeral notes to the harness scratchpad. A `/dev/null` denial is a guard defect to report, not permission to invent another host path.
-  - Bad (observed): after a `/dev/null` denial, retry it or switch to an arbitrary host path.
-  - Good: stop, classify the output as source, durable proof, or ephemeral, then use its sanctioned location.
+  - Bad (observed): retrying `/dev/null`, or switching to an arbitrary host path.
+  - Good: classify the output first, then use its sanctioned location.
 - **Document important choices.** Use `mcp__cs__task action=notes note_type=decision` for non-obvious decisions.
 - **Keep durable discoveries deliberately.** Relays are attributed, not auto-saved; use `mcp__cs__memory action=remember` for cross-session facts.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
@@ -74,7 +72,7 @@ Your scope is locked at assignment:
 
 ## cas-src surface checklist — required before close
 
-In the pre-close task note, every applicable entry must paste its proving file, command, or test; every `not applicable` entry must state why. This is a requirement, not a suggestion. Bare assertions such as “synced all mirrors” or “migration covered” are non-compliant.
+In the pre-close task note, every applicable entry must paste its proving file, command, or test; every `not applicable` entry must state why. This is a requirement, not a suggestion. Bare assertions are non-compliant.
 
 **Evidence pair (observed):** Bad: `Builtin skill/agent — synced all mirrors.` Good: `Builtin skill/agent — changed <three mirror paths>; proof: builtin flavor-drift test, 9/9 passed.`
 

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -52,20 +52,18 @@ Null means use judgment; other values are invalid.
 
 ## Rules of Engagement
 
-Your scope is locked at assignment:
-
 - **Cross-team routing.** Report CAS defects to `Richards-LLC/cassy`; file Richards-LLC team requests on its issue board, not its checkout. Save a memory receipt (URL, ask, date); `docs/requests` is legacy-only.
 
 - **Never self-dispatch.** Start only a task assigned by `action=mine` or named explicitly by the supervisor. `ready`/`available` are backlog *visibility*, never authorization to `start` a task yourself. Idle means wait.
 - **One task at a time.** Complete the current task before taking another.
 - **Scope is frozen.** Build exactly the spec; note related improvements without implementing them.
 - **Honor non-goals and layer boundaries.** Modify only assigned files/modules.
-- **Match existing patterns.** Follow established conventions; don't introduce new ones without asking.
+- **Match existing patterns.** Don't introduce new conventions without asking.
 - **Stow/install only from the main checkout, never a worktree.** Persistent symlinks otherwise break when the worktree is cleaned.
 - **No config surprises.** Don't hardcode values that should be configurable. Don't add config that wasn't requested.
 - **Recover from workspace denials; never retry the denied target.** Route source/build output to the worktree, durable proof to `[factory] artifacts_root/<task-id>/`, and ephemeral notes to the harness scratchpad. A `/dev/null` denial is a guard defect to report, not permission to invent another host path.
-  - Bad (observed): after a `/dev/null` denial, retry it or switch to an arbitrary host path.
-  - Good: stop, classify the output as source, durable proof, or ephemeral, then use its sanctioned location.
+  - Bad (observed): retrying `/dev/null`, or switching to an arbitrary host path.
+  - Good: classify the output first, then use its sanctioned location.
 - **Document important choices.** Use `cas__task action=notes note_type=decision` for non-obvious decisions.
 - **Keep durable discoveries deliberately.** Relays are attributed, not auto-saved; use `cas__memory action=remember` for cross-session facts.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
@@ -74,7 +72,7 @@ Your scope is locked at assignment:
 
 ## cas-src surface checklist — required before close
 
-In the pre-close task note, every applicable entry must paste its proving file, command, or test; every `not applicable` entry must state why. This is a requirement, not a suggestion. Bare assertions such as “synced all mirrors” or “migration covered” are non-compliant.
+In the pre-close task note, every applicable entry must paste its proving file, command, or test; every `not applicable` entry must state why. This is a requirement, not a suggestion. Bare assertions are non-compliant.
 
 **Evidence pair (observed):** Bad: `Builtin skill/agent — synced all mirrors.` Good: `Builtin skill/agent — changed <three mirror paths>; proof: builtin flavor-drift test, 9/9 passed.`
 

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -52,20 +52,18 @@ Null means use judgment; other values are invalid.
 
 ## Rules of Engagement
 
-Your scope is locked at assignment:
-
 - **Cross-team routing.** Report CAS defects to `Richards-LLC/cassy`; file Richards-LLC team requests on its issue board, not its checkout. Save a memory receipt (URL, ask, date); `docs/requests` is legacy-only.
 
 - **Never self-dispatch.** Start only a task assigned by `action=mine` or named explicitly by the supervisor. `ready`/`available` are backlog *visibility*, never authorization to `start` a task yourself. Idle means wait.
 - **One task at a time.** Complete the current task before taking another.
 - **Scope is frozen.** Build exactly the spec; note related improvements without implementing them.
 - **Honor non-goals and layer boundaries.** Modify only assigned files/modules.
-- **Match existing patterns.** Follow established conventions; don't introduce new ones without asking.
+- **Match existing patterns.** Don't introduce new conventions without asking.
 - **Stow/install only from the main checkout, never a worktree.** Persistent symlinks otherwise break when the worktree is cleaned.
 - **No config surprises.** Don't hardcode values that should be configurable. Don't add config that wasn't requested.
 - **Recover from workspace denials; never retry the denied target.** Route source/build output to the worktree, durable proof to `[factory] artifacts_root/<task-id>/`, and ephemeral notes to the harness scratchpad. A `/dev/null` denial is a guard defect to report, not permission to invent another host path.
-  - Bad (observed): after a `/dev/null` denial, retry it or switch to an arbitrary host path.
-  - Good: stop, classify the output as source, durable proof, or ephemeral, then use its sanctioned location.
+  - Bad (observed): retrying `/dev/null`, or switching to an arbitrary host path.
+  - Good: classify the output first, then use its sanctioned location.
 - **Document important choices.** Use `mcp__cas__task action=notes note_type=decision` for non-obvious decisions.
 - **Keep durable discoveries deliberately.** Relays are attributed, not auto-saved; use `mcp__cas__memory action=remember` for cross-session facts.
 - **Never block the pane.** Background anything over ~2 minutes or use `action=remind` and end the turn. Foreground `gh run watch`/poll loops are banned; servers use `action=server_start`.
@@ -74,7 +72,7 @@ Your scope is locked at assignment:
 
 ## cas-src surface checklist — required before close
 
-In the pre-close task note, every applicable entry must paste its proving file, command, or test; every `not applicable` entry must state why. This is a requirement, not a suggestion. Bare assertions such as “synced all mirrors” or “migration covered” are non-compliant.
+In the pre-close task note, every applicable entry must paste its proving file, command, or test; every `not applicable` entry must state why. This is a requirement, not a suggestion. Bare assertions are non-compliant.
 
 **Evidence pair (observed):** Bad: `Builtin skill/agent — synced all mirrors.` Good: `Builtin skill/agent — changed <three mirror paths>; proof: builtin flavor-drift test, 9/9 passed.`
 


### PR DESCRIPTION
Follow-up to #484 against the supervisor's acceptance harness for cas-0e4a: the conciseness contract cannot be additive prose — every byte added to a worker-facing prompt surface must be paid for by bytes removed, measured on the worker SessionStart protected context.

#484 landed the contract at **+8 bytes**. Green, but not net-negative. This pays the debt.

## Measured, not inferred

Taken directly by temporarily raising `REQUIRED_MARGIN` to force the test to print the real size, at all three points:

| State | Protected context | Delta |
|---|---:|---:|
| Pre-task baseline (before any cas-0e4a work) | 11451 B | — |
| After PR #484 (current main) | 11459 B | +8 |
| **After this change** | **11286 B** | **−165 vs baseline, −173 vs main** |

## What was cut, and why it qualifies

The trims come from the exact category the contract targets — preamble and restatement — taken out of the skill body that teaches it:

- `Your scope is locked at assignment:` — a preamble line restating both its own section heading and the "Scope is frozen" bullet directly beneath it.
- `Follow established conventions; don't introduce new ones without asking` — two clauses saying one thing.
- `Bare assertions such as "synced all mirrors" or "migration covered"` — "synced all mirrors" is demonstrated concretely two lines later in the Evidence pair, so naming it twice is the restatement being banned.
- The `/dev/null` denial Bad/Good pair was **compressed, not deleted**. It records an observed failure mode, and negative space is precisely what the contract protects — deleting it to hit a byte target would have contradicted the change.

## Guarding against the mistake #484 made

In #484 I trimmed prose in `pty.rs` and silently deleted two phrases the cas-83c8 test pins verbatim. So this time the check is programmatic: all **62** test-pinned literals present in the pre-task body were asserted to survive the trim, before running anything.

## Verification

- builtins lib **87/87** (includes the 12KB/8KB body ceilings and the protected-context margin)
- handlers_session **20/20**, builtin flavor drift **9/9**, contract parity **6/6**
- Mirrors re-synced, verified prefix-normalized identical to canonical
- No `references/` file changed, so reference-history needs no regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)