### PR TITLE
ci: route merge-queue archive to trusted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,43 @@ permissions:
   actions: read
 
 jobs:
+  # GitHub Actions cannot fall back after it has assigned an offline
+  # self-hosted runner: the job would simply remain queued. Select the runner
+  # before assignment instead. The repository variable is deliberately
+  # opt-in; its absent/disabled state is the fail-safe hosted path used before
+  # maintenance or whenever the runner's health is not established.
+  #
+  # This job never checks out the merge-queue tree and only selects a label.
+  # Therefore fork/pull-request code cannot use the persistent runner. The
+  # actual archive job repeats the merge_group-only guard before it compiles.
+  fast-validation-runner-route:
+    name: Fast Validation — merge-queue runner route
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'merge_group'
+      || (github.event_name == 'pull_request'
+      && github.base_ref == github.event.repository.default_branch)
+      || (github.event_name == 'push'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/')))
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.route.outputs.runner }}
+      mode: ${{ steps.route.outputs.mode }}
+    steps:
+      - id: route
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SELF_HOSTED_ENABLED: ${{ vars.CASSY_MERGE_QUEUE_SELF_HOSTED }}
+        run: |
+          if [[ "$EVENT_NAME" == merge_group && "$SELF_HOSTED_ENABLED" == enabled ]]; then
+            echo 'runner=["self-hosted","Linux","X64","cas-ci-32core"]' >> "$GITHUB_OUTPUT"
+            echo 'mode=self-hosted' >> "$GITHUB_OUTPUT"
+          else
+            echo 'runner=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+            echo 'mode=hosted' >> "$GITHUB_OUTPUT"
+          fi
+
   # Factory pushes and PRs that do not target the protected default branch get
   # one cheap target-scoped lane. Main PRs use the full required lanes below;
   # do not spend an additional runner on this redundant subset there.
@@ -267,14 +304,20 @@ jobs:
   fast-validation-suite-build:
     name: Fast Validation — suite archive build
     if: >-
-      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/tags/')))
-    runs-on: ubuntu-latest
+      || startsWith(github.ref, 'refs/tags/'))))
+      && (needs.fast-validation-runner-route.outputs.mode != 'self-hosted'
+      || (github.event_name == 'merge_group'
+      && github.repository == 'Richards-LLC/cassy'
+      && github.event.repository.fork == false
+      && vars.CASSY_MERGE_QUEUE_SELF_HOSTED == 'enabled'))
+    needs: fast-validation-runner-route
+    runs-on: ${{ fromJSON(needs.fast-validation-runner-route.outputs.runner) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -287,18 +330,61 @@ jobs:
         with:
           base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
 
+      - name: Verify merge-queue self-hosted trust boundary
+        if: needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        env:
+          SELF_HOSTED_ENABLED: ${{ vars.CASSY_MERGE_QUEUE_SELF_HOSTED }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_EVENT_NAME" = merge_group
+          test "$GITHUB_REPOSITORY" = Richards-LLC/cassy
+          test "$SELF_HOSTED_ENABLED" = enabled
+          case "$GITHUB_REF" in
+            refs/heads/gh-readonly-queue/*) ;;
+            *) echo "self-hosted route received a non-queue ref: $GITHUB_REF" >&2; exit 1 ;;
+          esac
+
       - name: Report Rust short-circuit
         if: steps.classify-diff.outputs.rust-unaffected == 'true'
         run: echo "Rust suite archive build skipped for ${{ steps.classify-diff.outputs.class }} diff."
 
-      - if: steps.classify-diff.outputs.rust-unaffected != 'true'
+      - if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'hosted'
         uses: ./.github/actions/setup-rust-linux
         with:
           cache-key: fast-validation-suite-archive
 
+      - name: Set up the isolated merge-queue runner
+        if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Zig on the isolated merge-queue runner
+        if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        run: ./scripts/bootstrap-zig.sh
+
       - name: Install nextest
         if: steps.classify-diff.outputs.rust-unaffected != 'true'
         uses: taiki-e/install-action@nextest
+
+      - name: Verify private self-hosted sccache
+        if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        run: |
+          set -euo pipefail
+          test "${SCCACHE_SERVER_PORT:?}" = 4227
+          case "${SCCACHE_DIR:?}" in
+            /var/lib/cassy-actions/*) ;;
+            *) echo "SCCACHE_DIR is not isolated from the runner cache" >&2; exit 1 ;;
+          esac
+          sccache rustc -vV
+          sccache --show-stats
+          echo 'SCCACHE_GHA_ENABLED=false' >> "$GITHUB_ENV"
 
       # Debug info is stripped from the archived test binaries (cas-59d3).
       # Every shard downloads this whole artifact, so its size is multiplied by

--- a/docs/ci/self-hosted-runner-pilot.md
+++ b/docs/ci/self-hosted-runner-pilot.md
@@ -1,12 +1,15 @@
 # Self-hosted Fast Validation pilot
 
-This pilot is an advisory duplicate of the required hosted Fast Validation
-archive producer. It measures the archive build on the 32-core `soundwave`
-host without making merge eligibility depend on that host. The first real
-measurement kept the three exhaustive partitions in the same local job for
+The push-triggered pilot is an advisory duplicate of the required hosted Fast
+Validation archive producer. Separately, the CI workflow may route the required
+archive producer for a `merge_group` tree to the same 32-core `soundwave` host.
+The route is explicit and fail-safe: unless repository variable
+`CASSY_MERGE_QUEUE_SELF_HOSTED` is exactly `enabled`, the required archive runs
+on GitHub-hosted Ubuntu. Pull-request work always remains hosted. The first
+real measurement kept the three exhaustive partitions in the same local job for
 evaluation; shard 1 stalled in three subprocess-spawning integration tests for
-more than seven minutes, so the pilot deliberately leaves every shard on
-GitHub-hosted runners.
+more than seven minutes, so required shards deliberately remain parallel on
+GitHub-hosted runners even when their archive producer uses the box.
 
 The uncached archive build in self-hosted run
 [32255590235](https://github.com/Richards-LLC/cassy/actions/runs/32255590235)
@@ -37,15 +40,29 @@ independent restrictions:
    create a red/queued advisory run.
 
 Fork pull requests continue to run only the existing GitHub-hosted required
-checks. Approval of a fork workflow does not grant it the selected runner
-group. Do not weaken any of the three restrictions independently.
+checks. The CI route selects the box only when `github.event_name` is
+`merge_group` and the explicit control variable is enabled; the route job does
+not check out source, and the archive job repeats the selected-mode guard.
+Approval of a fork workflow does not grant it the selected runner group. Do not
+weaken any of the three restrictions independently.
 
 ## Availability and isolation
 
-The pilot job is not present in `docs/branch-protection/main-ruleset.json`. Every
-required context, including `Fast Validation — suite archive build` and its
-shards, remains on `ubuntu-latest`. Stopping the local service can queue or
-cancel only the advisory pilot; the required hosted checks continue normally.
+The pilot job is not present in `docs/branch-protection/main-ruleset.json`. The
+ruleset still requires only the `Fast Validation` rollup and `macOS Check`.
+For ordinary PRs, and whenever the self-hosted control variable is absent or
+disabled, every Fast Validation component runs hosted. A merge-queue archive
+may use the trusted box only after the runner is confirmed online; its shards
+remain hosted and parallel.
+
+GitHub cannot reassign a job after it has been scheduled on an offline
+self-hosted label. The safe maintenance/offline-fallback sequence is therefore
+to disable the route first, verify a queue entry selected `ubuntu-latest`, and
+only then stop the listener. An unexpected host failure after an operator has
+explicitly enabled the route is a GitHub scheduler limitation, not a condition
+the workflow can repair after assignment; treat the variable as a readiness
+lease and disable it before any maintenance. This preserves a concrete hosted
+fallback instead of wedging planned queue work.
 
 The listener runs as the non-login `cassy-actions` system account under
 `cassy-actions-runner.service`. Its checkout, Cargo target directory, Rust
@@ -91,11 +108,18 @@ gh api orgs/Richards-LLC/actions/runners
 gh variable set CASSY_SELF_HOSTED_PILOT --repo Richards-LLC/cassy --body enabled
 ```
 
-Before planned maintenance or an offline-fallback drill, disable assignment
-first, then stop the listener:
+Enable required merge-queue archive routing only after that online check:
+
+```bash
+gh variable set CASSY_MERGE_QUEUE_SELF_HOSTED --repo Richards-LLC/cassy --body enabled
+```
+
+Before planned maintenance or an offline-fallback drill, disable required
+merge-queue routing and advisory assignment first, then stop the listener:
 
 ```bash
 gh variable set CASSY_SELF_HOSTED_PILOT --repo Richards-LLC/cassy --body disabled
+gh variable set CASSY_MERGE_QUEUE_SELF_HOSTED --repo Richards-LLC/cassy --body disabled
 sudo systemctl stop cassy-actions-runner.service
 ```
 

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -99,10 +99,10 @@ require_text "$ruleset_text" '"max_entries_to_build": 1' 'merge queue avoids bat
 require_text "$ruleset_text" '"max_entries_to_merge": 1' 'merge queue merges one proven PR at a time'
 require_text "$ruleset_text" '"min_entries_to_merge_wait_minutes": 0' 'merge queue adds no group-fill wait'
 
-# Self-hosted pilot security/availability contract (cas-f5638). This repo is
-# public, so fork/untrusted PR code must be unable to request the persistent
-# runner. Required checks remain hosted: the local box is advisory and an
-# outage cannot strand merge eligibility.
+# Self-hosted pilot security contract (cas-f5638). This repo is public, so
+# fork/untrusted PR code must be unable to request the persistent runner. The
+# old push-only pilot remains advisory; the merge-queue route below is the only
+# required-path use of the box.
 require_text "$self_hosted_text" 'push:' 'self-hosted pilot accepts canonical repository pushes'
 require_text "$self_hosted_text" '- "factory/**"' 'self-hosted pilot accepts trusted factory branches'
 require_text "$self_hosted_text" '- "epic/**"' 'self-hosted pilot accepts trusted epic branches'
@@ -133,8 +133,30 @@ require_absent "$(<"$ruleset")" 'Self-hosted pilot' 'self-hosted pilot is not a 
 
 suite_build="$(job_block fast-validation-suite-build)"
 suite_shards="$(job_block fast-validation-suite-shards)"
-require_text "$suite_build" 'runs-on: ubuntu-latest' 'required archive build retains automatic hosted availability'
-require_text "$suite_shards" 'runs-on: ubuntu-latest' 'required suite shards retain automatic hosted availability'
+route="$(job_block fast-validation-runner-route)"
+require_text "$route" "github.event_name == 'merge_group'" 'runner route only offers the box to merge-queue trees'
+require_text "$route" 'vars.CASSY_MERGE_QUEUE_SELF_HOSTED' 'runner route requires explicit self-hosted opt-in'
+require_text "$route" '"$SELF_HOSTED_ENABLED" == enabled' 'runner route defaults to hosted unless the box is declared ready'
+require_text "$route" 'runner=["self-hosted","Linux","X64","cas-ci-32core"]' 'merge-queue route selects the isolated runner label set'
+require_text "$route" 'runner=["ubuntu-latest"]' 'disabled or non-queue traffic routes to hosted runners'
+require_text "$route" 'mode=self-hosted' 'runner route exposes selected self-hosted mode'
+require_text "$route" 'mode=hosted' 'runner route exposes selected hosted fallback mode'
+require_absent "$route" 'actions/checkout' 'runner route does not execute merge-queue source before label selection'
+
+require_text "$suite_build" 'needs: fast-validation-runner-route' 'required archive build waits for explicit runner routing'
+require_text "$suite_build" 'fromJSON(needs.fast-validation-runner-route.outputs.runner)' 'archive build receives the fail-safe selected runner labels'
+require_text "$suite_build" "needs.fast-validation-runner-route.outputs.mode != 'self-hosted'" 'archive rejects an untrusted self-hosted route before assignment'
+require_text "$suite_build" "github.event_name == 'merge_group'" 'self-hosted archive is restricted to merge-queue events'
+require_text "$suite_build" "github.repository == 'Richards-LLC/cassy'" 'self-hosted archive pins the canonical repository'
+require_text "$suite_build" "vars.CASSY_MERGE_QUEUE_SELF_HOSTED == 'enabled'" 'self-hosted archive repeats explicit readiness opt-in'
+require_text "$suite_build" "needs.fast-validation-runner-route.outputs.mode == 'hosted'" 'hosted setup remains selected for PR and fallback validation'
+require_text "$suite_build" "needs.fast-validation-runner-route.outputs.mode == 'self-hosted'" 'self-hosted setup is limited to selected merge-queue validation'
+require_text "$suite_build" 'Verify merge-queue self-hosted trust boundary' 'self-hosted archive verifies queue-only trust at execution'
+require_text "$suite_build" 'refs/heads/gh-readonly-queue/*' 'self-hosted archive rejects non-queue refs'
+require_text "$suite_build" 'Verify private self-hosted sccache' 'merge-queue archive verifies its dedicated local cache service'
+require_text "$suite_build" 'test "${SCCACHE_SERVER_PORT:?}" = 4227' 'required self-hosted archive pins the private cache port'
+require_text "$suite_build" 'SCCACHE_GHA_ENABLED=false' 'required self-hosted archive never depends on hosted cache credentials'
+require_text "$suite_shards" 'runs-on: ubuntu-latest' 'required suite shards retain hosted parallel execution and availability'
 
 scoped="$(job_block scoped-validation)"
 require_text "$scoped" "refs/heads/factory/" 'scoped tier selects factory branches'


### PR DESCRIPTION
Implements cas-6600's merge_group-only Fast Validation archive route. The default/disabled route stays hosted; only an explicitly enabled merge queue may select the 32-core runner, with repeated queue/canonical-ref guards and local sccache validation. Shards remain hosted and parallel. Tier contract: 382/382.