### PR TITLE
fix(git): pin branch creation to commit IDs

### DIFF
--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -592,7 +592,7 @@ impl CasCore {
                         resolved.sha.clone()
                     };
                     let sha_preview = &base_sha[..base_sha.len().min(8)];
-                    match git_ops.create_branch_from(&branch_name, &base_ref) {
+                    match git_ops.create_branch_from(&branch_name, &base_sha) {
                         Ok(created) => {
                             // Update epic with branch info (no worktree)
                             let task_store = self.open_task_store()?;

--- a/cas-cli/src/ui/factory/app/init.rs
+++ b/cas-cli/src/ui/factory/app/init.rs
@@ -96,7 +96,7 @@ impl FactoryApp {
                 }
             }
             let resolved = git_ops.resolve_fresh_base(&trunk)?;
-            if git_ops.create_branch_from(&branch_name, &resolved.branch_ref)? {
+            if git_ops.create_branch_from(&branch_name, &resolved.sha)? {
                 tracing::info!(
                     "Created epic branch {} from base '{}' (sha={}, behind={})",
                     branch_name,

--- a/cas-cli/src/ui/factory/app/render_and_ops/worktree.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/worktree.rs
@@ -47,7 +47,7 @@ impl FactoryApp {
             (resolved.sha.clone(), resolved.behind_count)
         };
 
-        if git_ops.create_branch_from(&branch_name, &base_choice.base_ref)? {
+        if git_ops.create_branch_from(&branch_name, &base_sha)? {
             tracing::info!(
                 "Created epic branch {} from base '{}' (sha={}, behind={})",
                 branch_name,

--- a/cas-cli/src/ui/factory/daemon/fork_first.rs
+++ b/cas-cli/src/ui/factory/daemon/fork_first.rs
@@ -289,7 +289,7 @@ impl DaemonInitPhase {
                 }
             }
             let resolved = git_ops.resolve_fresh_base(&trunk)?;
-            if git_ops.create_branch_from(&branch_name, &resolved.branch_ref)? {
+            if git_ops.create_branch_from(&branch_name, &resolved.sha)? {
                 tracing::info!(
                     "Created epic branch {} from base '{}' (sha={}, behind={})",
                     branch_name,

--- a/cas-cli/src/worktree/git.rs
+++ b/cas-cli/src/worktree/git.rs
@@ -688,15 +688,15 @@ impl GitOperations {
             return Err(GitError::BranchExists(branch.to_string()));
         }
 
-        // Validate base branch is a valid ref (catches empty repos with no commits)
-        if let Some(base) = base_branch {
-            if !self.branch_exists(base)? {
-                return Err(GitError::CommandFailed(format!(
-                    "Base branch '{base}' is not a valid reference. Does the repository have any commits? \
-                     Try making an initial commit first."
-                )));
-            }
-        }
+        // Resolve before `git worktree add -b` writes refs/heads/<branch>.
+        // This is the worktree-creation sibling of `create_branch_from`: an
+        // unresolved or corrupt name must never reach a ref-writing command.
+        let start_point = base_branch.unwrap_or("HEAD");
+        let start_sha = self.resolve_commit(start_point).ok_or_else(|| {
+            GitError::CommandFailed(format!(
+                "Refusing to create worktree branch '{branch}': start point '{start_point}' does not resolve to a commit"
+            ))
+        })?;
 
         // Build command
         let mut args = vec!["worktree", "add"];
@@ -704,11 +704,7 @@ impl GitOperations {
         let path_str = path.to_str().ok_or_else(|| {
             GitError::CommandFailed(format!("Path contains invalid UTF-8: {}", path.display()))
         })?;
-        if let Some(base) = base_branch {
-            args.extend(["-b", branch, path_str, base]);
-        } else {
-            args.extend(["-b", branch, path_str]);
-        }
+        args.extend(["-b", branch, path_str, &start_sha]);
 
         let output = Command::new("git")
             .args(&args)
@@ -719,6 +715,18 @@ impl GitOperations {
             return Err(GitError::CommandFailed(
                 String::from_utf8_lossy(&output.stderr).to_string(),
             ));
+        }
+
+        let branch_ref = format!("refs/heads/{branch}");
+        let written_sha = self.resolve_commit(&branch_ref).ok_or_else(|| {
+            GitError::CommandFailed(format!(
+                "Created worktree branch '{branch}', but its ref '{branch_ref}' does not resolve to a commit"
+            ))
+        })?;
+        if written_sha != start_sha {
+            return Err(GitError::CommandFailed(format!(
+                "Created worktree branch '{branch}', but post-verification found {written_sha} instead of expected {start_sha}"
+            )));
         }
 
         // Initialize submodules in the new worktree

--- a/cas-cli/src/worktree/git/branch_ops.rs
+++ b/cas-cli/src/worktree/git/branch_ops.rs
@@ -186,8 +186,9 @@ impl GitOperations {
     /// Create a branch from a specific base ref if it doesn't exist.
     ///
     /// Unlike `create_branch_if_not_exists`, this uses an explicit start point
-    /// rather than the current HEAD. Pass the configured trunk (e.g. "main") so
-    /// epic and worker branches are always anchored to the correct base.
+    /// rather than the current HEAD. The start point is resolved to a commit ID
+    /// before any ref is written, and the new local branch is read back through
+    /// its fully-qualified ref before success is reported.
     ///
     /// Returns true if the branch was created, false if it already existed.
     pub fn create_branch_from(&self, branch: &str, base: &str) -> Result<bool> {
@@ -195,8 +196,14 @@ impl GitOperations {
             return Ok(false);
         }
 
+        let base_sha = self.resolve_commit(base).ok_or_else(|| {
+            GitError::CommandFailed(format!(
+                "Refusing to create branch '{branch}': start point '{base}' does not resolve to a commit"
+            ))
+        })?;
+
         let output = Command::new("git")
-            .args(["branch", branch, base])
+            .args(["branch", branch, &base_sha])
             .current_dir(&self.repo_root)
             .output()?;
 
@@ -204,6 +211,18 @@ impl GitOperations {
             return Err(GitError::CommandFailed(
                 String::from_utf8_lossy(&output.stderr).to_string(),
             ));
+        }
+
+        let branch_ref = format!("refs/heads/{branch}");
+        let written_sha = self.resolve_commit(&branch_ref).ok_or_else(|| {
+            GitError::CommandFailed(format!(
+                "Created branch '{branch}', but its ref '{branch_ref}' does not resolve to a commit"
+            ))
+        })?;
+        if written_sha != base_sha {
+            return Err(GitError::CommandFailed(format!(
+                "Created branch '{branch}', but post-verification found {written_sha} instead of expected {base_sha}"
+            )));
         }
 
         Ok(true)

--- a/cas-cli/src/worktree/git_tests/tests.rs
+++ b/cas-cli/src/worktree/git_tests/tests.rs
@@ -67,6 +67,89 @@ fn test_current_branch() {
     assert!(branch == "main" || branch == "master");
 }
 
+#[test]
+fn create_branch_from_resolves_start_point_and_verifies_exact_ref_cas_42a4() {
+    let (_temp, repo_path) = create_test_repo();
+    let git = GitOperations::new(repo_path.clone());
+    let expected = git.resolve_commit("HEAD").unwrap();
+
+    assert!(git.create_branch_from("epic/verified", "HEAD").unwrap());
+    assert_eq!(
+        git.resolve_commit("refs/heads/epic/verified").as_deref(),
+        Some(expected.as_str())
+    );
+    assert_eq!(
+        std::fs::read_to_string(repo_path.join(".git/refs/heads/epic/verified"))
+            .unwrap()
+            .trim(),
+        expected,
+        "the loose ref must contain the resolved object ID, never the start-point name"
+    );
+}
+
+#[test]
+fn create_branch_from_rejects_unresolvable_start_without_writing_ref_cas_42a4() {
+    let (_temp, repo_path) = create_test_repo();
+    let git = GitOperations::new(repo_path.clone());
+
+    // Reproduce the observed corruption shape: a loose branch ref contains
+    // its own branch name instead of an object ID.
+    let corrupt_ref = repo_path.join(".git/refs/heads/epic/corrupt-base");
+    std::fs::create_dir_all(corrupt_ref.parent().unwrap()).unwrap();
+    std::fs::write(&corrupt_ref, "epic/corrupt-base\n").unwrap();
+
+    let error = git
+        .create_branch_from("epic/must-not-exist", "epic/corrupt-base")
+        .expect_err("a corrupt start point must fail before branch creation");
+
+    assert!(
+        error.to_string().contains("does not resolve to a commit"),
+        "failure must identify the invalid start point: {error}"
+    );
+    assert!(
+        !repo_path
+            .join(".git/refs/heads/epic/must-not-exist")
+            .exists(),
+        "failure must not leave a loose branch ref"
+    );
+    assert!(
+        git.resolve_commit("refs/heads/epic/must-not-exist")
+            .is_none(),
+        "failure must not create any resolvable branch ref"
+    );
+}
+
+#[test]
+fn create_worktree_rejects_unresolvable_start_without_writing_ref_cas_42a4() {
+    let (temp, repo_path) = create_test_repo();
+    let git = GitOperations::new(repo_path.clone());
+    let worktree_path = temp.path().join("must-not-exist");
+
+    let corrupt_ref = repo_path.join(".git/refs/heads/epic/corrupt-worktree-base");
+    std::fs::create_dir_all(corrupt_ref.parent().unwrap()).unwrap();
+    std::fs::write(&corrupt_ref, "epic/corrupt-worktree-base\n").unwrap();
+
+    let error = git
+        .create_worktree(
+            &worktree_path,
+            "factory/must-not-exist",
+            Some("epic/corrupt-worktree-base"),
+        )
+        .expect_err("a corrupt worktree start point must fail before ref creation");
+
+    assert!(
+        error.to_string().contains("does not resolve to a commit"),
+        "failure must identify the invalid worktree start point: {error}"
+    );
+    assert!(!worktree_path.exists(), "failure must not create a worktree");
+    assert!(
+        !repo_path
+            .join(".git/refs/heads/factory/must-not-exist")
+            .exists(),
+        "failure must not create the worktree branch ref"
+    );
+}
+
 /// cas-9415: `git merge` commits to implicit HEAD. If another supervisor
 /// parks the shared checkout on a foreign branch after the target was
 /// resolved, the merge helper must refuse before changing any ref or file.

--- a/cas-cli/src/worktree/manager/epic_ops.rs
+++ b/cas-cli/src/worktree/manager/epic_ops.rs
@@ -56,7 +56,7 @@ impl WorktreeManager {
 
         let newly_created = match self
             .git
-            .create_branch_from(&branch_name, &base_choice.base_ref)
+            .create_branch_from(&branch_name, &base_sha)
         {
             Ok(true) => {
                 tracing::info!(

--- a/cas-cli/src/worktree/manager/tests.rs
+++ b/cas-cli/src/worktree/manager/tests.rs
@@ -985,6 +985,32 @@ fn test_create_epic_branch_honors_configured_epic_base_branch() {
     );
 }
 
+#[test]
+fn test_create_epic_branch_rejects_corrupt_base_without_writing_ref_cas_42a4() {
+    let (_temp, repo_path) = create_test_repo();
+    write_epic_base_branch_config(&repo_path, "epic/corrupt-base");
+
+    let corrupt_ref = repo_path.join(".git/refs/heads/epic/corrupt-base");
+    std::fs::create_dir_all(corrupt_ref.parent().unwrap()).unwrap();
+    std::fs::write(&corrupt_ref, "epic/corrupt-base\n").unwrap();
+
+    let manager = WorktreeManager::new(&repo_path, WorktreeConfig::default()).unwrap();
+    let error = manager
+        .create_epic_branch("Must Not Exist")
+        .expect_err("a corrupt configured base must abort epic branch creation");
+
+    assert!(
+        error.to_string().contains("does not resolve to a commit"),
+        "failure must identify the unresolvable start point: {error}"
+    );
+    assert!(
+        !repo_path
+            .join(".git/refs/heads/epic/must-not-exist")
+            .exists(),
+        "failed epic creation must not write a loose ref"
+    );
+}
+
 // --- cas-006c: merge/removal dirty-check classification --------------------
 
 /// AC1: a worktree whose only dirty entry is the Cassy-generated


### PR DESCRIPTION
## Summary
- resolve epic branch start points to commit IDs before invoking any ref-writing Git command
- verify newly-created branch refs resolve to the expected commit before reporting success
- apply the same invariant to the sibling `git worktree add -b` path
- reject corrupt or otherwise unresolvable start points before creating a branch, ref, or worktree

## Verification
- `cargo check -p cas --lib --tests`
- `scripts/run-scoped-tests.sh --proof -p cas --lib -E "test(cas_42a4) | test(test_create_epic_branch_) | test(test_create_and_remove_worktree)"` — 12 passed; committed-diff surface covered

## Forensics
The retained reflog contains only the manual recreation. Source sweep found no production filesystem writer targeting `.git/refs`; direct `git branch`/`update-ref` calls reject a non-object literal. This patch closes the confirmed unchecked-start-point and missing-post-verification gaps without claiming the original direct-write actor is recoverable.