### PR TITLE
fix: surface absent Viktor upstream

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/codex/skills/cas-viktor/references/gateway.md
@@ -17,6 +17,12 @@ The managed policy admits exactly these conversation tools:
 If `.cas/proxy.toml` exists, it opts out of the managed default. It must explicitly configure
 the required Viktor server and routes; the managed user configuration never widens a project.
 
+If `server:viktor` discovery reports that the upstream is absent, do not treat that as an empty
+tool catalog or retry a run-starting call. Run `cas viktor` for the credential-safe connection
+state and durable pending run IDs. On daemon restart, Cassy alerts a live session supervisor when
+such watches cannot be polled; restore `VIKTOR_API_KEY` to `cas serve` and let the existing watch
+resume rather than starting a replacement run.
+
 ## Conversation flow
 
 Use `mcp_search` with `server:viktor` before relying on a tool, then call an advertised,

--- a/cas-cli/src/builtins/grok/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/grok/skills/cas-viktor/references/gateway.md
@@ -17,6 +17,12 @@ The managed policy admits exactly these conversation tools:
 If `.cas/proxy.toml` exists, it opts out of the managed default. It must explicitly configure
 the required Viktor server and routes; the managed user configuration never widens a project.
 
+If `server:viktor` discovery reports that the upstream is absent, do not treat that as an empty
+tool catalog or retry a run-starting call. Run `cas viktor` for the credential-safe connection
+state and durable pending run IDs. On daemon restart, Cassy alerts a live session supervisor when
+such watches cannot be polled; restore `VIKTOR_API_KEY` to `cas serve` and let the existing watch
+resume rather than starting a replacement run.
+
 ## Conversation flow
 
 Use `mcp_search` with `server:viktor` before relying on a tool, then call an advertised,

--- a/cas-cli/src/builtins/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/skills/cas-viktor/references/gateway.md
@@ -17,6 +17,12 @@ The managed policy admits exactly these conversation tools:
 If `.cas/proxy.toml` exists, it opts out of the managed default. It must explicitly configure
 the required Viktor server and routes; the managed user configuration never widens a project.
 
+If `server:viktor` discovery reports that the upstream is absent, do not treat that as an empty
+tool catalog or retry a run-starting call. Run `cas viktor` for the credential-safe connection
+state and durable pending run IDs. On daemon restart, Cassy alerts a live session supervisor when
+such watches cannot be polled; restore `VIKTOR_API_KEY` to `cas serve` and let the existing watch
+resume rather than starting a replacement run.
+
 ## Conversation flow
 
 Use `mcp_search` with `server:viktor` before relying on a tool, then call an advertised,

--- a/cas-cli/src/cli/viktor.rs
+++ b/cas-cli/src/cli/viktor.rs
@@ -19,6 +19,9 @@ struct ViktorReport {
     project_policy: &'static str,
     startup_action: &'static str,
     reply_delivery: &'static str,
+    upstream_status: String,
+    watched_runs_pending: usize,
+    pending_run_ids: Vec<String>,
 }
 
 /// Print the configuration contract without reading or displaying the API key.
@@ -35,6 +38,36 @@ pub fn execute(_args: &ViktorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow
         .map(|root| root.join("proxy.toml"))
         .filter(|path| path.exists())
         .map(|path| path.display().to_string());
+    let watches = cas_root
+        .and_then(|root| cas_store::SqliteViktorWatchStore::open(root).ok())
+        .and_then(|store| store.list_live().ok())
+        .unwrap_or_default();
+    #[cfg(feature = "mcp-proxy")]
+    let upstream_status = cas_root
+        .and_then(|root| crate::mcp::read_proxy_health_cache(root).ok())
+        .and_then(|bytes| serde_json::from_slice::<cmcp_core::ProxyHealthSnapshot>(&bytes).ok())
+        .and_then(|snapshot| {
+            snapshot
+                .servers
+                .into_iter()
+                .find(|server| server.name.eq_ignore_ascii_case("viktor"))
+        })
+        .map(|server| {
+            if server.state == cmcp_core::UpstreamState::Healthy {
+                "connected".to_string()
+            } else {
+                format!(
+                    "upstream absent ({:?}; {})",
+                    server.state,
+                    server
+                        .last_error_code
+                        .unwrap_or_else(|| "unknown".to_string())
+                )
+            }
+        })
+        .unwrap_or_else(|| "not observed by this project daemon".to_string());
+    #[cfg(not(feature = "mcp-proxy"))]
+    let upstream_status = "requires mcp-proxy feature".to_string();
     let report = ViktorReport {
         credential_env: "VIKTOR_API_KEY",
         credential_present: std::env::var_os("VIKTOR_API_KEY").is_some(),
@@ -42,7 +75,10 @@ pub fn execute(_args: &ViktorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow
         project_config,
         project_policy: "an existing .cas/proxy.toml opts out of the managed Viktor default; explicitly configure the sanctioned Viktor server and routes before direct calls",
         startup_action: "run cas serve without a project proxy config; startup refreshes the credential-reference-only managed Viktor upstream",
-        reply_delivery: "run-starting calls are watched by CAS; replies arrive as inbound notifications (origin=viktor), so agents must not poll",
+        reply_delivery: "run-starting calls are durably watched by CAS; replies arrive as inbound notifications (origin=viktor), and a disconnected upstream surfaces pending run IDs instead of silently dropping them",
+        upstream_status,
+        watched_runs_pending: watches.len(),
+        pending_run_ids: watches.into_iter().map(|watch| watch.run_id).collect(),
     };
 
     if cli.json {
@@ -67,6 +103,16 @@ pub fn execute(_args: &ViktorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow
                 .unwrap_or("none; managed user policy applies")
         );
         println!("  start: {}", report.startup_action);
+        println!("  upstream: {}", report.upstream_status);
+        println!(
+            "  watched runs pending: {}{}",
+            report.watched_runs_pending,
+            if report.pending_run_ids.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", report.pending_run_ids.join(", "))
+            }
+        );
         println!("  replies: {}", report.reply_delivery);
     }
     Ok(())

--- a/cas-cli/src/hooks/handlers/handlers_session.rs
+++ b/cas-cli/src/hooks/handlers/handlers_session.rs
@@ -204,6 +204,11 @@ pub fn handle_session_start(
         assembler.append_protected(warning);
     }
 
+    #[cfg(feature = "mcp-proxy")]
+    if let Some(warning) = crate::mcp::viktor_watch::session_start_warning(cas_root) {
+        assembler.prepend_degradable(warning.clone(), warning);
+    }
+
     // Planning is a shared write surface: two live supervisors can otherwise
     // decompose the same epic before either sees the other's task set. Put
     // this at the protected top of supervisor context so it survives the

--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -359,6 +359,14 @@ async fn run_server_impl() -> anyhow::Result<()> {
                         {
                             eprintln!("[Cassy] Failed to publish MCP proxy state: {error}");
                         }
+                        if let Err(error) =
+                            crate::mcp::viktor_watch::alert_unpollable_watches(&cas_root, &engine)
+                                .await
+                        {
+                            eprintln!(
+                                "[Cassy] Failed to surface unpollable Viktor watches: {error}"
+                            );
+                        }
                         Some(std::sync::Arc::new(engine))
                     }
                     Err(e) => {

--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -1326,14 +1326,14 @@ mod tests {
             .await
             .unwrap_err()
             .to_string();
-        assert!(ordinary.contains("server 'github' not connected"));
+        assert!(ordinary.contains("MCP upstream 'github' is absent: it is configured but not connected"));
         assert!(!ordinary.contains("proxy policy denied"));
         let delegated = engine
             .call_external_production_verification_tool(&caller, "viktor", "ask_viktor", None)
             .await
             .unwrap_err()
             .to_string();
-        assert!(delegated.contains("server 'viktor' not connected"));
+        assert!(delegated.contains("MCP upstream 'viktor' is absent: it is configured but not connected"));
         assert!(!delegated.contains("proxy policy denied"));
 
         let audit = engine.policy_audit();

--- a/cas-cli/src/mcp/viktor_watch.rs
+++ b/cas-cli/src/mcp/viktor_watch.rs
@@ -28,6 +28,113 @@ pub(crate) struct ViktorWatchRecorder {
     cas_root: PathBuf,
 }
 
+/// Surface a restart that left the managed Viktor upstream disconnected before
+/// a pending watch silently retries forever. The queue receipt is keyed by the
+/// exact durable watch set, so another daemon restart cannot spam a supervisor
+/// while a newly-recorded run still produces a fresh alert.
+pub(crate) async fn alert_unpollable_watches(
+    cas_root: &Path,
+    proxy: &cmcp_core::ProxyEngine,
+) -> Result<usize, String> {
+    if proxy.upstream_connected("viktor").await {
+        return Ok(0);
+    }
+    let store = SqliteViktorWatchStore::open(cas_root).map_err(|error| error.to_string())?;
+    let watches = store.list_live().map_err(|error| error.to_string())?;
+    if watches.is_empty() {
+        return Ok(0);
+    }
+
+    let agents = crate::store::open_agent_store(cas_root).map_err(|error| error.to_string())?;
+    let live_agents = agents.list(None).map_err(|error| error.to_string())?;
+    let mut delivered = 0;
+    for supervisor in live_agents.into_iter().filter(|agent| {
+        matches!(agent.role, AgentRole::Supervisor | AgentRole::Director)
+            && matches!(agent.status, AgentStatus::Active | AgentStatus::Idle)
+    }) {
+        let run_ids: Vec<&str> = watches
+            .iter()
+            .filter(|watch| {
+                watch.factory_session.is_none()
+                    || watch.factory_session == supervisor.factory_session
+            })
+            .map(|watch| watch.run_id.as_str())
+            .collect();
+        if run_ids.is_empty() {
+            continue;
+        }
+        let run_ids_text = run_ids.join(", ");
+        let prompt = format!(
+            "<viktor-upstream-absent runs=\"{}\">\nViktor upstream is absent after daemon startup. {} watched run(s) cannot be polled until VIKTOR_API_KEY is available to cas serve and the daemon reconnects. Run IDs: {}.\n</viktor-upstream-absent>",
+            run_ids_text,
+            run_ids.len(),
+            run_ids_text,
+        );
+        let queue = SqlitePromptQueueStore::open(cas_root).map_err(|error| error.to_string())?;
+        queue.init().map_err(|error| error.to_string())?;
+        let receipt = format!(
+            "viktor-upstream-absent:{}:{}",
+            supervisor.id,
+            run_ids.join(",")
+        );
+        queue
+            .enqueue_idempotent(
+                "viktor",
+                &supervisor.name,
+                &prompt,
+                supervisor.factory_session.as_deref(),
+                Some(&format!(
+                    "Viktor upstream absent — {} watched run(s) unpollable",
+                    run_ids.len()
+                )),
+                Some(cas_store::NotificationPriority::High),
+                &receipt,
+            )
+            .map_err(|error| error.to_string())?;
+        delivered += 1;
+    }
+    Ok(delivered)
+}
+
+/// A bounded session-start warning derived from the same durable records that
+/// drive daemon polling. This remains visible even when no supervisor was live
+/// at daemon startup to receive the queue notification.
+pub(crate) fn session_start_warning(cas_root: &Path) -> Option<String> {
+    let health = crate::mcp::read_proxy_health_cache(cas_root).ok()?;
+    let snapshot: cmcp_core::ProxyHealthSnapshot = serde_json::from_slice(&health).ok()?;
+    let absent = snapshot
+        .servers
+        .iter()
+        .find(|server| server.name.eq_ignore_ascii_case("viktor"))
+        .filter(|server| server.state != cmcp_core::UpstreamState::Healthy)?;
+    let watches = SqliteViktorWatchStore::open(cas_root)
+        .ok()
+        .and_then(|store| store.list_live().ok())
+        .unwrap_or_default();
+    let run_ids = watches
+        .iter()
+        .take(8)
+        .map(|watch| watch.run_id.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let watch_detail = if watches.is_empty() {
+        "No watched runs are pending.".to_string()
+    } else {
+        format!(
+            "{} watched run(s) are unpollable: {}{}.",
+            watches.len(),
+            run_ids,
+            if watches.len() > 8 { ", …" } else { "" }
+        )
+    };
+    Some(format!(
+        "⚠ Viktor upstream absent ({:?}; {}). {} Restore VIKTOR_API_KEY to the cas serve process, then restart or wait for proxy reconnect; run `cas viktor` for durable watch status.",
+        absent.state,
+        absent.last_error_code.as_deref().unwrap_or("unknown"),
+        watch_detail
+    ))
+}
+
 impl ViktorWatchRecorder {
     pub(crate) fn new(cas_root: PathBuf) -> Self {
         Self { cas_root }
@@ -501,4 +608,71 @@ mod tests {
         engine.shutdown().await;
     }
 
+    #[tokio::test]
+    async fn restart_with_absent_viktor_notifies_supervisor_with_durable_run_ids() {
+        let temp = tempfile::tempdir().unwrap();
+        let agents = crate::store::open_agent_store(temp.path()).unwrap();
+        let mut supervisor = Agent::new_with_role(
+            "supervisor-session".to_string(),
+            "supervisor".to_string(),
+            AgentRole::Supervisor,
+        );
+        supervisor.factory_session = Some("factory-1".to_string());
+        agents.register(&supervisor).unwrap();
+
+        // This record stands in for the previous daemon's successful
+        // run-starting call. It must survive the replacement daemon even when
+        // that daemon has no credential with which to reconnect Viktor.
+        let watch_store = SqliteViktorWatchStore::open(temp.path()).unwrap();
+        watch_store
+            .record(
+                "thread-before-restart",
+                "run-before-restart",
+                "worker-session",
+                "worker-1",
+                "worker",
+                Some("factory-1"),
+                Some("cas-fixture"),
+                None,
+                cas_store::DEFAULT_VIKTOR_WATCH_TTL_SECS,
+            )
+            .unwrap();
+
+        let replacement = cmcp_core::ProxyEngine::from_configs(HashMap::from([(
+            "viktor".to_string(),
+            cmcp_core::config::ServerConfig::Http {
+                url: "https://example.invalid/mcp".to_string(),
+                auth: Some("env:CAS_TEST_MISSING_VIKTOR_KEY_8563".to_string()),
+                headers: HashMap::new(),
+                oauth: false,
+            },
+        )]))
+        .await
+        .unwrap();
+        assert!(!replacement.upstream_connected("viktor").await);
+
+        assert_eq!(
+            alert_unpollable_watches(temp.path(), &replacement)
+                .await
+                .unwrap(),
+            1
+        );
+        // The receipt is restart-idempotent: the same durable run does not
+        // create a second high-priority alert every time the daemon starts.
+        assert_eq!(
+            alert_unpollable_watches(temp.path(), &replacement)
+                .await
+                .unwrap(),
+            1
+        );
+        let queue = SqlitePromptQueueStore::open(temp.path()).unwrap();
+        queue.init().unwrap();
+        let messages = queue.poll_for_target("supervisor", 10).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].prompt.contains("Viktor upstream is absent"));
+        assert!(messages[0].prompt.contains("run-before-restart"));
+        assert_eq!(watch_store.list_live().unwrap().len(), 1);
+
+        replacement.shutdown().await;
+    }
 }

--- a/cas-cli/tests/mcp_proxy_test.rs
+++ b/cas-cli/tests/mcp_proxy_test.rs
@@ -217,7 +217,7 @@ tool = "list_issues"
         }),
     );
     let admitted_message = admitted["error"]["message"].as_str().unwrap();
-    assert!(admitted_message.contains("server 'github' not connected"));
+    assert!(admitted_message.contains("MCP upstream 'github' is absent: it is configured but not connected"));
     assert!(!admitted_message.contains("proxy policy denied"));
 }
 

--- a/crates/cas-mcp-proxy/README.md
+++ b/crates/cas-mcp-proxy/README.md
@@ -113,6 +113,10 @@ configuration and is never copied into tool arguments or model context.
 - **Server filter**: `server:github issue` filters to the `github` server first
 - **Empty query**: returns all tools
 
+An explicit `server:<name>` query for a configured upstream that is disconnected returns an
+`upstream ... is absent` error instead of an empty catalog. Inspect `proxy_health` and repair the
+credential or connection before retrying a run-starting call.
+
 ## Execute
 
 `ProxyEngine::execute(caller, code, max_length)` dispatches tool calls. The

--- a/crates/cas-mcp-proxy/src/lib.rs
+++ b/crates/cas-mcp-proxy/src/lib.rs
@@ -547,6 +547,31 @@ impl ProxyEngine {
         // Parse optional server: prefix
         let (server_filter, keywords) = parse_search_query(query);
 
+        // A configured upstream that failed to connect used to look exactly
+        // like an unknown server: `server:viktor` simply returned `[]`. That
+        // hides credential loss after a daemon restart and strands any
+        // durable work that relies on the upstream. Keep ordinary no-match
+        // searches empty, but make an explicitly selected, configured and
+        // disconnected server a visible gateway failure.
+        if let Some(filter) = server_filter.as_deref() {
+            let filter = filter.to_ascii_lowercase();
+            let unavailable = configs.keys().find(|name| {
+                public_servers
+                    .get(*name)
+                    .is_some_and(|public| public.to_ascii_lowercase() == filter)
+                    && !servers.contains_key(*name)
+            });
+            if let Some(name) = unavailable {
+                let public = public_servers
+                    .get(name)
+                    .cloned()
+                    .unwrap_or_else(|| public_upstream_id(name));
+                anyhow::bail!(
+                    "MCP upstream '{public}' is absent: it is configured but not connected; inspect proxy_health and restore its credential before retrying"
+                );
+            }
+        }
+
         let mut results: Vec<SearchResult> = Vec::new();
 
         for (server_name, connected) in servers.iter() {
@@ -678,6 +703,13 @@ impl ProxyEngine {
     pub async fn tool_count(&self) -> usize {
         let servers = self.servers.read().await;
         servers.values().map(|s| s.tools.len()).sum()
+    }
+
+    /// Whether a configured upstream has an active connection in this proxy
+    /// session. Callers use this only for explicit operator-facing recovery
+    /// paths; normal dispatch still goes through the policy and routing gates.
+    pub async fn upstream_connected(&self, server: &str) -> bool {
+        self.servers.read().await.contains_key(server)
     }
 
     /// Return catalog entries grouped by server name.
@@ -976,7 +1008,7 @@ impl ProxyEngine {
                 .collect();
             available.sort();
             format!(
-                "server '{}' not connected. Available: {}",
+                "MCP upstream '{}' is absent: it is configured but not connected; inspect proxy_health and restore its credential before retrying. Available: {}",
                 requested_public,
                 if available.is_empty() {
                     "(none)".to_string()
@@ -1730,6 +1762,46 @@ mod tests {
         assert!(!audit[0].allowed);
         assert_eq!(audit[0].server, "viktor-shadow");
         assert_eq!(audit[0].tool, "ask_viktor");
+    }
+
+    #[tokio::test]
+    async fn disconnected_configured_viktor_is_loud_in_search_and_execute() {
+        let config = ServerConfig::Http {
+            url: "https://example.invalid/mcp".to_string(),
+            auth: Some("env:CAS_TEST_MISSING_VIKTOR_KEY_8563".to_string()),
+            headers: HashMap::new(),
+            oauth: false,
+        };
+        let engine = ProxyEngine::from_configs(HashMap::from([("viktor".to_string(), config)]))
+            .await
+            .unwrap();
+        engine
+            .set_policy(Arc::new(ExternalToolAllowlistPolicy::new([
+                ExternalToolRoute::new("viktor", "ask_viktor"),
+            ])))
+            .await;
+
+        let search = engine.search("server:viktor", None).await.unwrap_err();
+        assert!(
+            search.to_string().contains("upstream 'viktor' is absent"),
+            "configured but disconnected discovery must not read as an empty catalog: {search}"
+        );
+        let execute = match engine
+            .execute(
+                &registered_worker_caller(),
+                r#"{"server":"viktor","tool":"ask_viktor","args":{}}"#,
+                None,
+            )
+            .await
+        {
+            Ok(_) => panic!("disconnected Viktor execution must fail loudly"),
+            Err(error) => error,
+        };
+        assert!(
+            execute.to_string().contains("upstream 'viktor' is absent"),
+            "configured but disconnected execution must identify the absent upstream: {execute}"
+        );
+        assert!(!engine.upstream_connected("viktor").await);
     }
 
     fn hanging_http_upstream(hold: Duration) -> (ServerConfig, std::thread::JoinHandle<()>) {


### PR DESCRIPTION
Fixes #506.\n\n- makes configured-but-disconnected Viktor discovery/execution explicit\n- alerts supervisors with durable pending run IDs after restart\n- exposes absent state and pending watches in SessionStart and Viktor provisioning
  credential: VIKTOR_API_KEY (not set)
  user config: /home/pippenz/.config/code-mode-mcp/config.toml
  project policy: none; managed user policy applies
  start: run cas serve without a project proxy config; startup refreshes the credential-reference-only managed Viktor upstream
  replies: run-starting calls are watched by CAS; replies arrive as inbound notifications (origin=viktor), so agents must not poll\n\nTests: scoped Viktor watch (4/4), proxy gateway (1/1), builtin flavor drift (9/9), cargo check -p cas --lib --tests.