### PR TITLE
docs(cas-4c61): surface concise worker contract

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -86,6 +86,8 @@ In the pre-close task note, every applicable entry must paste its proving file, 
 
 ## Communication
 
+- Facts, not narration; answer first. Use steps/bullets/table to scan. Keep SHA/ID, `file:line`, exits, failures, uncertainty/reasons; blockers/merges stay complete. See [discipline.md](cas-worker/references/discipline.md).
+
 ```
 mcp__cs__coordination action=message target=supervisor \
   summary="<brief preview>" message="<full body>"

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -86,6 +86,8 @@ In the pre-close task note, every applicable entry must paste its proving file, 
 
 ## Communication
 
+- Facts, not narration; answer first. Use steps/bullets/table to scan. Keep SHA/ID, `file:line`, exits, failures, uncertainty/reasons; blockers/merges stay complete. See [discipline.md](cas-worker/references/discipline.md).
+
 ```
 cas__coordination action=message target=supervisor \
   summary="<brief preview>" message="<full body>"

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -86,6 +86,8 @@ In the pre-close task note, every applicable entry must paste its proving file, 
 
 ## Communication
 
+- Facts, not narration; answer first. Use steps/bullets/table to scan. Keep SHA/ID, `file:line`, exits, failures, uncertainty/reasons; blockers/merges stay complete. See [discipline.md](cas-worker/references/discipline.md).
+
 ```
 mcp__cas__coordination action=message target=supervisor \
   summary="<brief preview>" message="<full body>"


### PR DESCRIPTION
## Summary\n- place the compact worker conciseness contract in all three always-loaded cas-worker mirrors\n- require visual structure where it scans better than dense prose\n- retain the long-form discipline reference as the linked rationale\n\n## Test\n- scripts/run-scoped-tests.sh -p cas --test builtin_flavor_drift_test