### PR TITLE
Two-way Viktor: gateway conversation surface, inbound inbox delivery, distributed skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,14 @@ cargo build --release
 
 See the [README](README.md) for full build instructions.
 
+## Viktor distribution
+
+Viktor changes must keep the Claude, Codex, and Grok builtin skill mirrors in sync, preserve the
+credential-safe `cas viktor` output, and retain the proxy's exact allowlist boundary. Do not add
+credential literals to source, fixtures, docs, or artifacts: `cas serve` receives only the
+`VIKTOR_API_KEY` environment reference. New behavior needs a clean-project `cas init`/command
+assertion and a registry test so every harness receives the managed skill.
+
 ## CI check names are pinned
 
 CI job names are not free text. `docs/branch-protection/main-ruleset.json` lists required

--- a/README.md
+++ b/README.md
@@ -266,6 +266,17 @@ cas cloud sync        # push + pull (optional)
 
 Cassy ships builtin skills (`cas-code-review`, `cas-worker`, `cas-github-issues`, `codemap`, …) in Claude, Codex and Grok flavors, kept in lockstep by a parity test. If they crowd your context, Claude Code's `skillOverrides` in `settings.json` can set any skill to `"off"`, `"user-invocable-only"`, or `"name-only"` without disabling Cassy.
 
+### Viktor delegation
+
+`cas init` installs the `cas-viktor` skill in the Claude, Codex, and Grok mirrors. For a
+credential-safe setup check, run `cas viktor`: it reports whether `VIKTOR_API_KEY` is available
+without reading or printing it, identifies the managed user configuration, and explains any
+project policy override. Start `cas serve` to refresh the managed Viktor upstream; it keeps only
+the `env:VIKTOR_API_KEY` reference and an exact conversation allowlist. Agents use the proxy's
+`mcp_search`/`mcp_execute` surface, and CAS delivers completed answers as inbound notifications
+instead of requiring agent-side polling. A committed `.cas/proxy.toml` replaces the managed
+allowlist, so it must explicitly opt in to the required Viktor routes.
+
 ## Diagnostics
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -271,11 +271,12 @@ Cassy ships builtin skills (`cas-code-review`, `cas-worker`, `cas-github-issues`
 `cas init` installs the `cas-viktor` skill in the Claude, Codex, and Grok mirrors. For a
 credential-safe setup check, run `cas viktor`: it reports whether `VIKTOR_API_KEY` is available
 without reading or printing it, identifies the managed user configuration, and explains any
-project policy override. Start `cas serve` to refresh the managed Viktor upstream; it keeps only
-the `env:VIKTOR_API_KEY` reference and an exact conversation allowlist. Agents use the proxy's
-`mcp_search`/`mcp_execute` surface, and CAS delivers completed answers as inbound notifications
-instead of requiring agent-side polling. A committed `.cas/proxy.toml` replaces the managed
-allowlist, so it must explicitly opt in to the required Viktor routes.
+project policy override. Start `cas serve` without `.cas/proxy.toml` to refresh the managed
+Viktor upstream; it keeps only the `env:VIKTOR_API_KEY` reference and an exact conversation
+allowlist. Agents use the proxy's `mcp_search`/`mcp_execute` surface, and CAS delivers completed
+answers as inbound notifications instead of requiring agent-side polling. A committed
+`.cas/proxy.toml` opts out of the managed default, so it must explicitly configure the required
+Viktor server and routes.
 
 ## Diagnostics
 

--- a/cas-cli/docs/CONTRIBUTING.md
+++ b/cas-cli/docs/CONTRIBUTING.md
@@ -100,6 +100,17 @@ Files under `cas-cli/src/builtins/**/references/` are owned by their skill and s
 
 and commit the regenerated JSON. Skipping it means the version you just replaced is not recognized as Cassy content downstream, so installs that still hold it will keep it forever instead of upgrading (cas-0c0a).
 
+### Viktor distribution
+
+The managed Viktor surface has three coupled user-facing pieces: its Claude/Codex/Grok builtin
+skill mirrors, `cas viktor` credential-safe provisioning output, and the proxy's configured
+allowlist. Keep the skill body compact and put operational detail in its reference. The mirrors
+must retain identical meaning after their mechanical tool-prefix substitutions; run the builtin
+flavor-drift test. Never add a credential literal to source, fixtures, docs, or artifacts: the
+only supported configuration is the `VIKTOR_API_KEY` environment reference held by `cas serve`.
+For a new CLI or proxy-facing behavior, add a clean-project `cas init`/command assertion and a
+direct registry test so the source cannot exist without reaching all three downstream harnesses.
+
 ## Releasing
 
 ### Version policy

--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -358,6 +358,14 @@ pub const BUILTIN_SKILLS: &[BuiltinFile] = &[
         content: include_str!("builtins/skills/mcp-integration/references/diagnosis.md"),
     },
     BuiltinFile {
+        path: "skills/cas-viktor/SKILL.md",
+        content: include_str!("builtins/skills/cas-viktor/SKILL.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-viktor/references/gateway.md",
+        content: include_str!("builtins/skills/cas-viktor/references/gateway.md"),
+    },
+    BuiltinFile {
         path: "skills/cas-html-reports/SKILL.md",
         content: include_str!("builtins/skills/cas-html-reports/SKILL.md"),
     },
@@ -732,6 +740,14 @@ pub const CODEX_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile {
         path: "skills/mcp-integration/references/diagnosis.md",
         content: include_str!("builtins/codex/skills/mcp-integration/references/diagnosis.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-viktor/SKILL.md",
+        content: include_str!("builtins/codex/skills/cas-viktor/SKILL.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-viktor/references/gateway.md",
+        content: include_str!("builtins/codex/skills/cas-viktor/references/gateway.md"),
     },
     BuiltinFile {
         path: "skills/cas-html-reports/SKILL.md",
@@ -1129,6 +1145,14 @@ pub const GROK_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile {
         path: "skills/mcp-integration/references/diagnosis.md",
         content: include_str!("builtins/grok/skills/mcp-integration/references/diagnosis.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-viktor/SKILL.md",
+        content: include_str!("builtins/grok/skills/cas-viktor/SKILL.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-viktor/references/gateway.md",
+        content: include_str!("builtins/grok/skills/cas-viktor/references/gateway.md"),
     },
     BuiltinFile {
         path: "skills/cas-html-reports/SKILL.md",

--- a/cas-cli/src/builtins/codex/skills/cas-viktor/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-viktor/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cas-viktor
+description: Use when a task needs long-horizon or parallel research, independent external verification, or a durable answer from Viktor through the managed CAS gateway.
+managed_by: cas
+---
+
+# Viktor delegation
+
+Use Viktor for long-running or parallel research and independent external verification; keep
+short, local questions in the current agent. Read [the gateway contract](references/gateway.md)
+before a paid or run-starting call.
+
+## Gateway
+
+Discover Viktor's currently connected surface with `mcp__cs__mcp_search` using
+`server:viktor`, then send an allowlisted conversation call through `mcp__cs__mcp_execute`.
+Include the active task context in the request. Do not invent tool names or bypass the gateway.
+
+## Replies and cost
+
+Run-starting calls are watched by CAS. End the turn or do other work; the result arrives as an
+inbound notification with `origin=viktor`. Do not poll `get_run` or `get_run_result` yourself.
+Treat starts as spend-bearing: use a bounded question, never auto-retry an uncertain start, and
+reconcile an existing thread/run before continuing.
+
+## Boundary
+
+The proxy has a fail-closed allowlist and holds the credential reference. Never handle,
+paste, request, log, or add `VIKTOR_API_KEY` to a project, artifact, prompt, or tool arguments.
+Use `cas viktor` for the credential-safe provisioning status; it never prints the key.

--- a/cas-cli/src/builtins/codex/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/codex/skills/cas-viktor/references/gateway.md
@@ -7,15 +7,15 @@
 `VIKTOR_API_KEY` is present, never its value. On the managed host, load the canonical
 credential file into the `cas serve` process; do not copy it to project configuration.
 
-At `cas serve` startup, Cassy refreshes the user-scoped `viktor` upstream at
-`https://api.viktor.com/mcp` with the credential reference `env:VIKTOR_API_KEY`. The managed
-policy admits exactly these conversation tools:
+At `cas serve` startup without `.cas/proxy.toml`, Cassy refreshes the user-scoped `viktor`
+upstream at `https://api.viktor.com/mcp` with the credential reference `env:VIKTOR_API_KEY`.
+The managed policy admits exactly these conversation tools:
 
 `ask_viktor`, `create_thread`, `send_message`, `wait_for_run`, `get_run`,
 `get_run_result`, `list_threads`, `list_messages`, and `whoami`.
 
-If `.cas/proxy.toml` exists, its policy replaces the user policy. It must explicitly configure
-the required Viktor server and routes; the managed user allowlist never widens a project.
+If `.cas/proxy.toml` exists, it opts out of the managed default. It must explicitly configure
+the required Viktor server and routes; the managed user configuration never widens a project.
 
 ## Conversation flow
 

--- a/cas-cli/src/builtins/codex/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/codex/skills/cas-viktor/references/gateway.md
@@ -1,0 +1,36 @@
+# Viktor gateway contract
+
+## Provisioning
+
+`cas init` and `cas update --sync` install the `cas-viktor` skill for Claude, Codex, and Grok. Run
+`cas viktor` to see the credential-safe local status. It reports only whether
+`VIKTOR_API_KEY` is present, never its value. On the managed host, load the canonical
+credential file into the `cas serve` process; do not copy it to project configuration.
+
+At `cas serve` startup, Cassy refreshes the user-scoped `viktor` upstream at
+`https://api.viktor.com/mcp` with the credential reference `env:VIKTOR_API_KEY`. The managed
+policy admits exactly these conversation tools:
+
+`ask_viktor`, `create_thread`, `send_message`, `wait_for_run`, `get_run`,
+`get_run_result`, `list_threads`, `list_messages`, and `whoami`.
+
+If `.cas/proxy.toml` exists, its policy replaces the user policy. It must explicitly configure
+the required Viktor server and routes; the managed user allowlist never widens a project.
+
+## Conversation flow
+
+Use `mcp_search` with `server:viktor` before relying on a tool, then call an advertised,
+allowlisted route with `mcp_execute`. Pass task context and a bounded objective. A successful
+`ask_viktor`, `create_thread`, or `send_message` is registered for daemon-owned follow-up.
+CAS polls the provider at its own cadence and queues the completed result as an inbound
+notification with `origin=viktor`. The requesting agent must not poll; it receives the reply
+normally on a later turn. If the requester is gone, CAS routes the notification to the live
+session supervisor.
+
+## Cost and security
+
+Viktor starts can cost money or outlive a client timeout. Do not automatically retry a start;
+reconcile the returned thread/run first. Keep questions bounded and use the existing thread for
+follow-ups. The CAS proxy records caller/task attribution and applies the exact allowlist.
+Credentials remain environment references at the proxy boundary: never pass a key in tool
+arguments, source control, artifacts, or agent context.

--- a/cas-cli/src/builtins/grok/skills/cas-viktor/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-viktor/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cas-viktor
+description: Use when a task needs long-horizon or parallel research, independent external verification, or a durable answer from Viktor through the managed CAS gateway.
+managed_by: cas
+---
+
+# Viktor delegation
+
+Use Viktor for long-running or parallel research and independent external verification; keep
+short, local questions in the current agent. Read [the gateway contract](references/gateway.md)
+before a paid or run-starting call.
+
+## Gateway
+
+Discover Viktor's currently connected surface with `cas__mcp_search` using `server:viktor`,
+then send an allowlisted conversation call through `cas__mcp_execute`. Include the active task
+context in the request. Do not invent tool names or bypass the gateway.
+
+## Replies and cost
+
+Run-starting calls are watched by CAS. End the turn or do other work; the result arrives as an
+inbound notification with `origin=viktor`. Do not poll `get_run` or `get_run_result` yourself.
+Treat starts as spend-bearing: use a bounded question, never auto-retry an uncertain start, and
+reconcile an existing thread/run before continuing.
+
+## Boundary
+
+The proxy has a fail-closed allowlist and holds the credential reference. Never handle,
+paste, request, log, or add `VIKTOR_API_KEY` to a project, artifact, prompt, or tool arguments.
+Use `cas viktor` for the credential-safe provisioning status; it never prints the key.

--- a/cas-cli/src/builtins/grok/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/grok/skills/cas-viktor/references/gateway.md
@@ -7,15 +7,15 @@
 `VIKTOR_API_KEY` is present, never its value. On the managed host, load the canonical
 credential file into the `cas serve` process; do not copy it to project configuration.
 
-At `cas serve` startup, Cassy refreshes the user-scoped `viktor` upstream at
-`https://api.viktor.com/mcp` with the credential reference `env:VIKTOR_API_KEY`. The managed
-policy admits exactly these conversation tools:
+At `cas serve` startup without `.cas/proxy.toml`, Cassy refreshes the user-scoped `viktor`
+upstream at `https://api.viktor.com/mcp` with the credential reference `env:VIKTOR_API_KEY`.
+The managed policy admits exactly these conversation tools:
 
 `ask_viktor`, `create_thread`, `send_message`, `wait_for_run`, `get_run`,
 `get_run_result`, `list_threads`, `list_messages`, and `whoami`.
 
-If `.cas/proxy.toml` exists, its policy replaces the user policy. It must explicitly configure
-the required Viktor server and routes; the managed user allowlist never widens a project.
+If `.cas/proxy.toml` exists, it opts out of the managed default. It must explicitly configure
+the required Viktor server and routes; the managed user configuration never widens a project.
 
 ## Conversation flow
 

--- a/cas-cli/src/builtins/grok/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/grok/skills/cas-viktor/references/gateway.md
@@ -1,0 +1,36 @@
+# Viktor gateway contract
+
+## Provisioning
+
+`cas init` and `cas update --sync` install the `cas-viktor` skill for Claude, Codex, and Grok. Run
+`cas viktor` to see the credential-safe local status. It reports only whether
+`VIKTOR_API_KEY` is present, never its value. On the managed host, load the canonical
+credential file into the `cas serve` process; do not copy it to project configuration.
+
+At `cas serve` startup, Cassy refreshes the user-scoped `viktor` upstream at
+`https://api.viktor.com/mcp` with the credential reference `env:VIKTOR_API_KEY`. The managed
+policy admits exactly these conversation tools:
+
+`ask_viktor`, `create_thread`, `send_message`, `wait_for_run`, `get_run`,
+`get_run_result`, `list_threads`, `list_messages`, and `whoami`.
+
+If `.cas/proxy.toml` exists, its policy replaces the user policy. It must explicitly configure
+the required Viktor server and routes; the managed user allowlist never widens a project.
+
+## Conversation flow
+
+Use `mcp_search` with `server:viktor` before relying on a tool, then call an advertised,
+allowlisted route with `mcp_execute`. Pass task context and a bounded objective. A successful
+`ask_viktor`, `create_thread`, or `send_message` is registered for daemon-owned follow-up.
+CAS polls the provider at its own cadence and queues the completed result as an inbound
+notification with `origin=viktor`. The requesting agent must not poll; it receives the reply
+normally on a later turn. If the requester is gone, CAS routes the notification to the live
+session supervisor.
+
+## Cost and security
+
+Viktor starts can cost money or outlive a client timeout. Do not automatically retry a start;
+reconcile the returned thread/run first. Keep questions bounded and use the existing thread for
+follow-ups. The CAS proxy records caller/task attribution and applies the exact allowlist.
+Credentials remain environment references at the proxy boundary: never pass a key in tool
+arguments, source control, artifacts, or agent context.

--- a/cas-cli/src/builtins/skills/cas-viktor/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-viktor/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cas-viktor
+description: Use when a task needs long-horizon or parallel research, independent external verification, or a durable answer from Viktor through the managed CAS gateway.
+managed_by: cas
+---
+
+# Viktor delegation
+
+Use Viktor for long-running or parallel research and independent external verification; keep
+short, local questions in the current agent. Read [the gateway contract](references/gateway.md)
+before a paid or run-starting call.
+
+## Gateway
+
+Discover Viktor's currently connected surface with `mcp__cas__mcp_search` using
+`server:viktor`, then send an allowlisted conversation call through `mcp__cas__mcp_execute`.
+Include the active task context in the request. Do not invent tool names or bypass the gateway.
+
+## Replies and cost
+
+Run-starting calls are watched by CAS. End the turn or do other work; the result arrives as an
+inbound notification with `origin=viktor`. Do not poll `get_run` or `get_run_result` yourself.
+Treat starts as spend-bearing: use a bounded question, never auto-retry an uncertain start, and
+reconcile an existing thread/run before continuing.
+
+## Boundary
+
+The proxy has a fail-closed allowlist and holds the credential reference. Never handle,
+paste, request, log, or add `VIKTOR_API_KEY` to a project, artifact, prompt, or tool arguments.
+Use `cas viktor` for the credential-safe provisioning status; it never prints the key.

--- a/cas-cli/src/builtins/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/skills/cas-viktor/references/gateway.md
@@ -7,15 +7,15 @@
 `VIKTOR_API_KEY` is present, never its value. On the managed host, load the canonical
 credential file into the `cas serve` process; do not copy it to project configuration.
 
-At `cas serve` startup, Cassy refreshes the user-scoped `viktor` upstream at
-`https://api.viktor.com/mcp` with the credential reference `env:VIKTOR_API_KEY`. The managed
-policy admits exactly these conversation tools:
+At `cas serve` startup without `.cas/proxy.toml`, Cassy refreshes the user-scoped `viktor`
+upstream at `https://api.viktor.com/mcp` with the credential reference `env:VIKTOR_API_KEY`.
+The managed policy admits exactly these conversation tools:
 
 `ask_viktor`, `create_thread`, `send_message`, `wait_for_run`, `get_run`,
 `get_run_result`, `list_threads`, `list_messages`, and `whoami`.
 
-If `.cas/proxy.toml` exists, its policy replaces the user policy. It must explicitly configure
-the required Viktor server and routes; the managed user allowlist never widens a project.
+If `.cas/proxy.toml` exists, it opts out of the managed default. It must explicitly configure
+the required Viktor server and routes; the managed user configuration never widens a project.
 
 ## Conversation flow
 

--- a/cas-cli/src/builtins/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/skills/cas-viktor/references/gateway.md
@@ -1,0 +1,36 @@
+# Viktor gateway contract
+
+## Provisioning
+
+`cas init` and `cas update --sync` install the `cas-viktor` skill for Claude, Codex, and Grok. Run
+`cas viktor` to see the credential-safe local status. It reports only whether
+`VIKTOR_API_KEY` is present, never its value. On the managed host, load the canonical
+credential file into the `cas serve` process; do not copy it to project configuration.
+
+At `cas serve` startup, Cassy refreshes the user-scoped `viktor` upstream at
+`https://api.viktor.com/mcp` with the credential reference `env:VIKTOR_API_KEY`. The managed
+policy admits exactly these conversation tools:
+
+`ask_viktor`, `create_thread`, `send_message`, `wait_for_run`, `get_run`,
+`get_run_result`, `list_threads`, `list_messages`, and `whoami`.
+
+If `.cas/proxy.toml` exists, its policy replaces the user policy. It must explicitly configure
+the required Viktor server and routes; the managed user allowlist never widens a project.
+
+## Conversation flow
+
+Use `mcp_search` with `server:viktor` before relying on a tool, then call an advertised,
+allowlisted route with `mcp_execute`. Pass task context and a bounded objective. A successful
+`ask_viktor`, `create_thread`, or `send_message` is registered for daemon-owned follow-up.
+CAS polls the provider at its own cadence and queues the completed result as an inbound
+notification with `origin=viktor`. The requesting agent must not poll; it receives the reply
+normally on a later turn. If the requester is gone, CAS routes the notification to the live
+session supervisor.
+
+## Cost and security
+
+Viktor starts can cost money or outlive a client timeout. Do not automatically retry a start;
+reconcile the returned thread/run first. Keep questions bounded and use the existing thread for
+follow-ups. The CAS proxy records caller/task attribution and applies the exact allowlist.
+Credentials remain environment references at the proxy boundary: never pass a key in tool
+arguments, source control, artifacts, or agent context.

--- a/cas-cli/src/cli/mod.rs
+++ b/cas-cli/src/cli/mod.rs
@@ -61,6 +61,7 @@ mod statusline;
 mod sync;
 mod update;
 pub mod update_transaction;
+mod viktor;
 
 use std::path::{Path, PathBuf};
 
@@ -89,6 +90,7 @@ pub use status::StatusArgs;
 pub use statusline::StatusLineArgs;
 pub use sync::SyncCommands;
 pub use update::UpdateArgs;
+pub use viktor::ViktorArgs;
 
 /// Build version string including git hash and date
 fn build_version() -> String {
@@ -223,6 +225,9 @@ pub enum Commands {
 
     /// Run diagnostics
     Doctor(DoctorArgs),
+
+    /// Show credential-safe provisioning status for the managed Viktor gateway
+    Viktor(ViktorArgs),
 
     /// Manage configuration
     #[command(subcommand)]
@@ -361,6 +366,7 @@ fn auth_requirement(command: &Option<Commands>) -> AuthRequirement {
         Commands::Init(_)
         | Commands::Open(_)
         | Commands::Doctor(_)
+        | Commands::Viktor(_)
         | Commands::Update(_)
         | Commands::Changelog(_)
         | Commands::Hook(_)
@@ -561,6 +567,7 @@ fn get_command_name(cmd: &Option<Commands>) -> String {
         Commands::Hub(_) => "hub".to_string(),
         Commands::Serve => "serve".to_string(),
         Commands::Doctor(_) => "doctor".to_string(),
+        Commands::Viktor(_) => "viktor".to_string(),
         Commands::Config(_) => "config".to_string(),
         Commands::Status(_) => "status".to_string(),
         Commands::Limits(_) => "limits".to_string(),
@@ -634,6 +641,7 @@ fn run_command(cli: &Cli, cas_root: Option<&Path>) -> anyhow::Result<()> {
         Commands::Hub(args) => hub::execute(args, cli),
         Commands::Serve => serve_execute(),
         Commands::Doctor(args) => doctor::execute(args, cli, cas_root),
+        Commands::Viktor(args) => viktor::execute(args, cli, cas_root),
         Commands::Config(cmd) => config::execute_subcommand(cmd, cli, require_cas_root(cas_root)?),
         Commands::Status(args) => status::execute(args, cli, require_cas_root(cas_root)?),
         Commands::Limits(args) => limits::execute(args, cli),

--- a/cas-cli/src/cli/viktor.rs
+++ b/cas-cli/src/cli/viktor.rs
@@ -1,0 +1,73 @@
+//! Credential-safe provisioning status for the managed Viktor gateway.
+
+use std::path::Path;
+
+use clap::Args;
+use serde::Serialize;
+
+use crate::cli::Cli;
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct ViktorArgs {}
+
+#[derive(Serialize)]
+struct ViktorReport {
+    credential_env: &'static str,
+    credential_present: bool,
+    user_config: String,
+    project_config: Option<String>,
+    project_policy: &'static str,
+    startup_action: &'static str,
+    reply_delivery: &'static str,
+}
+
+/// Print the configuration contract without reading or displaying the API key.
+pub fn execute(_args: &ViktorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow::Result<()> {
+    #[cfg(feature = "mcp-proxy")]
+    let user_config = cmcp_core::config::Scope::User
+        .config_path()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "<user MCP config path unavailable>".to_string());
+    #[cfg(not(feature = "mcp-proxy"))]
+    let user_config = "<requires mcp-proxy feature>".to_string();
+
+    let project_config = cas_root
+        .map(|root| root.join("proxy.toml"))
+        .filter(|path| path.exists())
+        .map(|path| path.display().to_string());
+    let report = ViktorReport {
+        credential_env: "VIKTOR_API_KEY",
+        credential_present: std::env::var_os("VIKTOR_API_KEY").is_some(),
+        user_config,
+        project_config,
+        project_policy: "an existing .cas/proxy.toml replaces the managed allowlist; explicitly add the sanctioned Viktor routes before direct calls",
+        startup_action: "run cas serve; startup refreshes the credential-reference-only managed Viktor upstream",
+        reply_delivery: "run-starting calls are watched by CAS; replies arrive as inbound notifications (origin=viktor), so agents must not poll",
+    };
+
+    if cli.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("Viktor provisioning");
+        println!(
+            "  credential: {} ({})",
+            report.credential_env,
+            if report.credential_present {
+                "set"
+            } else {
+                "not set"
+            }
+        );
+        println!("  user config: {}", report.user_config);
+        println!(
+            "  project policy: {}",
+            report
+                .project_config
+                .as_deref()
+                .unwrap_or("none; managed user policy applies")
+        );
+        println!("  start: {}", report.startup_action);
+        println!("  replies: {}", report.reply_delivery);
+    }
+    Ok(())
+}

--- a/cas-cli/src/cli/viktor.rs
+++ b/cas-cli/src/cli/viktor.rs
@@ -40,8 +40,8 @@ pub fn execute(_args: &ViktorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow
         credential_present: std::env::var_os("VIKTOR_API_KEY").is_some(),
         user_config,
         project_config,
-        project_policy: "an existing .cas/proxy.toml replaces the managed allowlist; explicitly add the sanctioned Viktor routes before direct calls",
-        startup_action: "run cas serve; startup refreshes the credential-reference-only managed Viktor upstream",
+        project_policy: "an existing .cas/proxy.toml opts out of the managed Viktor default; explicitly configure the sanctioned Viktor server and routes before direct calls",
+        startup_action: "run cas serve without a project proxy config; startup refreshes the credential-reference-only managed Viktor upstream",
         reply_delivery: "run-starting calls are watched by CAS; replies arrive as inbound notifications (origin=viktor), so agents must not poll",
     };
 

--- a/cas-cli/src/mcp/daemon.rs
+++ b/cas-cli/src/mcp/daemon.rs
@@ -779,6 +779,15 @@ impl EmbeddedDaemon {
                     // both-binaries data read as post-fix.
                     self.touch_binary_epoch();
                     self.send_agent_heartbeat().await;
+                    #[cfg(feature = "mcp-proxy")]
+                    if let Some(proxy) = self.proxy.read().await.clone() {
+                        if let Err(error) = crate::mcp::viktor_watch::poll_due_watches(
+                            &self.config.cas_root,
+                            &proxy,
+                        ).await {
+                            tracing::warn!(error = %error, "Viktor inbound watch tick failed");
+                        }
+                    }
                 }
 
                 // Code indexing - idle-PREFERRED, with a max-staleness override.

--- a/cas-cli/src/mcp/mod.rs
+++ b/cas-cli/src/mcp/mod.rs
@@ -46,6 +46,8 @@ pub(crate) mod daemon;
 mod server;
 pub mod socket;
 pub mod tools;
+#[cfg(feature = "mcp-proxy")]
+pub(crate) mod viktor_watch;
 
 pub use server::CasCore;
 pub use server::run_server;

--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -307,6 +307,16 @@ async fn run_server_impl() -> anyhow::Result<()> {
         }
     }
 
+    // Refresh the credential-free, user-scoped Viktor default before loading
+    // proxy configuration. A project .cas/proxy.toml remains authoritative for
+    // dispatch policy, so it can intentionally opt out of this default.
+    #[cfg(feature = "mcp-proxy")]
+    if let Ok(path) = cmcp_core::config::Scope::User.config_path()
+        && let Err(error) = cmcp_core::config::Config::refresh_viktor_managed_default(&path)
+    {
+        eprintln!("[Cassy] Failed to refresh managed Viktor proxy config: {error}");
+    }
+
     // Load MCP proxy config from .cas/proxy.toml (project) and ~/.config/code-mode-mcp/config.toml (user)
     #[cfg(feature = "mcp-proxy")]
     let proxy = {
@@ -1309,6 +1319,52 @@ mod tests {
         let audit = engine.policy_audit();
         assert_eq!(audit.iter().filter(|entry| entry.allowed).count(), 2);
         assert_eq!(audit.iter().filter(|entry| !entry.allowed).count(), 2);
+    }
+
+    #[cfg(feature = "mcp-proxy")]
+    #[tokio::test]
+    async fn managed_viktor_conversation_policy_is_exact_and_audits_worker_task_attribution() {
+        use cmcp_core::config::{Config as ProxyConfig, VIKTOR_CONVERSATION_TOOLS, VIKTOR_SERVER};
+
+        let engine = cmcp_core::ProxyEngine::from_configs(Default::default())
+            .await
+            .unwrap();
+        let mut config = ProxyConfig::default();
+        assert!(config.ensure_viktor_managed_default());
+        super::install_proxy_policy(&engine, &config).await;
+        let caller = cmcp_core::ProxyCaller {
+            agent_id: "worker-session".to_string(),
+            role: crate::types::AgentRole::Worker,
+            session_id: "worker-session".to_string(),
+            factory_session: Some("factory-2428".to_string()),
+            active_task_ids: vec!["cas-2428".to_string()],
+        };
+
+        for tool in VIKTOR_CONVERSATION_TOOLS {
+            let error = engine
+                .call_tool(&caller, VIKTOR_SERVER, tool, None)
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("not connected"), "{tool}: {error}");
+            assert!(!error.contains("policy denied"), "{tool}: {error}");
+        }
+        let forbidden = engine
+            .call_tool(&caller, VIKTOR_SERVER, "get_file_download_url", None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(forbidden.contains("external tool is not explicitly allowlisted"));
+
+        let audit = engine.policy_audit();
+        assert_eq!(audit.len(), VIKTOR_CONVERSATION_TOOLS.len() + 1);
+        for receipt in audit.iter().take(VIKTOR_CONVERSATION_TOOLS.len()) {
+            assert!(receipt.allowed);
+            assert_eq!(receipt.caller.agent_id, "worker-session");
+            assert_eq!(receipt.caller.active_task_ids, ["cas-2428"]);
+            assert!(receipt.timestamp_ms > 0);
+        }
+        assert!(!audit.last().unwrap().allowed);
     }
 
     fn make_m233_pending(cas_root: &std::path::Path, wrong_ledger_identity: bool) {

--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -336,6 +336,13 @@ async fn run_server_impl() -> anyhow::Result<()> {
                 match cmcp_core::ProxyEngine::from_configs(cfg.servers).await {
                     Ok(engine) => {
                         install_proxy_policy(&engine, &snapshot_config).await;
+                        engine
+                            .set_call_observer(std::sync::Arc::new(
+                                crate::mcp::viktor_watch::ViktorWatchRecorder::new(
+                                    cas_root.clone(),
+                                ),
+                            ))
+                            .await;
                         let count = engine.tool_count().await;
                         eprintln!("[Cassy] MCP proxy ready ({count} upstream tools)");
                         if let Err(error) = write_proxy_snapshot_cache_for_config(

--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -307,11 +307,17 @@ async fn run_server_impl() -> anyhow::Result<()> {
         }
     }
 
-    // Refresh the credential-free, user-scoped Viktor default before loading
-    // proxy configuration. A project .cas/proxy.toml remains authoritative for
-    // dispatch policy, so it can intentionally opt out of this default.
     #[cfg(feature = "mcp-proxy")]
-    if let Ok(path) = cmcp_core::config::Scope::User.config_path()
+    let project_proxy_path = cas_root.join("proxy.toml");
+
+    // Refresh the credential-free, user-scoped Viktor default before loading
+    // proxy configuration. An explicit project .cas/proxy.toml is an opt-out:
+    // loading it still inherits user server definitions, so refreshing the
+    // managed default here would otherwise make a project-selected proxy
+    // surface connect to Viktor unexpectedly.
+    #[cfg(feature = "mcp-proxy")]
+    if !project_proxy_path.exists()
+        && let Ok(path) = cmcp_core::config::Scope::User.config_path()
         && let Err(error) = cmcp_core::config::Config::refresh_viktor_managed_default(&path)
     {
         eprintln!("[Cassy] Failed to refresh managed Viktor proxy config: {error}");
@@ -320,9 +326,8 @@ async fn run_server_impl() -> anyhow::Result<()> {
     // Load MCP proxy config from .cas/proxy.toml (project) and ~/.config/code-mode-mcp/config.toml (user)
     #[cfg(feature = "mcp-proxy")]
     let proxy = {
-        let proxy_path = cas_root.join("proxy.toml");
-        let cfg = cmcp_core::config::Config::load_merged(if proxy_path.exists() {
-            Some(&proxy_path)
+        let cfg = cmcp_core::config::Config::load_merged(if project_proxy_path.exists() {
+            Some(&project_proxy_path)
         } else {
             None
         });

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -4377,6 +4377,30 @@ impl CasCore {
             ),
         }
 
+        // Viktor inbound watches carry the same frozen task context as
+        // reminders. A reply arriving after task close must not wake a worker
+        // against an obsolete premise, so quarantine it at the close boundary.
+        match cas_store::SqliteViktorWatchStore::open(&self.cas_root) {
+            Ok(store) => match store.quarantine_for_task(&req.id) {
+                Ok(quarantined) if quarantined > 0 => tracing::info!(
+                    task_id = %req.id,
+                    quarantined,
+                    "quarantined Viktor watches on task close"
+                ),
+                Ok(_) => {}
+                Err(error) => tracing::error!(
+                    task_id = %req.id,
+                    error = %error,
+                    "task closed but Viktor watch quarantine failed"
+                ),
+            },
+            Err(error) => tracing::error!(
+                task_id = %req.id,
+                error = %error,
+                "task closed but Viktor watch store could not open for quarantine"
+            ),
+        }
+
         // cas-062d / cas-17e4: durable Closed outbox push after successful close.
         {
             let actor = self

--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -29,6 +29,8 @@ pub(crate) const INBOX_REDELIVERY_MARKER: &str = "[redelivery]";
 pub(crate) fn queued_message_provenance(message: &cas_store::QueuedPrompt) -> String {
     let origin = if message.source.eq_ignore_ascii_case("supervisor") {
         "supervisor-authored"
+    } else if message.source.eq_ignore_ascii_case("viktor") {
+        "viktor"
     } else if message.source.eq_ignore_ascii_case("director")
         && message
             .summary
@@ -55,6 +57,36 @@ pub(crate) fn queued_message_provenance(message: &cas_store::QueuedPrompt) -> St
         message.created_at.to_rfc3339(),
         delivery,
     )
+}
+
+#[cfg(test)]
+mod viktor_provenance_tests {
+    use super::queued_message_provenance;
+    use cas_store::{NotificationPriority, QueuedPrompt};
+
+    #[test]
+    fn viktor_queue_rows_keep_the_standard_provenance_envelope() {
+        let row = QueuedPrompt {
+            id: 73,
+            source: "viktor".to_string(),
+            target: "worker-1".to_string(),
+            prompt: "reply".to_string(),
+            created_at: chrono::DateTime::parse_from_rfc3339("2026-08-18T20:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            processed_at: None,
+            factory_session: Some("factory-1".to_string()),
+            summary: Some("Viktor reply".to_string()),
+            priority: NotificationPriority::High,
+            acked_at: None,
+            urgent: false,
+        };
+
+        assert_eq!(
+            queued_message_provenance(&row),
+            "CAS provenance: notification_id=73 origin=viktor queued_at=2026-08-18T20:00:00+00:00 delivery=first-delivery"
+        );
+    }
 }
 
 /// cas-99d2 (GH #127): what to do with one row an inbox poll selected.

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -3780,6 +3780,9 @@ impl CasService {
             )
         })?;
         let pending_prompts = prompt_queue.pending_count().unwrap_or(0);
+        let live_viktor_watches = cas_store::SqliteViktorWatchStore::open(&self.inner.cas_root)
+            .and_then(|store| store.list_live())
+            .unwrap_or_default();
 
         let worktree_store = open_worktree_store(&self.inner.cas_root).map_err(|e| {
             Self::error(
@@ -3833,10 +3836,11 @@ impl CasService {
 
         let mut out = String::from("Factory GC Report\n=================\n");
         out.push_str(&format!(
-            "\nStale agent threshold: {}s\nStale agents: {}\nPending prompts: {}\nActive worktrees: {}\nOrphan worktrees: {}\nOrphan worker process groups: {}\nLive-owned process groups skipped: {}\nUnverifiable process-group records preserved: {}\nStale process-group records: {}\nHost-registry open processes: {}\nOrphan processes in worktrees: {}\nStale server registrations: {}\nReapable orphans: {}\n",
+            "\nStale agent threshold: {}s\nStale agents: {}\nPending prompts: {}\nLive Viktor watches: {}\nActive worktrees: {}\nOrphan worktrees: {}\nOrphan worker process groups: {}\nLive-owned process groups skipped: {}\nUnverifiable process-group records preserved: {}\nStale process-group records: {}\nHost-registry open processes: {}\nOrphan processes in worktrees: {}\nStale server registrations: {}\nReapable orphans: {}\n",
             stale_after,
             stale_agents.len(),
             pending_prompts,
+            live_viktor_watches.len(),
             active_worktrees.len(),
             orphan_worktrees.len(),
             orphan_process_groups.len(),
@@ -3850,6 +3854,22 @@ impl CasService {
         ));
         out.push_str(&orphan_processes.render());
         out.push_str(&artifact_report.render());
+
+        if !live_viktor_watches.is_empty() {
+            out.push_str("\nLive Viktor watches:\n");
+            for watch in &live_viktor_watches {
+                out.push_str(&format!(
+                    "  - #{} thread={} run={} requester={} task={} polls={} expires={}\n",
+                    watch.id,
+                    watch.thread_id,
+                    watch.run_id,
+                    watch.requesting_agent_name,
+                    watch.task_id.as_deref().unwrap_or("-"),
+                    watch.poll_count,
+                    watch.expires_at.to_rfc3339(),
+                ));
+            }
+        }
 
         if !stale_agents.is_empty() {
             out.push_str("\nStale agents:\n");

--- a/cas-cli/src/mcp/viktor_watch.rs
+++ b/cas-cli/src/mcp/viktor_watch.rs
@@ -1,0 +1,504 @@
+//! Viktor's inbound half: record run-starting proxy calls and poll them from
+//! the embedded daemon into the ordinary CAS prompt queue.
+
+use std::path::{Path, PathBuf};
+
+use cas_store::{
+    EnqueueIdempotentResult, PromptQueueStore, SqlitePromptQueueStore, SqliteViktorWatchStore,
+    ViktorThreadWatch,
+};
+use cas_types::{AgentRole, AgentStatus};
+use serde_json::{Map, Value};
+
+pub(crate) const VIKTOR_WATCH_POLL_INTERVAL_SECS: i64 = 30;
+pub(crate) const VIKTOR_WATCH_MAX_PER_TICK: usize = 16;
+pub(crate) const VIKTOR_WATCH_MAX_CALLS_PER_TICK: usize = VIKTOR_WATCH_MAX_PER_TICK * 2;
+pub(crate) const VIKTOR_WATCH_TICK_BUDGET_SECS: u64 = 20;
+
+const START_TOOLS: &[&str] = &["ask_viktor", "create_thread", "send_message"];
+const TERMINAL_RUN_STATES: &[&str] = &[
+    "completed",
+    "requires_action",
+    "failed",
+    "cancelled",
+    "timed_out",
+];
+
+pub(crate) struct ViktorWatchRecorder {
+    cas_root: PathBuf,
+}
+
+impl ViktorWatchRecorder {
+    pub(crate) fn new(cas_root: PathBuf) -> Self {
+        Self { cas_root }
+    }
+}
+
+impl cmcp_core::ProxyCallObserver for ViktorWatchRecorder {
+    fn call_succeeded(&self, event: cmcp_core::ProxyCallEvent<'_>) {
+        if !event.server.eq_ignore_ascii_case("viktor") || !START_TOOLS.contains(&event.tool) {
+            return;
+        }
+
+        let Some(thread_id) = find_identifier(event.result, "thread_id", "thread") else {
+            tracing::error!(
+                server = event.server,
+                tool = event.tool,
+                "Viktor run-starting call succeeded without a thread id; inbound watch not recorded"
+            );
+            return;
+        };
+        let Some(run_id) = find_identifier(event.result, "run_id", "run") else {
+            tracing::error!(
+                server = event.server,
+                tool = event.tool,
+                thread_id,
+                "Viktor run-starting call succeeded without a run id; inbound watch not recorded"
+            );
+            return;
+        };
+        let watermark = find_identifier(event.result, "message_id", "message").or_else(|| {
+            event
+                .arguments
+                .as_ref()
+                .and_then(|arguments| arguments.get("after"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
+
+        let agent_name = crate::store::open_agent_store(&self.cas_root)
+            .ok()
+            .and_then(|store| store.get(&event.caller.agent_id).ok())
+            .map(|agent| agent.name)
+            .unwrap_or_else(|| event.caller.agent_id.clone());
+        let task_id = event.caller.active_task_ids.first().map(String::as_str);
+
+        match SqliteViktorWatchStore::open(&self.cas_root).and_then(|store| {
+            store.record(
+                &thread_id,
+                &run_id,
+                &event.caller.agent_id,
+                &agent_name,
+                &event.caller.role.to_string(),
+                event.caller.factory_session.as_deref(),
+                task_id,
+                watermark.as_deref(),
+                cas_store::DEFAULT_VIKTOR_WATCH_TTL_SECS,
+            )
+        }) {
+            Ok(watch_id) => tracing::info!(
+                watch_id,
+                thread_id,
+                run_id,
+                agent_id = event.caller.agent_id,
+                task_id,
+                "recorded Viktor inbound watch"
+            ),
+            Err(error) => tracing::error!(
+                thread_id,
+                run_id,
+                error = %error,
+                "Viktor call succeeded but inbound watch persistence failed"
+            ),
+        }
+    }
+}
+
+/// Poll one bounded batch. A non-terminal watch costs one `get_run`; a
+/// terminal successful watch costs one additional `get_run_result`.
+pub(crate) async fn poll_due_watches(
+    cas_root: &Path,
+    proxy: &cmcp_core::ProxyEngine,
+) -> Result<usize, String> {
+    let store = SqliteViktorWatchStore::open(cas_root).map_err(|error| error.to_string())?;
+    store.expire_stale().map_err(|error| error.to_string())?;
+    let watches = store
+        .list_due(VIKTOR_WATCH_MAX_PER_TICK)
+        .map_err(|error| error.to_string())?;
+    tracing::debug!(
+        due = watches.len(),
+        max_watches = VIKTOR_WATCH_MAX_PER_TICK,
+        max_calls = VIKTOR_WATCH_MAX_CALLS_PER_TICK,
+        budget_secs = VIKTOR_WATCH_TICK_BUDGET_SECS,
+        "Viktor inbound watch tick"
+    );
+    let mut delivered = 0;
+    let deadline =
+        tokio::time::Instant::now() + std::time::Duration::from_secs(VIKTOR_WATCH_TICK_BUDGET_SECS);
+    for watch in watches {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, poll_one(cas_root, proxy, &store, &watch)).await {
+            Ok(Ok(true)) => delivered += 1,
+            Ok(Ok(false)) => {}
+            Ok(Err(error)) => return Err(error),
+            Err(_) => {
+                store
+                    .record_poll(
+                        watch.id,
+                        VIKTOR_WATCH_POLL_INTERVAL_SECS,
+                        None,
+                        Some("Viktor watch tick exhausted its 20s wall-clock budget"),
+                    )
+                    .map_err(|error| error.to_string())?;
+                break;
+            }
+        }
+    }
+    Ok(delivered)
+}
+
+async fn poll_one(
+    cas_root: &Path,
+    proxy: &cmcp_core::ProxyEngine,
+    store: &SqliteViktorWatchStore,
+    watch: &ViktorThreadWatch,
+) -> Result<bool, String> {
+    let role = watch
+        .requesting_agent_role
+        .parse::<AgentRole>()
+        .unwrap_or(AgentRole::Standard);
+    let caller = cmcp_core::ProxyCaller {
+        agent_id: watch.requesting_agent_id.clone(),
+        role,
+        session_id: watch.requesting_agent_id.clone(),
+        factory_session: watch.factory_session.clone(),
+        active_task_ids: watch.task_id.iter().cloned().collect(),
+    };
+    let args = Map::from_iter([("run_id".to_string(), Value::String(watch.run_id.clone()))]);
+    let run = match proxy
+        .call_tool(&caller, "viktor", "get_run", Some(args.clone()))
+        .await
+    {
+        Ok(value) => value,
+        Err(error) => {
+            store
+                .record_poll(
+                    watch.id,
+                    VIKTOR_WATCH_POLL_INTERVAL_SECS,
+                    None,
+                    Some(&bounded_error(&error.to_string())),
+                )
+                .map_err(|error| error.to_string())?;
+            return Ok(false);
+        }
+    };
+    let status = find_string_by_key(&run, "status")
+        .unwrap_or_else(|| "unknown".to_string())
+        .to_ascii_lowercase();
+    if !TERMINAL_RUN_STATES.contains(&status.as_str()) {
+        store
+            .record_poll(watch.id, VIKTOR_WATCH_POLL_INTERVAL_SECS, None, None)
+            .map_err(|error| error.to_string())?;
+        return Ok(false);
+    }
+
+    let payload = if matches!(status.as_str(), "completed" | "requires_action") {
+        match proxy
+            .call_tool(&caller, "viktor", "get_run_result", Some(args))
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                store
+                    .record_poll(
+                        watch.id,
+                        VIKTOR_WATCH_POLL_INTERVAL_SECS,
+                        None,
+                        Some(&bounded_error(&error.to_string())),
+                    )
+                    .map_err(|error| error.to_string())?;
+                return Ok(false);
+            }
+        }
+    } else {
+        run
+    };
+
+    let Some((target, fallback)) = delivery_target(cas_root, watch) else {
+        store
+            .mark_undeliverable(
+                watch.id,
+                "requesting agent ended and no live session supervisor was registered",
+            )
+            .map_err(|error| error.to_string())?;
+        return Ok(false);
+    };
+    let body = render_provider_payload(&payload);
+    let fallback_line = if fallback {
+        format!(
+            "Requesting agent '{}' is no longer live; routed to its factory supervisor.\n",
+            watch.requesting_agent_name
+        )
+    } else {
+        String::new()
+    };
+    let prompt = format!(
+        "<viktor-reply thread_id=\"{}\" run_id=\"{}\" status=\"{}\">\n{}{}\n</viktor-reply>",
+        watch.thread_id, watch.run_id, status, fallback_line, body
+    );
+    let summary = format!("Viktor reply: {} / {}", watch.thread_id, watch.run_id);
+    let queue = SqlitePromptQueueStore::open(cas_root).map_err(|error| error.to_string())?;
+    queue.init().map_err(|error| error.to_string())?;
+    let enqueued = queue
+        .enqueue_idempotent(
+            "viktor",
+            &target,
+            &prompt,
+            watch.factory_session.as_deref(),
+            Some(&summary),
+            Some(cas_store::NotificationPriority::High),
+            &format!("viktor-watch:{}", watch.id),
+        )
+        .map_err(|error| error.to_string())?;
+    let notification_id = match enqueued {
+        EnqueueIdempotentResult::Created(id) | EnqueueIdempotentResult::AlreadyExists(id) => id,
+    };
+    store
+        .mark_delivered(watch.id, notification_id)
+        .map_err(|error| error.to_string())?;
+    let _ = cas_factory::notify_daemon(cas_root);
+    Ok(true)
+}
+
+fn delivery_target(cas_root: &Path, watch: &ViktorThreadWatch) -> Option<(String, bool)> {
+    let store = crate::store::open_agent_store(cas_root).ok()?;
+    if let Ok(agent) = store.get(&watch.requesting_agent_id)
+        && matches!(agent.status, AgentStatus::Active | AgentStatus::Idle)
+    {
+        return Some((agent.name, false));
+    }
+    let session = watch.factory_session.as_deref()?;
+    store.list(None).ok()?.into_iter().find_map(|agent| {
+        (agent.factory_session.as_deref() == Some(session)
+            && matches!(agent.role, AgentRole::Supervisor | AgentRole::Director)
+            && matches!(agent.status, AgentStatus::Active | AgentStatus::Idle))
+        .then_some((agent.name, true))
+    })
+}
+
+fn bounded_error(message: &str) -> String {
+    message.chars().take(512).collect()
+}
+
+fn render_provider_payload(value: &Value) -> String {
+    let mut texts = Vec::new();
+    collect_content_text(value, &mut texts);
+    let rendered = if texts.is_empty() {
+        serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+    } else {
+        texts.join("\n\n")
+    };
+    rendered.chars().take(16_000).collect()
+}
+
+fn collect_content_text(value: &Value, texts: &mut Vec<String>) {
+    match value {
+        Value::Object(object) => {
+            if let Some(Value::String(text)) = object.get("text") {
+                texts.push(text.clone());
+            } else {
+                for child in object.values() {
+                    collect_content_text(child, texts);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_content_text(item, texts);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn find_identifier(value: &Value, flat_key: &str, object_key: &str) -> Option<String> {
+    find_string_by_key(value, flat_key).or_else(|| find_nested_id(value, object_key))
+}
+
+fn find_nested_id(value: &Value, object_key: &str) -> Option<String> {
+    match value {
+        Value::Object(object) => {
+            if let Some(Value::Object(nested)) = object.get(object_key)
+                && let Some(id) = nested.get("id").and_then(Value::as_str)
+            {
+                return Some(id.to_string());
+            }
+            object
+                .values()
+                .find_map(|child| find_nested_id(child, object_key))
+        }
+        Value::Array(items) => items
+            .iter()
+            .find_map(|child| find_nested_id(child, object_key)),
+        Value::String(text) => serde_json::from_str::<Value>(text)
+            .ok()
+            .and_then(|parsed| find_nested_id(&parsed, object_key)),
+        _ => None,
+    }
+}
+
+fn find_string_by_key(value: &Value, key: &str) -> Option<String> {
+    match value {
+        Value::Object(object) => {
+            if let Some(text) = object.get(key).and_then(Value::as_str) {
+                return Some(text.to_string());
+            }
+            object
+                .values()
+                .find_map(|child| find_string_by_key(child, key))
+        }
+        Value::Array(items) => items
+            .iter()
+            .find_map(|child| find_string_by_key(child, key)),
+        Value::String(text) => serde_json::from_str::<Value>(text)
+            .ok()
+            .and_then(|parsed| find_string_by_key(&parsed, key)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cas_store::PromptQueueStore;
+    use cas_types::{Agent, AgentRole, AgentStatus};
+    use std::collections::HashMap;
+
+    #[test]
+    fn extracts_viktor_ids_from_mcp_text_content() {
+        let result = serde_json::json!({
+            "content": [{"type": "text", "text": "{\"thread\":{\"id\":\"th-1\"},\"run\":{\"id\":\"run-1\"},\"message\":{\"id\":\"msg-1\"}}"}]
+        });
+        assert_eq!(
+            find_identifier(&result, "thread_id", "thread").as_deref(),
+            Some("th-1")
+        );
+        assert_eq!(
+            find_identifier(&result, "run_id", "run").as_deref(),
+            Some("run-1")
+        );
+        assert_eq!(
+            find_identifier(&result, "message_id", "message").as_deref(),
+            Some("msg-1")
+        );
+    }
+
+    #[test]
+    fn terminal_states_match_viktor_contract() {
+        for state in [
+            "completed",
+            "requires_action",
+            "failed",
+            "cancelled",
+            "timed_out",
+        ] {
+            assert!(TERMINAL_RUN_STATES.contains(&state));
+        }
+        assert!(!TERMINAL_RUN_STATES.contains(&"running"));
+        assert_eq!(VIKTOR_WATCH_MAX_CALLS_PER_TICK, 32);
+        assert_eq!(VIKTOR_WATCH_TICK_BUDGET_SECS, 20);
+    }
+
+    #[tokio::test]
+    async fn daemon_poll_delivers_and_falls_back_to_the_session_supervisor() {
+        let temp = tempfile::tempdir().unwrap();
+        let agents = crate::store::open_agent_store(temp.path()).unwrap();
+        let mut worker = Agent::new_with_role(
+            "worker-session".to_string(),
+            "worker-1".to_string(),
+            AgentRole::Worker,
+        );
+        worker.factory_session = Some("factory-1".to_string());
+        agents.register(&worker).unwrap();
+        let mut supervisor = Agent::new_with_role(
+            "supervisor-session".to_string(),
+            "supervisor".to_string(),
+            AgentRole::Supervisor,
+        );
+        supervisor.factory_session = Some("factory-1".to_string());
+        agents.register(&supervisor).unwrap();
+
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/mock_mcp_viktor_thread_server.py");
+        let config = cmcp_core::config::ServerConfig::Stdio {
+            command: "python3".to_string(),
+            args: vec![fixture.display().to_string()],
+            env: HashMap::new(),
+        };
+        let engine =
+            cmcp_core::ProxyEngine::from_configs(HashMap::from([("viktor".to_string(), config)]))
+                .await
+                .unwrap();
+        engine
+            .set_call_observer(std::sync::Arc::new(ViktorWatchRecorder::new(
+                temp.path().to_path_buf(),
+            )))
+            .await;
+        let caller = cmcp_core::ProxyCaller {
+            agent_id: worker.id.clone(),
+            role: AgentRole::Worker,
+            session_id: worker.id.clone(),
+            factory_session: worker.factory_session.clone(),
+            active_task_ids: vec!["cas-fixture".to_string()],
+        };
+        engine
+            .call_tool(
+                &caller,
+                "viktor",
+                "create_thread",
+                Some(Map::from_iter([(
+                    "message".to_string(),
+                    Value::String("reply asynchronously".to_string()),
+                )])),
+            )
+            .await
+            .unwrap();
+
+        let watches = SqliteViktorWatchStore::open(temp.path())
+            .unwrap()
+            .list_live()
+            .unwrap();
+        assert_eq!(watches.len(), 1, "proxy completion must arm one watch");
+        assert_eq!(poll_due_watches(temp.path(), &engine).await.unwrap(), 1);
+        let queue = SqlitePromptQueueStore::open(temp.path()).unwrap();
+        queue.init().unwrap();
+        let delivered = queue.poll_for_target("worker-1", 10).unwrap();
+        assert_eq!(delivered.len(), 1);
+        assert_eq!(delivered[0].source, "viktor");
+        assert!(delivered[0].prompt.contains("thread-fixture-1"));
+        assert!(delivered[0].prompt.contains("run-fixture-1"));
+        assert!(delivered[0].prompt.contains("fixture Viktor reply"));
+
+        let store = SqliteViktorWatchStore::open(temp.path()).unwrap();
+        store
+            .record(
+                "thread-fixture-2",
+                "run-fixture-2",
+                &worker.id,
+                &worker.name,
+                "worker",
+                worker.factory_session.as_deref(),
+                Some("cas-fixture"),
+                None,
+                cas_store::DEFAULT_VIKTOR_WATCH_TTL_SECS,
+            )
+            .unwrap();
+        worker.status = AgentStatus::Shutdown;
+        agents.update(&worker).unwrap();
+        assert_eq!(poll_due_watches(temp.path(), &engine).await.unwrap(), 1);
+        let fallback = queue.poll_for_target("supervisor", 10).unwrap();
+        assert_eq!(fallback.len(), 1);
+        assert!(
+            fallback[0]
+                .prompt
+                .contains("routed to its factory supervisor")
+        );
+        assert!(fallback[0].prompt.contains("run-fixture-2"));
+
+        engine.shutdown().await;
+    }
+
+}

--- a/cas-cli/tests/fixtures/mock_mcp_viktor_thread_server.py
+++ b/cas-cli/tests/fixtures/mock_mcp_viktor_thread_server.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Deterministic Viktor thread/run MCP fixture for inbound-watch tests."""
+
+import json
+import sys
+
+
+TOOLS = [
+    {"name": "create_thread", "description": "start", "inputSchema": {"type": "object"}},
+    {"name": "get_run", "description": "status", "inputSchema": {"type": "object"}},
+    {"name": "get_run_result", "description": "result", "inputSchema": {"type": "object"}},
+]
+
+
+def respond(request_id, result):
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}) + "\n")
+    sys.stdout.flush()
+
+
+def tool_result(payload):
+    return {"content": [{"type": "text", "text": json.dumps(payload)}]}
+
+
+for line in sys.stdin:
+    request = json.loads(line)
+    request_id = request.get("id")
+    if request_id is None:
+        continue
+    method = request.get("method")
+    if method == "initialize":
+        respond(
+            request_id,
+            {
+                "protocolVersion": request.get("params", {}).get("protocolVersion", "2024-11-05"),
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "mock-viktor-thread", "version": "0.0.1"},
+            },
+        )
+    elif method == "tools/list":
+        respond(request_id, {"tools": TOOLS})
+    elif method == "tools/call":
+        name = request.get("params", {}).get("name")
+        if name == "create_thread":
+            payload = {
+                "thread": {"id": "thread-fixture-1"},
+                "message": {"id": "message-fixture-1"},
+                "run": {"id": "run-fixture-1"},
+            }
+        elif name == "get_run":
+            payload = {"run_id": "run-fixture-1", "status": "completed"}
+        elif name == "get_run_result":
+            payload = {"markdown": "fixture Viktor reply", "json": {"answer": 42}}
+        else:
+            payload = {"error": "unsupported", "message": name}
+        respond(request_id, tool_result(payload))
+    elif method in ("ping", "shutdown", "exit"):
+        respond(request_id, {})
+    else:
+        respond(request_id, tool_result({"error": "unsupported", "message": method}))

--- a/cas-cli/tests/mcp_proxy_test.rs
+++ b/cas-cli/tests/mcp_proxy_test.rs
@@ -593,6 +593,13 @@ fn nonempty_to_empty_restart_clears_public_proxy_state_without_a_live_engine() {
         assert_eq!(health["servers"].as_array().unwrap().len(), 1);
         assert_eq!(health["servers"][0]["name"], public_name);
     }
+    assert!(
+        !sandbox
+            .xdg_config_home()
+            .join("code-mode-mcp/config.toml")
+            .exists(),
+        "an explicit project proxy configuration must not install the managed user default"
+    );
 
     let populated_catalog = std::fs::read(sandbox.cas_root().join("proxy_catalog.json")).unwrap();
     let populated_health = std::fs::read(sandbox.cas_root().join("proxy_health.json")).unwrap();

--- a/cas-cli/tests/viktor_distribution_test.rs
+++ b/cas-cli/tests/viktor_distribution_test.rs
@@ -1,0 +1,78 @@
+//! Distribution contract for the managed Viktor gateway.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn cas_cmd(root: &std::path::Path) -> Command {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cas"));
+    let home = root.join(".test-home");
+    let xdg = root.join(".test-xdg-config");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&xdg).unwrap();
+    if let Some(host_home) = std::env::var_os("HOME") {
+        cmd.env("CAS_TEST_PROTECTED_HOME", host_home);
+    }
+    cmd.env("HOME", home)
+        .env("XDG_CONFIG_HOME", xdg)
+        .env_remove("CAS_ROOT")
+        .env_remove("VIKTOR_API_KEY")
+        .env("CAS_SKIP_FACTORY_TOOLING", "1");
+    cmd
+}
+
+#[test]
+fn clean_init_and_sync_distribute_viktor_skill_and_status_never_prints_a_key() {
+    let temp = TempDir::new().unwrap();
+
+    cas_cmd(temp.path())
+        .current_dir(&temp)
+        .args(["init", "--yes"])
+        .assert()
+        .success();
+
+    assert!(
+        temp.path()
+            .join(".claude/skills/cas-viktor/SKILL.md")
+            .is_file(),
+        "missing Claude Viktor skill after cas init"
+    );
+
+    // `cas init` configures only detected harnesses. Once a project opts into
+    // Codex/Grok by creating their project directories, `cas update --sync`
+    // refreshes each enabled mirror through the ordinary downstream path.
+    std::fs::create_dir_all(temp.path().join(".codex")).unwrap();
+    std::fs::create_dir_all(temp.path().join(".grok")).unwrap();
+    cas_cmd(temp.path())
+        .current_dir(&temp)
+        .args(["update", "--sync"])
+        .assert()
+        .success();
+
+    for path in [
+        ".claude/skills/cas-viktor/SKILL.md",
+        ".claude/skills/cas-viktor/references/gateway.md",
+        ".codex/skills/cas-viktor/SKILL.md",
+        ".codex/skills/cas-viktor/references/gateway.md",
+        ".grok/skills/cas-viktor/SKILL.md",
+        ".grok/skills/cas-viktor/references/gateway.md",
+    ] {
+        assert!(
+            temp.path().join(path).is_file(),
+            "missing {path} after cas init"
+        );
+    }
+
+    let sentinel = "viktor-test-secret-must-not-appear";
+    cas_cmd(temp.path())
+        .current_dir(&temp)
+        .args(["--json", "viktor"])
+        .env("VIKTOR_API_KEY", sentinel)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "\"credential_env\": \"VIKTOR_API_KEY\"",
+        ))
+        .stdout(predicate::str::contains("\"credential_present\": true"))
+        .stdout(predicate::str::contains(sentinel).not());
+}

--- a/crates/cas-mcp-proxy/README.md
+++ b/crates/cas-mcp-proxy/README.md
@@ -6,6 +6,28 @@ MCP proxy engine for CAS. Connects to upstream MCP servers and exposes their too
 
 Upstream servers are configured in `.cas/proxy.toml` (project-scoped) and `~/.config/code-mode-mcp/config.toml` (user-scoped). Project config takes precedence.
 
+### Managed Viktor default
+
+On `cas serve` startup, Cassy refreshes a user-scoped `viktor` upstream using
+streamable HTTP at `https://api.viktor.com/mcp` and the credential reference
+`env:VIKTOR_API_KEY`. The API key is read only when the connection is made; it
+is never written to the config file. On this managed host, source the canonical
+credential file `~/.cas/viktor.env` into the serving process; never copy its
+value into a project file, artifact, or command output. The managed direct-call allowlist is
+exactly `ask_viktor`, `create_thread`, `send_message`, `wait_for_run`,
+`get_run`, `get_run_result`, `list_threads`, `list_messages`, and `whoami`.
+Every forwarded call is attributed by the proxy policy audit to the registered
+CAS caller, active task leases, and dispatch timestamp; request arguments and
+upstream output are not retained in that receipt.
+
+An existing `.cas/proxy.toml` intentionally replaces the user allowlist and
+delegation policy rather than widening it. Projects that have one must add the
+same exact routes there to opt into direct Viktor conversations. This preserves
+the fail-closed project boundary. The separate
+`delegation.external_production_verification` configuration remains the
+supervisor-only external-verification gateway; it is not installed by the
+managed Viktor default.
+
 ### Supported transports
 
 **Stdio** — spawns a child process:

--- a/crates/cas-mcp-proxy/src/config.rs
+++ b/crates/cas-mcp-proxy/src/config.rs
@@ -4,6 +4,23 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+/// Canonical Viktor streamable-HTTP upstream. The credential is resolved at
+/// connection time so it is safe to place this managed default on disk.
+pub const VIKTOR_MCP_URL: &str = "https://api.viktor.com/mcp";
+pub const VIKTOR_API_KEY_ENV: &str = "VIKTOR_API_KEY";
+pub const VIKTOR_SERVER: &str = "viktor";
+pub const VIKTOR_CONVERSATION_TOOLS: [&str; 9] = [
+    "ask_viktor",
+    "create_thread",
+    "send_message",
+    "wait_for_run",
+    "get_run",
+    "get_run_result",
+    "list_threads",
+    "list_messages",
+    "whoami",
+];
+
 /// MCP proxy configuration containing upstream server definitions.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Config {
@@ -211,6 +228,59 @@ impl Config {
     pub fn remove_server(&mut self, name: &str) -> bool {
         self.servers.remove(name).is_some()
     }
+
+    /// Install the credential-free Viktor default in a user-scoped config.
+    ///
+    /// A pre-existing Viktor server is operator-owned and therefore retained,
+    /// while its dispatch surface is refreshed to the deliberately small
+    /// conversation contract. Project configuration remains authoritative for
+    /// policy because [`Self::load_merged`] replaces (rather than unions) the
+    /// user allowlist when `.cas/proxy.toml` exists.
+    pub fn ensure_viktor_managed_default(&mut self) -> bool {
+        let mut changed = false;
+        if !self.servers.contains_key(VIKTOR_SERVER) {
+            self.servers.insert(
+                VIKTOR_SERVER.to_string(),
+                ServerConfig::Http {
+                    url: VIKTOR_MCP_URL.to_string(),
+                    auth: Some(format!("env:{VIKTOR_API_KEY_ENV}")),
+                    headers: HashMap::new(),
+                    oauth: false,
+                },
+            );
+            changed = true;
+        }
+
+        let desired = VIKTOR_CONVERSATION_TOOLS
+            .iter()
+            .map(|tool| ExternalToolConfig {
+                server: VIKTOR_SERVER.to_string(),
+                tool: (*tool).to_string(),
+            })
+            .collect::<Vec<_>>();
+        if self
+            .allowlist
+            .iter()
+            .filter(|route| route.server == VIKTOR_SERVER)
+            .ne(desired.iter())
+        {
+            self.allowlist.retain(|route| route.server != VIKTOR_SERVER);
+            self.allowlist.extend(desired);
+            changed = true;
+        }
+        changed
+    }
+
+    /// Refresh the user-scoped managed Viktor default without copying a
+    /// credential into configuration.
+    pub fn refresh_viktor_managed_default(path: &Path) -> Result<bool> {
+        let mut config = Self::load_from(path)?;
+        let changed = config.ensure_viktor_managed_default();
+        if changed {
+            config.save_to(path)?;
+        }
+        Ok(changed)
+    }
 }
 
 #[cfg(test)]
@@ -354,5 +424,74 @@ tool = "ask_viktor"
     fn scope_user_config_path() {
         let path = Scope::User.config_path().unwrap();
         assert!(path.ends_with("code-mode-mcp/config.toml"));
+    }
+
+    #[test]
+    fn managed_viktor_default_is_credential_free_and_exactly_allowlisted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[[allowlist]]
+server = "github"
+tool = "list_issues"
+
+[[allowlist]]
+server = "viktor"
+tool = "get_file_download_url"
+"#,
+        )
+        .unwrap();
+
+        assert!(Config::refresh_viktor_managed_default(&path).unwrap());
+        assert!(!Config::refresh_viktor_managed_default(&path).unwrap());
+        let config = Config::load_from(&path).unwrap();
+        assert_eq!(
+            config.servers.get(VIKTOR_SERVER),
+            Some(&ServerConfig::Http {
+                url: VIKTOR_MCP_URL.to_string(),
+                auth: Some(format!("env:{VIKTOR_API_KEY_ENV}")),
+                headers: HashMap::new(),
+                oauth: false,
+            })
+        );
+        assert_eq!(
+            config
+                .allowlist
+                .iter()
+                .filter(|route| route.server == VIKTOR_SERVER)
+                .map(|route| route.tool.as_str())
+                .collect::<Vec<_>>(),
+            VIKTOR_CONVERSATION_TOOLS
+        );
+        assert!(
+            config
+                .allowlist
+                .iter()
+                .any(|route| { route.server == "github" && route.tool == "list_issues" })
+        );
+        assert!(!toml::to_string(&config).unwrap().contains("zt_live"));
+    }
+
+    #[test]
+    fn managed_viktor_default_preserves_an_operator_owned_upstream() {
+        let mut config = Config::default();
+        config.add_server(
+            VIKTOR_SERVER.to_string(),
+            ServerConfig::Http {
+                url: "https://operator.example/mcp".to_string(),
+                auth: Some("env:OPERATOR_VIKTOR_KEY".to_string()),
+                headers: HashMap::new(),
+                oauth: false,
+            },
+        );
+        assert!(config.ensure_viktor_managed_default());
+        assert!(matches!(
+            config.servers.get(VIKTOR_SERVER),
+            Some(ServerConfig::Http { url, auth, .. })
+                if url == "https://operator.example/mcp"
+                    && auth.as_deref() == Some("env:OPERATOR_VIKTOR_KEY")
+        ));
     }
 }

--- a/crates/cas-mcp-proxy/src/lib.rs
+++ b/crates/cas-mcp-proxy/src/lib.rs
@@ -1300,7 +1300,10 @@ fn http_transport_config(
     let mut config = StreamableHttpClientTransportConfig::with_uri(Arc::<str>::from(url));
     config.custom_headers = custom_headers;
     if let Some(auth) = auth {
-        config.auth_header = Some(format!("Bearer {}", resolve_credential(auth)?));
+        // RMCP owns the Authorization header and applies the Bearer scheme itself.
+        // Supplying a pre-prefixed value sends `Bearer Bearer <token>`, which a
+        // conforming streamable HTTP server rejects during initialization.
+        config.auth_header = Some(resolve_credential(auth)?);
     }
     Ok(config)
 }
@@ -1918,7 +1921,7 @@ mod tests {
     }
 
     #[test]
-    fn imported_http_headers_and_literal_or_env_auth_are_applied_as_bearer_tokens() {
+    fn imported_http_headers_and_literal_or_env_auth_are_forwarded_as_raw_bearer_tokens() {
         let config = http_transport_config(
             "https://example.invalid/mcp",
             Some("literal-token"),
@@ -1926,7 +1929,7 @@ mod tests {
         )
         .expect("valid HTTP config");
 
-        assert_eq!(config.auth_header.as_deref(), Some("Bearer literal-token"));
+        assert_eq!(config.auth_header.as_deref(), Some("literal-token"));
         assert_eq!(
             config
                 .custom_headers
@@ -1950,10 +1953,9 @@ mod tests {
         .expect("valid env-backed auth");
         unsafe { std::env::remove_var(&env_name) };
 
-        let expected_auth = format!("Bearer {env_secret}");
         assert_eq!(
             env_config.auth_header.as_deref(),
-            Some(expected_auth.as_str())
+            Some(env_secret)
         );
         let health = serde_json::to_string(&ProxyHealthSnapshot {
             session_id: "redaction-test".to_string(),

--- a/crates/cas-mcp-proxy/src/lib.rs
+++ b/crates/cas-mcp-proxy/src/lib.rs
@@ -62,6 +62,24 @@ pub struct ProxyCaller {
     pub active_task_ids: Vec<String>,
 }
 
+/// A successful direct upstream call, exposed to CAS-owned durable side effects.
+///
+/// The observer runs only after the provider accepted the call. Its return
+/// value is intentionally ignored by the transport: turning a local recording
+/// failure into an MCP error would invite callers to retry a run-starting tool
+/// and spend twice. Implementations must emit their own durable diagnostics.
+pub struct ProxyCallEvent<'a> {
+    pub caller: &'a ProxyCaller,
+    pub server: &'a str,
+    pub tool: &'a str,
+    pub arguments: &'a Option<serde_json::Map<String, Value>>,
+    pub result: &'a Value,
+}
+
+pub trait ProxyCallObserver: Send + Sync {
+    fn call_succeeded(&self, event: ProxyCallEvent<'_>);
+}
+
 /// A policy decision requested before an upstream MCP tool call is forwarded.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProxyPolicyDecision {
@@ -312,6 +330,7 @@ pub struct ProxyEngine {
     health: RwLock<HashMap<String, UpstreamHealth>>,
     session_id: String,
     policy: RwLock<Arc<dyn ProxyPolicy>>,
+    observer: RwLock<Option<Arc<dyn ProxyCallObserver>>>,
     policy_audit: Mutex<VecDeque<ProxyPolicyAuditEntry>>,
 }
 
@@ -349,6 +368,7 @@ impl ProxyEngine {
             health: RwLock::new(health),
             session_id,
             policy: RwLock::new(Arc::new(AllowAllProxyPolicy)),
+            observer: RwLock::new(None),
             policy_audit: Mutex::new(VecDeque::new()),
         };
 
@@ -370,6 +390,11 @@ impl ProxyEngine {
     /// records intact for operator inspection.
     pub async fn set_policy(&self, policy: Arc<dyn ProxyPolicy>) {
         *self.policy.write().await = policy;
+    }
+
+    /// Install the observer for successful upstream calls.
+    pub async fn set_call_observer(&self, observer: Arc<dyn ProxyCallObserver>) {
+        *self.observer.write().await = Some(observer);
     }
 
     /// Return the bounded, redacted authorization audit trail for this proxy
@@ -813,16 +838,35 @@ impl ProxyEngine {
         self.authorize(caller, dispatch_kind, server_name, tool_name, &arguments)
             .await?;
 
-        self.call_upstream(
-            server_name,
-            CallToolRequestParams {
-                name: tool_name.to_string().into(),
-                arguments,
-                meta: None,
-                task: None,
-            },
-        )
-        .await
+        let result = self
+            .call_upstream(
+                server_name,
+                CallToolRequestParams {
+                    name: tool_name.to_string().into(),
+                    arguments: arguments.clone(),
+                    meta: None,
+                    task: None,
+                },
+            )
+            .await?;
+
+        // The receipted external-verification lane owns its own polling and
+        // lifecycle. Observing it here would create a second inbound watch and
+        // duplicate its result into the prompt queue.
+        if dispatch_kind == ProxyDispatchKind::Direct
+            && let Some(observer) = self.observer.read().await.clone()
+        {
+            let serialized = serde_json::to_value(&result).unwrap_or(Value::Null);
+            observer.call_succeeded(ProxyCallEvent {
+                caller,
+                server: server_name,
+                tool: tool_name,
+                arguments: &arguments,
+                result: &serialized,
+            });
+        }
+
+        Ok(result)
     }
 
     async fn authorize(

--- a/crates/cas-store/src/lib.rs
+++ b/crates/cas-store/src/lib.rs
@@ -71,6 +71,7 @@ mod supervisor_queue_store;
 mod task_store;
 pub mod tracing;
 mod verification_store;
+mod viktor_watch_store;
 mod worktree_store;
 
 pub mod code_review;
@@ -183,6 +184,12 @@ pub use verification_store::{
     reopen_terminal_task_atomic, request_changes_for_parked_delivery,
     resolve_verification_dispatch_with_conn, save_verification_issues_with_conn,
     timeout_verification_dispatch, update_system_verification,
+};
+
+// Durable Viktor thread watches used by the embedded daemon's inbound bridge.
+pub use viktor_watch_store::{
+    DEFAULT_VIKTOR_WATCH_TTL_SECS, SqliteViktorWatchStore, ViktorThreadWatch,
+    ViktorWatchStatus,
 };
 
 // Worktree store for git worktree tracking

--- a/crates/cas-store/src/viktor_watch_store.rs
+++ b/crates/cas-store/src/viktor_watch_store.rs
@@ -1,0 +1,446 @@
+//! Durable Viktor run watches for daemon-owned inbound delivery.
+
+use chrono::{DateTime, TimeZone, Utc};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use crate::{Result, StoreError};
+
+/// A day is long enough for an intentionally slow delegated run while still
+/// bounding forgotten watches and provider polling cost.
+pub const DEFAULT_VIKTOR_WATCH_TTL_SECS: i64 = 24 * 60 * 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ViktorWatchStatus {
+    Pending,
+    Delivered,
+    Expired,
+    Quarantined,
+    Undeliverable,
+}
+
+impl std::fmt::Display for ViktorWatchStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Pending => "pending",
+            Self::Delivered => "delivered",
+            Self::Expired => "expired",
+            Self::Quarantined => "quarantined",
+            Self::Undeliverable => "undeliverable",
+        })
+    }
+}
+
+impl std::str::FromStr for ViktorWatchStatus {
+    type Err = StoreError;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "delivered" => Ok(Self::Delivered),
+            "expired" => Ok(Self::Expired),
+            "quarantined" => Ok(Self::Quarantined),
+            "undeliverable" => Ok(Self::Undeliverable),
+            other => Err(StoreError::Parse(format!(
+                "unknown Viktor watch status: {other}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViktorThreadWatch {
+    pub id: i64,
+    pub thread_id: String,
+    pub run_id: String,
+    pub requesting_agent_id: String,
+    pub requesting_agent_name: String,
+    pub requesting_agent_role: String,
+    pub factory_session: Option<String>,
+    pub task_id: Option<String>,
+    pub watermark: Option<String>,
+    pub status: ViktorWatchStatus,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub next_poll_at: DateTime<Utc>,
+    pub last_polled_at: Option<DateTime<Utc>>,
+    pub poll_count: u32,
+    pub delivered_at: Option<DateTime<Utc>>,
+    pub notification_id: Option<i64>,
+    pub last_error: Option<String>,
+}
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS viktor_thread_watches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    thread_id TEXT NOT NULL,
+    run_id TEXT NOT NULL UNIQUE,
+    requesting_agent_id TEXT NOT NULL,
+    requesting_agent_name TEXT NOT NULL,
+    requesting_agent_role TEXT NOT NULL,
+    factory_session TEXT,
+    task_id TEXT,
+    watermark TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    next_poll_at TEXT NOT NULL,
+    last_polled_at TEXT,
+    poll_count INTEGER NOT NULL DEFAULT 0,
+    delivered_at TEXT,
+    notification_id INTEGER,
+    last_error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_viktor_watches_due
+    ON viktor_thread_watches(status, next_poll_at, expires_at);
+CREATE INDEX IF NOT EXISTS idx_viktor_watches_task
+    ON viktor_thread_watches(task_id, status);
+"#;
+
+pub struct SqliteViktorWatchStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl SqliteViktorWatchStore {
+    pub fn open(cas_dir: &Path) -> Result<Self> {
+        let conn = crate::shared_db::shared_connection(&cas_dir.join("cas.db"))?;
+        let store = Self { conn };
+        store.init()?;
+        Ok(store)
+    }
+
+    pub fn init(&self) -> Result<()> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.execute_batch(SCHEMA)?;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn record(
+        &self,
+        thread_id: &str,
+        run_id: &str,
+        requesting_agent_id: &str,
+        requesting_agent_name: &str,
+        requesting_agent_role: &str,
+        factory_session: Option<&str>,
+        task_id: Option<&str>,
+        watermark: Option<&str>,
+        ttl_secs: i64,
+    ) -> Result<i64> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        let now = Utc::now();
+        let expires_at = now + chrono::Duration::seconds(ttl_secs.max(1));
+        conn.execute(
+            "INSERT INTO viktor_thread_watches (
+                thread_id, run_id, requesting_agent_id, requesting_agent_name,
+                requesting_agent_role, factory_session, task_id, watermark,
+                status, created_at, expires_at, next_poll_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'pending', ?9, ?10, ?9)
+             ON CONFLICT(run_id) DO UPDATE SET
+                thread_id = excluded.thread_id,
+                requesting_agent_id = excluded.requesting_agent_id,
+                requesting_agent_name = excluded.requesting_agent_name,
+                requesting_agent_role = excluded.requesting_agent_role,
+                factory_session = excluded.factory_session,
+                task_id = excluded.task_id,
+                watermark = COALESCE(excluded.watermark, viktor_thread_watches.watermark)",
+            params![
+                thread_id,
+                run_id,
+                requesting_agent_id,
+                requesting_agent_name,
+                requesting_agent_role,
+                factory_session,
+                task_id,
+                watermark,
+                now.to_rfc3339(),
+                expires_at.to_rfc3339(),
+            ],
+        )?;
+        conn.query_row(
+            "SELECT id FROM viktor_thread_watches WHERE run_id = ?1",
+            [run_id],
+            |row| row.get(0),
+        )
+        .map_err(Into::into)
+    }
+
+    pub fn get(&self, id: i64) -> Result<Option<ViktorThreadWatch>> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.query_row(
+            &format!(
+                "SELECT {} FROM viktor_thread_watches WHERE id = ?1",
+                Self::COLUMNS
+            ),
+            [id],
+            Self::from_row,
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
+    /// Return a fair, bounded due batch. `next_poll_at` is advanced by each
+    /// attempted poll, so a busy fleet cannot let one watch monopolize ticks.
+    pub fn list_due(&self, limit: usize) -> Result<Vec<ViktorThreadWatch>> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        let mut statement = conn.prepare(&format!(
+            "SELECT {} FROM viktor_thread_watches
+             WHERE status = 'pending'
+               AND datetime(expires_at) > datetime('now')
+               AND datetime(next_poll_at) <= datetime('now')
+             ORDER BY datetime(next_poll_at), id LIMIT ?1",
+            Self::COLUMNS
+        ))?;
+        statement
+            .query_map([i64::try_from(limit).unwrap_or(i64::MAX)], Self::from_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    pub fn list_live(&self) -> Result<Vec<ViktorThreadWatch>> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        let mut statement = conn.prepare(&format!(
+            "SELECT {} FROM viktor_thread_watches
+             WHERE status = 'pending' AND datetime(expires_at) > datetime('now')
+             ORDER BY id",
+            Self::COLUMNS
+        ))?;
+        statement
+            .query_map([], Self::from_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    pub fn record_poll(
+        &self,
+        id: i64,
+        interval_secs: i64,
+        watermark: Option<&str>,
+        error: Option<&str>,
+    ) -> Result<()> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        let now = Utc::now();
+        let next = now + chrono::Duration::seconds(interval_secs.max(1));
+        conn.execute(
+            "UPDATE viktor_thread_watches SET
+                last_polled_at = ?2, next_poll_at = ?3,
+                poll_count = poll_count + 1,
+                watermark = COALESCE(?4, watermark), last_error = ?5
+             WHERE id = ?1 AND status = 'pending'",
+            params![id, now.to_rfc3339(), next.to_rfc3339(), watermark, error],
+        )?;
+        Ok(())
+    }
+
+    pub fn mark_delivered(&self, id: i64, notification_id: i64) -> Result<()> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.execute(
+            "UPDATE viktor_thread_watches SET status = 'delivered', delivered_at = ?2,
+             notification_id = ?3, last_error = NULL WHERE id = ?1 AND status = 'pending'",
+            params![id, Utc::now().to_rfc3339(), notification_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn mark_undeliverable(&self, id: i64, reason: &str) -> Result<()> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.execute(
+            "UPDATE viktor_thread_watches SET status = 'undeliverable', last_error = ?2
+             WHERE id = ?1 AND status = 'pending'",
+            params![id, reason],
+        )?;
+        Ok(())
+    }
+
+    pub fn expire_stale(&self) -> Result<usize> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.execute(
+            "UPDATE viktor_thread_watches SET status = 'expired',
+             last_error = COALESCE(last_error, 'watch TTL elapsed')
+             WHERE status = 'pending' AND datetime(expires_at) <= datetime('now')",
+            [],
+        )
+        .map_err(Into::into)
+    }
+
+    pub fn quarantine_for_task(&self, task_id: &str) -> Result<usize> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.execute(
+            "UPDATE viktor_thread_watches SET status = 'quarantined',
+             last_error = 'task closed before inbound delivery'
+             WHERE status = 'pending' AND task_id = ?1",
+            [task_id],
+        )
+        .map_err(Into::into)
+    }
+
+    const COLUMNS: &str = "id, thread_id, run_id, requesting_agent_id,
+        requesting_agent_name, requesting_agent_role, factory_session, task_id,
+        watermark, status, created_at, expires_at, next_poll_at, last_polled_at,
+        poll_count, delivered_at, notification_id, last_error";
+
+    fn parse_datetime(value: String) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(&value)
+            .map(|value| value.with_timezone(&Utc))
+            .or_else(|_| {
+                chrono::NaiveDateTime::parse_from_str(&value, "%Y-%m-%d %H:%M:%S")
+                    .map(|value| Utc.from_utc_datetime(&value))
+            })
+            .unwrap_or_else(|_| Utc::now())
+    }
+
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ViktorThreadWatch> {
+        let status: String = row.get(9)?;
+        let last_polled_at: Option<String> = row.get(13)?;
+        let delivered_at: Option<String> = row.get(15)?;
+        Ok(ViktorThreadWatch {
+            id: row.get(0)?,
+            thread_id: row.get(1)?,
+            run_id: row.get(2)?,
+            requesting_agent_id: row.get(3)?,
+            requesting_agent_name: row.get(4)?,
+            requesting_agent_role: row.get(5)?,
+            factory_session: row.get(6)?,
+            task_id: row.get(7)?,
+            watermark: row.get(8)?,
+            status: status.parse().unwrap_or(ViktorWatchStatus::Undeliverable),
+            created_at: Self::parse_datetime(row.get(10)?),
+            expires_at: Self::parse_datetime(row.get(11)?),
+            next_poll_at: Self::parse_datetime(row.get(12)?),
+            last_polled_at: last_polled_at.map(Self::parse_datetime),
+            poll_count: row.get::<_, u32>(14)?,
+            delivered_at: delivered_at.map(Self::parse_datetime),
+            notification_id: row.get(16)?,
+            last_error: row.get(17)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_deduplicates_and_quarantines_task_watches() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SqliteViktorWatchStore::open(temp.path()).unwrap();
+        let first = store
+            .record(
+                "thread-1",
+                "run-1",
+                "agent-1",
+                "worker-1",
+                "worker",
+                Some("factory-1"),
+                Some("cas-1"),
+                Some("message-1"),
+                DEFAULT_VIKTOR_WATCH_TTL_SECS,
+            )
+            .unwrap();
+        let duplicate = store
+            .record(
+                "thread-1",
+                "run-1",
+                "agent-1",
+                "worker-1",
+                "worker",
+                Some("factory-1"),
+                Some("cas-1"),
+                None,
+                DEFAULT_VIKTOR_WATCH_TTL_SECS,
+            )
+            .unwrap();
+
+        assert_eq!(first, duplicate);
+        assert_eq!(store.list_due(16).unwrap().len(), 1);
+        assert_eq!(store.quarantine_for_task("cas-1").unwrap(), 1);
+        assert!(store.list_live().unwrap().is_empty());
+        assert_eq!(
+            store.get(first).unwrap().unwrap().status,
+            ViktorWatchStatus::Quarantined
+        );
+    }
+
+    #[test]
+    fn delivery_is_terminal_and_keeps_prompt_receipt() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SqliteViktorWatchStore::open(temp.path()).unwrap();
+        let id = store
+            .record(
+                "thread-2",
+                "run-2",
+                "agent-2",
+                "worker-2",
+                "worker",
+                None,
+                None,
+                None,
+                DEFAULT_VIKTOR_WATCH_TTL_SECS,
+            )
+            .unwrap();
+        store.mark_delivered(id, 41).unwrap();
+        let watch = store.get(id).unwrap().unwrap();
+        assert_eq!(watch.status, ViktorWatchStatus::Delivered);
+        assert_eq!(watch.notification_id, Some(41));
+        assert!(store.list_due(16).unwrap().is_empty());
+    }
+
+    #[test]
+    fn stale_and_unroutable_watches_reach_terminal_states() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SqliteViktorWatchStore::open(temp.path()).unwrap();
+        let expired = store
+            .record(
+                "thread-expired",
+                "run-expired",
+                "agent-3",
+                "worker-3",
+                "worker",
+                None,
+                None,
+                None,
+                DEFAULT_VIKTOR_WATCH_TTL_SECS,
+            )
+            .unwrap();
+        let unroutable = store
+            .record(
+                "thread-unroutable",
+                "run-unroutable",
+                "agent-4",
+                "worker-4",
+                "worker",
+                None,
+                None,
+                None,
+                DEFAULT_VIKTOR_WATCH_TTL_SECS,
+            )
+            .unwrap();
+
+        {
+            let conn = crate::shared_db::lock_connection(&store.conn).unwrap();
+            conn.execute(
+                "UPDATE viktor_thread_watches SET expires_at = '2000-01-01T00:00:00Z' WHERE id = ?1",
+                [expired],
+            )
+            .unwrap();
+        }
+        assert_eq!(store.expire_stale().unwrap(), 1);
+        store
+            .mark_undeliverable(unroutable, "requester and supervisor are gone")
+            .unwrap();
+
+        let expired = store.get(expired).unwrap().unwrap();
+        assert_eq!(expired.status, ViktorWatchStatus::Expired);
+        assert_eq!(expired.last_error.as_deref(), Some("watch TTL elapsed"));
+        let unroutable = store.get(unroutable).unwrap().unwrap();
+        assert_eq!(unroutable.status, ViktorWatchStatus::Undeliverable);
+        assert_eq!(
+            unroutable.last_error.as_deref(),
+            Some("requester and supervisor are gone")
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Completes the Viktor delegation gateway (v2.71.0 groundwork) into a usable two-way surface and distributes it to every project:

- **Outbound**: managed, credential-free Viktor upstream in the cas-mcp-proxy (streamable HTTP, `env:VIKTOR_API_KEY`), an exact nine-tool conversation allowlist (fail-closed preserved), startup refresh with operator-owned config retention, and an RMCP auth fix (double-`Bearer`). Live proxied whoami + ask receipts recorded.
- **Inbound (the two-way half)**: the daemon watches threads/runs started through the gateway and delivers Viktor replies as injected CAS inbox notifications (`origin=viktor`) — live demo: reply arrived ~29s after turn-end with zero agent polling. Bounded cost (30s interval, 16 watches / 32 calls per tick, 20s budget), TTL/expiry, gc-listable watches, departed-agent fallback.
- **Distribution**: built-in `cas-viktor` skill in all three harness mirrors (use-cases, gateway contract, no-polling, no-key-handling), a secret-redacting `cas viktor` provisioning status command, README/CONTRIBUTING docs, and a clean-init distribution test proving the skill reaches new projects. Supervisor-only `external_verify` flow unchanged.

## Testing
- Scoped: proxy config/runtime/auth tests, watcher runtime 3/3 + store lifecycle 3/3 + provenance shape 1/1, flavor-drift 9/9, codex guardrails 8/8, viktor_distribution_test 1/1; `cargo check`/build clean. Live receipts under artifacts for both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)