### PR TITLE
ci(cas-5496): configure merge-queue required path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ name: CI
 
 on:
   pull_request:
+  # The protected-default merge queue creates a synthetic merged-tree ref. Its
+  # required contexts must report on that ref or queue entries time out rather
+  # than proving the tree that will actually land.
+  merge_group:
   push:
     branches:
       - main
@@ -187,6 +191,7 @@ jobs:
     name: Fast Validation — preflight (no test suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'merge_group'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
@@ -263,6 +268,7 @@ jobs:
     name: Fast Validation — suite archive build
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'merge_group'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
@@ -353,6 +359,7 @@ jobs:
     name: Fast Validation — suite shard ${{ matrix.shard }}/3
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'merge_group'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
@@ -410,6 +417,7 @@ jobs:
     name: Fast Validation — full suite
     if: >-
       always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'merge_group'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
@@ -441,6 +449,7 @@ jobs:
     name: Fast Validation — doctests
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'merge_group'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
@@ -496,6 +505,7 @@ jobs:
     name: Fast Validation
     if: >-
       always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'merge_group'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
@@ -588,6 +598,7 @@ jobs:
     name: macOS Check
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'merge_group'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'

--- a/docs/branch-protection/README.md
+++ b/docs/branch-protection/README.md
@@ -10,7 +10,7 @@ The two required contexts are deliberately minimal, but neither removes coverage
 
 | Required context | Unique protection | Steady-state wall | Verdict |
 | --- | --- | --- | --- |
-| `Fast Validation — full suite` | Its fan-in rejects a failed preflight, every exhaustive nextest shard, **and doctests**. | Dominated by the suite archive build/shards; target is under five minutes after the self-hosted archive path. | Required. |
+| `Fast Validation` | Its rollup rejects a failed preflight, the full-suite fan-in (and every exhaustive nextest shard), **and doctests**. | Dominated by the suite archive build/shards; target is under five minutes after the self-hosted archive path. | Required. |
 | `macOS Check` | Darwin/Xcode/SDK compile surface that Linux does not exercise. | Measured about 4.2–4.3 minutes. | Required; no equivalent scoped macOS proof exists yet. |
 
 `Fast Validation — doctests` is intentionally not a separate required context: the required
@@ -62,7 +62,7 @@ Live API application remains operator-visible and must be receipted.
 
 | Job (`name:`) | Triggers | Required? |
 | --- | --- | --- |
-| `Fast Validation` | `pull_request`, `merge_group`, push to `main`, schedule, dispatch | **Yes** |
+| `Fast Validation` | `pull_request`, `merge_group`, push to `main`, schedule, dispatch | **Yes — the rollup, not the lower full-suite fan-in** |
 | `macOS Check` | `pull_request`, `merge_group`, push to `main`, schedule, dispatch | **Yes** — see below |
 | `Release-Profile & Build Guard (compile-only, no test suite)` | `if:` limits it to `schedule` or `refs/heads/main` | **No — must not be required** |
 

--- a/docs/branch-protection/README.md
+++ b/docs/branch-protection/README.md
@@ -1,40 +1,46 @@
-# `main` branch protection — prepared ruleset and decision memo
+# `main` branch protection — live required-set and merge-queue contract
 
-**Status: PREPARED, NOT APPLIED. Applying this changes live repository settings and is
-pippenz's call alone.** Nothing in this directory has been POSTed to GitHub. The only API
-calls made while preparing it were read-only (`GET /rulesets`, `GET /branches/main/protection`).
+**Status: the matching repository ruleset is live.** This file is the reviewed
+configuration source for operator-visible changes. Capture a before/after API dump whenever
+the live ruleset changes; do not treat editing this JSON as applying the change.
 
-Prepared for GH #142 (cas-f650).
+## 1. Required-set audit
 
-## 1. The problem this addresses
+The two required contexts are deliberately minimal, but neither removes coverage:
 
-Verified 2026-08-07 against `pippenz/cas`:
+| Required context | Unique protection | Steady-state wall | Verdict |
+| --- | --- | --- | --- |
+| `Fast Validation — full suite` | Its fan-in rejects a failed preflight, every exhaustive nextest shard, **and doctests**. | Dominated by the suite archive build/shards; target is under five minutes after the self-hosted archive path. | Required. |
+| `macOS Check` | Darwin/Xcode/SDK compile surface that Linux does not exercise. | Measured about 4.2–4.3 minutes. | Required; no equivalent scoped macOS proof exists yet. |
 
-| Check | Result |
-| --- | --- |
-| `GET repos/pippenz/cas/rulesets` | `[]` — no rulesets exist |
-| `GET repos/pippenz/cas/branches/main/protection` | `404 Branch not protected` |
+`Fast Validation — doctests` is intentionally not a separate required context: the required
+`Fast Validation` fan-in already requires `fast-validation-docs` to succeed. Its coverage is
+therefore retained in the fan-in, not dropped.
 
-So CI on `main` is **purely advisory today**. That is not theoretical: a red Fast Validation
-rode the v2.46.0 release commit onto `main` and nothing stopped it or flagged it.
+## 2. Merge queue
 
-## 2. The prepared ruleset
+[`main-ruleset.json`](main-ruleset.json) requires the two contexts above, blocks branch
+deletion and force-pushes, and requires GitHub's merge queue. The queue is single-entry
+(`min/max entries to merge = 1`, zero fill wait, one concurrent build) so it supplies a
+merged-tree revalidation without batching a second PR onto the headline latency path. It uses
+`ALLGREEN`, so each entry in any future group must pass its required checks.
 
-[`main-ruleset.json`](main-ruleset.json) requires two status checks on the default branch,
-and additionally blocks branch deletion and force-pushes.
+Apply or update command (capture the response as the after receipt):
 
-Apply command (**do not run without a decision on §4**):
-
-    gh api --method POST repos/pippenz/cas/rulesets \
+    gh api --method PUT repos/Richards-LLC/cassy/rulesets/<id> \
       --input docs/branch-protection/main-ruleset.json
 
 Verify afterwards, and roll back if needed:
 
-    gh api repos/pippenz/cas/rulesets
-    gh api --method DELETE repos/pippenz/cas/rulesets/<id>
+    gh api repos/Richards-LLC/cassy/rulesets/<id>
+    gh api --method PUT repos/Richards-LLC/cassy/rulesets/<id> --input <before-receipt.json>
 
 `~DEFAULT_BRANCH` is used instead of a literal `refs/heads/main` so the rule follows the
 default branch if it is ever renamed. Substitute `"refs/heads/main"` if you prefer it pinned.
+
+The CI workflow must include the `merge_group` trigger and make both required contexts report
+on the synthetic merged-tree SHA. Without that trigger, merge-queue entries wait until their
+status-check timeout because no required context can report.
 
 ### Validation performed
 
@@ -44,10 +50,10 @@ Dry validation only, as required:
 - Field names, nesting and the `rules[].type` values follow the repository-rulesets schema:
   `target: "branch"`, `conditions.ref_name.include/exclude`, and a `required_status_checks`
   rule whose `parameters.required_status_checks[]` entries are `{ "context": ... }` objects.
-- Both required contexts were matched **programmatically** against the job `name:` values in
-  `.github/workflows/ci.yml`, not eyeballed.
+- Both required contexts are matched **programmatically** against job names, and the tier
+  contract pins the `merge_group` trigger plus every required fan-in dependency.
 
-Not validated: acceptance by the live API. That requires a POST, which is out of scope here.
+Live API application remains operator-visible and must be receipted.
 
 ## 3. Which checks belong in the list — and which deliberately do not
 
@@ -56,8 +62,8 @@ Not validated: acceptance by the live API. That requires a POST, which is out of
 
 | Job (`name:`) | Triggers | Required? |
 | --- | --- | --- |
-| `Fast Validation` | `pull_request`, push to `main`, schedule, dispatch | **Yes** |
-| `macOS Check` | `pull_request`, push to `main`, schedule, dispatch | **Yes** — see below |
+| `Fast Validation` | `pull_request`, `merge_group`, push to `main`, schedule, dispatch | **Yes** |
+| `macOS Check` | `pull_request`, `merge_group`, push to `main`, schedule, dispatch | **Yes** — see below |
 | `Release-Profile & Build Guard (compile-only, no test suite)` | `if:` limits it to `schedule` or `refs/heads/main` | **No — must not be required** |
 
 **Release-Profile & Build Guard is excluded, and this is the load-bearing exclusion.** Its
@@ -72,54 +78,24 @@ it runs on `macos-26` with a pinned Xcode 26.3 `DEVELOPER_DIR`, so runner or SDK
 becomes a merge blocker, and macOS minutes are billed at a higher multiplier. If that proves
 too costly, drop it from the JSON — but drop it deliberately, not by forgetting it.
 
-## 4. Factory impact — the decision that actually matters
+## 4. Factory flow
 
-**This factory pushes merges DIRECTLY to `main`. It does not open PRs.** That is the crux.
-
-A `required_status_checks` rule is evaluated against the commit at the tip of the push, not
-only at PR-merge time. A brand-new commit created locally and pushed straight to `main` has no
-check runs attached to it yet, so the required checks are "not passing" and **the push is
-rejected**. CI cannot rescue this, because CI is triggered *by* the push that was just refused.
-
-That is a genuine deadlock, not a slowdown. Consequences, ref by ref:
+Factory branches continue to push normally. Integration to `main` is a pull request, and its
+queue entry replaces supervisor polling: after review, enable auto-merge with the queue's
+configured `MERGE` method. GitHub validates the synthetic merged tree, then lands it or reports
+the failing required context. Record the PR URL and queue entry; do not retry manual merging.
 
 | Operation | Effect |
 | --- | --- |
-| Supervisor pushes a merge commit directly to `main` | **BLOCKED.** This is the current release path and it stops working. |
 | Worker pushes `factory/<name>` | Unaffected — the ruleset targets only the default branch. |
 | Supervisor pushes/merges an `epic/<slug>` branch | Unaffected — same reason. |
+| `main` PR after review | Enable auto-merge; GitHub queues and validates the merged tree before landing. |
 | Release tag push (`v*`, `refs/tags/…`) | Unaffected — this is a **branch** ruleset; tags are a separate target. `release.yml` triggers on tag push and keeps working. |
 | Force-push / branch deletion on `main` | Blocked by the `non_fast_forward` and `deletion` rules. Intended. |
 
-Also worth knowing before applying: **repository admins do not bypass rulesets automatically.**
-Bypass requires an explicit `bypass_actors` entry. `bypass_actors` is deliberately left `[]`
-here, so as written this rule applies to pippenz too.
-
-### Recommendation
-
-**Adopt the ruleset, and move `main` integration to PRs.** The supervisor pushes the epic
-branch (unaffected), opens a PR into `main`, CI runs on the PR, and the merge lands only when
-Fast Validation and macOS Check are green. This costs one `gh pr create` + one merge per
-release cycle and it directly prevents the v2.46.0 failure — a red suite could no longer reach
-`main` unnoticed.
-
-Two alternatives, both weaker, recorded so the choice is informed:
-
-1. **Apply the ruleset and add a bypass actor for the release identity.** Keeps direct pushes
-   working, but a bypass used routinely is protection in name only — it would not have stopped
-   v2.46.0 either.
-2. **Do not apply; add a pre-push guard instead.** No settings change and no workflow change,
-   but it is advisory again — the exact property that failed. Reasonable only as an interim
-   step if the PR flow cannot be adopted now.
-
-If option 1 is chosen, look the actor id up from the live API rather than guessing it; the
-`bypass_actors` array is intentionally left empty here rather than filled with an unverified id.
-
-There is a lower-risk trial available if the account tier supports it: `"enforcement":
-"evaluate"` logs what *would* have been blocked without blocking anything. Evaluate mode is not
-available on every plan, so confirm it applies to this repository before relying on it — if it
-is unavailable, the equivalent is to apply with `"enforcement": "disabled"`, inspect, then flip
-to `"active"`.
+**Repository admins do not bypass rulesets automatically.** Bypass requires an explicit
+`bypass_actors` entry. `bypass_actors` is deliberately left `[]`, so this rule applies to
+repository admins as well.
 
 ## 5. Check names are pinned
 

--- a/docs/branch-protection/main-ruleset.json
+++ b/docs/branch-protection/main-ruleset.json
@@ -16,7 +16,7 @@
         "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "Fast Validation — full suite" },
+          { "context": "Fast Validation" },
           { "context": "macOS Check" }
         ]
       }

--- a/docs/branch-protection/main-ruleset.json
+++ b/docs/branch-protection/main-ruleset.json
@@ -1,5 +1,5 @@
 {
-  "name": "main: require test suite and macOS validation",
+  "name": "main: required validation and merge queue",
   "target": "branch",
   "enforcement": "active",
   "conditions": {
@@ -17,9 +17,20 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           { "context": "Fast Validation — full suite" },
-          { "context": "Fast Validation — doctests" },
           { "context": "macOS Check" }
         ]
+      }
+    },
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 15,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 1,
+        "max_entries_to_merge": 1,
+        "merge_method": "MERGE",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 0
       }
     },
     { "type": "deletion" },

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -84,8 +84,9 @@ require_text "$ci_text" '- "epic/**"' 'epic pushes trigger CI'
 require_text "$ci_text" '- "v*"' 'release tags trigger CI'
 require_text "$ci_text" 'merge_group:' 'CI accepts merge-queue merged-tree events'
 require_text "$ci_text" 'make -C cas-cli test-ci-tiers' 'Fast Validation invokes release publication guard scripts'
-require_count "$ruleset_text" '"context": "Fast Validation — full suite"' 1 'ruleset requires the Fast Validation fan-in once'
+require_count "$ruleset_text" '"context": "Fast Validation"' 1 'ruleset requires the complete Fast Validation rollup once'
 require_count "$ruleset_text" '"context": "macOS Check"' 1 'ruleset requires macOS validation once'
+require_absent "$ruleset_text" '"context": "Fast Validation — full suite"' 'ruleset does not mistake the lower suite fan-in for complete validation'
 require_absent "$ruleset_text" '"context": "Fast Validation — doctests"' 'ruleset does not duplicate Fast Validation doctest coverage'
 require_text "$ruleset_text" '"type": "merge_queue"' 'ruleset requires the GitHub merge queue'
 require_text "$ruleset_text" '"grouping_strategy": "ALLGREEN"' 'merge queue validates every entry in its group'
@@ -345,6 +346,22 @@ require_text "$fan_in" 'fast-validation-docs' 'required Fast Validation waits fo
 require_text "$fan_in" 'test "$PREFLIGHT" = success' 'required Fast Validation rejects a failed preflight'
 require_text "$fan_in" 'test "$SUITE" = success' 'required Fast Validation rejects a failed full suite'
 require_text "$fan_in" 'test "$DOCS" = success' 'required Fast Validation rejects failed doctests'
+
+# Required-context closure (cas-5496): the ruleset must select the top-level
+# Fast Validation rollup, never its lower suite-only fan-in. This is the
+# coverage proof that a failed OR cancelled preflight, shard, or doctest blocks
+# a merge: always() ensures the fan-in gate still runs after a dependency fails,
+# and each need result must be success.
+require_text "$ruleset_text" '"context": "Fast Validation"' 'required context selects the complete validation rollup'
+require_text "$fan_in" 'always()' 'required validation rollup still runs after a failed dependency'
+require_text "$fan_in" 'fast-validation-preflight' 'required validation closure includes preflight'
+require_text "$fan_in" 'fast-validation-suite' 'required validation closure includes suite fan-in'
+require_text "$fan_in" 'fast-validation-docs' 'required validation closure includes doctests'
+require_text "$fan_in" 'test "$PREFLIGHT" = success' 'required validation rejects failed or cancelled preflight'
+require_text "$fan_in" 'test "$SUITE" = success' 'required validation rejects failed or cancelled suite fan-in'
+require_text "$fan_in" 'test "$DOCS" = success' 'required validation rejects failed or cancelled doctests'
+require_text "$suite" 'always()' 'suite fan-in still runs after a failed shard'
+require_text "$suite" 'test "$SHARDS" = success' 'suite fan-in rejects failed or cancelled shards'
 
 # Merge queue validates GitHub's synthetic merged tree, not the PR head. Both
 # required contexts and every Fast Validation dependency must report there.

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -67,6 +67,7 @@ release_job_block() {
 }
 
 ci_text="$(<"$ci")"
+ruleset_text="$(<"$ruleset")"
 mapfile -t required_contexts < <(
     grep -oE '"context": "[^"]+"' "$ruleset" | sed -E 's/"context": "(.*)"/\1/'
 )
@@ -81,7 +82,16 @@ fi
 require_text "$ci_text" '- "factory/**"' 'factory pushes trigger CI'
 require_text "$ci_text" '- "epic/**"' 'epic pushes trigger CI'
 require_text "$ci_text" '- "v*"' 'release tags trigger CI'
+require_text "$ci_text" 'merge_group:' 'CI accepts merge-queue merged-tree events'
 require_text "$ci_text" 'make -C cas-cli test-ci-tiers' 'Fast Validation invokes release publication guard scripts'
+require_count "$ruleset_text" '"context": "Fast Validation — full suite"' 1 'ruleset requires the Fast Validation fan-in once'
+require_count "$ruleset_text" '"context": "macOS Check"' 1 'ruleset requires macOS validation once'
+require_absent "$ruleset_text" '"context": "Fast Validation — doctests"' 'ruleset does not duplicate Fast Validation doctest coverage'
+require_text "$ruleset_text" '"type": "merge_queue"' 'ruleset requires the GitHub merge queue'
+require_text "$ruleset_text" '"grouping_strategy": "ALLGREEN"' 'merge queue validates every entry in its group'
+require_text "$ruleset_text" '"max_entries_to_build": 1' 'merge queue avoids batching extra PRs into the latency path'
+require_text "$ruleset_text" '"max_entries_to_merge": 1' 'merge queue merges one proven PR at a time'
+require_text "$ruleset_text" '"min_entries_to_merge_wait_minutes": 0' 'merge queue adds no group-fill wait'
 
 scoped="$(job_block scoped-validation)"
 require_text "$scoped" "refs/heads/factory/" 'scoped tier selects factory branches'
@@ -335,6 +345,12 @@ require_text "$fan_in" 'fast-validation-docs' 'required Fast Validation waits fo
 require_text "$fan_in" 'test "$PREFLIGHT" = success' 'required Fast Validation rejects a failed preflight'
 require_text "$fan_in" 'test "$SUITE" = success' 'required Fast Validation rejects a failed full suite'
 require_text "$fan_in" 'test "$DOCS" = success' 'required Fast Validation rejects failed doctests'
+
+# Merge queue validates GitHub's synthetic merged tree, not the PR head. Both
+# required contexts and every Fast Validation dependency must report there.
+for job in fast-validation-preflight fast-validation-suite-build fast-validation-suite-shards fast-validation-suite fast-validation-docs fast-validation macos-check; do
+    require_text "$(job_block "$job")" "github.event_name == 'merge_group'" "$job runs on merge-queue merged trees"
+done
 
 # Main PRs validate the reusable compile surfaces while the release-profile
 # panic probes and cold benchmark remain schedule/manual workloads.


### PR DESCRIPTION
## Required-set audit

- retain Fast Validation: its rollup fails on failed preflight, exhaustive suite shards, or doctests
- retain macOS Check: unique Darwin/Xcode/SDK compile coverage
- remove only the redundant standalone doctest context; the required Fast Validation rollup retains that coverage

## Merge queue

- add merge_group workflow support for every required Fast Validation dependency and macOS Check
- pin a single-entry, zero-wait, ALLGREEN merge queue in the reviewed ruleset source
- extend the tier contract (327 assertions) with the required-context closure: Fast Validation uses always() and rejects non-success preflight, suite, or doctest dependencies; the suite fan-in likewise rejects non-success shard work

Live settings are deliberately changed only after this workflow support is on main; before/after API receipts will be attached to cas-5496.