### PR TITLE
fix: preserve named Codex worker liveness

### DIFF
--- a/cas-cli/src/cli/factory/wedged.rs
+++ b/cas-cli/src/cli/factory/wedged.rs
@@ -47,7 +47,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use crate::mcp::tools::service::factory_ops::{
-    resolve_worker_transcript_path, worker_cli_from_agent, worker_scope_paths,
+    resolve_worker_transcript_path_for_account, worker_cli_from_agent, worker_scope_paths,
 };
 
 /// Window in which a Claude transcript mtime counts as "recent" — used to
@@ -817,7 +817,12 @@ pub(crate) fn resolve_worker(cas_root: &Path, worker_name: &str) -> Result<Resol
     // resolver as worker_status so the human and director stall surfaces
     // cannot disagree about which transcript is evidence.
     let cli = worker_cli_from_agent(&agent);
-    let transcript_path = resolve_worker_transcript_path(clone_path.as_deref(), &session_id, cli);
+    let transcript_path = resolve_worker_transcript_path_for_account(
+        clone_path.as_deref(),
+        &session_id,
+        cli,
+        agent.metadata.get("worker_account_dir").map(String::as_str),
+    );
     Ok(ResolvedWorker {
         name: worker_name.to_string(),
         pid,

--- a/cas-cli/src/daemon/maintenance.rs
+++ b/cas-cli/src/daemon/maintenance.rs
@@ -8,6 +8,29 @@ use crate::daemon::observation::process_observations;
 use crate::daemon::{DaemonConfig, DaemonRunResult};
 use crate::error::CasError;
 
+/// A stale heartbeat is not enough to kill a factory worker.  Codex has no
+/// lifecycle hooks, so a worker may remain busy while its heartbeat path is
+/// unavailable; a process that identifies itself by argv or `CAS_AGENT_NAME`
+/// is independent liveness evidence and wins over the stale timestamp.
+///
+/// Non-worker agents retain the historical heartbeat-only cleanup policy.
+pub(crate) fn heartbeat_stale_agent_should_be_reaped(
+    agent: &crate::types::Agent,
+    find_live_worker_pid: impl FnOnce(&str) -> Option<u32>,
+) -> bool {
+    agent.role != crate::types::AgentRole::Worker || find_live_worker_pid(&agent.name).is_none()
+}
+
+fn heartbeat_stale_agent_has_live_process(agent: &crate::types::Agent) -> bool {
+    !heartbeat_stale_agent_should_be_reaped(agent, |worker_name| {
+        crate::cli::factory::wedged::find_worker_pid(
+            &crate::cli::factory::wedged::RealProcessTable,
+            worker_name,
+        )
+        .filter(|pid| crate::mcp::daemon::pid_alive(*pid))
+    })
+}
+
 /// Run a single maintenance cycle.
 pub fn run_maintenance(config: &DaemonConfig) -> Result<DaemonRunResult, CasError> {
     use crate::store::{open_agent_store, open_event_store, open_recording_store, open_store};
@@ -85,6 +108,14 @@ pub fn run_maintenance(config: &DaemonConfig) -> Result<DaemonRunResult, CasErro
         // Grace period is 90s (not 60s) to accommodate the known first-MCP-call timeout.
         if let Ok(failed_startup_agents) = agent_store.list_failed_startup(90) {
             for agent in &failed_startup_agents {
+                if heartbeat_stale_agent_has_live_process(agent) {
+                    tracing::warn!(
+                        worker = %agent.name,
+                        agent_id = %agent.id,
+                        "heartbeat stale but live factory worker process found; skipping reap"
+                    );
+                    continue;
+                }
                 let agent_id = agent.id.clone();
 
                 // Re-check: a heartbeat may have arrived between list_failed_startup
@@ -116,6 +147,14 @@ pub fn run_maintenance(config: &DaemonConfig) -> Result<DaemonRunResult, CasErro
 
         if let Ok(stale_agents) = agent_store.list_stale(600) {
             for agent in &stale_agents {
+                if heartbeat_stale_agent_has_live_process(agent) {
+                    tracing::warn!(
+                        worker = %agent.name,
+                        agent_id = %agent.id,
+                        "heartbeat stale but live factory worker process found; skipping reap"
+                    );
+                    continue;
+                }
                 let held_tasks = agent_store.list_agent_leases(&agent.id).unwrap_or_default();
                 let held_ids: Vec<String> = held_tasks.iter().map(|l| l.task_id.clone()).collect();
                 let agent_id = agent.id.clone();
@@ -339,4 +378,96 @@ fn cleanup_orphaned_worktrees(config: &DaemonConfig) -> Result<usize, CasError> 
 /// Run daemon once (for testing or one-shot mode).
 pub fn run_once(config: &DaemonConfig) -> Result<DaemonRunResult, CasError> {
     run_maintenance(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_named_codex_worker_with_live_process_is_not_reaped() {
+        let mut worker = crate::types::Agent::new(
+            "codex-kind-owl-71-session".to_string(),
+            "kind-owl-71".to_string(),
+        );
+        worker.role = crate::types::AgentRole::Worker;
+        worker
+            .metadata
+            .insert("worker_cli".to_string(), "codex".to_string());
+        worker.metadata.insert(
+            "worker_account_dir".to_string(),
+            "/home/operator/.codex-support@example.test".to_string(),
+        );
+
+        assert!(
+            !heartbeat_stale_agent_should_be_reaped(&worker, |name| {
+                (name == "kind-owl-71").then_some(4242)
+            }),
+            "a stale heartbeat alone must not park a named-account Codex worker while its argv/env-identifiable process is live"
+        );
+    }
+
+    #[test]
+    fn stale_worker_without_live_process_is_reaped() {
+        let mut worker = crate::types::Agent::new("dead-worker".to_string(), "dead-owl".to_string());
+        worker.role = crate::types::AgentRole::Worker;
+        assert!(heartbeat_stale_agent_should_be_reaped(&worker, |_| None));
+    }
+
+    /// Incident-shaped cas-66fd regression: a Codex worker on a named account
+    /// can go 10+ minutes without a heartbeat because Codex has no hooks, but
+    /// its live process still carries `CAS_AGENT_NAME`. Maintenance must not
+    /// revoke its lease or park its task on heartbeat staleness alone.
+    #[cfg(unix)]
+    #[test]
+    fn maintenance_keeps_named_account_codex_worker_with_live_env_identity() {
+        use crate::store::{init_cas_dir, open_agent_store};
+        use std::process::Command;
+
+        let temp = tempfile::tempdir().expect("temp CAS root");
+        let cas_root = init_cas_dir(temp.path()).expect("initialize CAS root");
+        let worker_name = format!("cas-66fd-live-{}", std::process::id());
+        let mut child = Command::new("sleep")
+            .arg("60")
+            .env("CAS_AGENT_NAME", &worker_name)
+            .spawn()
+            .expect("spawn identifiable worker process");
+
+        let store = open_agent_store(&cas_root).expect("open agent store");
+        let mut worker = crate::types::Agent::new(
+            "cas-66fd-live-session".to_string(),
+            worker_name.clone(),
+        );
+        worker.role = crate::types::AgentRole::Worker;
+        worker.last_heartbeat = Utc::now() - chrono::Duration::seconds(601);
+        worker.metadata.insert("worker_cli".to_string(), "codex".to_string());
+        worker.metadata.insert(
+            "worker_account_dir".to_string(),
+            "/home/operator/.codex-support@example.test".to_string(),
+        );
+        store.register(&worker).expect("register stale worker");
+
+        let result = run_maintenance(&DaemonConfig {
+            cas_root: cas_root.clone(),
+            process_observations: false,
+            consolidate_memories: false,
+            auto_prune: false,
+            apply_decay: false,
+            update_entity_summaries: false,
+            index_code: false,
+            index_bm25: false,
+            agent_purge_age_hours: 0,
+            ..DaemonConfig::default()
+        })
+        .expect("maintenance succeeds");
+
+        let _ = child.kill();
+        let _ = child.wait();
+        assert_eq!(result.agents_cleaned, 0);
+        assert_eq!(
+            store.get(&worker.id).expect("read worker after maintenance").status,
+            crate::types::AgentStatus::Active,
+            "a live env-identified Codex worker must not be reaped solely for heartbeat age"
+        );
+    }
 }

--- a/cas-cli/src/daemon/mod.rs
+++ b/cas-cli/src/daemon/mod.rs
@@ -29,6 +29,7 @@ pub use indexing::{
     index_code_files, reconcile_code_tree, run_code_index_cycle, run_embedding_cycle,
     run_indexing_cycle,
 };
+pub(crate) use maintenance::heartbeat_stale_agent_should_be_reaped;
 pub use maintenance::{run_maintenance, run_once};
 pub use queue::{
     MaintenanceTask, TaskQueue, TaskType, global_queue, queue_embedding_task,

--- a/cas-cli/src/mcp/daemon.rs
+++ b/cas-cli/src/mcp/daemon.rs
@@ -1237,6 +1237,20 @@ impl EmbeddedDaemon {
             // This is only for crash detection - normal cleanup via SessionEnd hook
             if let Ok(stale_agents) = agent_store.list_stale(600) {
                 for agent in stale_agents {
+                    if !crate::daemon::heartbeat_stale_agent_should_be_reaped(&agent, |name| {
+                        crate::cli::factory::wedged::find_worker_pid(
+                            &crate::cli::factory::wedged::RealProcessTable,
+                            name,
+                        )
+                        .filter(|pid| pid_alive(*pid))
+                    }) {
+                        tracing::warn!(
+                            worker = %agent.name,
+                            agent_id = %agent.id,
+                            "heartbeat stale but live factory worker process found; skipping reap"
+                        );
+                        continue;
+                    }
                     let held: Vec<String> = agent_store
                         .list_agent_leases(&agent.id)
                         .unwrap_or_default()

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -2517,10 +2517,11 @@ impl CasService {
                 // stat fast path.
                 let transcript_resolution_for_worker =
                     worker_status_uses_scanned_transcript(worker_cli).then(|| {
-                        worker_status_cached_transcript_resolution(
+                        worker_status_cached_transcript_resolution_for_account(
                             clone_path.as_deref(),
                             session_uuid,
                             worker_cli,
+                            agent.metadata.get("worker_account_dir").map(String::as_str),
                         )
                     });
                 let transcript_path_for_worker = transcript_resolution_for_worker
@@ -3036,7 +3037,12 @@ impl CasService {
                 let cli = worker_cli_from_agent(agent);
                 let clone_path = agent.metadata.get("clone_path").map(String::as_str);
                 let session_id = agent.cc_session_id.as_deref().unwrap_or(&agent.id);
-                let transcript_path = worker_status_transcript_path(clone_path, session_id, cli)?;
+                let transcript_path = worker_status_transcript_path_for_account(
+                    clone_path,
+                    session_id,
+                    cli,
+                    agent.metadata.get("worker_account_dir").map(String::as_str),
+                )?;
                 let event_activity = last_worker_activity_secs(&activity_events, &agent.id);
                 let effective_activity = last_worker_activity_secs_with_transcript(
                     &activity_events,
@@ -5197,7 +5203,12 @@ pub(crate) fn worker_transcript_path_for_agent(
     };
     let cli = worker_cli_from_agent(agent);
     let session_id = agent.cc_session_id.as_deref().unwrap_or(&agent.id);
-    worker_status_transcript_path(clone_path.to_str(), session_id, cli)
+    worker_status_transcript_path_for_account(
+        clone_path.to_str(),
+        session_id,
+        cli,
+        agent.metadata.get("worker_account_dir").map(String::as_str),
+    )
 }
 
 fn run_git(path: &std::path::Path, args: &[&str]) -> std::result::Result<String, String> {
@@ -6712,6 +6723,42 @@ fn default_transcript_roots(cli: cas_mux::SupervisorCli) -> Vec<std::path::PathB
     }
 }
 
+/// Return the rollout root for the account a Codex worker was actually
+/// launched under.  `worker_account_dir` is durable spawn metadata, whereas
+/// this process's `CODEX_HOME` belongs to whichever supervisor/daemon happens
+/// to be answering an operator query.  Those are often different accounts.
+fn codex_sessions_dir_for_worker_account(account_dir: Option<&str>) -> Option<std::path::PathBuf> {
+    let account_dir = account_dir?.trim();
+    if account_dir.is_empty() {
+        return None;
+    }
+    let expanded = account_dir.strip_prefix('~').map_or_else(
+        || std::path::PathBuf::from(account_dir),
+        |suffix| {
+            dirs::home_dir()
+                .map(|home| home.join(suffix.trim_start_matches('/')))
+                .unwrap_or_else(|| std::path::PathBuf::from(account_dir))
+        },
+    );
+    Some(expanded.join("sessions"))
+}
+
+/// Harness transcript roots for one registered worker.  Codex is special:
+/// each worker may have been spawned under a named `CODEX_HOME`, and querying
+/// from a supervisor must not silently substitute the supervisor's account.
+fn transcript_roots_for_worker(
+    cli: cas_mux::SupervisorCli,
+    account_dir: Option<&str>,
+) -> Vec<std::path::PathBuf> {
+    if cli == cas_mux::SupervisorCli::Codex {
+        return codex_sessions_dir_for_worker_account(account_dir)
+            .or_else(default_codex_sessions_dir)
+            .into_iter()
+            .collect();
+    }
+    default_transcript_roots(cli)
+}
+
 /// [`resolve_transcript`] over a set of roots rather than a single one.
 ///
 /// Only Claude actually searches more than one (cas-9e81); Codex and Grok keep
@@ -7176,13 +7223,25 @@ pub(crate) fn resolve_worker_transcript_path(
     session_id: &str,
     cli: cas_mux::SupervisorCli,
 ) -> Option<std::path::PathBuf> {
+    resolve_worker_transcript_path_for_account(clone_path, session_id, cli, None)
+}
+
+/// Account-aware form of [`resolve_worker_transcript_path`].  Callers that
+/// have the agent row (is-wedged, debug, and worker_status) must use this so a
+/// named Codex account resolves its own rollout tree.
+pub(crate) fn resolve_worker_transcript_path_for_account(
+    clone_path: Option<&str>,
+    session_id: &str,
+    cli: cas_mux::SupervisorCli,
+    account_dir: Option<&str>,
+) -> Option<std::path::PathBuf> {
     // cas-9e81: search every root this harness could have written under, not
     // just the default one. On a two-account factory the single-root lookup
     // returned None for every pane on the non-default `CLAUDE_CONFIG_DIR`, and
     // the daemon's wake gate treats an unresolvable transcript as evidence of
     // an in-flight tool call — a permanent, silent refusal to wake.
     transcript_path_from_resolution(resolve_transcript_in_roots(
-        &default_transcript_roots(cli),
+        &transcript_roots_for_worker(cli, account_dir),
         clone_path,
         session_id,
         cli,
@@ -7202,9 +7261,23 @@ fn worker_status_transcript_path(
     session_id: &str,
     cli: cas_mux::SupervisorCli,
 ) -> Option<std::path::PathBuf> {
+    worker_status_transcript_path_for_account(clone_path, session_id, cli, None)
+}
+
+fn worker_status_transcript_path_for_account(
+    clone_path: Option<&str>,
+    session_id: &str,
+    cli: cas_mux::SupervisorCli,
+    account_dir: Option<&str>,
+) -> Option<std::path::PathBuf> {
     match cli {
         cas_mux::SupervisorCli::Codex | cas_mux::SupervisorCli::Grok => {
-            let cached = worker_status_cached_transcript_resolution(clone_path, session_id, cli);
+            let cached = worker_status_cached_transcript_resolution_for_account(
+                clone_path,
+                session_id,
+                cli,
+                account_dir,
+            );
             worker_status_path_from_resolution(cached.resolution, cli)
         }
         cas_mux::SupervisorCli::Claude => transcript_path_fast(clone_path, session_id),
@@ -7240,15 +7313,16 @@ fn hard_dead_worker_transcript_block(
     )
 }
 
-fn worker_status_cached_transcript_resolution(
+fn worker_status_cached_transcript_resolution_for_account(
     clone_path: Option<&str>,
     session_id: &str,
     cli: cas_mux::SupervisorCli,
+    account_dir: Option<&str>,
 ) -> WorkerStatusTranscriptResolution {
     // cas-9e81: same multi-root search as `resolve_worker_transcript_path`, so
     // `worker_status` and the daemon's wake gate cannot disagree about whether
     // a worker has a readable transcript.
-    let roots = default_transcript_roots(cli);
+    let roots = transcript_roots_for_worker(cli, account_dir);
     WorkerStatusTranscriptResolution {
         resolution: worker_status_cached_transcript_resolution_in_roots(
             &roots, clone_path, session_id, cli,
@@ -10886,6 +10960,49 @@ effort = "high"
             }
         }
         assert_eq!(got, Some(sessions.join(rel)));
+    }
+
+    /// cas-66fd: the supervisor normally runs under its own (often default)
+    /// CODEX_HOME.  A worker's persisted spawn account must win, otherwise
+    /// worker_status, is-wedged, and debug all report its live rollout as
+    /// unresolved despite a fresh named-account transcript on disk.
+    #[test]
+    fn codex_worker_account_dir_resolves_its_own_rollout_not_supervisor_home() {
+        let clone = "/tmp/cas-66fd-named-account-worker";
+        let rel = "2026/08/18/rollout-2026-08-18T17-22-01-live.jsonl";
+        let (account_home, sessions) = fake_codex_sessions_dir(&[(rel, clone)]);
+        let account_dir = account_home.path().to_str().expect("utf-8 account home");
+
+        let resolved = resolve_worker_transcript_path_for_account(
+            Some(clone),
+            "codex-kind-owl-71-session",
+            cas_mux::SupervisorCli::Codex,
+            Some(account_dir),
+        );
+        assert_eq!(resolved, Some(sessions.join(rel)));
+
+        let status_path = worker_status_transcript_path_for_account(
+            Some(clone),
+            "codex-kind-owl-71-session",
+            cas_mux::SupervisorCli::Codex,
+            Some(account_dir),
+        );
+        assert_eq!(status_path, Some(sessions.join(rel)));
+
+        let mut agent = cas_types::Agent::new(
+            "codex-kind-owl-71-session".to_string(),
+            "kind-owl-71".to_string(),
+        );
+        agent.metadata.insert("worker_cli".to_string(), "codex".to_string());
+        agent.metadata.insert("clone_path".to_string(), clone.to_string());
+        agent
+            .metadata
+            .insert("worker_account_dir".to_string(), account_dir.to_string());
+        assert_eq!(
+            worker_transcript_path_for_agent(account_home.path(), &agent),
+            Some(sessions.join(rel)),
+            "the registered worker's spawn-time CODEX_HOME must reach all agent-aware callers"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Resolve Codex worker transcripts from persisted spawn-time `worker_account_dir`.
- Preserve a stale-heartbeat worker when an argv/env-identifiable process is live in both maintenance reapers.
- Cover named-account transcript and process-liveness regressions.

## Verification

- `scripts/run-scoped-tests.sh --proof -p cas --lib` — 4,751 passed, 6 skipped.
