### PR TITLE
Operational intelligence periodic sweep (cas-93de)

### DIFF
--- a/docs/analysis/2026-08-18-operational-intelligence-sweep.md
+++ b/docs/analysis/2026-08-18-operational-intelligence-sweep.md
@@ -1,0 +1,61 @@
+# Operational intelligence periodic sweep
+
+`docs/analysis/scripts/operational_sweep.py` is the read-only operator command
+that joins the M1 evidence namespace, M2 evaluated hybrid retrieval, M3
+deployed-binary recurrence verdicts, and the M4 memory contradiction queue.
+One invocation emits a Markdown report, structured JSON, stage receipts, and
+ready-to-review issue/task drafts beneath its configured artifact root.
+
+The supervisor explicitly chose this Python analysis-lane command over a Rust
+`cas sweep` wrapper. A Rust wrapper remains an epic-close follow-up: shipping
+one here would either reimplement M1–M4 or make the CAS binary depend on the
+repository's `docs/analysis` tree and Python runtime.
+
+## Safety contract
+
+- Every SQLite source is opened with URI `mode=ro` and `PRAGMA query_only=ON`.
+- Only `artifact_root` is written. The prior-run watermark is advanced only
+  after M2's gate, M3, and M4 all complete successfully.
+- M2 failure, unavailable evaluation gate, malformed output, M3 failure, or M4
+  failure produces `failed-run.json` and leaves the prior watermark unchanged.
+- Only M1 units in `correction_state='current'` are eligible. First observation
+  is `MIN(evidence_provenance.timestamp)`, so a pre-fix claim repeated later is
+  not relabelled as new. Retention and redaction receipt hashes are carried in
+  the M1 watermark card.
+- Reports omit source paths and raw stage output. Evidence excerpts are capped
+  at 280 characters; subprocess output is byte-counted and hashed.
+- The command has no issue/task filing, memory mutation, or automatic model-turn
+  route. Every proposal is marked `draft-human-review-required`.
+
+## Run it
+
+Copy `operational-sweep-config.example.json`, replace the absolute paths, and
+run:
+
+```bash
+python3 docs/analysis/scripts/operational_sweep.py run \
+  --config docs/analysis/operational-sweep-config.json
+```
+
+Start with `mode: backfill`. The report distinguishes cursor progress from
+corpus exhaustion, so a large M1 events backlog cannot masquerade as “no new
+evidence.” After every source is drained, switch to `steady-state`.
+
+`operational-sweep.cron.example` is the supervisor-armable hourly path. It is a
+template rather than a committed live cron entry: installation changes operator
+runtime state and therefore requires the supervisor's explicit action.
+
+## Report contract
+
+Every analytical claim in `report.json` has one or more `evidence_card_ids`.
+The Markdown report prints those IDs beside the claim. M3 `recurred` verdicts
+and actionable M4 contradiction rows graduate into the same proposal queue as
+the two recurring-failure and two instruction-drift probes. A proposal contains
+the standard issue body headings, in order: Environment, Repro, Actual,
+Expected, Impact, Suggested fix. The paired task spec carries the same evidence
+IDs and remains a draft.
+
+Run receipts record stage and total latency, final artifact bytes, model turns,
+and M2 retrieval-query count. M2 does not expose provider billing through its
+query contract; USD cost is recorded as unknown instead of estimated without
+evidence.

--- a/docs/analysis/operational-sweep-config.example.json
+++ b/docs/analysis/operational-sweep-config.example.json
@@ -1,0 +1,12 @@
+{
+  "artifact_root": "/home/OPERATOR/.cas/artifacts/operational-sweep",
+  "epochs_db": "/ABS/PATH/TO/cas-src/.cas/cas.db",
+  "index": "/home/OPERATOR/.cas/artifacts/cas-2556/operational-index/index.sqlite3",
+  "memories_db": "/home/OPERATOR/.cas/cas.db",
+  "mode": "steady-state",
+  "seeds": "v2.71.0-fix-wave-seeds.json",
+  "semantic_evidence": null,
+  "top": 5,
+  "units_db": "/home/OPERATOR/.cas/artifacts/cas-b78b/evidence/units.sqlite3",
+  "window_days": 7
+}

--- a/docs/analysis/operational-sweep.cron.example
+++ b/docs/analysis/operational-sweep.cron.example
@@ -1,0 +1,5 @@
+# Operational intelligence sweep — arm only after replacing both absolute paths.
+# The command is read-only outside its configured artifact_root. stdout is one
+# status JSON line; the durable report and receipt live beneath artifact_root.
+# First drain the M1 backlog with mode=backfill, then change it to steady-state.
+17 * * * * cd /ABS/PATH/TO/cas-src && /usr/bin/python3 docs/analysis/scripts/operational_sweep.py run --config /ABS/PATH/TO/cas-src/docs/analysis/operational-sweep-config.json

--- a/docs/analysis/scripts/operational_sweep.py
+++ b/docs/analysis/scripts/operational_sweep.py
@@ -390,7 +390,11 @@ def proposals(findings: Sequence[dict[str, Any]], cards: dict[str, dict[str, Any
     for finding in findings:
         if not finding["evidence_card_ids"]:
             continue
-        card = cards[finding["evidence_card_ids"][0]]
+        candidate_cards = [cards[item] for item in finding["evidence_card_ids"]]
+        card = next(
+            (item for item in candidate_cards if item.get("epoch_class") == "clean-post" and item.get("excerpt")),
+            next((item for item in candidate_cards if item.get("excerpt")), candidate_cards[0]),
+        )
         drafts.append({
             "proposal_id": f"proposal:{finding['id']}",
             "status": "draft-human-review-required",
@@ -411,12 +415,18 @@ def proposals(findings: Sequence[dict[str, Any]], cards: dict[str, dict[str, Any
 
 def add_m3_m4_claims(
     verdicts: dict[str, Any], contradictions: dict[str, Any], cards: dict[str, dict[str, Any]], claims: list[dict[str, Any]],
-) -> None:
+) -> list[dict[str, Any]]:
+    proposal_findings = []
     for verdict in verdicts.get("verdicts", []):
         evidence_ids = []
         for item in verdict.get("evidence_cards", []):
             card_id = f"m3:{verdict['id']}:{item.get('evidence_id')}"
-            cards[card_id] = {"card_id": card_id, "kind": "recurrence_evidence", **item}
+            cards[card_id] = {
+                "card_id": card_id,
+                "kind": "recurrence_evidence",
+                **{key: value for key, value in item.items() if key != "excerpt"},
+                "excerpt": compact(item.get("excerpt", "")),
+            }
             evidence_ids.append(card_id)
         epoch_id = f"epoch:{verdict['id']}"
         cards[epoch_id] = {
@@ -430,6 +440,18 @@ def add_m3_m4_claims(
             "statement": f"{verdict['id']} is {verdict['state']}: {verdict['reason']}",
             "evidence_card_ids": [epoch_id, *evidence_ids],
         })
+        if verdict.get("state") == "recurred" and evidence_ids:
+            proposal_findings.append({
+                "id": f"recurrence-{verdict['id']}",
+                "section": "recurrence_verdicts",
+                "title": f"Possible recurrence: {verdict.get('title') or verdict['id']}",
+                "statement": f"{verdict['id']} has clean-post symptom evidence: {verdict['reason']}",
+                "expected": (
+                    "After the fix is observed in the deployed binary, the fixed symptom should not appear "
+                    "in the clean-post window; a human must confirm the evidence is the same symptom."
+                ),
+                "evidence_card_ids": [epoch_id, *evidence_ids],
+            })
     for index, item in enumerate(contradictions.get("items", [])):
         memory = item.get("memory", {})
         verdict = item.get("verdict", {})
@@ -451,6 +473,16 @@ def add_m3_m4_claims(
             ),
             "evidence_card_ids": [card_id],
         })
+        if item.get("suggested_action"):
+            proposal_findings.append({
+                "id": f"memory-{memory.get('id', index)}-{verdict.get('id', index)}",
+                "section": "contradiction_queue",
+                "title": f"Review observed contradiction for memory {memory.get('id', 'unknown')}",
+                "statement": f"M4 suggests {item['suggested_action']} after a human reviews the memory-to-evidence link.",
+                "expected": "The memory should agree with behavior observed after the deployed-binary boundary.",
+                "evidence_card_ids": [card_id],
+            })
+    return proposal_findings
 
 
 def render_report(payload: dict[str, Any]) -> str:
@@ -461,10 +493,9 @@ def render_report(payload: dict[str, Any]) -> str:
         "## Corpus and watermark status", "",
         f"M1 source status: **{payload['backlog']['status']}**; estimated remaining cursor units/bytes: "
         f"{payload['backlog'].get('remaining_total', 'unknown')}. This is reported separately from new evidence since the prior sweep.", "",
-        f"New current evidence units since `{payload['run']['since'] or 'first run'}`: "
-        f"{payload['new_evidence']['metadata']['new_units_total']} (showing {payload['new_evidence']['metadata']['returned']}).", "",
     ]
     sections = (
+        ("new_evidence", "New evidence since the previous run"),
         ("recurring_failure", "Top recurring failure narratives"),
         ("instruction_drift", "Instruction-drift clusters"),
         ("recurrence_verdicts", "Deployed-binary recurrence verdicts"),
@@ -568,7 +599,24 @@ def run(config: dict[str, Any], argv: Sequence[str]) -> Path:
             runner, python, m2_script, index, units_db, probes, int(config.get("top", 5))
         )
         cards.update({card["card_id"]: card for card in new_cards})
+        watermark_card_id = f"m1-watermark:{run_id}"
+        cards[watermark_card_id] = {
+            "card_id": watermark_card_id,
+            "kind": "m1_watermark_receipt",
+            "since": since,
+            "new_evidence": new_metadata,
+            "backlog": backlog,
+        }
         claims = [
+            {
+                "section": "new_evidence",
+                "statement": (
+                    f"M1 contains {new_metadata['new_units_total']} current unit(s) first observed since "
+                    f"{since or 'the first sweep'}; {new_metadata['returned']} review card(s) are included."
+                ),
+                "evidence_card_ids": [watermark_card_id, *[card["card_id"] for card in new_cards[:10]]],
+            }
+        ] + [
             {
                 "section": finding["section"],
                 "statement": finding["statement"],
@@ -603,9 +651,9 @@ def run(config: dict[str, Any], argv: Sequence[str]) -> Path:
             [contradiction_path],
         )
         contradictions = json.loads(contradiction_path.read_text())
-        add_m3_m4_claims(verdicts, contradictions, cards, claims)
+        followup_findings = add_m3_m4_claims(verdicts, contradictions, cards, claims)
         invocation = " ".join(shlex.quote(part) for part in argv)
-        drafts = proposals(findings, cards, invocation)
+        drafts = proposals([*followup_findings, *findings], cards, invocation)
         report_json = run_dir / "report.json"
         report_md = run_dir / "report.md"
         payload = {

--- a/docs/analysis/scripts/operational_sweep.py
+++ b/docs/analysis/scripts/operational_sweep.py
@@ -1,0 +1,674 @@
+#!/usr/bin/env python3
+"""Run the read-only operational-intelligence sweep (M1 -> M2 -> M3 -> M4).
+
+The command reads the evidence, operational-index, epoch, and memory stores in
+read-only mode.  Its only durable writes are beneath ``artifact_root``: one
+run directory plus an artifact-local watermark after a completely successful
+run.  Findings are proposals for a human reviewer; this module has no issue,
+task, memory, or model-turn execution path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shlex
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+
+DEFAULT_PROBES = (
+    {
+        "id": "silent-test-suite",
+        "family": "recurring_failure",
+        "title": "Test command reports success while the intended suite did not run",
+        "query": "test suite silently skipped zero tests ran command reported success",
+        "expected": "A verification command must prove that the intended test target executed, or fail loudly.",
+    },
+    {
+        "id": "release-claim-drift",
+        "family": "recurring_failure",
+        "title": "Release claim differs from behavior in the deployed binary",
+        "query": "release claimed fixed shipped behavior still old stale running binary",
+        "expected": "Release claims must be checked against behavior observed from the deployed binary.",
+    },
+    {
+        "id": "repeated-policy-correction",
+        "family": "instruction_drift",
+        "title": "Standing instruction repeatedly requires correction",
+        "query": "worker repeatedly failed standing rule corrected more than once instruction drift",
+        "expected": "One unambiguous standing instruction should produce the same compliant behavior across harnesses.",
+    },
+    {
+        "id": "opposite-policy-interpretation",
+        "family": "instruction_drift",
+        "title": "Instruction wording permits the opposite interpretation",
+        "query": "ambiguous instruction model did opposite operator intended policy conflict",
+        "expected": "Policy wording should exclude the unsafe or opposite interpretation.",
+    },
+)
+
+ISSUE_HEADINGS = ("Environment", "Repro", "Actual", "Expected", "Impact", "Suggested fix")
+DB_CURSOR_SPECS = {
+    "task": ("tasks", "rowid"),
+    "lifecycle_event": ("events", "id"),
+    "prompt_queue": ("prompt_queue", "id"),
+    "supervisor_queue": ("supervisor_queue", "id"),
+}
+
+
+class SweepError(RuntimeError):
+    """A stage could not make an evidence-backed statement."""
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso(value: datetime) -> str:
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def parse_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def compact(text: str, limit: int = 280) -> str:
+    value = " ".join(str(text).split())
+    return value if len(value) <= limit else value[: limit - 1] + "…"
+
+
+def connect_ro(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(f"file:{path.resolve()}?mode=ro", uri=True)
+    connection.execute("PRAGMA query_only=ON")
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def size_of(paths: Sequence[Path]) -> int:
+    return sum(path.stat().st_size for path in paths if path.exists() and path.is_file())
+
+
+def table_exists(db: sqlite3.Connection, name: str) -> bool:
+    return db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)).fetchone() is not None
+
+
+def latest_receipts(db: sqlite3.Connection) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {"redaction": [], "retention": []}
+    if table_exists(db, "redaction_receipts"):
+        columns = {row[1] for row in db.execute("PRAGMA table_info(redaction_receipts)")}
+        selected = [name for name in ("run_at", "source_key", "secrets", "emails", "receipt_hash") if name in columns]
+        if selected:
+            rows = db.execute(f"SELECT {','.join(selected)} FROM redaction_receipts ORDER BY rowid DESC LIMIT 20")
+            result["redaction"] = [dict(row) for row in rows]
+    if table_exists(db, "retention_receipts"):
+        columns = {row[1] for row in db.execute("PRAGMA table_info(retention_receipts)")}
+        selected = [name for name in ("run_at", "privacy_scope", "cutoff", "provenance_deleted", "units_deleted", "receipt_hash") if name in columns]
+        if selected:
+            rows = db.execute(f"SELECT {','.join(selected)} FROM retention_receipts ORDER BY rowid DESC LIMIT 20")
+            result["retention"] = [dict(row) for row in rows]
+    return result
+
+
+def evidence_rows(units_db: Path, since: str | None, limit: int) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Return current, redacted units first observed after ``since``.
+
+    The timestamp is MIN(provenance.timestamp), never a later repeat.  This is
+    the same conservative first-observation rule M3 relies on.
+    """
+    db = connect_ro(units_db)
+    try:
+        query = """
+            SELECT u.id,u.content_hash,u.unit_type,u.text,u.occurrence_count,
+                   u.redaction_secrets,u.redaction_emails,u.first_seen_at,
+                   COALESCE(MIN(NULLIF(p.timestamp,'')),u.first_seen_at) AS observed_at
+            FROM evidence_units u
+            LEFT JOIN evidence_provenance p ON p.unit_id=u.id
+            WHERE u.correction_state='current'
+            GROUP BY u.id
+        """
+        rows = list(db.execute(query))
+        cutoff = parse_time(since)
+        selected = []
+        for row in rows:
+            observed = parse_time(row["observed_at"])
+            if cutoff and (not observed or observed <= cutoff):
+                continue
+            provenance = [
+                {
+                    "source_key": item["source_key"],
+                    "timestamp": item["timestamp"],
+                    "task_id": item["task_id"],
+                }
+                for item in db.execute(
+                    "SELECT source_key,timestamp,task_id FROM evidence_provenance "
+                    "WHERE unit_id=? ORDER BY timestamp LIMIT 3",
+                    (row["id"],),
+                )
+            ]
+            selected.append(
+                {
+                    "card_id": f"eu:{row['id']}",
+                    "content_hash": row["content_hash"],
+                    "kind": "evidence_unit",
+                    "unit_type": row["unit_type"],
+                    "timestamp": row["observed_at"],
+                    "occurrence_count": row["occurrence_count"],
+                    "excerpt": compact(row["text"]),
+                    "redaction": {"secrets": row["redaction_secrets"], "emails": row["redaction_emails"]},
+                    "provenance": provenance,
+                }
+            )
+        selected.sort(key=lambda item: item["timestamp"] or "", reverse=True)
+        maximum = db.execute(
+            "SELECT MAX(COALESCE(NULLIF(p.timestamp,''),u.first_seen_at)) "
+            "FROM evidence_units u LEFT JOIN evidence_provenance p ON p.unit_id=u.id "
+            "WHERE u.correction_state='current'"
+        ).fetchone()[0]
+        metadata = {
+            "new_units_total": len(selected),
+            "returned": min(len(selected), limit),
+            "max_current_timestamp": maximum,
+            "receipts_honored": latest_receipts(db),
+        }
+        return selected[:limit], metadata
+    finally:
+        db.close()
+
+
+def evidence_by_hash(units_db: Path, hashes: Sequence[str]) -> dict[str, dict[str, Any]]:
+    if not hashes:
+        return {}
+    db = connect_ro(units_db)
+    try:
+        result = {}
+        for content_hash in sorted(set(hashes)):
+            row = db.execute(
+                "SELECT id,content_hash,unit_type,text,occurrence_count,redaction_secrets,redaction_emails,first_seen_at "
+                "FROM evidence_units WHERE content_hash=? AND correction_state='current'",
+                (content_hash,),
+            ).fetchone()
+            if not row:
+                continue
+            first = db.execute(
+                "SELECT source_key,timestamp,task_id FROM evidence_provenance WHERE unit_id=? ORDER BY timestamp LIMIT 1",
+                (row["id"],),
+            ).fetchone()
+            result[content_hash] = {
+                "card_id": f"eu:{row['id']}",
+                "content_hash": content_hash,
+                "kind": "evidence_unit",
+                "unit_type": row["unit_type"],
+                "timestamp": first["timestamp"] if first else row["first_seen_at"],
+                "occurrence_count": row["occurrence_count"],
+                "excerpt": compact(row["text"]),
+                "redaction": {"secrets": row["redaction_secrets"], "emails": row["redaction_emails"]},
+                "provenance": [dict(first)] if first else [],
+            }
+        return result
+    finally:
+        db.close()
+
+
+def backlog_status(units_db: Path) -> dict[str, Any]:
+    """Describe watermark progress separately from corpus exhaustion."""
+    db = connect_ro(units_db)
+    try:
+        if not table_exists(db, "ingest_watermarks"):
+            return {"status": "unknown", "reason": "ingest_watermarks table absent", "sources": []}
+        marks = list(db.execute(
+            "SELECT source_key,source_path,cursor_kind,byte_offset,row_cursor,size_bytes,updated_at "
+            "FROM ingest_watermarks ORDER BY source_key"
+        ))
+    finally:
+        db.close()
+    sources = []
+    unknown = 0
+    remaining_total = 0
+    for mark in marks:
+        remaining: int | None = None
+        try:
+            source = Path(mark["source_path"])
+            if mark["cursor_kind"] == "byte-offset":
+                remaining = max(0, source.stat().st_size - int(mark["byte_offset"]))
+            elif mark["source_key"].startswith("db:"):
+                unit_type = mark["source_key"].split(":", 1)[1]
+                table, cursor = DB_CURSOR_SPECS[unit_type]
+                source_db = connect_ro(source)
+                try:
+                    maximum = source_db.execute(f"SELECT COALESCE(MAX({cursor}),0) FROM {table}").fetchone()[0]
+                finally:
+                    source_db.close()
+                remaining = max(0, int(maximum) - int(mark["row_cursor"]))
+        except (OSError, KeyError, sqlite3.Error, ValueError):
+            unknown += 1
+        if remaining is not None:
+            remaining_total += remaining
+        sources.append({
+            "source_key": mark["source_key"],
+            "cursor_kind": mark["cursor_kind"],
+            "remaining": remaining,
+            "updated_at": mark["updated_at"],
+        })
+    status = "drained" if not unknown and remaining_total == 0 else "backlog"
+    if unknown and remaining_total == 0:
+        status = "unknown"
+    return {"status": status, "remaining_total": remaining_total, "unknown_sources": unknown, "sources": sources}
+
+
+@dataclass
+class StageRunner:
+    receipts: list[dict[str, Any]]
+
+    def run(self, name: str, command: Sequence[str], outputs: Sequence[Path] = ()) -> dict[str, Any]:
+        started = time.monotonic()
+        process = subprocess.run(
+            list(command), capture_output=True, text=True, check=False,
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        )
+        elapsed = round((time.monotonic() - started) * 1000, 1)
+        receipt = {
+            "stage": name,
+            "latency_ms": elapsed,
+            "exit_code": process.returncode,
+            "stdout_bytes": len(process.stdout.encode()),
+            "stdout_sha256": sha256_text(process.stdout),
+            "stderr_bytes": len(process.stderr.encode()),
+            "output_bytes": size_of(outputs),
+        }
+        self.receipts.append(receipt)
+        if process.returncode:
+            raise SweepError(f"{name} failed with exit {process.returncode}: {compact(process.stderr, 500)}")
+        try:
+            return json.loads(process.stdout) if process.stdout.strip() else {}
+        except json.JSONDecodeError as exc:
+            raise SweepError(f"{name} returned non-JSON output (sha256 {receipt['stdout_sha256']})") from exc
+
+
+def m2_findings(
+    runner: StageRunner, python: str, script: Path, index: Path, units_db: Path,
+    probes: Sequence[dict[str, str]], top: int,
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    payloads = []
+    hashes = []
+    for probe in probes:
+        payload = runner.run(
+            f"m2-query:{probe['id']}",
+            [python, str(script), "query", probe["query"], "--index", str(index), "--mode", "hybrid", "--top", str(top)],
+        )
+        if payload.get("gate_available") is not True:
+            raise SweepError(f"m2-query:{probe['id']} refused: evaluation gate is unavailable")
+        rows = payload.get("rows")
+        if not isinstance(rows, list):
+            raise SweepError(f"m2-query:{probe['id']} returned no reviewable rows list")
+        hashes.extend(str(row.get("content_hash", "")) for row in rows)
+        payloads.append((probe, payload))
+    mapped = evidence_by_hash(units_db, hashes)
+    cards: dict[str, dict[str, Any]] = {}
+    findings = []
+    for probe, payload in payloads:
+        card_ids = []
+        candidates = []
+        for row in payload["rows"]:
+            content_hash = str(row.get("content_hash", ""))
+            card = mapped.get(content_hash)
+            if not card:
+                card = {
+                    "card_id": f"m2:{row.get('event_id')}",
+                    "kind": "operational_index_candidate",
+                    "timestamp": (row.get("provenance") or [{}])[0].get("timestamp"),
+                    "occurrence_count": int(row.get("duplicate_count", 1)),
+                    "excerpt": compact(row.get("text", "")),
+                    "provenance": [
+                        {key: item.get(key) for key in ("timestamp", "task_id", "worker")}
+                        for item in (row.get("provenance") or [])[:3]
+                    ],
+                }
+            cards[card["card_id"]] = card
+            card_ids.append(card["card_id"])
+            candidates.append({
+                "evidence_card_id": card["card_id"],
+                "retrieval_score": row.get("score"),
+                "occurrence_count": card.get("occurrence_count", 1),
+            })
+        findings.append({
+            "id": probe["id"],
+            "section": probe["family"],
+            "title": probe["title"],
+            "statement": (
+                f"Hybrid retrieval surfaced {len(card_ids)} candidate(s) for “{probe['title']}”; "
+                "these are review candidates, not an automated defect verdict."
+            ),
+            "expected": probe["expected"],
+            "evidence_card_ids": card_ids,
+            "candidates": candidates,
+            "query_latency_ms": payload.get("latency_ms"),
+        })
+    return findings, cards
+
+
+def issue_body(finding: dict[str, Any], card: dict[str, Any], invocation: str) -> str:
+    values = {
+        "Environment": f"Generated by operational_sweep.py on {platform.platform()}; Python {platform.python_version()}.",
+        "Repro": f"```bash\n{invocation}\n```",
+        "Actual": f"> {card.get('excerpt') or finding['statement']}\n\nEvidence card: `{card['card_id']}`.",
+        "Expected": finding["expected"],
+        "Impact": "Human triage required. Recurrence and severity have not been inferred automatically.",
+        "Suggested fix": "Unknown — inspect the evidence card and linked provenance before tasking.",
+    }
+    return "\n\n".join(f"## {heading}\n\n{values[heading]}" for heading in ISSUE_HEADINGS) + "\n"
+
+
+def proposals(findings: Sequence[dict[str, Any]], cards: dict[str, dict[str, Any]], invocation: str) -> list[dict[str, Any]]:
+    drafts = []
+    for finding in findings:
+        if not finding["evidence_card_ids"]:
+            continue
+        card = cards[finding["evidence_card_ids"][0]]
+        drafts.append({
+            "proposal_id": f"proposal:{finding['id']}",
+            "status": "draft-human-review-required",
+            "never_auto_file": True,
+            "title": finding["title"],
+            "evidence_card_ids": finding["evidence_card_ids"],
+            "issue_body": issue_body(finding, card, invocation),
+            "task_spec": {
+                "title": finding["title"],
+                "description": finding["statement"],
+                "acceptance_criteria": finding["expected"],
+                "evidence_card_ids": finding["evidence_card_ids"],
+                "status": "draft-human-review-required",
+            },
+        })
+    return drafts
+
+
+def add_m3_m4_claims(
+    verdicts: dict[str, Any], contradictions: dict[str, Any], cards: dict[str, dict[str, Any]], claims: list[dict[str, Any]],
+) -> None:
+    for verdict in verdicts.get("verdicts", []):
+        evidence_ids = []
+        for item in verdict.get("evidence_cards", []):
+            card_id = f"m3:{verdict['id']}:{item.get('evidence_id')}"
+            cards[card_id] = {"card_id": card_id, "kind": "recurrence_evidence", **item}
+            evidence_ids.append(card_id)
+        epoch_id = f"epoch:{verdict['id']}"
+        cards[epoch_id] = {
+            "card_id": epoch_id,
+            "kind": "deployed_epoch_boundary",
+            "epoch_evidence": verdict.get("epoch_evidence"),
+            "exposure": verdict.get("exposure"),
+        }
+        claims.append({
+            "section": "recurrence_verdicts",
+            "statement": f"{verdict['id']} is {verdict['state']}: {verdict['reason']}",
+            "evidence_card_ids": [epoch_id, *evidence_ids],
+        })
+    for index, item in enumerate(contradictions.get("items", [])):
+        memory = item.get("memory", {})
+        verdict = item.get("verdict", {})
+        card_id = f"m4:{memory.get('id', index)}:{verdict.get('id', index)}"
+        cards[card_id] = {
+            "card_id": card_id,
+            "kind": "memory_contradiction_review",
+            "memory_id": memory.get("id"),
+            "claim": memory.get("claim"),
+            "link": item.get("link"),
+            "verdict": verdict,
+            "suggested_action": item.get("suggested_action"),
+        }
+        claims.append({
+            "section": "contradiction_queue",
+            "statement": (
+                f"Memory {memory.get('id', 'unknown')} is linked to {verdict.get('id', 'an observed fix')}; "
+                f"suggested action: {item.get('suggested_action') or 'hold for review'}."
+            ),
+            "evidence_card_ids": [card_id],
+        })
+
+
+def render_report(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Operational intelligence periodic sweep", "",
+        "> Proposals only. No issue, task, memory operation, or model turn was executed.", "",
+        f"Run `{payload['run']['id']}` completed in **{payload['run']['mode']}** mode at {payload['run']['completed_at']}.", "",
+        "## Corpus and watermark status", "",
+        f"M1 source status: **{payload['backlog']['status']}**; estimated remaining cursor units/bytes: "
+        f"{payload['backlog'].get('remaining_total', 'unknown')}. This is reported separately from new evidence since the prior sweep.", "",
+        f"New current evidence units since `{payload['run']['since'] or 'first run'}`: "
+        f"{payload['new_evidence']['metadata']['new_units_total']} (showing {payload['new_evidence']['metadata']['returned']}).", "",
+    ]
+    sections = (
+        ("recurring_failure", "Top recurring failure narratives"),
+        ("instruction_drift", "Instruction-drift clusters"),
+        ("recurrence_verdicts", "Deployed-binary recurrence verdicts"),
+        ("contradiction_queue", "Memory contradiction queue"),
+    )
+    for key, title in sections:
+        lines.extend([f"## {title}", ""])
+        section_claims = [claim for claim in payload["claims"] if claim["section"] == key]
+        if not section_claims:
+            lines.extend(["No evidence-backed claim was produced for this section.", ""])
+        for claim in section_claims:
+            cards = ", ".join(f"`{item}`" for item in claim["evidence_card_ids"])
+            lines.extend([f"- {claim['statement']} Evidence: {cards}.", ""])
+    lines.extend(["## Proposal review queue", ""])
+    for proposal in payload["proposals"]:
+        lines.extend([
+            f"### {proposal['title']}", "",
+            "Status: **draft — explicit human review required; never auto-filed**.", "",
+            proposal["issue_body"],
+        ])
+    if not payload["proposals"]:
+        lines.extend(["No draft met the minimum evidence-card requirement.", ""])
+    cost = payload["run"]["cost"]
+    lines.extend([
+        "## Run receipt", "",
+        f"- Latency: {payload['run']['latency_ms']} ms.",
+        f"- Storage: {payload['run']['storage_bytes']} bytes beneath the artifact run directory.",
+        f"- Cost: {cost['model_turns']} model turns; {cost['m2_queries']} M2 retrieval queries. "
+        "The M2 contract does not expose provider billing, so USD cost is recorded as unknown rather than invented.",
+        "- Stage stdout is hashed and byte-counted in `report.json`; it is not copied into this report.", "",
+        "## Evidence cards", "",
+        "See `report.json` for the structured, redacted evidence-card map. Excerpts are capped at 280 characters; source paths and raw prompt/log payloads are omitted.", "",
+    ])
+    return "\n".join(lines)
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text())
+    if not isinstance(payload, dict):
+        raise SweepError("config must be a JSON object")
+    base = path.resolve().parent
+    path_keys = {
+        "artifact_root", "units_db", "index", "epochs_db", "memories_db", "seeds",
+        "semantic_evidence", "m2_script", "m3_script", "m4_script", "join_script",
+    }
+    for key in path_keys.intersection(payload):
+        if payload[key] is None:
+            continue
+        candidate = Path(payload[key]).expanduser()
+        payload[key] = str(candidate if candidate.is_absolute() else base / candidate)
+    return payload
+
+
+def validate_paths(config: dict[str, Any]) -> None:
+    required = ("artifact_root", "units_db", "index", "epochs_db", "memories_db", "seeds")
+    missing = [key for key in required if not config.get(key)]
+    if missing:
+        raise SweepError(f"config missing required key(s): {', '.join(missing)}")
+    artifact_root = Path(config["artifact_root"]).resolve()
+    for key in required[1:]:
+        source = Path(config[key]).resolve()
+        if not source.is_file():
+            raise SweepError(f"{key} is not a readable file: {source}")
+        if source == artifact_root or artifact_root in source.parents:
+            raise SweepError(f"input {key} must not live beneath artifact_root")
+
+
+def run(config: dict[str, Any], argv: Sequence[str]) -> Path:
+    validate_paths(config)
+    started_at = utc_now()
+    started = time.monotonic()
+    artifact_root = Path(config["artifact_root"]).resolve()
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    state_path = artifact_root / "state.json"
+    prior_state = json.loads(state_path.read_text()) if state_path.exists() else {}
+    since = config.get("since") or prior_state.get("last_evidence_timestamp")
+    mode = config.get("mode", "steady-state")
+    if mode not in {"backfill", "steady-state"}:
+        raise SweepError("mode must be backfill or steady-state")
+    run_id = started_at.strftime("%Y%m%dT%H%M%SZ")
+    run_dir = artifact_root / "runs" / run_id
+    if run_dir.exists():
+        run_id += f"-{os.getpid()}"
+        run_dir = artifact_root / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    runner = StageRunner([])
+    python = str(config.get("python", sys.executable))
+    script_dir = Path(__file__).resolve().parent
+    units_db = Path(config["units_db"])
+    index = Path(config["index"])
+    seeds = Path(config["seeds"])
+    m2_script = Path(config.get("m2_script", script_dir / "operational_index.py"))
+    m3_script = Path(config.get("m3_script", script_dir / "deployed_epoch_verdicts.py"))
+    m4_script = Path(config.get("m4_script", script_dir / "memory_contradictions.py"))
+    join_script = Path(config.get("join_script", script_dir / "seed_evidence_inputs.py"))
+    try:
+        new_cards, new_metadata = evidence_rows(units_db, since, int(config.get("new_evidence_limit", 100)))
+        backlog = backlog_status(units_db)
+        probes = config.get("probes", DEFAULT_PROBES)
+        findings, cards = m2_findings(
+            runner, python, m2_script, index, units_db, probes, int(config.get("top", 5))
+        )
+        cards.update({card["card_id"]: card for card in new_cards})
+        claims = [
+            {
+                "section": finding["section"],
+                "statement": finding["statement"],
+                "evidence_card_ids": finding["evidence_card_ids"],
+            }
+            for finding in findings if finding["evidence_card_ids"]
+        ]
+        verdict_path = run_dir / "m3-verdicts.json"
+        contradiction_path = run_dir / "m4-contradictions.json"
+        with tempfile.TemporaryDirectory(dir=run_dir, prefix="private-stage-") as temporary:
+            evidence_path = Path(temporary) / "evidence.json"
+            window_start = config.get("window_start") or iso(started_at - timedelta(days=int(config.get("window_days", 7))))
+            runner.run(
+                "m1-export",
+                [python, str(join_script), "evidence", "--units-db", str(units_db), "--since", window_start,
+                 "--output", str(evidence_path)],
+                [evidence_path],
+            )
+            m3_command = [
+                python, str(m3_script), "--seeds", str(seeds), "--epochs-db", str(config["epochs_db"]),
+                "--evidence", str(evidence_path), "--output-json", str(verdict_path),
+                "--output-report", str(Path(temporary) / "m3-report.md"),
+            ]
+            if config.get("semantic_evidence"):
+                m3_command.extend(["--semantic-evidence", str(config["semantic_evidence"])])
+            runner.run("m3-verdicts", m3_command, [verdict_path])
+        verdicts = json.loads(verdict_path.read_text())
+        runner.run(
+            "m4-contradictions",
+            [python, str(m4_script), "queue", "--memories-db", str(config["memories_db"]),
+             "--seeds", str(seeds), "--verdicts", str(verdict_path), "--output", str(contradiction_path)],
+            [contradiction_path],
+        )
+        contradictions = json.loads(contradiction_path.read_text())
+        add_m3_m4_claims(verdicts, contradictions, cards, claims)
+        invocation = " ".join(shlex.quote(part) for part in argv)
+        drafts = proposals(findings, cards, invocation)
+        report_json = run_dir / "report.json"
+        report_md = run_dir / "report.md"
+        payload = {
+            "run": {
+                "id": run_id,
+                "mode": mode,
+                "since": since,
+                "started_at": iso(started_at),
+                "completed_at": iso(utc_now()),
+                "latency_ms": round((time.monotonic() - started) * 1000, 1),
+                "storage_bytes": 0,
+                "cost": {"model_turns": 0, "m2_queries": len(probes), "reported_usd": None},
+                "stage_receipts": runner.receipts,
+            },
+            "backlog": backlog,
+            "new_evidence": {"cards": [card["card_id"] for card in new_cards], "metadata": new_metadata},
+            "findings": findings,
+            "claims": claims,
+            "proposals": drafts,
+            "evidence_cards": cards,
+            "contradiction_counts": contradictions.get("counts", {}),
+        }
+        write_json(report_json, payload)
+        report_md.write_text(render_report(payload))
+        payload["run"]["storage_bytes"] = size_of(path for path in run_dir.rglob("*") if path.is_file())
+        write_json(report_json, payload)
+        report_md.write_text(render_report(payload))
+        state = {
+            "last_completed_run": run_id,
+            "last_completed_at": payload["run"]["completed_at"],
+            "last_evidence_timestamp": new_metadata.get("max_current_timestamp") or since,
+            "mode": mode,
+            "backlog_status": backlog["status"],
+        }
+        write_json(state_path, state)
+        return report_md
+    except Exception as exc:
+        write_json(run_dir / "failed-run.json", {
+            "run_id": run_id,
+            "failed_at": iso(utc_now()),
+            "error": compact(str(exc), 800),
+            "stage_receipts": runner.receipts,
+            "state_advanced": False,
+        })
+        raise
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    run_parser = sub.add_parser("run", help="produce one artifact-only sweep report")
+    run_parser.add_argument("--config", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        config = load_config(args.config)
+        invocation = [sys.executable, str(Path(__file__).resolve()), *(argv or sys.argv[1:])]
+        report = run(config, invocation)
+    except (OSError, ValueError, SweepError, sqlite3.Error, json.JSONDecodeError) as exc:
+        print(f"operational sweep failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({"status": "complete", "report": str(report)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/docs/analysis/scripts/test_operational_sweep.py
+++ b/docs/analysis/scripts/test_operational_sweep.py
@@ -118,6 +118,24 @@ class EvidenceTest(unittest.TestCase):
         self.assertNotIn("gh issue create", source)
         self.assertNotIn("mcp__cs__task", source)
 
+    def test_recurrence_verdict_becomes_a_human_reviewed_draft(self) -> None:
+        cards = {}
+        claims = []
+        followups = sweep.add_m3_m4_claims(
+            {"verdicts": [{
+                "id": "cas-fix", "title": "fixed symptom", "state": "recurred", "reason": "clean-post match",
+                "epoch_evidence": {"clean_post_from": "2026-08-12T00:00:00Z"},
+                "exposure": {"clean_post": 100},
+                "evidence_cards": [{"evidence_id": "9", "excerpt": "x" * 400}],
+            }]},
+            {"items": []}, cards, claims,
+        )
+        self.assertEqual(followups[0]["id"], "recurrence-cas-fix")
+        self.assertLessEqual(len(cards["m3:cas-fix:9"]["excerpt"]), 280)
+        self.assertTrue(claims[0]["evidence_card_ids"])
+        draft = sweep.proposals(followups, cards, "sweep")[0]
+        self.assertIn("x" * 20, draft["issue_body"])
+
 
 class EndToEndTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -147,6 +165,7 @@ class EndToEndTest(unittest.TestCase):
         payload = json.loads(report.with_name("report.json").read_text())
         self.assertTrue(payload["claims"])
         self.assertTrue(all(claim["evidence_card_ids"] for claim in payload["claims"]))
+        self.assertIn("new_evidence", {claim["section"] for claim in payload["claims"]})
         self.assertEqual(payload["run"]["cost"]["model_turns"], 0)
         self.assertEqual(payload["run"]["cost"]["m2_queries"], 1)
         self.assertGreater(payload["run"]["latency_ms"], 0)

--- a/docs/analysis/scripts/test_operational_sweep.py
+++ b/docs/analysis/scripts/test_operational_sweep.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Focused tests for the artifact-only M1 -> M4 operational sweep."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import operational_sweep as sweep  # noqa: E402
+
+
+def make_units(path: Path) -> None:
+    db = sqlite3.connect(path)
+    db.executescript(
+        """
+        CREATE TABLE evidence_units(
+          id INTEGER PRIMARY KEY, content_hash TEXT UNIQUE, unit_type TEXT, text TEXT,
+          occurrence_count INTEGER, redaction_secrets INTEGER, redaction_emails INTEGER,
+          first_seen_at TEXT, correction_state TEXT);
+        CREATE TABLE evidence_provenance(
+          id INTEGER PRIMARY KEY, unit_id INTEGER, source_key TEXT, source_path TEXT,
+          source_locator TEXT, session_id TEXT DEFAULT '', task_id TEXT DEFAULT '', worker TEXT DEFAULT '',
+          commit_sha TEXT DEFAULT '', file_path TEXT DEFAULT '', symbol TEXT DEFAULT '', timestamp TEXT,
+          epoch TEXT DEFAULT '', epoch_version TEXT DEFAULT '', privacy_scope TEXT DEFAULT '', host TEXT DEFAULT '',
+          project TEXT DEFAULT '', team TEXT DEFAULT '');
+        CREATE TABLE ingest_watermarks(
+          source_key TEXT PRIMARY KEY, source_path TEXT, cursor_kind TEXT, byte_offset INTEGER,
+          line_offset INTEGER, row_cursor INTEGER, size_bytes INTEGER, inode TEXT, updated_at TEXT);
+        CREATE TABLE redaction_receipts(run_at TEXT, source_key TEXT, secrets INTEGER, emails INTEGER, receipt_hash TEXT);
+        CREATE TABLE retention_receipts(run_at TEXT, privacy_scope TEXT, cutoff TEXT, provenance_deleted INTEGER,
+          units_deleted INTEGER, receipt_hash TEXT);
+        """
+    )
+    rows = [
+        (1, "hash-current", "task", "suite passed but zero tests ran " + "x" * 400, 7, 2, 1, "2026-08-12T00:00:00Z", "current"),
+        (2, "hash-withdrawn", "task", "withdrawn claim", 99, 0, 0, "2026-08-13T00:00:00Z", "withdrawn"),
+        (3, "hash-old", "task", "old evidence", 2, 0, 0, "2026-08-01T00:00:00Z", "current"),
+    ]
+    db.executemany("INSERT INTO evidence_units VALUES (?,?,?,?,?,?,?,?,?)", rows)
+    db.executemany(
+        "INSERT INTO evidence_provenance(id,unit_id,source_key,source_path,task_id,timestamp) VALUES (?,?,?,?,?,?)",
+        [
+            (1, 1, "db:task", "/private/live.db", "cas-a111", "2026-08-12T00:00:00Z"),
+            (2, 1, "db:task", "/private/live.db", "cas-a111", "2026-08-14T00:00:00Z"),
+            (3, 2, "db:task", "/private/live.db", "cas-b222", "2026-08-13T00:00:00Z"),
+            (4, 3, "db:task", "/private/live.db", "cas-c333", "2026-08-01T00:00:00Z"),
+        ],
+    )
+    db.execute("INSERT INTO redaction_receipts VALUES ('2026-08-12','db:task',2,1,'redacted')")
+    db.execute("INSERT INTO retention_receipts VALUES ('2026-08-12','project','2026-08-01',4,2,'retained')")
+    db.commit()
+    db.close()
+
+
+def make_stub(path: Path) -> None:
+    path.write_text(textwrap.dedent(
+        """
+        import json, pathlib, sys
+        args = sys.argv[1:]
+        if 'query' in args:
+            if 'FAIL_GATE' in args:
+                print(json.dumps({'gate_available': False, 'rows': []}))
+            else:
+                print(json.dumps({'gate_available': True, 'latency_ms': 3.5, 'rows': [{
+                    'event_id': 9, 'content_hash': 'hash-current', 'duplicate_count': 7,
+                    'score': 0.03, 'text': 'suite passed but zero tests ran',
+                    'provenance': [{'timestamp': '2026-08-12T00:00:00Z', 'task_id': 'cas-a111', 'worker': 'w'}]
+                }]}))
+        elif 'evidence' in args:
+            output = pathlib.Path(args[args.index('--output') + 1]); output.write_text('[]\\n')
+            print(json.dumps({'units': 0}))
+        elif '--output-json' in args:
+            output = pathlib.Path(args[args.index('--output-json') + 1])
+            report = pathlib.Path(args[args.index('--output-report') + 1])
+            output.write_text(json.dumps({'verdicts': [{
+                'id': 'cas-fix1', 'state': 'fixed', 'reason': 'clean observed window',
+                'epoch_evidence': {'clean_post_from': '2026-08-12T00:00:00Z'},
+                'exposure': {'clean_post': 100, 'threshold': 100}, 'evidence_cards': []
+            }]}))
+            report.write_text('private intermediate')
+        elif 'queue' in args:
+            output = pathlib.Path(args[args.index('--output') + 1])
+            output.write_text(json.dumps({'counts': {'items': 0}, 'items': []}))
+            print(json.dumps({'items': 0}))
+        else:
+            raise SystemExit(2)
+        """
+    ))
+
+
+class EvidenceTest(unittest.TestCase):
+    def test_new_evidence_uses_first_observation_and_honors_corrections(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "units.db"
+            make_units(path)
+            cards, metadata = sweep.evidence_rows(path, "2026-08-10T00:00:00Z", 10)
+            self.assertEqual([card["card_id"] for card in cards], ["eu:1"])
+            self.assertEqual(cards[0]["timestamp"], "2026-08-12T00:00:00Z")
+            self.assertLessEqual(len(cards[0]["excerpt"]), 280)
+            self.assertNotIn("source_path", cards[0]["provenance"][0])
+            self.assertEqual(metadata["receipts_honored"]["redaction"][0]["receipt_hash"], "redacted")
+            self.assertEqual(metadata["receipts_honored"]["retention"][0]["receipt_hash"], "retained")
+
+    def test_issue_draft_has_house_headings_and_no_filing_path(self) -> None:
+        finding = {"id": "x", "title": "candidate", "statement": "observed", "expected": "expected", "evidence_card_ids": ["eu:1"]}
+        drafts = sweep.proposals([finding], {"eu:1": {"card_id": "eu:1", "excerpt": "actual"}}, "python sweep.py run --config c.json")
+        body = drafts[0]["issue_body"]
+        self.assertEqual([line[3:] for line in body.splitlines() if line.startswith("## ")], list(sweep.ISSUE_HEADINGS))
+        self.assertTrue(drafts[0]["never_auto_file"])
+        source = Path(sweep.__file__).read_text()
+        self.assertNotIn("gh issue create", source)
+        self.assertNotIn("mcp__cs__task", source)
+
+
+class EndToEndTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        root = Path(self.tmp.name)
+        self.units = root / "units.db"; make_units(self.units)
+        self.index = root / "index.db"; sqlite3.connect(self.index).close()
+        self.epochs = root / "epochs.db"; sqlite3.connect(self.epochs).close()
+        self.memories = root / "memories.db"; sqlite3.connect(self.memories).close()
+        self.seeds = root / "seeds.json"; self.seeds.write_text("[]\n")
+        self.stub = root / "stub.py"; make_stub(self.stub)
+        self.artifacts = root / "artifacts"
+
+    def config(self) -> dict:
+        return {
+            "artifact_root": str(self.artifacts), "units_db": str(self.units), "index": str(self.index),
+            "epochs_db": str(self.epochs), "memories_db": str(self.memories), "seeds": str(self.seeds),
+            "m2_script": str(self.stub), "m3_script": str(self.stub), "m4_script": str(self.stub),
+            "join_script": str(self.stub), "since": "2026-08-10T00:00:00Z", "window_start": "2026-08-10T00:00:00Z",
+            "probes": [{"id": "suite", "family": "recurring_failure", "title": "silent suite",
+                        "query": "suite", "expected": "tests execute"}],
+        }
+
+    def test_success_records_receipts_and_advances_artifact_state(self) -> None:
+        report = sweep.run(self.config(), ["python", "operational_sweep.py", "run", "--config", "config.json"])
+        payload = json.loads(report.with_name("report.json").read_text())
+        self.assertTrue(payload["claims"])
+        self.assertTrue(all(claim["evidence_card_ids"] for claim in payload["claims"]))
+        self.assertEqual(payload["run"]["cost"]["model_turns"], 0)
+        self.assertEqual(payload["run"]["cost"]["m2_queries"], 1)
+        self.assertGreater(payload["run"]["latency_ms"], 0)
+        self.assertGreater(payload["run"]["storage_bytes"], 0)
+        self.assertEqual(len(payload["run"]["stage_receipts"]), 4)
+        self.assertTrue((self.artifacts / "state.json").exists())
+        self.assertFalse(any("private-stage" in str(path) for path in report.parent.iterdir()))
+        markdown = report.read_text()
+        self.assertIn("Top recurring failure narratives", markdown)
+        self.assertIn("never auto-filed", markdown)
+
+    def test_m2_gate_failure_is_fail_closed_and_does_not_advance_state(self) -> None:
+        config = self.config()
+        config["probes"][0]["query"] = "FAIL_GATE"
+        with self.assertRaises(sweep.SweepError):
+            sweep.run(config, ["sweep"])
+        self.assertFalse((self.artifacts / "state.json").exists())
+        failure = next((self.artifacts / "runs").glob("*/failed-run.json"))
+        self.assertFalse(json.loads(failure.read_text())["state_advanced"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/analysis/scripts/test_operational_sweep.py
+++ b/docs/analysis/scripts/test_operational_sweep.py
@@ -161,6 +161,8 @@ class EndToEndTest(unittest.TestCase):
         }
 
     def test_success_records_receipts_and_advances_artifact_state(self) -> None:
+        sources = (self.units, self.index, self.epochs, self.memories, self.seeds)
+        before = {path: path.read_bytes() for path in sources}
         report = sweep.run(self.config(), ["python", "operational_sweep.py", "run", "--config", "config.json"])
         payload = json.loads(report.with_name("report.json").read_text())
         self.assertTrue(payload["claims"])
@@ -176,6 +178,7 @@ class EndToEndTest(unittest.TestCase):
         markdown = report.read_text()
         self.assertIn("Top recurring failure narratives", markdown)
         self.assertIn("never auto-filed", markdown)
+        self.assertEqual({path: path.read_bytes() for path in sources}, before)
 
     def test_m2_gate_failure_is_fail_closed_and_does_not_advance_state(self) -> None:
         config = self.config()


### PR DESCRIPTION
## Summary
- add one artifact-only Python command orchestrating M1–M4
- emit evidence-card-backed reports plus human-review-only issue/task drafts
- record latency, storage, retrieval count, backlog state, and artifact-local watermarks
- add a supervisor-armable cron template and operating contract

## Proof
- `python3 -m unittest discover -s docs/analysis/scripts -p "test_*.py"` — 106 passed
- real-week runs: `/home/pippenz/.cas/artifacts/cas-93de/sweep/runs/20260818T172048Z/`
- full fixture run leaves all source stores byte-identical

No live-store mutation, issue filing, task creation, or automatic model-turn path exists. The supervisor-approved scope amendment keeps this as the Python analysis command; a Rust wrapper is an epic-close follow-up.