### PR TITLE
fix(cas-b78f): require executed test receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
       # their own required lane because nextest cannot run them.
       - name: Test full suite shard ${{ matrix.shard }}/3
         if: steps.classify-diff.outputs.rust-unaffected != 'true'
-        run: cargo nextest run --archive-file fast-validation-suite.tar.zst --no-fail-fast --partition count:${{ matrix.shard }}/3
+        run: scripts/run-verified-tests.sh nextest run --archive-file fast-validation-suite.tar.zst --no-fail-fast --partition count:${{ matrix.shard }}/3
 
   # Keep the protected ruleset's exact full-suite context while the actual
   # test execution fans out after the shared archive. This job runs even when a shard fails and
@@ -483,7 +483,7 @@ jobs:
         if: steps.classify-diff.outputs.rust-unaffected != 'true'
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: cargo test -p cas --doc
+        run: scripts/run-verified-tests.sh test -p cas --doc
 
       - name: Report sccache stats
         if: always() && steps.classify-diff.outputs.rust-unaffected != 'true'

--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -31,17 +31,17 @@ CARGO ?= cargo
 
 # Run all tests
 test:
-	$(CARGO) nextest run --workspace --no-fail-fast
-	$(CARGO) test -p cas --doc
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run --workspace --no-fail-fast
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh test -p cas --doc
 
 # Run full test matrix
 test-full:
-	$(CARGO) nextest run -p cas --all-features --no-fail-fast
-	$(CARGO) test -p cas --all-features --doc
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas --all-features --no-fail-fast
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh test -p cas --all-features --doc
 
 # Run tests with output
 test-verbose:
-	$(CARGO) nextest run -p cas --no-capture
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas --no-capture
 
 # Reproduce the clean-CI environment shape locally (cas-43ce / GH #136).
 #
@@ -72,11 +72,11 @@ test-clean-env:
 		echo "No CAS_* variables set — already in the clean-CI shape."; \
 	fi; \
 	unset_args=$$(echo "$$stripped" | sed 's/^/-u /'); \
-	env $$unset_args $(CARGO) nextest run -p cas $(CLEAN_ENV_ARGS)
+	env $$unset_args CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas $(CLEAN_ENV_ARGS)
 
 # Run specific test module
 test-%:
-	$(CARGO) nextest run -p cas $* --no-capture
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas $* --no-capture
 
 # Generate coverage report (requires cargo-tarpaulin)
 # Install: cargo install cargo-tarpaulin
@@ -157,12 +157,12 @@ release-fast:
 test-release-panic: test-release-panic-release test-release-panic-release-fast
 
 test-release-panic-release:
-	$(CARGO) nextest run -p cas --release --lib panic_regression
-	$(CARGO) nextest run -p cas --release --test search_utf8_regression_test
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas --release --lib panic_regression
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas --release --test search_utf8_regression_test
 
 test-release-panic-release-fast:
-	$(CARGO) nextest run -p cas --cargo-profile release-fast --lib panic_regression
-	$(CARGO) nextest run -p cas --cargo-profile release-fast --test search_utf8_regression_test
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas --cargo-profile release-fast --lib panic_regression
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas --cargo-profile release-fast --test search_utf8_regression_test
 
 # Prove a test run writes nothing into a real CAS store (cas-78c8 / GH #156).
 #
@@ -200,6 +200,7 @@ test-scoped:
 # Prove the GH #173 guard itself still fails every silent-success shape.
 test-scoped-selftest:
 	../scripts/test-run-scoped-tests.sh
+	../scripts/test-run-verified-tests.sh
 
 # Prove factory pushes stay scoped while epic/main/tag gates retain the full
 # matrix, including macOS, and reject the retired sccache cache protocol.
@@ -211,6 +212,7 @@ test-scoped-selftest:
 # migration-snapshot suite went stale for five days (cas-66ee). Keep this list
 # exhaustive — if you add a scripts/test-*.sh, wire it into a lane here.
 test-ci-tiers:
+	cd .. && ./scripts/test-run-verified-tests.sh
 	cd .. && ./scripts/test-ci-test-tiers.sh
 	cd .. && ./scripts/test-release-publication-policy.sh
 	cd .. && ./scripts/test-release-published-receipt.sh
@@ -245,23 +247,23 @@ install-tools:
 
 # Run tests with nextest (faster parallel execution)
 test-nextest:
-	$(CARGO) nextest run -p cas --all-features
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas --all-features
 
 # Watch for changes and run tests
 watch:
-	$(CARGO) watch -x "nextest run -p cas"
+	$(CARGO) watch -s '../scripts/run-verified-tests.sh nextest run -p cas'
 
 # Integration tests only
 integration:
-	$(CARGO) test -p cas --all-features --test "*" -- --test-threads=1
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh test -p cas --all-features --test "*" -- --test-threads=1
 
 # Unit tests only (lib tests)
 unit:
-	$(CARGO) nextest run -p cas --lib
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas --lib
 
 # Run library tests without the optional MCP proxy
 dev-test:
-	$(CARGO) nextest run -p cas --lib --no-default-features
+	CARGO="$(CARGO)" ../scripts/run-verified-tests.sh nextest run -p cas --lib --no-default-features
 
 # Generate cargo timing report
 timings:

--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -30,8 +30,8 @@ pub fn handle_pre_tool_use(
     // In a workspace that is not fmt-clean, either shape spills unrelated
     // changes. A full test invocation similarly links dozens of binaries.
     // Workers use non-mutating/scoped format commands, iterate with cargo check,
-    // and run a test target (`--lib`, `--test`, etc.); the supervisor integration
-    // merge and release gate own full-suite runs.
+    // and run a test target through the receipt wrapper; the supervisor
+    // integration merge and release gate own full-suite runs.
     // Hoist this before the cas_root early return and factory Bash auto-allow so
     // an unscoped run always gets the loud, actionable refusal.
     // ========================================================================
@@ -53,14 +53,14 @@ pub fn handle_pre_tool_use(
                  A workspace normalization requires separate operator approval and must not be run from a worker.",
             ));
         }
-        if command.is_some_and(worker_command_runs_unscoped_tests) {
+        if command.is_some_and(worker_command_runs_unguarded_tests) {
             return Ok(HookOutput::with_pre_tool_permission(
                 "deny",
-                "🚫 UNSCOPED WORKER TEST RUN: a full suite links dozens of test binaries in this worktree.\n\n\
-                 Iterate with `cargo check -p cas --lib --tests`, then run the affected target through the guarded nextest recipe:\n  \
+                "🚫 UNVERIFIED WORKER TEST RUN: Cargo can exit 0 when a filter selected zero tests, so direct Cargo test output is not a verification receipt.\n\n\
+                 Iterate with `cargo check -p cas --lib --tests`, then run the affected target through the guarded recipe:\n  \
                  `scripts/run-scoped-tests.sh -p cas --lib <module>`\n  \
                  `scripts/run-scoped-tests.sh -p cas --test <name>`\n\n\
-                 Full-suite runs are reserved for the supervisor integration merge and the release gate.",
+                 The wrapper requires a nonzero passed count. Full-suite runs are reserved for the supervisor integration merge and the release gate.",
             ));
         }
     }
@@ -908,16 +908,13 @@ pub fn handle_pre_tool_use(
     Ok(HookOutput::empty())
 }
 
-/// Detect a worker shell command that launches an entire Cargo test matrix.
-///
-/// Package selection alone (`-p cas`) is not a test-target scope: this repo's
-/// one package still owns dozens of integration binaries. A target selector is
-/// required. Runtime name filters do not count either because Cargo links all
-/// test targets before applying them.
-fn worker_command_runs_unscoped_tests(command: &str) -> bool {
+/// Detect a worker shell command that executes Cargo tests without the
+/// zero-executed receipt wrapper.  A target scope controls cost but does not
+/// prove the filter matched anything, because Cargo exits zero for zero tests.
+fn worker_command_runs_unguarded_tests(command: &str) -> bool {
     super::attribution::split_shell_statements(command)
         .iter()
-        .any(|words| test_invocation_without_target_scope(words))
+        .any(|words| direct_test_invocation_without_receipt(words))
 }
 
 /// Detect formatter invocations that can mutate files outside a worker's scope.
@@ -976,7 +973,7 @@ fn formatter_invocation_can_spill(words: &[String]) -> bool {
     !skips_children
 }
 
-fn test_invocation_without_target_scope(words: &[String]) -> bool {
+fn direct_test_invocation_without_receipt(words: &[String]) -> bool {
     let Some(cargo_index) = words
         .iter()
         .position(|word| word == "cargo" || word.ends_with("/cargo"))
@@ -991,23 +988,9 @@ fn test_invocation_without_target_scope(words: &[String]) -> bool {
         return false;
     }
 
-    !cargo_args.iter().any(|arg| {
-        matches!(
-            arg.as_str(),
-            "--lib"
-                | "--test"
-                | "--bin"
-                | "--bins"
-                | "--example"
-                | "--examples"
-                | "--bench"
-                | "--benches"
-                | "--doc"
-        ) || arg.starts_with("--test=")
-            || arg.starts_with("--bin=")
-            || arg.starts_with("--example=")
-            || arg.starts_with("--bench=")
-    })
+    // `--no-run` intentionally compiles test targets without claiming tests
+    // passed. It is not a test-execution receipt and remains available.
+    !cargo_args.iter().any(|arg| arg == "--no-run")
 }
 
 // ── Worker commit guard helpers (cas-bea2, LAYER 1) ───────────────────────

--- a/cas-cli/src/hooks/handlers/handlers_tests/unscoped_test_guard.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/unscoped_test_guard.rs
@@ -25,16 +25,18 @@ fn deny_reason(out: &HookOutput) -> Option<String> {
 }
 
 #[test]
-fn worker_unscoped_cargo_test_and_nextest_are_denied_with_scoped_recipe() {
+fn worker_direct_cargo_test_and_nextest_are_denied_with_receipt_recipe() {
     for command in [
         "cargo test",
         "cargo test -p cas --no-fail-fast",
+        "cargo test -p cas --test cli_test",
         "RUSTC_WRAPPER=sccache cargo nextest run -p cas",
+        "cargo nextest run -p cas --lib hooks::",
         "cargo check -p cas && cargo test store::tests",
     ] {
         let out = handle_pre_tool_use(&input(command, "worker"), None).expect("handler ok");
         let reason = deny_reason(&out).unwrap_or_else(|| panic!("expected deny for {command:?}"));
-        assert!(reason.contains("UNSCOPED WORKER TEST RUN"), "{reason}");
+        assert!(reason.contains("UNVERIFIED WORKER TEST RUN"), "{reason}");
         assert!(reason.contains("scripts/run-scoped-tests.sh"), "{reason}");
         assert!(
             reason.contains("cargo check -p cas --lib --tests"),
@@ -45,13 +47,12 @@ fn worker_unscoped_cargo_test_and_nextest_are_denied_with_scoped_recipe() {
 }
 
 #[test]
-fn worker_target_scopes_and_non_test_commands_are_not_denied() {
+fn worker_receipted_test_commands_and_non_test_commands_are_not_denied() {
     for command in [
-        "cargo nextest run -p cas --lib hooks::",
-        "cargo test -p cas --test cli_test",
-        "cargo test -p cas --doc",
-        "cargo check -p cas --lib --tests",
         "scripts/run-scoped-tests.sh -p cas --lib hooks::",
+        "scripts/run-verified-tests.sh test -p cas --doc",
+        "cargo test -p cas --test cli_test --no-run",
+        "cargo check -p cas --lib --tests",
         "echo 'cargo test'",
     ] {
         let out = handle_pre_tool_use(&input(command, "worker"), None).expect("handler ok");

--- a/docs/testing-execution-honesty.md
+++ b/docs/testing-execution-honesty.md
@@ -1,0 +1,30 @@
+# Test-execution honesty
+
+Cargo and nextest can exit zero when a requested filter matches no tests. A
+green exit code is therefore not a test receipt. Any test result consumed by a
+worker, CI lane, Make target, or release gate must run through
+`scripts/run-verified-tests.sh` (or the stricter scoped wrapper).
+
+The wrapper fails unless Cargo exits zero, prints at least one Cargo/nextest
+harness summary, and reports a total passed count greater than zero. It
+understands both Cargo test and nextest summaries, including ANSI-colored CI
+output. `scripts/test-run-verified-tests.sh` replays green, zero-match Cargo,
+zero-match nextest, swallowed-pre-harness, and real-failure receipts.
+
+## Consumer inventory
+
+| Consumer | Path | Zero-executed disposition |
+| --- | --- | --- |
+| Factory worker | `scripts/run-scoped-tests.sh` | Already guarded; also refuses an unscoped command and validates proof scope. |
+| Factory hook | `pre_tool.rs` worker Bash gate | Direct `cargo test` and `cargo nextest run` are denied; workers must use the scoped receipt wrapper. `--no-run` remains allowed because it claims compilation only. |
+| Local Make targets | `cas-cli/Makefile` test, test-full, test-verbose, test-%, clean-env, panic, test-nextest, integration, unit, dev-test, watch | Execution targets route through `run-verified-tests.sh`; test-scoped retains the stricter scoped wrapper. |
+| CI scoped lane | `.github/workflows/ci.yml` | Already uses `run-scoped-tests.sh`. |
+| CI full suite | `.github/workflows/ci.yml` shard step | Routes archived nextest shards through `run-verified-tests.sh`. |
+| CI doctests | `.github/workflows/ci.yml` doctest step | Routes `cargo test --doc` through `run-verified-tests.sh`. |
+| Release migration guard | `scripts/check-release-migration-snapshots.sh` | Routes component-output snapshots through `run-verified-tests.sh`. |
+| Real-store test guard | `scripts/check-real-store-untouched.sh` | Routes its protected nextest invocation through `run-verified-tests.sh` before accepting an untouched-store result. |
+| Compile-only / measurement commands | CI `cargo test --no-run`; benchmark `cargo test --no-run`; Cargo checks | Intentionally execute no tests and are labelled compile-only or build measurement; they are not test-pass consumers. |
+
+`scripts/test-ci-test-tiers.sh` pins the CI and primary Make routing. The hook
+unit tests pin the worker denial, and the release migration self-test exercises
+the wrapper with a stubbed nextest receipt.

--- a/scripts/check-real-store-untouched.sh
+++ b/scripts/check-real-store-untouched.sh
@@ -109,7 +109,8 @@ echo
 echo "Running: ${CARGO} ${CARGO_CMD} $*"
 echo "CAS_TEST_PROTECTED_DBS=${CAS_TEST_PROTECTED_DBS}"
 echo
-(cd "${REPO_ROOT}" && "${CARGO}" ${CARGO_CMD} "$@")
+read -r -a cargo_cmd_args <<<"${CARGO_CMD}"
+(cd "${REPO_ROOT}" && CARGO="${CARGO}" "${REPO_ROOT}/scripts/run-verified-tests.sh" "${cargo_cmd_args[@]}" "$@")
 test_status=$?
 
 echo

--- a/scripts/check-release-migration-snapshots.sh
+++ b/scripts/check-release-migration-snapshots.sh
@@ -22,5 +22,5 @@ else
   echo "release guard: $migration_registry changed since $previous_tag; running migration snapshots"
 fi
 
-echo "+ cargo nextest run -p cas --test component_output_test"
-"$cargo_bin" nextest run -p cas --test component_output_test
+echo "+ scripts/run-verified-tests.sh nextest run -p cas --test component_output_test"
+CARGO="$cargo_bin" "$repo_root/scripts/run-verified-tests.sh" nextest run -p cas --test component_output_test

--- a/scripts/run-verified-tests.sh
+++ b/scripts/run-verified-tests.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Mechanical receipt for every Cargo test command whose success is consumed by
+# a worker, CI lane, Make target, or release gate (GH #499).  Cargo and
+# nextest both exit zero when a filter selects no tests.  Exit status alone is
+# therefore not evidence that the intended suite ran.
+#
+# Usage:
+#   scripts/run-verified-tests.sh nextest run -p cas --lib module
+#   scripts/run-verified-tests.sh test -p cas --doc
+#
+# CARGO may replace the cargo binary in self-tests.  VERIFIED_TEST_LOG keeps
+# the raw captured output when a caller needs a durable receipt.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CARGO="${CARGO:-cargo}"
+
+if [[ $# -eq 0 ]]; then
+    echo "error: pass a Cargo test command, e.g. nextest run -p cas --lib module" >&2
+    exit 1
+fi
+
+if [[ -n "${VERIFIED_TEST_LOG:-}" ]]; then
+    log="${VERIFIED_TEST_LOG}"
+    : >"${log}"
+    clean_log="$(mktemp)"
+    trap 'rm -f "${clean_log}"' EXIT
+else
+    log="$(mktemp)"
+    clean_log="$(mktemp)"
+    trap 'rm -f "${log}" "${clean_log}"' EXIT
+fi
+
+echo "Running: ${CARGO} $*"
+echo
+(cd "${REPO_ROOT}" && "${CARGO}" "$@" 2>&1) | tee "${log}"
+cargo_status="${PIPESTATUS[0]}"
+
+# Cargo and nextest color their summary lines in CI.  Preserve the requested
+# raw log while parsing an ANSI-free copy.
+sed -E $'s/\x1b\\[[0-9;]*[A-Za-z]//g' "${log}" >"${clean_log}"
+
+cargo_test_summaries="$(grep -c '^test result:' "${clean_log}" 2>/dev/null || true)"
+cargo_test_passed="$(
+    sed -n 's/^test result: [a-zA-Z]*\. \([0-9]\{1,\}\) passed.*/\1/p' "${clean_log}" 2>/dev/null |
+        awk '{ total += $1 } END { print total + 0 }'
+)"
+nextest_summaries="$(grep -cE '^ *Summary +\[.*\] +[0-9]+ tests? run:' "${clean_log}" 2>/dev/null || true)"
+nextest_passed="$(
+    sed -n 's/^ *Summary \{1,\}\[.*\] *[0-9]\{1,\} tests\{0,1\} run: \([0-9]\{1,\}\) passed.*/\1/p' "${clean_log}" 2>/dev/null |
+        awk '{ total += $1 } END { print total + 0 }'
+)"
+
+summaries=$((cargo_test_summaries + nextest_summaries))
+passed=$((cargo_test_passed + nextest_passed))
+
+fail() {
+    echo "FAIL: $1" >&2
+    shift
+    for line in "$@"; do
+        echo "      ${line}" >&2
+    done
+    exit 1
+}
+
+echo
+echo "--- verified-test guard (GH #499) ---"
+if [[ "${cargo_status}" -ne 0 ]]; then
+    echo "FAIL: the test run exited ${cargo_status}." >&2
+    exit "${cargo_status}"
+fi
+if [[ "${summaries}" -eq 0 ]]; then
+    fail "cargo exited 0 but no test harness ever reported." \
+        "No Cargo or nextest summary was emitted, so this command proved no test completed."
+fi
+if [[ "${passed}" -eq 0 ]]; then
+    fail "0 tests passed across ${summaries} harness summary line(s)." \
+        "A zero-test result is a failed verification, even when Cargo reports success."
+fi
+
+echo "PASS: ${passed} test(s) passed across ${summaries} harness summary line(s)."

--- a/scripts/test-check-release-migration-snapshots.sh
+++ b/scripts/test-check-release-migration-snapshots.sh
@@ -15,7 +15,8 @@ cargo_stub="$tmpdir/cargo"
 git init -q "$repo"
 git -C "$repo" config user.email release-guard@example.test
 git -C "$repo" config user.name release-guard-test
-mkdir -p "$repo/cas-cli/src/migration/migrations"
+mkdir -p "$repo/cas-cli/src/migration/migrations" "$repo/scripts"
+cp "$script_dir/run-verified-tests.sh" "$repo/scripts/run-verified-tests.sh"
 printf '// baseline\n' >"$repo/cas-cli/src/migration/migrations/mod.rs"
 git -C "$repo" add .
 git -C "$repo" commit -qm 'baseline migration registry'
@@ -24,6 +25,7 @@ git -C "$repo" tag v0.0.1
 cat >"$cargo_stub" <<EOF
 #!/usr/bin/env bash
 printf '%s\\n' "\$*" >>"$cargo_log"
+printf '%s\\n' '     Summary [   0.001s] 1 test run: 1 passed, 0 skipped'
 exit "\${CARGO_EXIT:-0}"
 EOF
 chmod +x "$cargo_stub"
@@ -85,7 +87,8 @@ no_tag_repo="$tmpdir/no-tag-repo"
 git init -q "$no_tag_repo"
 git -C "$no_tag_repo" config user.email release-guard@example.test
 git -C "$no_tag_repo" config user.name release-guard-test
-mkdir -p "$no_tag_repo/cas-cli/src/migration/migrations"
+mkdir -p "$no_tag_repo/cas-cli/src/migration/migrations" "$no_tag_repo/scripts"
+cp "$script_dir/run-verified-tests.sh" "$no_tag_repo/scripts/run-verified-tests.sh"
 printf '// first release\n' >"$no_tag_repo/cas-cli/src/migration/migrations/mod.rs"
 git -C "$no_tag_repo" add .
 git -C "$no_tag_repo" commit -qm 'first migration registry'

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -9,6 +9,9 @@ setup="$repo_root/.github/actions/setup-rust-linux/action.yml"
 fallback="$repo_root/scripts/sccache-unavailable.sh"
 ruleset="$repo_root/docs/branch-protection/main-ruleset.json"
 makefile="$repo_root/cas-cli/Makefile"
+verified="$repo_root/scripts/run-verified-tests.sh"
+real_store_guard="$repo_root/scripts/check-real-store-untouched.sh"
+migration_guard="$repo_root/scripts/check-release-migration-snapshots.sh"
 
 pass=0
 fail=0
@@ -99,7 +102,7 @@ require_text "$scoped" "refs/heads/factory/" 'scoped tier selects factory branch
 require_text "$scoped" "github.event_name == 'pull_request'" 'pull requests use scoped tier'
 require_text "$scoped" 'github.base_ref != github.event.repository.default_branch' 'scoped tier skips protected-default PRs'
 require_text "$scoped" 'cargo check -p cas --lib --tests' 'scoped tier checks target surface'
-require_text "$scoped" 'scripts/run-scoped-tests.sh -p cas --lib' 'scoped tier runs one test binary'
+require_text "$scoped" 'scripts/run-scoped-tests.sh -p cas --lib' 'scoped tier runs one guarded test binary'
 
 # Merge-latency contract for the scoped lane (cas-3e14). This lane is not a
 # required check, but it reports last on a factory PR, so a merge that waits for
@@ -335,11 +338,20 @@ require_text "$suite_shards" 'needs: fast-validation-suite-build' 'shards wait f
 require_text "$suite_shards" 'actions/download-artifact@v4' 'shards download the shared nextest archive'
 require_text "$suite_shards" 'tar -xzf fast-validation-suite-runner.tar.gz' 'shards restore the executable CLI runner payload'
 require_text "$suite_shards" 'test -x target/debug/cas' 'shards verify the restored CLI runner remains executable'
-require_text "$suite_shards" 'cargo nextest run --archive-file fast-validation-suite.tar.zst --no-fail-fast --partition count:${{ matrix.shard }}/3' 'shards execute every archived workspace nextest binary exactly once'
+require_text "$suite_shards" 'scripts/run-verified-tests.sh nextest run --archive-file fast-validation-suite.tar.zst --no-fail-fast --partition count:${{ matrix.shard }}/3' 'shards execute every archived workspace nextest binary exactly once'
 require_text "$suite" 'needs: fast-validation-suite-shards' 'required full-suite context fans in every shard'
 require_text "$suite" 'test "$SHARDS" = success' 'required full-suite context rejects failed shards'
-require_text "$(<"$makefile")" '$(CARGO) nextest run --workspace --no-fail-fast' 'local make test matches CI workspace nextest scope'
-require_text "$docs" 'cargo test -p cas --doc' 'doctest coverage remains in Fast Validation'
+require_text "$(<"$makefile")" '../scripts/run-verified-tests.sh nextest run --workspace --no-fail-fast' 'local make test verifies CI workspace nextest scope'
+require_text "$docs" 'scripts/run-verified-tests.sh test -p cas --doc' 'doctest coverage remains in Fast Validation with an execution receipt'
+require_text "$(<"$real_store_guard")" 'run-verified-tests.sh' 'real-store guard requires an executed-test receipt'
+require_text "$(<"$migration_guard")" 'run-verified-tests.sh nextest run -p cas --test component_output_test' 'release migration snapshots require an executed-test receipt'
+if [[ -x "$verified" ]]; then
+    printf 'ok   verified-test receipt wrapper is executable\n'
+    pass=$((pass + 1))
+else
+    printf 'FAIL verified-test receipt wrapper is executable\n'
+    fail=$((fail + 1))
+fi
 require_text "$fan_in" 'fast-validation-preflight' 'required Fast Validation waits for preflight'
 require_text "$fan_in" 'fast-validation-suite' 'required Fast Validation waits for the full suite'
 require_text "$fan_in" 'fast-validation-docs' 'required Fast Validation waits for doctests'

--- a/scripts/test-run-verified-tests.sh
+++ b/scripts/test-run-verified-tests.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Self-test for scripts/run-verified-tests.sh (GH #499).
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+guard="${script_dir}/run-verified-tests.sh"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+pass=0
+fail=0
+
+make_stub() {
+    local name="$1" status="$2"
+    local stub="${tmpdir}/${name}"
+    {
+        echo '#!/usr/bin/env bash'
+        echo "cat <<'STUB_EOF'"
+        cat
+        echo 'STUB_EOF'
+        echo "exit ${status}"
+    } >"${stub}"
+    chmod +x "${stub}"
+    echo "${stub}"
+}
+
+expect() {
+    local wanted="$1" needle="$2" label="$3"
+    shift 3
+    local output status
+    output="$("$@" 2>&1)"
+    status=$?
+    local ok=1
+    [[ "${wanted}" == pass && "${status}" -ne 0 ]] && ok=0
+    [[ "${wanted}" == fail && "${status}" -eq 0 ]] && ok=0
+    [[ "${ok}" -eq 1 && "${needle}" != - ]] && ! grep -qF -- "${needle}" <<<"${output}" && ok=0
+    if [[ "${ok}" -eq 1 ]]; then
+        pass=$((pass + 1))
+        echo "ok   ${label}"
+    else
+        fail=$((fail + 1))
+        echo "FAIL ${label} (exit ${status})" >&2
+        echo "${output}" >&2
+    fi
+}
+
+stub="$(make_stub green-nextest 0 <<'EOF'
+    Starting 2 tests across 1 binary (0 skipped)
+------------
+     Summary [   0.012s] 2 tests run: 2 passed, 0 skipped
+EOF
+)"
+expect pass 'PASS: 2 test(s) passed' 'nextest green receipt passes' \
+    env CARGO="${stub}" "${guard}" nextest run -p cas --lib module
+
+stub="$(make_stub zero-cargo 0 <<'EOF'
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+EOF
+)"
+expect fail '0 tests passed' 'zero-match Cargo result fails loudly' \
+    env CARGO="${stub}" "${guard}" test -p cas --lib stale_filter
+
+stub="$(make_stub zero-nextest 0 <<'EOF'
+    Starting 0 tests across 1 binary (4 skipped)
+------------
+     Summary [   0.001s] 0 tests run: 0 passed, 4 skipped
+EOF
+)"
+expect fail '0 tests passed' 'zero-match nextest result fails loudly' \
+    env CARGO="${stub}" "${guard}" nextest run -p cas --lib stale_filter
+
+stub="$(make_stub no-harness 0 <<'EOF'
+Finished `test` profile after a swallowed build failure
+EOF
+)"
+expect fail 'no test harness ever reported' 'swallowed pre-harness failure fails loudly' \
+    env CARGO="${stub}" "${guard}" test -p cas --doc
+
+stub="$(make_stub failing 42 <<'EOF'
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+EOF
+)"
+expect fail 'the test run exited 42' 'real Cargo failure propagates' \
+    env CARGO="${stub}" "${guard}" test -p cas --doc
+
+if [[ "${fail}" -ne 0 ]]; then
+    echo "FAIL: ${fail} verified-test guard self-test(s) failed" >&2
+    exit 1
+fi
+echo "PASS: ${pass} verified-test guard self-test(s) passed."


### PR DESCRIPTION
## Summary
- require Cargo/nextest harness summaries with nonzero passed counts for consumed test results
- route worker, Make, CI, release, and real-store paths through guarded receipts
- document and regression-test zero-executed failures

## Verification
- 
- Running: cargo nextest run -p cas --lib handlers_tests::unscoped_test_guard

   Compiling cas v3.1.0 (/home/pippenz/Petrastella/cas-src/.cas/worktrees/kind-lion-90/cas-cli)
warning: unused import: `global_has_cas_hooks`
  --> cas-cli/src/cli/hook.rs:22:27
   |
22 |     configure_mcp_server, global_has_cas_hooks, provision_codex_project,
   |                           ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: unused import: `AgentStore`
  --> cas-cli/src/cli/cloud.rs:21:5
   |
21 |     AgentStore, open_agent_store, open_commit_link_store, open_event_sto...
   |     ^^^^^^^^^^

warning: unused import: `AgentStore`
  --> cas-cli/src/hooks/handlers/session_hygiene.rs:27:20
   |
27 | use crate::store::{AgentStore, TaskStore, open_agent_store, open_task_st...
   |                    ^^^^^^^^^^

warning: unused import: `TaskStore`
  --> cas-cli/src/hooks/handlers/session_hygiene.rs:27:32
   |
27 | use crate::store::{AgentStore, TaskStore, open_agent_store, open_task_st...
   |                                ^^^^^^^^^

warning: unused variable: `bundle_paths`
   --> cas-cli/src/hub/tailscale.rs:282:59
    |
282 | ..._cli: Option<PathBuf>, bundle_paths: &[&Path]) -> OsString {
    |                           ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_bundle_paths`
    |
    = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

warning: unused variable: `attempt`
    --> cas-cli/src/ui/factory/orphan_gc.rs:1222:13
     |
1222 |         for attempt in 1..=PLANT_ATTEMPTS {
     |             ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_attempt`

warning: variants `Launchd` and `Unsupported` are never constructed
  --> cas-cli/src/cli/hub_service.rs:24:5
   |
23 | enum ServicePlatform {
   |      --------------- variants in this enum
24 |     Launchd,
   |     ^^^^^^^
...
27 |     Unsupported,
   |     ^^^^^^^^^^^
   |
   = note: `ServicePlatform` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: function `global_has_cas_hooks` is never used
   --> cas-cli/src/cli/hook/config_gen.rs:139:8
    |
139 | pub fn global_has_cas_hooks() -> bool {
    |        ^^^^^^^^^^^^^^^^^^^^

warning: methods `is_safe_to_type_into` and `is_safe_to_wake_an_active_looking_recipient` are never used
   --> cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs:795:8
    |
786 | impl PaneWakeState {
    | ------------------ methods in this implementation
...
795 |     fn is_safe_to_type_into(self) -> bool {
    |        ^^^^^^^^^^^^^^^^^^^^
...
855 |     fn is_safe_to_wake_an_active_looking_recipient(self) -> bool {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: associated functions `supervisor_wake_is_eligible` and `active_looking_recipient_is_parked` are never used
    --> cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs:2194:8
     |
1306 | impl FactoryDaemon {
     | ------------------ associated functions in this implementation
...
2194 |     fn supervisor_wake_is_eligible(
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
2338 |     fn active_looking_recipient_is_parked(
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `default_claude_projects_dir` is never used
    --> cas-cli/src/mcp/tools/service/factory_ops.rs:6610:15
     |
6610 | pub(crate) fn default_claude_projects_dir() -> Option<std::path::PathB...
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: `cas` (lib test) generated 11 warnings (run `cargo fix --lib -p cas --tests` to apply 3 suggestions)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 13.43s
────────────
 Nextest run ID a725f419-bf7a-43ab-ba7f-036bd859f2d2 with nextest profile: default
    Starting 3 tests across 1 binary (4748 tests skipped)
        PASS [   0.007s] (1/3) cas hooks::handlers::handlers_tests::unscoped_test_guard::worker_receipted_test_commands_and_non_test_commands_are_not_denied
        PASS [   0.009s] (2/3) cas hooks::handlers::handlers_tests::unscoped_test_guard::worker_direct_cargo_test_and_nextest_are_denied_with_receipt_recipe
        PASS [   0.010s] (3/3) cas hooks::handlers::handlers_tests::unscoped_test_guard::supervisor_retains_full_suite_authority
────────────
     Summary [   0.018s] 3 tests run: 3 passed, 4748 skipped

--- scoped-test guard (GH #173) ---
PASS: 3 test(s) passed across 1 harness summary line(s).
Quote that passed count in your close note (rule-173).
      Iteration receipt only. Add --proof for committed-diff surface validation at handoff.
- Running: cargo nextest run -p cas --lib handlers_tests::formatter_scope_guard

   Compiling cas v3.1.0 (/home/pippenz/Petrastella/cas-src/.cas/worktrees/kind-lion-90/cas-cli)
warning: unused import: `global_has_cas_hooks`
  --> cas-cli/src/cli/hook.rs:22:27
   |
22 |     configure_mcp_server, global_has_cas_hooks, provision_codex_project,
   |                           ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: unused import: `AgentStore`
  --> cas-cli/src/cli/cloud.rs:21:5
   |
21 |     AgentStore, open_agent_store, open_commit_link_store, open_event_sto...
   |     ^^^^^^^^^^

warning: unused import: `AgentStore`
  --> cas-cli/src/hooks/handlers/session_hygiene.rs:27:20
   |
27 | use crate::store::{AgentStore, TaskStore, open_agent_store, open_task_st...
   |                    ^^^^^^^^^^

warning: unused import: `TaskStore`
  --> cas-cli/src/hooks/handlers/session_hygiene.rs:27:32
   |
27 | use crate::store::{AgentStore, TaskStore, open_agent_store, open_task_st...
   |                                ^^^^^^^^^

warning: unused variable: `bundle_paths`
   --> cas-cli/src/hub/tailscale.rs:282:59
    |
282 | ..._cli: Option<PathBuf>, bundle_paths: &[&Path]) -> OsString {
    |                           ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_bundle_paths`
    |
    = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

warning: unused variable: `attempt`
    --> cas-cli/src/ui/factory/orphan_gc.rs:1222:13
     |
1222 |         for attempt in 1..=PLANT_ATTEMPTS {
     |             ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_attempt`

warning: variants `Launchd` and `Unsupported` are never constructed
  --> cas-cli/src/cli/hub_service.rs:24:5
   |
23 | enum ServicePlatform {
   |      --------------- variants in this enum
24 |     Launchd,
   |     ^^^^^^^
...
27 |     Unsupported,
   |     ^^^^^^^^^^^
   |
   = note: `ServicePlatform` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: function `global_has_cas_hooks` is never used
   --> cas-cli/src/cli/hook/config_gen.rs:139:8
    |
139 | pub fn global_has_cas_hooks() -> bool {
    |        ^^^^^^^^^^^^^^^^^^^^

warning: methods `is_safe_to_type_into` and `is_safe_to_wake_an_active_looking_recipient` are never used
   --> cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs:795:8
    |
786 | impl PaneWakeState {
    | ------------------ methods in this implementation
...
795 |     fn is_safe_to_type_into(self) -> bool {
    |        ^^^^^^^^^^^^^^^^^^^^
...
855 |     fn is_safe_to_wake_an_active_looking_recipient(self) -> bool {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: associated functions `supervisor_wake_is_eligible` and `active_looking_recipient_is_parked` are never used
    --> cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs:2194:8
     |
1306 | impl FactoryDaemon {
     | ------------------ associated functions in this implementation
...
2194 |     fn supervisor_wake_is_eligible(
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
2338 |     fn active_looking_recipient_is_parked(
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: function `default_claude_projects_dir` is never used
    --> cas-cli/src/mcp/tools/service/factory_ops.rs:6610:15
     |
6610 | pub(crate) fn default_claude_projects_dir() -> Option<std::path::PathB...
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: `cas` (lib test) generated 11 warnings (run `cargo fix --lib -p cas --tests` to apply 3 suggestions)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 10.32s
────────────
 Nextest run ID 68199141-bbd9-4d32-b77e-bd3317e00495 with nextest profile: default
    Starting 5 tests across 1 binary (4746 tests skipped)
        PASS [   0.007s] (1/5) cas hooks::handlers::handlers_tests::formatter_scope_guard::worker_mutating_cargo_fmt_is_denied
        PASS [   0.010s] (2/5) cas hooks::handlers::handlers_tests::formatter_scope_guard::checks_and_non_recursive_rustfmt_remain_available
        PASS [   0.011s] (3/5) cas hooks::handlers::handlers_tests::formatter_scope_guard::codex_routes_unified_exec_through_the_pre_tool_hook
        PASS [   0.011s] (4/5) cas hooks::handlers::handlers_tests::formatter_scope_guard::supervisor_retains_normalization_authority
        PASS [   0.011s] (5/5) cas hooks::handlers::handlers_tests::formatter_scope_guard::worker_recursive_rustfmt_is_denied
────────────
     Summary [   0.018s] 5 tests run: 5 passed, 4746 skipped

--- verified-test guard (GH #499) ---
PASS: 5 test(s) passed across 1 harness summary line(s).
- ok   nextest green receipt passes
ok   zero-match Cargo result fails loudly
ok   zero-match nextest result fails loudly
ok   swallowed pre-harness failure fails loudly
ok   real Cargo failure propagates
PASS: 5 verified-test guard self-test(s) passed.
- ok   unchanged registry skips component-output snapshots
ok   changed registry runs exact component-output snapshot command
ok   snapshot failure prevents the release path from continuing
ok   first release runs snapshots conservatively
PASS: release migration snapshot guard behavior verified.
- ok   ruleset-required context is a CI job: Fast Validation — full suite
ok   ruleset-required context is a CI job: Fast Validation — doctests
ok   ruleset-required context is a CI job: macOS Check
ok   factory pushes trigger CI
ok   epic pushes trigger CI
ok   release tags trigger CI
ok   Fast Validation invokes release publication guard scripts
ok   scoped tier selects factory branches
ok   pull requests use scoped tier
ok   scoped tier skips protected-default PRs
ok   scoped tier checks target surface
ok   scoped tier runs one guarded test binary
ok   scoped lane classifies before expensive work
ok   scoped lane uses the shared classifier
ok   scoped lane computes a real merge base
ok   scoped lane classifies the PR head rather than its synthetic merge commit
ok   scoped lane compares against its own event base
ok   scoped lane gates Rust work only after a safe classification
ok   scoped lane checks for a PR event on the same head SHA
ok   scoped lane uses the shared fail-closed PR coverage guard
ok   scoped lane gates expensive work on the dedupe verdict
ok   scoped lane groups runs by pull request, falling back to the branch ref
ok   scoped lane cancels its own superseded runs
ok   scoped lane reads PR metadata without write access
ok   only the push copy may dedupe; the PR event always validates
ok   scoped lane step is dedupe-gated: ./.github/actions/setup-rust-linux
ok   scoped lane step is classification-gated: ./.github/actions/setup-rust-linux
ok   scoped lane step is dedupe-gated: taiki-e/install-action@nextest
ok   scoped lane step is classification-gated: taiki-e/install-action@nextest
ok   scoped lane step is dedupe-gated: cargo check -p cas --lib --tests
ok   scoped lane step is classification-gated: cargo check -p cas --lib --tests
ok   scoped lane step is dedupe-gated: scripts/run-scoped-tests.sh -p cas --lib
ok   scoped lane step is classification-gated: scripts/run-scoped-tests.sh -p cas --lib
ok   scoped lane still validates factory branch pushes
ok   an open PR on this exact head SHA dedupes the push copy
ok   dedupe records which pull request covers the commit
ok   coverage lookup asks about the exact head commit
ok   coverage lookup accepts only a PR whose head is this commit
ok   coverage lookup ignores closed pull requests
ok   miss pull-request evidence fails closed to running the lane
ok   garbage pull-request evidence fails closed to running the lane
ok   error pull-request evidence fails closed to running the lane
ok   a pull request event never dedupes itself
ok   a missing repository slug fails closed to running the lane
ok   fast-validation-preflight runs on main
ok   fast-validation-preflight is not double-run from epic pushes
ok   fast-validation-preflight is absent from factory pushes
ok   fast-validation-suite-build runs on main
ok   fast-validation-suite-build is not double-run from epic pushes
ok   fast-validation-suite-build is absent from factory pushes
ok   fast-validation-suite-shards runs on main
ok   fast-validation-suite-shards is not double-run from epic pushes
ok   fast-validation-suite-shards is absent from factory pushes
ok   fast-validation-suite runs on main
ok   fast-validation-suite is not double-run from epic pushes
ok   fast-validation-suite is absent from factory pushes
ok   fast-validation-docs runs on main
ok   fast-validation-docs is not double-run from epic pushes
ok   fast-validation-docs is absent from factory pushes
ok   fast-validation runs on main
ok   fast-validation is not double-run from epic pushes
ok   fast-validation is absent from factory pushes
ok   macos-check runs on main
ok   macos-check is not double-run from epic pushes
ok   macos-check is absent from factory pushes
ok   fast-validation-preflight classifies before expensive work
ok   fast-validation-preflight uses the shared classifier
ok   fast-validation-preflight computes a real merge base
ok   fast-validation-preflight classifies the PR head rather than its synthetic merge commit
ok   fast-validation-preflight gates Rust work only after a safe classification
ok   fast-validation-suite-build classifies before expensive work
ok   fast-validation-suite-build uses the shared classifier
ok   fast-validation-suite-build computes a real merge base
ok   fast-validation-suite-build classifies the PR head rather than its synthetic merge commit
ok   fast-validation-suite-build gates Rust work only after a safe classification
ok   fast-validation-suite-shards classifies before expensive work
ok   fast-validation-suite-shards uses the shared classifier
ok   fast-validation-suite-shards computes a real merge base
ok   fast-validation-suite-shards classifies the PR head rather than its synthetic merge commit
ok   fast-validation-suite-shards gates Rust work only after a safe classification
ok   fast-validation-suite classifies before expensive work
ok   fast-validation-suite uses the shared classifier
ok   fast-validation-suite computes a real merge base
ok   fast-validation-suite classifies the PR head rather than its synthetic merge commit
ok   fast-validation-suite gates Rust work only after a safe classification
ok   fast-validation-docs classifies before expensive work
ok   fast-validation-docs uses the shared classifier
ok   fast-validation-docs computes a real merge base
ok   fast-validation-docs classifies the PR head rather than its synthetic merge commit
ok   fast-validation-docs gates Rust work only after a safe classification
ok   macos-check classifies before expensive work
ok   macos-check uses the shared classifier
ok   macos-check computes a real merge base
ok   macos-check classifies the PR head rather than its synthetic merge commit
ok   macos-check gates Rust work only after a safe classification
ok   empty ancestry merge fast-passes
ok   docs-only change fast-passes
ok   hub-web-only change skips Rust work
ok   two-file package version bump fast-passes
ok   workspace-wide seven-file version bump fast-passes
ok   version bump plus changelog runs Rust tier
ok   code diff runs Rust tier
::notice title=CI diff class::No comparable base; running Rust tier
::notice title=CI Rust tier::Diff class 'rust-touched' runs the full Rust tier
ok   tag push with all-zero BASE_SHA falls back to Rust tier
ok   tag push all-zero BASE_SHA never fast-passes
ok   tag push all-zero BASE_SHA never skips Rust
::warning title=CI diff class::Could not find merge base; running Rust tier
::notice title=CI Rust tier::Diff class 'rust-touched' runs the full Rust tier
ok   unresolvable base falls back to Rust tier
ok   unresolvable base never skips Rust
ok   fast-validation-preflight runs on release tags
ok   fast-validation-suite-build runs on release tags
ok   fast-validation-suite-shards runs on release tags
ok   fast-validation-suite runs on release tags
ok   fast-validation-docs runs on release tags
ok   fast-validation runs on release tags
ok   macos-check runs on release tags
ok   fast-validation runs for pull requests
ok   fast-validation targets the default PR base
ok   fast-validation groups runs by pull request rather than by head SHA
ok   fast-validation releases runners held by its own superseded runs
ok   macos-check runs for pull requests
ok   macos-check targets the default PR base
ok   macos-check groups runs by pull request rather than by head SHA
ok   macos-check releases runners held by its own superseded runs
ok   suite uses three nextest shards
ok   suite keeps running other shards after a failure
ok   suite compiles the workspace test graph once into an archive
ok   suite build publishes the shared nextest archive
ok   suite archive drops dev debug info
ok   suite archive drops test debug info
ok   suite archive strips dev debug sections
ok   suite archive strips test debug sections
ok   archive keeps symbol names for readable panics
ok   fast-validation-preflight keeps normal debug info: fast-validation-preflight
ok   fast-validation-docs keeps normal debug info: fast-validation-docs
ok   clippy keeps normal debug info: clippy
ok   test-compile-guard keeps normal debug info: test-compile-guard
ok   suite packages the executable CLI runner with its mode bits
ok   shards wait for the shared test archive
ok   shards download the shared nextest archive
ok   shards restore the executable CLI runner payload
ok   shards verify the restored CLI runner remains executable
ok   shards execute every archived workspace nextest binary exactly once
ok   required full-suite context fans in every shard
ok   required full-suite context rejects failed shards
ok   local make test verifies CI workspace nextest scope
ok   doctest coverage remains in Fast Validation with an execution receipt
ok   real-store guard requires an executed-test receipt
ok   release migration snapshots require an executed-test receipt
ok   verified-test receipt wrapper is executable
ok   required Fast Validation waits for preflight
ok   required Fast Validation waits for the full suite
ok   required Fast Validation waits for doctests
ok   required Fast Validation rejects a failed preflight
ok   required Fast Validation rejects a failed full suite
ok   required Fast Validation rejects failed doctests
ok   non-required scoped lane skips main PRs
ok   clippy runs on main
ok   clippy runs on schedule
ok   clippy supports supervisor dispatch
ok   clippy validates protected PR trees
ok   clippy targets the protected PR base
ok   clippy cannot run on epic pushes
ok   clippy cannot run on factory pushes
ok   clippy cannot run on tag pushes
ok   clippy checks for an identical PR-validated tree first
ok   clippy uses the shared fail-closed tree guard
ok   clippy gates expensive work on the tree receipt
ok   clippy logs the validating run URL when deduped
ok   test-compile-guard runs on main
ok   test-compile-guard runs on schedule
ok   test-compile-guard supports supervisor dispatch
ok   test-compile-guard validates protected PR trees
ok   test-compile-guard targets the protected PR base
ok   test-compile-guard cannot run on epic pushes
ok   test-compile-guard cannot run on factory pushes
ok   test-compile-guard cannot run on tag pushes
ok   test-compile-guard checks for an identical PR-validated tree first
ok   test-compile-guard uses the shared fail-closed tree guard
ok   test-compile-guard gates expensive work on the tree receipt
ok   test-compile-guard logs the validating run URL when deduped
ok   panic-isolation-release runs on schedule
ok   panic-isolation-release supports supervisor dispatch
ok   panic-isolation-release does not consume runners on ordinary main pushes
ok   panic-isolation-release does not delay PR validation
ok   panic-isolation-release-fast runs on schedule
ok   panic-isolation-release-fast supports supervisor dispatch
ok   panic-isolation-release-fast does not consume runners on ordinary main pushes
ok   panic-isolation-release-fast does not delay PR validation
ok   build-benchmark runs on schedule
ok   build-benchmark supports supervisor dispatch
ok   build-benchmark does not consume runners on ordinary main pushes
ok   build-benchmark does not delay PR validation
ok   CI may query validation receipt artifacts
ok   tree receipt waits for every per-tree validation lane
ok   tree receipt requires successful Fast Validation
ok   tree receipt requires successful macOS Check
ok   tree receipt requires successful Clippy
ok   tree receipt requires successful test compilation
ok   tree receipt keys exact Git contents
ok   tree receipt artifact is named by tree hash
ok   matching successful PR receipt skips heavy work
ok   matching receipt exposes the prior run URL
ok   tree lookup queries the exact current Git tree
ok   miss receipt evidence fails closed to heavy work
ok   miss receipt evidence never dedupes
ok   wrong-event receipt evidence fails closed to heavy work
ok   wrong-event receipt evidence never dedupes
ok   error receipt evidence fails closed to heavy work
ok   error receipt evidence never dedupes
ok   cache-v2-capable sccache action is pinned
ok   retired sccache action v0.0.5 is absent
ok   CI enables GitHub cache-v2 backend
ok   release enables GitHub cache-v2 backend
ok   Linux release build starts in parallel with input verification
ok   macOS release build starts in parallel with input verification
ok   release publication waits for verification and both platform builds
ok   platform release build uses the thin-LTO profile
ok   platform package strips symbols before publication
ok   platform package selects the configured profile output
ok   platform release build uses the thin-LTO profile
ok   platform package strips symbols before publication
ok   platform package selects the configured profile output
ok   Linux release audits BLAKE3 inputs from the selected profile
ok   Linux release audits the exact stripped executable
ok   Linux release asset remains required
ok   macOS release asset remains required
ok   release never replaces published assets after a receipt
ok   release rerun with an existing release fails loudly
ok   release rerun names its recovery procedure
ok   release rubric documents partial-release recovery
ok   partial-release retry refuses loudly and does not upload replacement bytes
ok   first release run creates the release when no object exists
ok   sccache setup step has a probe handle
ok   sccache action download may fail open
ok   sccache download and backend startup both select fallback
ok   sccache outage emits an uncached-build warning
ok   sccache outage clears compiler wrapper
ok   sccache outage disables its backend
ok   every sccache setup is accounted for
ok   every sccache setup action and post-step fails open
ok   every sccache setup probes backend availability
ok   every sccache outage logs its uncached fallback
ok   every sccache fallback makes the action post hook harmless
ok   sccache post fallback is executable and emits valid zero stats
ok   CI pins one shared cache-v2 object namespace
ok   release shares the CI cache-v2 object namespace
ok   macos-check publishes its own sccache hit stats
ok   macos-check reports cache stats even when the lane fails
ok   macos-check keeps the cache-v2 backend enabled
ok   macos-check survives a checkout that predates the stats script
ok   fast-validation-preflight publishes its own sccache hit stats
ok   fast-validation-preflight reports cache stats even when the lane fails
ok   fast-validation-preflight keeps the cache-v2 backend enabled
ok   fast-validation-preflight survives a checkout that predates the stats script
ok   fast-validation-docs publishes its own sccache hit stats
ok   fast-validation-docs reports cache stats even when the lane fails
ok   fast-validation-docs keeps the cache-v2 backend enabled
ok   fast-validation-docs survives a checkout that predates the stats script
ok   fast-validation-suite-build publishes its own sccache hit stats
ok   fast-validation-suite-build reports cache stats even when the lane fails
ok   fast-validation-suite-build keeps the cache-v2 backend enabled
ok   fast-validation-suite-build survives a checkout that predates the stats script
ok   scoped-validation publishes its own sccache hit stats
ok   scoped-validation reports cache stats even when the lane fails
ok   scoped-validation keeps the cache-v2 backend enabled
ok   scoped-validation survives a checkout that predates the stats script
ok   test-compile-guard publishes its own sccache hit stats
ok   test-compile-guard reports cache stats even when the lane fails
ok   test-compile-guard keeps the cache-v2 backend enabled
ok   test-compile-guard survives a checkout that predates the stats script
ok   panic-isolation-release-fast publishes its own sccache hit stats
ok   panic-isolation-release-fast reports cache stats even when the lane fails
ok   panic-isolation-release-fast keeps the cache-v2 backend enabled
ok   panic-isolation-release-fast survives a checkout that predates the stats script
ok   clippy publishes its own sccache hit stats
ok   clippy reports cache stats even when the lane fails
ok   clippy keeps the cache-v2 backend enabled
ok   clippy survives a checkout that predates the stats script
ok   panic-isolation-release publishes its own sccache hit stats
ok   panic-isolation-release reports cache stats even when the lane fails
ok   panic-isolation-release keeps the cache-v2 backend enabled
ok   panic-isolation-release survives a checkout that predates the stats script
ok   every sccache stats invocation is existence-guarded (12 of them)
ok   every missing stats script says so instead of failing the lane
ok   a checkout without the stats script reports and passes
ok   a checkout with the stats script still reports its lane
ok   release build publishes its own sccache hit stats
ok   release build-macos publishes its own sccache hit stats
ok   release verify publishes its own sccache hit stats
ok   Build Benchmark stays deliberately uncached
ok   Build Benchmark clears the compiler wrapper
ok   Build Benchmark documents why it is exempt
ok   Build Benchmark reports no cache stats
ok   suite shards compile nothing and report no cache stats
ok   sccache summary script is executable
ok   sccache summary exits 0 (warm)
ok   warm lane summary reports hits and misses
ok   warm lane summary reports a hit rate
ok   warm lane summary names the configured backend
ok   the lane states that its stats reached the job summary, not just the log
ok   the job summary file itself carries the rendered table
ok   sccache summary exits 0 (cold)
ok   a lane below the hit-rate floor is annotated, not failed
ok   sccache summary exits 0 (missing)
ok   a missing sccache binary degrades to a visible note
ok   sccache summary exits 0 (disabled)
ok   the probe-disabled backend is reported as uncached

test result: 304 passed; 0 failed