### PR TITLE
chore(release): prepare v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-08-18
+
+### Added
+- **Viktor conversations now work through a managed, two-way Cassy gateway.** When a project has no `.cas/proxy.toml`, `cas serve` refreshes a credential-reference-only Viktor upstream with an exact, fail-closed allowlist of nine conversation tools; an explicit project proxy configuration opts out. Run-starting calls are registered for daemon-owned follow-up, so Cassy delivers completed replies as inbound `origin=viktor` notifications instead of agents polling. `cas init` and `cas update --sync` install the `cas-viktor` skill for Claude, Codex, and Grok, and `cas viktor` reports credential-safe provisioning status.
+- **Factory spawns can now select each worker's harness and account independently.** `spawn_workers` resolves per-worker `name`, CLI, model, effort, and `config_dir` overrides, validates the matching Claude or Codex account directory, and carries the resolved account into the spawned worker rather than flattening a mixed fleet to one supervisor profile.
+- **Ben's Apple Silicon Mac setup guide is now part of the repository.** The guide covers the supported release-binary install, machine-wide Cloud login, project initialization, Commander service, source-checkout maintenance, recovery, and the current macOS process-restart limitation.
+
 ## [3.0.0] - 2026-08-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"


### PR DESCRIPTION
## Summary
Version bump + changelog for v3.1.0: two-way Viktor gateway (managed upstream, fail-closed nine-tool allowlist, inbound origin=viktor inbox delivery, distributed cas-viktor skill + provisioning status command, explicit-project opt-out), per-worker harness/account spawn selection, and Ben's Apple Silicon setup guide. Every claim verified at its production call site against v3.0.0..main.

After merge: annotated tag v3.1.0 on the landed tip → tag-triggered publish → receipt → Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)