### PR TITLE
fix(factory): harden alternate Codex worker launches

### DIFF
--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -1419,8 +1419,10 @@ impl CasService {
             }
         }
 
-        let strict_cli =
-            strict_cli_from_project_config(Some(&self.inner.cas_root.join("config.toml")));
+        // A caller who requested Codex must either receive Codex or an
+        // actionable refusal. Rewriting the provider/tier to Claude here is
+        // a cost and capability change the supervisor did not approve.
+        let strict_cli = true;
         let notices = cas_factory::apply_codex_fallback(
             &mut specs,
             strict_cli,
@@ -1581,6 +1583,7 @@ impl CasService {
         req: FactoryRequest,
     ) -> Result<CallToolResult, McpError> {
         use crate::store::{open_agent_store, open_spawn_queue_store, open_task_store};
+        use cas_store::SpawnLifecycleState;
         use cas_types::{AgentRole, AgentStatus};
 
         let requested_names: Vec<String> = req
@@ -1616,6 +1619,31 @@ impl CasService {
         })?;
         let owned = supervisor_owned_workers();
         let factory_session = current_factory_session();
+        let queue = open_spawn_queue_store(&self.inner.cas_root).map_err(|e| {
+            Self::error(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to open spawn queue: {e}"),
+            )
+        })?;
+        // A launched PTY has a durable lifecycle row before it has an Agent
+        // row. Keep that control-plane identity available to shutdown instead
+        // of making a wedged pre-registration process untargetable.
+        let launched_workers = factory_session
+            .as_deref()
+            .map(|session| queue.recent_spawn_lifecycle(session, 200))
+            .transpose()
+            .map_err(|e| {
+                Self::error(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to list launched workers: {e}"),
+                )
+            })?
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|spawn| {
+                spawn.state == SpawnLifecycleState::Launched && spawn.worker_name.is_some()
+            })
+            .collect::<Vec<_>>();
         let all_agents = agent_store.list(None).map_err(|e| {
             Self::error(
                 ErrorCode::INTERNAL_ERROR,
@@ -1671,8 +1699,43 @@ impl CasService {
                 .collect()
         };
 
+        let selected_launched: Vec<_> = if let Some(id) = requested_id {
+            // `id` accepts either the familiar worker id/name or the spawn
+            // request id printed in the launch receipt.
+            launched_workers
+                .iter()
+                .filter(|spawn| {
+                    spawn.worker_name.as_deref() == Some(id) || spawn.id.to_string() == id
+                })
+                .cloned()
+                .collect()
+        } else if !requested_names.is_empty() {
+            launched_workers
+                .iter()
+                .filter(|spawn| {
+                    spawn.worker_name.as_deref().is_some_and(|name| {
+                        requested_names.iter().any(|requested| requested == name)
+                    })
+                })
+                .cloned()
+                .collect()
+        } else if req.count.unwrap_or(0) == 0 {
+            launched_workers.clone()
+        } else {
+            launched_workers
+                .iter()
+                .take(req.count.unwrap_or_default() as usize)
+                .cloned()
+                .collect()
+        };
+        let selected_launched_names: Vec<String> = selected_launched
+            .iter()
+            .filter_map(|spawn| spawn.worker_name.clone())
+            .filter(|name| !selected.iter().any(|worker| worker.name == *name))
+            .collect();
+
         let missing: Vec<String> = if let Some(id) = requested_id {
-            if selected.is_empty() {
+            if selected.is_empty() && selected_launched.is_empty() {
                 vec![id.to_string()]
             } else {
                 Vec::new()
@@ -1684,14 +1747,23 @@ impl CasService {
                     !selected
                         .iter()
                         .any(|worker| worker.name.as_str() == name.as_str())
+                        && !selected_launched_names
+                            .iter()
+                            .any(|launched| launched == name)
                 })
                 .cloned()
                 .collect()
         };
-        if !missing.is_empty() || selected.is_empty() {
+        if !missing.is_empty() || (selected.is_empty() && selected_launched_names.is_empty()) {
             let known = known_workers
                 .iter()
                 .map(|worker| format!("{} ({})", worker.name, worker.id))
+                .chain(selected_launched.iter().filter_map(|spawn| {
+                    spawn
+                        .worker_name
+                        .as_ref()
+                        .map(|name| format!("{name} (launched; spawn request {})", spawn.id))
+                }))
                 .collect::<Vec<_>>();
             return Err(Self::error(
                 ErrorCode::INVALID_PARAMS,
@@ -1746,16 +1818,14 @@ impl CasService {
             ));
         }
 
-        let worker_names: Vec<String> = selected.iter().map(|worker| worker.name.clone()).collect();
+        let worker_names: Vec<String> = selected
+            .iter()
+            .map(|worker| worker.name.clone())
+            .chain(selected_launched_names.iter().cloned())
+            .collect();
 
         // Validation passed: queue only the exact resolved names. `count=None`
         // is intentional — the daemon must not re-expand this decision.
-        let queue = open_spawn_queue_store(&self.inner.cas_root).map_err(|e| {
-            Self::error(
-                ErrorCode::INTERNAL_ERROR,
-                format!("Failed to open spawn queue: {e}"),
-            )
-        })?;
 
         let request_id = queue
             .enqueue_shutdown(None, &worker_names, force, factory_session.as_deref())

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -609,34 +609,6 @@ fn spawn_worker_entries_len(raw: Option<&str>) -> Result<Option<usize>, String> 
     Ok(Some(values.len()))
 }
 
-/// `[factory] strict_cli` lookup for the cas-7199 / cas-a487 Codex-fallback
-/// check applied in `factory_spawn_workers`. Deliberately NOT inside
-/// `build_spawn_spec_json_with_project_config` above: that function is pure
-/// cascade resolution + serialization, exercised directly by unit tests
-/// (e.g. `spawn_spec_omitted_cli_without_config_uses_stock_codex_defaults`)
-/// that assert the stock/default `cli` value itself and run under an
-/// isolated fake `HOME` — folding a REAL `codex_available()` probe in
-/// there would make those tests depend on whether the isolated `HOME`
-/// happens to contain a `.codex/auth.json` (it never does), silently
-/// changing their resolved `cli` out from under them and making the whole
-/// suite depend on the test machine's actual Codex install/login state.
-/// The availability check belongs at the actual "about to queue this for
-/// spawn" checkpoint instead — see `factory_spawn_workers` below, which
-/// mirrors exactly where `cli/factory/mod.rs` applies the same fallback:
-/// AFTER cascade resolution, not inside it.
-fn strict_cli_from_project_config(project_config: Option<&std::path::Path>) -> bool {
-    project_config
-        .and_then(|p| p.parent())
-        .map(|cas_root| {
-            use crate::config::Config;
-            Config::load(cas_root)
-                .unwrap_or_default()
-                .factory()
-                .strict_cli
-        })
-        .unwrap_or(false)
-}
-
 fn spawn_specs_summary(specs: &[cas_mux::WorkerSpec], worker_names: &[String]) -> String {
     specs
         .iter()
@@ -898,6 +870,43 @@ fn format_undelivered_relay_section(
          (`task action=show id=<id>`) — a missing relay is not evidence the work was handled.\n\n",
     );
     out
+}
+
+/// Select launch records that can be stopped before their PTY has registered
+/// an Agent row. `id` accepts either the eventual worker name or the durable
+/// spawn-request id included in the launch receipt.
+fn select_launched_shutdown_targets(
+    launched_workers: &[cas_store::SpawnLifecycle],
+    requested_id: Option<&str>,
+    requested_names: &[String],
+    count: Option<i32>,
+) -> Vec<cas_store::SpawnLifecycle> {
+    if let Some(id) = requested_id {
+        launched_workers
+            .iter()
+            .filter(|spawn| spawn.worker_name.as_deref() == Some(id) || spawn.id.to_string() == id)
+            .cloned()
+            .collect()
+    } else if !requested_names.is_empty() {
+        launched_workers
+            .iter()
+            .filter(|spawn| {
+                spawn
+                    .worker_name
+                    .as_deref()
+                    .is_some_and(|name| requested_names.iter().any(|requested| requested == name))
+            })
+            .cloned()
+            .collect()
+    } else if count.unwrap_or(0) == 0 {
+        launched_workers.to_vec()
+    } else {
+        launched_workers
+            .iter()
+            .take(count.unwrap_or_default() as usize)
+            .cloned()
+            .collect()
+    }
 }
 
 fn format_spawn_lifecycle_section(
@@ -1699,35 +1708,12 @@ impl CasService {
                 .collect()
         };
 
-        let selected_launched: Vec<_> = if let Some(id) = requested_id {
-            // `id` accepts either the familiar worker id/name or the spawn
-            // request id printed in the launch receipt.
-            launched_workers
-                .iter()
-                .filter(|spawn| {
-                    spawn.worker_name.as_deref() == Some(id) || spawn.id.to_string() == id
-                })
-                .cloned()
-                .collect()
-        } else if !requested_names.is_empty() {
-            launched_workers
-                .iter()
-                .filter(|spawn| {
-                    spawn.worker_name.as_deref().is_some_and(|name| {
-                        requested_names.iter().any(|requested| requested == name)
-                    })
-                })
-                .cloned()
-                .collect()
-        } else if req.count.unwrap_or(0) == 0 {
-            launched_workers.clone()
-        } else {
-            launched_workers
-                .iter()
-                .take(req.count.unwrap_or_default() as usize)
-                .cloned()
-                .collect()
-        };
+        let selected_launched = select_launched_shutdown_targets(
+            &launched_workers,
+            requested_id,
+            &requested_names,
+            req.count,
+        );
         let selected_launched_names: Vec<String> = selected_launched
             .iter()
             .filter_map(|spawn| spawn.worker_name.clone())
@@ -7979,6 +7965,24 @@ mod spawn_lifecycle_tests {
         format_spawn_lifecycle_section(rows, chrono::Utc::now())
     }
 
+    #[test]
+    fn launched_pty_can_be_shutdown_by_name_or_spawn_request_id_before_registration() {
+        let launched = vec![row(
+            491,
+            Some("kind-dragon-90"),
+            SpawnLifecycleState::Launched,
+            2,
+            None,
+        )];
+
+        let by_name =
+            select_launched_shutdown_targets(&launched, Some("kind-dragon-90"), &[], None);
+        let by_request_id = select_launched_shutdown_targets(&launched, Some("491"), &[], None);
+
+        assert_eq!(by_name[0].worker_name.as_deref(), Some("kind-dragon-90"));
+        assert_eq!(by_request_id[0].id, 491);
+    }
+
     fn lost_relay(task_summary: &str) -> cas_store::UndeliveredLifecycleRelay {
         cas_store::UndeliveredLifecycleRelay {
             prompt_id: 7783,
@@ -9054,38 +9058,6 @@ effort = "high"
         assert_eq!(spec.model.as_deref(), Some("opus"));
         assert_eq!(spec.effort, Some(cas_mux::Effort::High));
         assert!(warning.contains("frontier-tier"), "{warning}");
-    }
-
-    // cas-7199 / cas-a487: `strict_cli_from_project_config` tests.
-
-    #[test]
-    fn strict_cli_from_project_config_true_when_set() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(
-            tmp.path().join("config.toml"),
-            "[factory]\nstrict_cli = true\n",
-        )
-        .unwrap();
-        assert!(strict_cli_from_project_config(Some(
-            &tmp.path().join("config.toml")
-        )));
-    }
-
-    #[test]
-    fn strict_cli_from_project_config_false_by_default() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(tmp.path().join("config.toml"), "[factory]\n").unwrap();
-        assert!(!strict_cli_from_project_config(Some(
-            &tmp.path().join("config.toml")
-        )));
-    }
-
-    #[test]
-    fn strict_cli_from_project_config_false_when_missing_or_none() {
-        assert!(!strict_cli_from_project_config(None));
-        assert!(!strict_cli_from_project_config(Some(
-            &std::path::PathBuf::from("/tmp/cas-7199-definitely-missing/config.toml")
-        )));
     }
 
     /// Run the real unavailable-Codex probe in a dedicated process. PATH is

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -1749,7 +1749,7 @@ impl CasService {
                         .any(|worker| worker.name.as_str() == name.as_str())
                         && !selected_launched_names
                             .iter()
-                            .any(|launched| launched == name)
+                            .any(|launched| launched == *name)
                 })
                 .cloned()
                 .collect()
@@ -2547,6 +2547,14 @@ impl CasService {
                             .then(|| transcript_path_fast(clone_path.as_deref(), session_uuid))
                             .flatten()
                     });
+                // A Codex MCP server can keep the registry heartbeat fresh
+                // after the interactive harness has terminally rejected every
+                // turn for exhausted account credits. Prefer the harness's
+                // own terminal record over that process-only heartbeat.
+                let usage_limited = codex_rollout_reports_usage_limit(
+                    transcript_path_for_worker.as_deref(),
+                    worker_cli,
+                );
                 // cas-4fb9 / cas-71d9: checkpoint/heartbeat freshness cannot
                 // answer whether the harness actually started a turn. Render
                 // the harness's own artifact-backed turn observation
@@ -2872,7 +2880,11 @@ impl CasService {
                     "  • {} (heartbeat: {}){}{}{}{}{}{}{}{}{}{}{}{}{}{}\n    session: {}\n",
                     &agent.name,
                     since,
-                    liveness_label,
+                    if usage_limited {
+                        " [UNAVAILABLE: Codex usage limit]"
+                    } else {
+                        liveness_label
+                    },
                     held_label,
                     clone_info,
                     git_info,
@@ -6867,6 +6879,43 @@ pub(crate) fn default_codex_sessions_dir() -> Option<std::path::PathBuf> {
     dirs::home_dir().map(|h| h.join(".codex").join("sessions"))
 }
 
+/// Whether a resolved Codex rollout records the terminal account-limit failure
+/// that leaves its MCP child heartbeating while no harness turn can proceed.
+///
+/// This intentionally requires the exact user-facing terminal error and the
+/// machine-readable exhausted-credit state in the same bounded tail. A generic
+/// error, an old rate-limit record, or an unresolved rollout is not enough to
+/// declare a live worker unavailable.
+fn codex_rollout_reports_usage_limit(
+    rollout: Option<&std::path::Path>,
+    cli: cas_mux::SupervisorCli,
+) -> bool {
+    if cli != cas_mux::SupervisorCli::Codex {
+        return false;
+    }
+    let Some(rollout) = rollout else {
+        return false;
+    };
+    let Ok(metadata) = std::fs::metadata(rollout) else {
+        return false;
+    };
+    const TAIL_BYTES: u64 = 256 * 1024;
+    let start = metadata.len().saturating_sub(TAIL_BYTES);
+    let Ok(mut file) = std::fs::File::open(rollout) else {
+        return false;
+    };
+    use std::io::{Read, Seek, SeekFrom};
+    if file.seek(SeekFrom::Start(start)).is_err() {
+        return false;
+    }
+    let mut tail = String::new();
+    if file.read_to_string(&mut tail).is_err() {
+        return false;
+    }
+    tail.contains("You've hit your usage limit")
+        && (tail.contains("\"has_credits\":false") || tail.contains("\"has_credits\": false"))
+}
+
 fn synthesized_codex_transcript_path(clone_path: &str, session_id: &str) -> String {
     format!(
         "~/.codex/sessions/<YYYY/MM/DD>/rollout-*-*.jsonl (cwd={clone_path}; cas_session={session_id})"
@@ -8347,6 +8396,24 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         std::fs::write(temp.path().join("auth.json"), "{}").unwrap();
         preflight_codex_config_dir(temp.path().to_str().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn codex_usage_limit_rollout_overrides_a_healthy_heartbeat_claim() {
+        let rollout = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            rollout.path(),
+            r#"{"type":"event_msg","payload":{"type":"task_complete","error":"You've hit your usage limit","rate_limits":{"credits":{"has_credits":false}}}}"#,
+        )
+        .unwrap();
+        assert!(codex_rollout_reports_usage_limit(
+            Some(rollout.path()),
+            cas_mux::SupervisorCli::Codex
+        ));
+        assert!(!codex_rollout_reports_usage_limit(
+            Some(rollout.path()),
+            cas_mux::SupervisorCli::Claude
+        ));
     }
 
     /// cas-4a5e: a typo'd/missing codex config_dir must fail with a message

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -1110,9 +1110,20 @@ async fn test_spawn_workers_requires_epic() {
     );
 }
 
+#[test]
+fn test_spawn_workers_enqueues_with_epic() {
+    run_isolated_codex_test(
+        "test_spawn_workers_enqueues_with_epic_in_isolated_child",
+        IsolatedCodexState::Available,
+    );
+}
+
 #[tokio::test]
-async fn test_spawn_workers_enqueues_with_epic() {
-    let env = FactoryTestEnv::new();
+#[ignore = "subprocess helper for deterministic available-Codex probe"]
+async fn test_spawn_workers_enqueues_with_epic_in_isolated_child() {
+    let env = factory_env_in_isolated_codex_child(
+        "test_spawn_workers_enqueues_with_epic_in_isolated_child",
+    );
     env.create_epic("Test Epic");
 
     let mut req = factory_req("spawn_workers");
@@ -1174,9 +1185,20 @@ async fn test_spawn_workers_isolate_flag_in_isolated_child() {
 /// follow-on task must be spawnable without inventing a ceremonial
 /// single-child epic. The epic gate exists to stop *unscoped* spawning; a
 /// concrete open task_id already states the work.
+#[test]
+fn test_spawn_workers_with_task_id_succeeds_after_epic_closed() {
+    run_isolated_codex_test(
+        "test_spawn_workers_with_task_id_succeeds_after_epic_closed_in_isolated_child",
+        IsolatedCodexState::Available,
+    );
+}
+
 #[tokio::test]
-async fn test_spawn_workers_with_task_id_succeeds_after_epic_closed() {
-    let env = FactoryTestEnv::new();
+#[ignore = "subprocess helper for deterministic available-Codex probe"]
+async fn test_spawn_workers_with_task_id_succeeds_after_epic_closed_in_isolated_child() {
+    let env = factory_env_in_isolated_codex_child(
+        "test_spawn_workers_with_task_id_succeeds_after_epic_closed_in_isolated_child",
+    );
     let task_store = env.task_store();
 
     // The exact reported sequence: an epic existed, was completed, and closed.
@@ -1223,6 +1245,7 @@ async fn test_spawn_workers_with_task_id_succeeds_with_no_epic_at_all() {
     let mut req = factory_req("spawn_workers");
     req.worker_names = Some("swift-fox".to_string());
     req.task_id = Some(task_id.clone());
+    req.cli = Some("claude".to_string());
 
     let result = env.service.factory(Parameters(req)).await;
     assert!(
@@ -1309,14 +1332,25 @@ async fn test_spawn_workers_undispatchable_task_id_is_rejected_without_epic() {
 /// cas-549c review follow-up: the SAME statuses must still be accepted when
 /// an epic is open — the tightening only ever withholds the epic bypass, it
 /// must not change pre-assignment rules for an epic-backed factory.
+#[test]
+fn test_undispatchable_task_id_still_allowed_when_an_epic_is_open() {
+    run_isolated_codex_test(
+        "test_undispatchable_task_id_still_allowed_when_an_epic_is_open_in_isolated_child",
+        IsolatedCodexState::Available,
+    );
+}
+
 #[tokio::test]
-async fn test_undispatchable_task_id_still_allowed_when_an_epic_is_open() {
+#[ignore = "subprocess helper for deterministic available-Codex probe"]
+async fn test_undispatchable_task_id_still_allowed_when_an_epic_is_open_in_isolated_child() {
     for (status, assignee) in [
         (TaskStatus::AwaitingMerge, None),
         (TaskStatus::Open, Some("alpha")),
         (TaskStatus::InProgress, Some("alpha")),
     ] {
-        let env = FactoryTestEnv::new();
+        let env = factory_env_in_isolated_codex_child(
+            "test_undispatchable_task_id_still_allowed_when_an_epic_is_open_in_isolated_child",
+        );
         env.create_epic("Live Epic");
         let task_store = env.task_store();
         let id = task_store.generate_id().expect("generate_id");
@@ -1352,6 +1386,7 @@ async fn test_task_id_authorizes_only_one_epic_free_spawn() {
     let mut first = factory_req("spawn_workers");
     first.count = Some(1);
     first.task_id = Some(task_id.clone());
+    first.cli = Some("claude".to_string());
     env.service
         .factory(Parameters(first))
         .await
@@ -1464,6 +1499,7 @@ async fn test_spawn_workers_task_id_enqueues_for_single_worker() {
     let mut req = factory_req("spawn_workers");
     req.count = Some(1);
     req.task_id = Some(task_id.clone());
+    req.cli = Some("claude".to_string());
 
     let result = env.service.factory(Parameters(req)).await;
     assert!(
@@ -1497,6 +1533,7 @@ async fn test_spawn_workers_task_id_accepts_stale_assignee_for_reset_preassign()
 
     let mut req = factory_req("spawn_workers");
     req.task_id = Some(task_id.clone());
+    req.cli = Some("claude".to_string());
     let text = get_text(
         &env.service
             .factory(Parameters(req))
@@ -1551,6 +1588,7 @@ async fn test_spawn_workers_task_id_enqueues_for_single_named_worker() {
     let mut req = factory_req("spawn_workers");
     req.worker_names = Some("swift-fox".to_string());
     req.task_id = Some(task_id.clone());
+    req.cli = Some("claude".to_string());
 
     let result = env.service.factory(Parameters(req)).await;
     assert!(
@@ -1739,21 +1777,21 @@ async fn test_spawn_workers_codex_available_enqueues_codex_spec_in_isolated_chil
 }
 
 #[test]
-fn test_spawn_workers_codex_unavailable_falls_back_to_claude() {
+fn test_spawn_workers_codex_unavailable_fails_loudly() {
     run_isolated_codex_test(
-        "test_spawn_workers_codex_unavailable_falls_back_to_claude_in_isolated_child",
+        "test_spawn_workers_codex_unavailable_fails_loudly_in_isolated_child",
         IsolatedCodexState::Unavailable,
     );
 }
 
 #[tokio::test]
 #[ignore = "subprocess helper for deterministic unavailable-Codex probe"]
-async fn test_spawn_workers_codex_unavailable_falls_back_to_claude_in_isolated_child() {
+async fn test_spawn_workers_codex_unavailable_fails_loudly_in_isolated_child() {
     // The child removes BOTH independent availability signals: PATH has no
     // codex executable and temp HOME has no auth marker. This deliberately
     // exercises the real public probe + fallback composition.
     let env = factory_env_in_isolated_codex_child(
-        "test_spawn_workers_codex_unavailable_falls_back_to_claude_in_isolated_child",
+        "test_spawn_workers_codex_unavailable_fails_loudly_in_isolated_child",
     );
     env.create_epic("Test Epic");
 
@@ -1773,25 +1811,18 @@ async fn test_spawn_workers_codex_unavailable_falls_back_to_claude_in_isolated_c
     req.count = Some(1);
     req.cli = Some("codex".to_string());
 
-    let result = env
+    let error = env
         .service
         .factory(Parameters(req))
         .await
-        .expect("non-strict unavailable Codex should fall back");
-    let text = get_text(&result);
+        .expect_err("unavailable Codex must refuse rather than substitute Claude");
     assert!(
-        text.contains("codex unavailable") && text.contains("falling back to claude"),
-        "caller must see the fallback reason: {text}"
+        error.message.contains("codex is unavailable")
+            && error.message.contains("refusing to silently fall back"),
+        "caller must see the loud refusal: {}",
+        error.message
     );
-
-    let entries = env.spawn_queue().peek(10).expect("peek");
-    assert_eq!(entries.len(), 1, "should have one queue entry");
-    let spec_json = entries[0]
-        .worker_spec
-        .as_deref()
-        .expect("fallback spawn must queue a concrete worker spec");
-    let spec: cas_mux::WorkerSpec = serde_json::from_str(spec_json).expect("valid WorkerSpec");
-    assert_eq!(spec.cli, cas_mux::SupervisorCli::Claude);
+    assert!(env.spawn_queue().peek(10).expect("peek").is_empty());
 }
 
 #[tokio::test]
@@ -4632,6 +4663,7 @@ async fn test_spawn_then_shutdown_sequence() {
     // Spawn
     let mut req = factory_req("spawn_workers");
     req.count = Some(2);
+    req.cli = Some("claude".to_string());
     let result = env.service.factory(Parameters(req)).await;
     assert!(result.is_ok());
 

--- a/crates/cas-mux/src/backend/codex.rs
+++ b/crates/cas-mux/src/backend/codex.rs
@@ -142,30 +142,22 @@ mod tests {
         let home = root.join("alt-home");
         std::fs::create_dir_all(&worktree).unwrap();
         std::fs::create_dir_all(&home).unwrap();
-        std::fs::write(home.join("hooks.json"), "{\"hooks\":{}}").unwrap();
+        std::fs::write(
+            home.join("hooks.json"),
+            r#"{"hooks":{"PreToolUse":[{"matcher":"^Bash$","hooks":[{"type":"command","command":"CAS_HOOK_HARNESS=codex cas hook PreToolUse"}]}],"PostToolUse":[{"matcher":"^Bash$","hooks":[{"type":"command","command":"cas hook PostToolUse"}]}]}}"#,
+        )
+        .unwrap();
 
         CODEX
             .prepare_workdir(&worktree, Some(home.to_str().unwrap()))
             .unwrap();
 
-        let config: toml::Value =
-            toml::from_str(&std::fs::read_to_string(home.join("config.toml")).unwrap()).unwrap();
-        let project = worktree.to_string_lossy().to_string();
-        assert_eq!(
-            config["projects"][&project]["trust_level"].as_str(),
-            Some("trusted")
-        );
+        let config = std::fs::read_to_string(home.join("config.toml")).unwrap();
+        assert!(config.contains("trust_level = \"trusted\""));
         let hooks = home.join("hooks.json").to_string_lossy().to_string();
-        assert!(
-            config["hooks"]["state"]
-                .get(format!("{hooks}:pre_tool_use:0:0"))
-                .is_some()
-        );
-        assert!(
-            config["hooks"]["state"]
-                .get(format!("{hooks}:post_tool_use:0:0"))
-                .is_some()
-        );
+        assert!(config.contains(&hooks));
+        assert!(config.contains(":pre_tool_use:0:0"));
+        assert!(config.contains(":post_tool_use:0:0"));
         std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/crates/cas-mux/src/backend/codex.rs
+++ b/crates/cas-mux/src/backend/codex.rs
@@ -77,15 +77,37 @@ impl Backend for Codex {
         config
     }
 
-    fn prepare_workdir(&self, cwd: &Path) -> Result<()> {
-        match cas_pty::ensure_project_trusted(cwd)? {
-            cas_pty::CodexTrustOutcome::Added(_) | cas_pty::CodexTrustOutcome::AlreadyPresent => {
-                Ok(())
+    fn prepare_workdir(&self, cwd: &Path, config_dir: Option<&str>) -> Result<()> {
+        // A per-worker CODEX_HOME is only installed in the child environment
+        // below. Trust must therefore target that explicit home here, before
+        // the CLI starts; consulting the daemon's own home leaves alternate
+        // accounts at Codex's interactive hooks-review prompt.
+        let trust = match config_dir.filter(|dir| !dir.trim().is_empty()) {
+            Some(home) => {
+                let config = Path::new(home).join("config.toml");
+                match cas_pty::ensure_project_trusted_in(&config, cwd)? {
+                    cas_pty::CodexTrustOutcome::Added(_)
+                    | cas_pty::CodexTrustOutcome::AlreadyPresent => {
+                        cas_pty::ensure_cas_hooks_trusted_in(
+                            &config,
+                            &Path::new(home).join("hooks.json"),
+                        )?;
+                        Ok(())
+                    }
+                    cas_pty::CodexTrustOutcome::Skipped(reason) => Err(Error::pty(format!(
+                        "refusing to launch Codex before its project trust is verified: {reason}"
+                    ))),
+                }
             }
-            cas_pty::CodexTrustOutcome::Skipped(reason) => Err(Error::pty(format!(
-                "refusing to launch Codex before its project trust is verified: {reason}"
-            ))),
-        }
+            None => match cas_pty::ensure_project_trusted(cwd)? {
+                cas_pty::CodexTrustOutcome::Added(_)
+                | cas_pty::CodexTrustOutcome::AlreadyPresent => Ok(()),
+                cas_pty::CodexTrustOutcome::Skipped(reason) => Err(Error::pty(format!(
+                    "refusing to launch Codex before its project trust is verified: {reason}"
+                ))),
+            },
+        };
+        trust
     }
 
     fn push_factory_session(&self, config: &mut PtyConfig, session: &str) {
@@ -99,5 +121,51 @@ impl Backend for Codex {
 
     fn turn_cancel_bytes(&self) -> &'static [u8] {
         &[0x1b]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Backend, CODEX};
+
+    #[test]
+    fn alternate_codex_home_trusts_project_and_home_hook_paths() {
+        let root = std::env::temp_dir().join(format!(
+            "cas-mux-alt-codex-home-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let worktree = root.join("worktree");
+        let home = root.join("alt-home");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(home.join("hooks.json"), "{\"hooks\":{}}").unwrap();
+
+        CODEX
+            .prepare_workdir(&worktree, Some(home.to_str().unwrap()))
+            .unwrap();
+
+        let config: toml::Value =
+            toml::from_str(&std::fs::read_to_string(home.join("config.toml")).unwrap()).unwrap();
+        let project = worktree.to_string_lossy().to_string();
+        assert_eq!(
+            config["projects"][&project]["trust_level"].as_str(),
+            Some("trusted")
+        );
+        let hooks = home.join("hooks.json").to_string_lossy().to_string();
+        assert!(
+            config["hooks"]["state"]
+                .get(format!("{hooks}:pre_tool_use:0:0"))
+                .is_some()
+        );
+        assert!(
+            config["hooks"]["state"]
+                .get(format!("{hooks}:post_tool_use:0:0"))
+                .is_some()
+        );
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/crates/cas-mux/src/backend/mod.rs
+++ b/crates/cas-mux/src/backend/mod.rs
@@ -62,7 +62,7 @@ pub trait Backend: Sync {
     fn build_supervisor_config(&self, launch: SupervisorLaunchConfig<'_>) -> PtyConfig;
 
     /// Complete any backend-specific launch precondition before spawning.
-    fn prepare_workdir(&self, _cwd: &Path) -> Result<()> {
+    fn prepare_workdir(&self, _cwd: &Path, _config_dir: Option<&str>) -> Result<()> {
         Ok(())
     }
 

--- a/crates/cas-mux/src/pane/mod.rs
+++ b/crates/cas-mux/src/pane/mod.rs
@@ -362,7 +362,7 @@ impl Pane {
         factory_session: Option<&str>,
         active_workers: Option<usize>,
     ) -> Result<Self> {
-        cli.backend().prepare_workdir(&cwd)?;
+        cli.backend().prepare_workdir(&cwd, config_dir)?;
         let mut config = Self::build_worker_config(
             name,
             cwd,
@@ -429,7 +429,7 @@ impl Pane {
         teams: Option<&TeamsSpawnConfig>,
         factory_session: Option<&str>,
     ) -> Result<Self> {
-        cli.backend().prepare_workdir(&cwd)?;
+        cli.backend().prepare_workdir(&cwd, None)?;
         let mut config = Self::build_supervisor_config(
             name,
             cwd,


### PR DESCRIPTION
## Delivered\n\n- #492: Codex workers fail loudly when unavailable; no Claude substitution.\n- #493: shutdown accepts launched, pre-registration PTYs by worker name or spawn request ID.\n- #494: alternate CODEX_HOME trusts both the worktree and that home’s generated hooks.\n- #496: a terminal Codex usage-limit rollout with exhausted credits reports UNAVAILABLE instead of a healthy heartbeat.\n\n## Validation\n\n- cargo check -p cas --lib --tests\n- cargo test -p cas-mux --lib alternate_codex_home_trusts_project_and_home_hook_paths\n- scripts/run-scoped-tests.sh -p cas --lib codex_usage_limit_rollout_overrides_a_healthy_heartbeat_claim (1 passed)\n\nRefs #492 #493 #494 #496\n\nTask: cas-a636