### PR TITLE
Route Viktor-originated questions into live Cassy sessions

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-viktor/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-viktor/SKILL.md
@@ -23,6 +23,10 @@ inbound notification with `origin=viktor`. Do not poll `get_run` or `get_run_res
 Treat starts as spend-bearing: use a bounded question, never auto-retry an uncertain start, and
 reconcile an existing thread/run before continuing.
 
+Viktor may also originate a thread and question Cassy. That arrives through the same inbound
+notification channel with `origin=viktor`; answer on the supplied thread with the existing
+`send_message` tool instead of creating a replacement thread.
+
 ## Boundary
 
 The proxy has a fail-closed allowlist and holds the credential reference. Never handle,

--- a/cas-cli/src/builtins/codex/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/codex/skills/cas-viktor/references/gateway.md
@@ -33,6 +33,13 @@ notification with `origin=viktor`. The requesting agent must not poll; it receiv
 normally on a later turn. If the requester is gone, CAS routes the notification to the live
 session supervisor.
 
+Viktor-originated threads require no prior CAS watch. The daemon checks Viktor's newest threads
+on the same 30-second cadence, skips every thread with any local watch row, and spends at most one
+32-thread `list_threads` scan plus four `list_messages` calls and four seconds per tick. Each provider message ID
+is durable and idempotent. It is routed with `origin=viktor` to one live, factory-session-filtered
+supervisor; when none is live, the question is retained and surfaced exactly once at the next
+supervisor SessionStart. Reply with `send_message` on the supplied thread ID.
+
 ## Cost and security
 
 Viktor starts can cost money or outlive a client timeout. Do not automatically retry a start;

--- a/cas-cli/src/builtins/grok/skills/cas-viktor/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-viktor/SKILL.md
@@ -23,6 +23,10 @@ inbound notification with `origin=viktor`. Do not poll `get_run` or `get_run_res
 Treat starts as spend-bearing: use a bounded question, never auto-retry an uncertain start, and
 reconcile an existing thread/run before continuing.
 
+Viktor may also originate a thread and question Cassy. That arrives through the same inbound
+notification channel with `origin=viktor`; answer on the supplied thread with the existing
+`send_message` tool instead of creating a replacement thread.
+
 ## Boundary
 
 The proxy has a fail-closed allowlist and holds the credential reference. Never handle,

--- a/cas-cli/src/builtins/grok/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/grok/skills/cas-viktor/references/gateway.md
@@ -33,6 +33,13 @@ notification with `origin=viktor`. The requesting agent must not poll; it receiv
 normally on a later turn. If the requester is gone, CAS routes the notification to the live
 session supervisor.
 
+Viktor-originated threads require no prior CAS watch. The daemon checks Viktor's newest threads
+on the same 30-second cadence, skips every thread with any local watch row, and spends at most one
+32-thread `list_threads` scan plus four `list_messages` calls and four seconds per tick. Each provider message ID
+is durable and idempotent. It is routed with `origin=viktor` to one live, factory-session-filtered
+supervisor; when none is live, the question is retained and surfaced exactly once at the next
+supervisor SessionStart. Reply with `send_message` on the supplied thread ID.
+
 ## Cost and security
 
 Viktor starts can cost money or outlive a client timeout. Do not automatically retry a start;

--- a/cas-cli/src/builtins/skills/cas-viktor/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-viktor/SKILL.md
@@ -23,6 +23,10 @@ inbound notification with `origin=viktor`. Do not poll `get_run` or `get_run_res
 Treat starts as spend-bearing: use a bounded question, never auto-retry an uncertain start, and
 reconcile an existing thread/run before continuing.
 
+Viktor may also originate a thread and question Cassy. That arrives through the same inbound
+notification channel with `origin=viktor`; answer on the supplied thread with the existing
+`send_message` tool instead of creating a replacement thread.
+
 ## Boundary
 
 The proxy has a fail-closed allowlist and holds the credential reference. Never handle,

--- a/cas-cli/src/builtins/skills/cas-viktor/references/gateway.md
+++ b/cas-cli/src/builtins/skills/cas-viktor/references/gateway.md
@@ -33,6 +33,13 @@ notification with `origin=viktor`. The requesting agent must not poll; it receiv
 normally on a later turn. If the requester is gone, CAS routes the notification to the live
 session supervisor.
 
+Viktor-originated threads require no prior CAS watch. The daemon checks Viktor's newest threads
+on the same 30-second cadence, skips every thread with any local watch row, and spends at most one
+32-thread `list_threads` scan plus four `list_messages` calls and four seconds per tick. Each provider message ID
+is durable and idempotent. It is routed with `origin=viktor` to one live, factory-session-filtered
+supervisor; when none is live, the question is retained and surfaced exactly once at the next
+supervisor SessionStart. Reply with `send_message` on the supplied thread ID.
+
 ## Cost and security
 
 Viktor starts can cost money or outlive a client timeout. Do not automatically retry a start;

--- a/cas-cli/src/cli/viktor.rs
+++ b/cas-cli/src/cli/viktor.rs
@@ -22,6 +22,8 @@ struct ViktorReport {
     upstream_status: String,
     watched_runs_pending: usize,
     pending_run_ids: Vec<String>,
+    inbound_questions_pending: usize,
+    pending_inbound_message_ids: Vec<String>,
 }
 
 /// Print the configuration contract without reading or displaying the API key.
@@ -41,6 +43,10 @@ pub fn execute(_args: &ViktorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow
     let watches = cas_root
         .and_then(|root| cas_store::SqliteViktorWatchStore::open(root).ok())
         .and_then(|store| store.list_live().ok())
+        .unwrap_or_default();
+    let inbound = cas_root
+        .and_then(|root| cas_store::SqliteViktorInboundStore::open(root).ok())
+        .and_then(|store| store.list_pending(32).ok())
         .unwrap_or_default();
     #[cfg(feature = "mcp-proxy")]
     let upstream_status = cas_root
@@ -75,10 +81,15 @@ pub fn execute(_args: &ViktorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow
         project_config,
         project_policy: "an existing .cas/proxy.toml opts out of the managed Viktor default; explicitly configure the sanctioned Viktor server and routes before direct calls",
         startup_action: "run cas serve without a project proxy config; startup refreshes the credential-reference-only managed Viktor upstream",
-        reply_delivery: "run-starting calls are durably watched by CAS; replies arrive as inbound notifications (origin=viktor), and a disconnected upstream surfaces pending run IDs instead of silently dropping them",
+        reply_delivery: "run-starting calls are durably watched by CAS; replies and Viktor-originated questions arrive as inbound notifications (origin=viktor), and disconnected/no-live states remain durable instead of being dropped",
         upstream_status,
         watched_runs_pending: watches.len(),
         pending_run_ids: watches.into_iter().map(|watch| watch.run_id).collect(),
+        inbound_questions_pending: inbound.len(),
+        pending_inbound_message_ids: inbound
+            .into_iter()
+            .map(|message| message.message_id)
+            .collect(),
     };
 
     if cli.json {
@@ -111,6 +122,15 @@ pub fn execute(_args: &ViktorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow
                 String::new()
             } else {
                 format!(" ({})", report.pending_run_ids.join(", "))
+            }
+        );
+        println!(
+            "  inbound questions pending: {}{}",
+            report.inbound_questions_pending,
+            if report.pending_inbound_message_ids.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", report.pending_inbound_message_ids.join(", "))
             }
         );
         println!("  replies: {}", report.reply_delivery);

--- a/cas-cli/src/hooks/handlers/handlers_session.rs
+++ b/cas-cli/src/hooks/handlers/handlers_session.rs
@@ -205,6 +205,16 @@ pub fn handle_session_start(
     }
 
     #[cfg(feature = "mcp-proxy")]
+    if is_supervisor
+        && let Some(inbound) = crate::mcp::viktor_watch::surface_inbound_at_session_start(
+            cas_root,
+            std::env::var("CAS_FACTORY_SESSION").ok().as_deref(),
+        )
+    {
+        assembler.prepend_protected(inbound);
+    }
+
+    #[cfg(feature = "mcp-proxy")]
     if let Some(warning) = crate::mcp::viktor_watch::session_start_warning(cas_root) {
         assembler.prepend_degradable(warning.clone(), warning);
     }
@@ -620,6 +630,43 @@ mod large_artifact_staging_tests {
         assert!(
             !context.contains("CONCURRENT SUPERVISORS ACTIVE"),
             "a lone supervisor must not receive a false concurrent-supervisor warning: {context}"
+        );
+    }
+
+    #[cfg(feature = "mcp-proxy")]
+    #[test]
+    fn supervisor_session_start_surfaces_viktor_inbound_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inbound = cas_store::SqliteViktorInboundStore::open(tmp.path()).unwrap();
+        assert!(
+            inbound
+                .record(
+                    "thread-provider-question",
+                    "message-provider-question",
+                    "Can Cassy answer from SessionStart?",
+                )
+                .unwrap()
+        );
+        inbound
+            .mark_delivery_error(
+                "message-provider-question",
+                "no live factory supervisor was registered at discovery time",
+            )
+            .unwrap();
+
+        let mut env = staging_env("supervisor");
+        env.set("CAS_AGENT_NAME", "next-supervisor");
+        env.set("CAS_FACTORY_SESSION", "factory-viktor-inbound");
+        let input = session_input(tmp.path().to_str().unwrap());
+        let first = additional_context(handle_session_start(&input, Some(tmp.path())).unwrap());
+        assert!(first.contains("Viktor-originated message arrived"));
+        assert!(first.contains("thread-provider-question"));
+        assert!(first.contains("Can Cassy answer from SessionStart?"));
+
+        let second = additional_context(handle_session_start(&input, Some(tmp.path())).unwrap());
+        assert!(
+            !second.contains("thread-provider-question"),
+            "the durable inbound question must be receipted after one SessionStart"
         );
     }
 

--- a/cas-cli/src/hooks/handlers/session_budget.rs
+++ b/cas-cli/src/hooks/handlers/session_budget.rs
@@ -184,6 +184,11 @@ impl SessionContextAssembler {
         self.push(false, text, None);
     }
 
+    /// Prepend a safety segment that must survive verbatim.
+    pub(crate) fn prepend_protected(&mut self, text: String) {
+        self.push(true, text, None);
+    }
+
     /// Append a segment that degrades to `compact` when over budget.
     pub(crate) fn append_degradable(&mut self, full: String, compact: String) {
         self.push(false, full, Some(compact));

--- a/cas-cli/src/mcp/daemon.rs
+++ b/cas-cli/src/mcp/daemon.rs
@@ -787,6 +787,12 @@ impl EmbeddedDaemon {
                         ).await {
                             tracing::warn!(error = %error, "Viktor inbound watch tick failed");
                         }
+                        if let Err(error) = crate::mcp::viktor_watch::discover_originated_messages(
+                            &self.config.cas_root,
+                            &proxy,
+                        ).await {
+                            tracing::warn!(error = %error, "Viktor originated-thread discovery tick failed");
+                        }
                     }
                 }
 

--- a/cas-cli/src/mcp/viktor_watch.rs
+++ b/cas-cli/src/mcp/viktor_watch.rs
@@ -4,16 +4,24 @@
 use std::path::{Path, PathBuf};
 
 use cas_store::{
-    EnqueueIdempotentResult, PromptQueueStore, SqlitePromptQueueStore, SqliteViktorWatchStore,
-    ViktorThreadWatch,
+    EnqueueIdempotentResult, PromptQueueStore, SqlitePromptQueueStore, SqliteViktorInboundStore,
+    SqliteViktorWatchStore, ViktorInboundMessage, ViktorThreadWatch,
 };
-use cas_types::{AgentRole, AgentStatus};
+use cas_types::{Agent, AgentRole, AgentStatus};
 use serde_json::{Map, Value};
 
 pub(crate) const VIKTOR_WATCH_POLL_INTERVAL_SECS: i64 = 30;
 pub(crate) const VIKTOR_WATCH_MAX_PER_TICK: usize = 16;
 pub(crate) const VIKTOR_WATCH_MAX_CALLS_PER_TICK: usize = VIKTOR_WATCH_MAX_PER_TICK * 2;
 pub(crate) const VIKTOR_WATCH_TICK_BUDGET_SECS: u64 = 20;
+pub(crate) const VIKTOR_INBOUND_DISCOVERY_SCAN_THREADS: usize = 32;
+pub(crate) const VIKTOR_INBOUND_DISCOVERY_MAX_THREADS: usize = 4;
+pub(crate) const VIKTOR_INBOUND_DISCOVERY_MAX_CALLS: usize =
+    VIKTOR_INBOUND_DISCOVERY_MAX_THREADS + 1;
+pub(crate) const VIKTOR_INBOUND_DISCOVERY_BUDGET_SECS: u64 = 4;
+const VIKTOR_INBOUND_MESSAGES_PER_THREAD: usize = 8;
+const VIKTOR_INBOUND_SESSION_START_LIMIT: usize = 1;
+const VIKTOR_INBOUND_SESSION_START_BODY_CHARS: usize = 2_000;
 
 const START_TOOLS: &[&str] = &["ask_viktor", "create_thread", "send_message"];
 const TERMINAL_RUN_STATES: &[&str] = &[
@@ -99,6 +107,37 @@ pub(crate) async fn alert_unpollable_watches(
 /// A bounded session-start warning derived from the same durable records that
 /// drive daemon polling. This remains visible even when no supervisor was live
 /// at daemon startup to receive the queue notification.
+pub(crate) fn surface_inbound_at_session_start(
+    cas_root: &Path,
+    factory_session: Option<&str>,
+) -> Option<String> {
+    let store = SqliteViktorInboundStore::open(cas_root).ok()?;
+    let messages = store
+        .surface_pending(factory_session, VIKTOR_INBOUND_SESSION_START_LIMIT)
+        .ok()?;
+    if messages.is_empty() {
+        return None;
+    }
+    let mut rendered = String::from(
+        "⚠ Viktor-originated message arrived while no live Cassy supervisor could receive it. It is surfaced once here; answer on its existing thread through Viktor `send_message`.",
+    );
+    for message in messages {
+        let body = message
+            .body
+            .chars()
+            .take(VIKTOR_INBOUND_SESSION_START_BODY_CHARS)
+            .collect::<String>();
+        let truncated = (message.body.chars().count() > VIKTOR_INBOUND_SESSION_START_BODY_CHARS)
+            .then_some("\n[message truncated to the SessionStart safety bound]")
+            .unwrap_or_default();
+        rendered.push_str(&format!(
+            "\n\n<viktor-inbound thread_id=\"{}\" message_id=\"{}\">\n{}{}\n</viktor-inbound>",
+            message.thread_id, message.message_id, body, truncated
+        ));
+    }
+    Some(rendered)
+}
+
 pub(crate) fn session_start_warning(cas_root: &Path) -> Option<String> {
     let health = crate::mcp::read_proxy_health_cache(cas_root).ok()?;
     let snapshot: cmcp_core::ProxyHealthSnapshot = serde_json::from_slice(&health).ok()?;
@@ -133,6 +172,205 @@ pub(crate) fn session_start_warning(cas_root: &Path) -> Option<String> {
         absent.last_error_code.as_deref().unwrap_or("unknown"),
         watch_detail
     ))
+}
+
+/// Discover provider-originated threads on the same cadence as run watches.
+/// One tick costs at most one `list_threads` plus four `list_messages` calls,
+/// and the whole discovery pass is cancelled after four seconds.
+pub(crate) async fn discover_originated_messages(
+    cas_root: &Path,
+    proxy: &cmcp_core::ProxyEngine,
+) -> Result<usize, String> {
+    if !proxy.upstream_connected("viktor").await {
+        return Ok(0);
+    }
+    tracing::debug!(
+        max_threads = VIKTOR_INBOUND_DISCOVERY_MAX_THREADS,
+        scan_threads = VIKTOR_INBOUND_DISCOVERY_SCAN_THREADS,
+        max_calls = VIKTOR_INBOUND_DISCOVERY_MAX_CALLS,
+        budget_secs = VIKTOR_INBOUND_DISCOVERY_BUDGET_SECS,
+        "Viktor originated-thread discovery tick"
+    );
+    let deadline = tokio::time::Instant::now()
+        + std::time::Duration::from_secs(VIKTOR_INBOUND_DISCOVERY_BUDGET_SECS);
+    let caller = discovery_caller();
+    let list_args = Map::from_iter([(
+        "limit".to_string(),
+        Value::from(VIKTOR_INBOUND_DISCOVERY_SCAN_THREADS as u64),
+    )]);
+    let threads = tokio::time::timeout_at(
+        deadline,
+        proxy.call_tool(&caller, "viktor", "list_threads", Some(list_args)),
+    )
+    .await
+    .map_err(|_| "Viktor inbound discovery exhausted its 4s wall-clock budget".to_string())?
+    .map_err(|error| bounded_error(&error.to_string()))?;
+
+    let watch_store = SqliteViktorWatchStore::open(cas_root).map_err(|error| error.to_string())?;
+    let inbound_store =
+        SqliteViktorInboundStore::open(cas_root).map_err(|error| error.to_string())?;
+    let mut thread_ids = provider_items(&threads, "threads")
+        .into_iter()
+        .filter_map(|thread| item_id(&thread, "thread_id"))
+        .collect::<Vec<_>>();
+    thread_ids.dedup();
+    thread_ids.truncate(VIKTOR_INBOUND_DISCOVERY_SCAN_THREADS);
+    let mut candidates = Vec::new();
+    for thread_id in thread_ids {
+        if watch_store
+            .contains_thread(&thread_id)
+            .map_err(|error| error.to_string())?
+        {
+            continue;
+        }
+        let known = inbound_store
+            .contains_thread(&thread_id)
+            .map_err(|error| error.to_string())?;
+        candidates.push((known, thread_id));
+    }
+    // Drain newly observed threads before refreshing known inbound threads so
+    // a busy unresolved conversation cannot permanently starve the next one.
+    candidates.sort_by_key(|(known, _)| *known);
+
+    for (_, thread_id) in candidates
+        .into_iter()
+        .take(VIKTOR_INBOUND_DISCOVERY_MAX_THREADS)
+    {
+        let args = Map::from_iter([
+            ("thread_id".to_string(), Value::String(thread_id.clone())),
+            (
+                "limit".to_string(),
+                Value::from(VIKTOR_INBOUND_MESSAGES_PER_THREAD as u64),
+            ),
+        ]);
+        let messages = tokio::time::timeout_at(
+            deadline,
+            proxy.call_tool(&caller, "viktor", "list_messages", Some(args)),
+        )
+        .await
+        .map_err(|_| "Viktor inbound discovery exhausted its 4s wall-clock budget".to_string())?
+        .map_err(|error| bounded_error(&error.to_string()))?;
+        for message in provider_items(&messages, "messages") {
+            let Some(message_id) = item_id(&message, "message_id") else {
+                tracing::error!(thread_id, "Viktor inbound message had no stable message id");
+                continue;
+            };
+            let body = render_message_body(&message);
+            if body.trim().is_empty() {
+                tracing::error!(
+                    thread_id,
+                    message_id,
+                    "Viktor inbound message had no content"
+                );
+                continue;
+            }
+            inbound_store
+                .record(&thread_id, &message_id, &body)
+                .map_err(|error| error.to_string())?;
+        }
+    }
+
+    deliver_pending_inbound(cas_root, &inbound_store)
+}
+
+fn discovery_caller() -> cmcp_core::ProxyCaller {
+    cmcp_core::ProxyCaller {
+        agent_id: "cas-daemon-viktor-inbound".to_string(),
+        role: AgentRole::Supervisor,
+        session_id: "cas-daemon-viktor-inbound".to_string(),
+        factory_session: None,
+        active_task_ids: Vec::new(),
+    }
+}
+
+fn live_supervisor(cas_root: &Path) -> Option<Agent> {
+    let store = crate::store::open_agent_store(cas_root).ok()?;
+    store
+        .list(None)
+        .ok()?
+        .into_iter()
+        .filter(|agent| {
+            matches!(agent.role, AgentRole::Supervisor | AgentRole::Director)
+                && matches!(agent.status, AgentStatus::Active | AgentStatus::Idle)
+                && agent.factory_session.is_some()
+        })
+        .max_by_key(|agent| agent.last_heartbeat)
+}
+
+fn deliver_pending_inbound(
+    cas_root: &Path,
+    store: &SqliteViktorInboundStore,
+) -> Result<usize, String> {
+    let pending = store
+        .list_pending(VIKTOR_INBOUND_DISCOVERY_MAX_THREADS * VIKTOR_INBOUND_MESSAGES_PER_THREAD)
+        .map_err(|error| error.to_string())?;
+    if pending.is_empty() {
+        return Ok(0);
+    }
+    let Some(supervisor) = live_supervisor(cas_root) else {
+        for message in pending {
+            store
+                .mark_delivery_error(
+                    &message.message_id,
+                    "no live factory supervisor was registered at discovery time",
+                )
+                .map_err(|error| error.to_string())?;
+        }
+        return Ok(0);
+    };
+    let queue = SqlitePromptQueueStore::open(cas_root).map_err(|error| error.to_string())?;
+    queue.init().map_err(|error| error.to_string())?;
+    let mut delivered = 0;
+    for message in pending {
+        let prompt = render_originated_message(&message);
+        let enqueued = queue
+            .enqueue_idempotent(
+                "viktor",
+                &supervisor.name,
+                &prompt,
+                supervisor.factory_session.as_deref(),
+                Some(&format!("Viktor question on {}", message.thread_id)),
+                Some(cas_store::NotificationPriority::High),
+                &format!("viktor-inbound:{}", message.message_id),
+            )
+            .map_err(|error| error.to_string())?;
+        let notification_id = match enqueued {
+            EnqueueIdempotentResult::Created(id) => {
+                delivered += 1;
+                id
+            }
+            EnqueueIdempotentResult::AlreadyExists(id) => id,
+        };
+        store
+            .mark_delivered(
+                &message.message_id,
+                supervisor.factory_session.as_deref(),
+                Some(notification_id),
+            )
+            .map_err(|error| error.to_string())?;
+    }
+    let _ = cas_factory::notify_daemon(cas_root);
+    Ok(delivered)
+}
+
+fn render_originated_message(message: &ViktorInboundMessage) -> String {
+    format!(
+        "<viktor-inbound thread_id=\"{}\" message_id=\"{}\">\n{}\n\nReply on this thread through the existing Viktor `send_message` tool with `thread_id=\"{}\"`; do not start a replacement thread.\n</viktor-inbound>",
+        message.thread_id, message.message_id, message.body, message.thread_id
+    )
+}
+
+fn render_message_body(value: &Value) -> String {
+    for key in ["content", "text", "message", "markdown"] {
+        if let Some(text) = value
+            .as_object()
+            .and_then(|object| object.get(key))
+            .and_then(Value::as_str)
+        {
+            return text.chars().take(16_000).collect();
+        }
+    }
+    render_provider_payload(value)
 }
 
 impl ViktorWatchRecorder {
@@ -401,6 +639,63 @@ fn render_provider_payload(value: &Value) -> String {
     rendered.chars().take(16_000).collect()
 }
 
+fn provider_items(value: &Value, collection_key: &str) -> Vec<Value> {
+    let decoded = decode_provider_payload(value);
+    match decoded {
+        Value::Array(items) => items,
+        Value::Object(mut object) => object
+            .remove(collection_key)
+            .and_then(|items| items.as_array().cloned())
+            .or_else(|| {
+                object
+                    .values()
+                    .find_map(|child| find_array_by_key(child, collection_key))
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+fn decode_provider_payload(value: &Value) -> Value {
+    if let Value::Object(object) = value
+        && let Some(Value::Array(content)) = object.get("content")
+        && let Some(text) = content.iter().find_map(|item| {
+            item.as_object()
+                .and_then(|item| item.get("text"))
+                .and_then(Value::as_str)
+        })
+        && let Ok(decoded) = serde_json::from_str(text)
+    {
+        return decoded;
+    }
+    value.clone()
+}
+
+fn find_array_by_key(value: &Value, key: &str) -> Option<Vec<Value>> {
+    match value {
+        Value::Object(object) => object
+            .get(key)
+            .and_then(Value::as_array)
+            .cloned()
+            .or_else(|| {
+                object
+                    .values()
+                    .find_map(|child| find_array_by_key(child, key))
+            }),
+        Value::Array(items) => items.iter().find_map(|child| find_array_by_key(child, key)),
+        _ => None,
+    }
+}
+
+fn item_id(value: &Value, flat_key: &str) -> Option<String> {
+    value
+        .as_object()
+        .and_then(|object| object.get(flat_key).or_else(|| object.get("id")))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| find_string_by_key(value, flat_key))
+}
+
 fn collect_content_text(value: &Value, texts: &mut Vec<String>) {
     match value {
         Value::Object(object) => {
@@ -507,6 +802,10 @@ mod tests {
         assert!(!TERMINAL_RUN_STATES.contains(&"running"));
         assert_eq!(VIKTOR_WATCH_MAX_CALLS_PER_TICK, 32);
         assert_eq!(VIKTOR_WATCH_TICK_BUDGET_SECS, 20);
+        assert_eq!(VIKTOR_INBOUND_DISCOVERY_SCAN_THREADS, 32);
+        assert_eq!(VIKTOR_INBOUND_DISCOVERY_MAX_THREADS, 4);
+        assert_eq!(VIKTOR_INBOUND_DISCOVERY_MAX_CALLS, 5);
+        assert_eq!(VIKTOR_INBOUND_DISCOVERY_BUDGET_SECS, 4);
     }
 
     #[tokio::test]
@@ -605,6 +904,208 @@ mod tests {
         );
         assert!(fallback[0].prompt.contains("run-fixture-2"));
 
+        engine.shutdown().await;
+    }
+
+    async fn inbound_fixture_engine(cas_root: &Path) -> cmcp_core::ProxyEngine {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/mock_mcp_viktor_inbound_server.py");
+        let config = cmcp_core::config::ServerConfig::Stdio {
+            command: "python3".to_string(),
+            args: vec![fixture.display().to_string()],
+            env: HashMap::new(),
+        };
+        let engine =
+            cmcp_core::ProxyEngine::from_configs(HashMap::from([("viktor".to_string(), config)]))
+                .await
+                .unwrap();
+        engine
+            .set_call_observer(std::sync::Arc::new(ViktorWatchRecorder::new(
+                cas_root.to_path_buf(),
+            )))
+            .await;
+        engine
+    }
+
+    #[tokio::test]
+    async fn provider_originated_thread_reaches_live_supervisor_once_and_can_reply() {
+        let temp = tempfile::tempdir().unwrap();
+        let agents = crate::store::open_agent_store(temp.path()).unwrap();
+        let mut other_supervisor = Agent::new_with_role(
+            "other-supervisor-session".to_string(),
+            "other-supervisor".to_string(),
+            AgentRole::Supervisor,
+        );
+        other_supervisor.factory_session = Some("factory-other".to_string());
+        agents.register(&other_supervisor).unwrap();
+        let mut supervisor = Agent::new_with_role(
+            "supervisor-session".to_string(),
+            "live-supervisor".to_string(),
+            AgentRole::Supervisor,
+        );
+        supervisor.factory_session = Some("factory-inbound".to_string());
+        supervisor.last_heartbeat = other_supervisor.last_heartbeat + chrono::Duration::seconds(1);
+        agents.register(&supervisor).unwrap();
+
+        // The second fixture thread was opened by CAS earlier. Discovery must
+        // leave that existing watch path alone, including after its run ends.
+        let watch_store = SqliteViktorWatchStore::open(temp.path()).unwrap();
+        let prior_watch = watch_store
+            .record(
+                "thread-cas-opened",
+                "run-cas-opened",
+                &supervisor.id,
+                &supervisor.name,
+                "supervisor",
+                supervisor.factory_session.as_deref(),
+                None,
+                None,
+                cas_store::DEFAULT_VIKTOR_WATCH_TTL_SECS,
+            )
+            .unwrap();
+        watch_store.mark_delivered(prior_watch, 404).unwrap();
+
+        let engine = inbound_fixture_engine(temp.path()).await;
+        assert_eq!(
+            discover_originated_messages(temp.path(), &engine)
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            discover_originated_messages(temp.path(), &engine)
+                .await
+                .unwrap(),
+            0,
+            "the same provider message id must not enqueue twice"
+        );
+
+        let queue = SqlitePromptQueueStore::open(temp.path()).unwrap();
+        queue.init().unwrap();
+        let messages = queue
+            .poll_for_target_with_session(
+                &supervisor.name,
+                supervisor.factory_session.as_deref(),
+                10,
+            )
+            .unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].source, "viktor");
+        assert_eq!(
+            messages[0].factory_session.as_deref(),
+            Some("factory-inbound")
+        );
+        assert!(messages[0].prompt.contains("thread-viktor-originated"));
+        assert!(messages[0].prompt.contains("message-viktor-question"));
+        assert!(
+            messages[0]
+                .prompt
+                .contains("Can Cassy answer this question on-thread?")
+        );
+        assert!(messages[0].prompt.contains("send_message"));
+        assert!(!messages[0].prompt.contains("thread-cas-opened"));
+        assert!(
+            queue
+                .poll_for_target_with_session(
+                    &other_supervisor.name,
+                    other_supervisor.factory_session.as_deref(),
+                    10,
+                )
+                .unwrap()
+                .is_empty(),
+            "an originated question must route to one supervisor session, not broadcast"
+        );
+
+        // No new write surface is needed: the existing send_message route is
+        // still observed and arms the ordinary watched-run reply path.
+        let caller = cmcp_core::ProxyCaller {
+            agent_id: supervisor.id.clone(),
+            role: AgentRole::Supervisor,
+            session_id: supervisor.id.clone(),
+            factory_session: supervisor.factory_session.clone(),
+            active_task_ids: vec![],
+        };
+        engine
+            .call_tool(
+                &caller,
+                "viktor",
+                "send_message",
+                Some(Map::from_iter([
+                    (
+                        "thread_id".to_string(),
+                        Value::String("thread-viktor-originated".to_string()),
+                    ),
+                    (
+                        "message".to_string(),
+                        Value::String("Cassy's on-thread answer".to_string()),
+                    ),
+                ])),
+            )
+            .await
+            .unwrap();
+        assert!(
+            SqliteViktorWatchStore::open(temp.path())
+                .unwrap()
+                .list_live()
+                .unwrap()
+                .iter()
+                .any(|watch| watch.run_id == "run-cassy-reply")
+        );
+        engine.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn no_live_supervisor_is_durable_and_surfaces_once_at_session_start() {
+        let temp = tempfile::tempdir().unwrap();
+        SqliteViktorWatchStore::open(temp.path())
+            .unwrap()
+            .record(
+                "thread-cas-opened",
+                "run-cas-opened",
+                "ended-agent",
+                "ended-agent",
+                "standard",
+                None,
+                None,
+                None,
+                cas_store::DEFAULT_VIKTOR_WATCH_TTL_SECS,
+            )
+            .unwrap();
+        let engine = inbound_fixture_engine(temp.path()).await;
+        assert_eq!(
+            discover_originated_messages(temp.path(), &engine)
+                .await
+                .unwrap(),
+            0,
+            "discovery cannot claim live delivery when no supervisor exists"
+        );
+        let pending = SqliteViktorInboundStore::open(temp.path())
+            .unwrap()
+            .list_pending(8)
+            .unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(
+            pending[0].last_error.as_deref(),
+            Some("no live factory supervisor was registered at discovery time")
+        );
+
+        let warning = surface_inbound_at_session_start(temp.path(), Some("factory-next"))
+            .expect("the next supervisor SessionStart must surface the durable question");
+        assert!(warning.contains("while no live Cassy supervisor could receive"));
+        assert!(warning.contains("thread-viktor-originated"));
+        assert!(warning.contains("Can Cassy answer this question on-thread?"));
+        assert!(warning.contains("send_message"));
+        assert!(
+            surface_inbound_at_session_start(temp.path(), Some("factory-next")).is_none(),
+            "SessionStart surfacing must be exactly once"
+        );
+        assert!(
+            SqliteViktorInboundStore::open(temp.path())
+                .unwrap()
+                .list_pending(8)
+                .unwrap()
+                .is_empty()
+        );
         engine.shutdown().await;
     }
 

--- a/cas-cli/tests/fixtures/mock_mcp_viktor_inbound_server.py
+++ b/cas-cli/tests/fixtures/mock_mcp_viktor_inbound_server.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Deterministic Viktor MCP fixture for provider-originated inbound tests."""
+
+import json
+import sys
+
+
+TOOLS = [
+    {"name": "list_threads", "description": "list", "inputSchema": {"type": "object"}},
+    {"name": "list_messages", "description": "messages", "inputSchema": {"type": "object"}},
+    {"name": "send_message", "description": "reply", "inputSchema": {"type": "object"}},
+]
+
+
+def respond(request_id, result):
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}) + "\n")
+    sys.stdout.flush()
+
+
+def tool_result(payload):
+    return {"content": [{"type": "text", "text": json.dumps(payload)}]}
+
+
+for line in sys.stdin:
+    request = json.loads(line)
+    request_id = request.get("id")
+    if request_id is None:
+        continue
+    method = request.get("method")
+    if method == "initialize":
+        respond(
+            request_id,
+            {
+                "protocolVersion": request.get("params", {}).get("protocolVersion", "2024-11-05"),
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "mock-viktor-inbound", "version": "0.0.1"},
+            },
+        )
+    elif method == "tools/list":
+        respond(request_id, {"tools": TOOLS})
+    elif method == "tools/call":
+        name = request.get("params", {}).get("name")
+        arguments = request.get("params", {}).get("arguments", {})
+        if name == "list_threads":
+            # Viktor's MCP route returns the public API array directly.
+            payload = [
+                {"id": "thread-viktor-originated", "status": "waiting"},
+                {"id": "thread-cas-opened", "status": "completed"},
+            ]
+        elif name == "list_messages":
+            thread_id = arguments.get("thread_id")
+            payload = [
+                {
+                    "id": "message-viktor-question",
+                    "thread_id": thread_id,
+                    "role": "user",
+                    "content": "Can Cassy answer this question on-thread?",
+                }
+            ]
+        elif name == "send_message":
+            payload = {
+                "thread": {"id": arguments.get("thread_id")},
+                "message": {"id": "message-cassy-reply"},
+                "run": {"id": "run-cassy-reply"},
+            }
+        else:
+            payload = {"error": "unsupported", "message": name}
+        respond(request_id, tool_result(payload))
+    elif method in ("ping", "shutdown", "exit"):
+        respond(request_id, {})
+    else:
+        respond(request_id, tool_result({"error": "unsupported", "message": method}))

--- a/crates/cas-mcp-proxy/README.md
+++ b/crates/cas-mcp-proxy/README.md
@@ -20,6 +20,14 @@ Every forwarded call is attributed by the proxy policy audit to the registered
 CAS caller, active task leases, and dispatch timestamp; request arguments and
 upstream output are not retained in that receipt.
 
+The embedded daemon also discovers Viktor-originated threads that have no
+CAS-created watch row. Discovery reuses the 30-second watcher cadence, is
+bounded to one 32-thread `list_threads` scan plus at most four `list_messages`
+calls and four seconds per tick, and deduplicates durably by provider message ID. A question
+is queued with `origin=viktor` to one live factory supervisor; if none exists,
+the durable message is surfaced exactly once at the next supervisor
+SessionStart. Replies use the existing `send_message` tool on that thread.
+
 An existing `.cas/proxy.toml` intentionally replaces the user allowlist and
 delegation policy rather than widening it. Projects that have one must add the
 same exact routes there to opt into direct Viktor conversations. This preserves

--- a/crates/cas-store/src/lib.rs
+++ b/crates/cas-store/src/lib.rs
@@ -71,6 +71,7 @@ mod supervisor_queue_store;
 mod task_store;
 pub mod tracing;
 mod verification_store;
+mod viktor_inbound_store;
 mod viktor_watch_store;
 mod worktree_store;
 
@@ -187,9 +188,9 @@ pub use verification_store::{
 };
 
 // Durable Viktor thread watches used by the embedded daemon's inbound bridge.
+pub use viktor_inbound_store::{SqliteViktorInboundStore, ViktorInboundMessage};
 pub use viktor_watch_store::{
-    DEFAULT_VIKTOR_WATCH_TTL_SECS, SqliteViktorWatchStore, ViktorThreadWatch,
-    ViktorWatchStatus,
+    DEFAULT_VIKTOR_WATCH_TTL_SECS, SqliteViktorWatchStore, ViktorThreadWatch, ViktorWatchStatus,
 };
 
 // Worktree store for git worktree tracking

--- a/crates/cas-store/src/viktor_inbound_store.rs
+++ b/crates/cas-store/src/viktor_inbound_store.rs
@@ -1,0 +1,231 @@
+//! Durable provider-originated Viktor messages awaiting a Cassy supervisor.
+
+use chrono::{DateTime, TimeZone, Utc};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use crate::Result;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViktorInboundMessage {
+    pub message_id: String,
+    pub thread_id: String,
+    pub body: String,
+    pub created_at: DateTime<Utc>,
+    pub delivered_at: Option<DateTime<Utc>>,
+    pub factory_session: Option<String>,
+    pub notification_id: Option<i64>,
+    pub last_error: Option<String>,
+}
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS viktor_inbound_messages (
+    message_id TEXT PRIMARY KEY,
+    thread_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    delivered_at TEXT,
+    factory_session TEXT,
+    notification_id INTEGER,
+    last_error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_viktor_inbound_pending
+    ON viktor_inbound_messages(delivered_at, created_at);
+"#;
+
+pub struct SqliteViktorInboundStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl SqliteViktorInboundStore {
+    pub fn open(cas_dir: &Path) -> Result<Self> {
+        let conn = crate::shared_db::shared_connection(&cas_dir.join("cas.db"))?;
+        let store = Self { conn };
+        store.init()?;
+        Ok(store)
+    }
+
+    pub fn init(&self) -> Result<()> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.execute_batch(SCHEMA)?;
+        Ok(())
+    }
+
+    /// Persist a provider message before attempting delivery. Returns `true`
+    /// only for the first observation of this provider message ID.
+    pub fn record(&self, thread_id: &str, message_id: &str, body: &str) -> Result<bool> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        Ok(conn.execute(
+            "INSERT OR IGNORE INTO viktor_inbound_messages
+                (message_id, thread_id, body, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![message_id, thread_id, body, Utc::now().to_rfc3339()],
+        )? > 0)
+    }
+
+    pub fn list_pending(&self, limit: usize) -> Result<Vec<ViktorInboundMessage>> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        let mut statement = conn.prepare(&format!(
+            "SELECT {} FROM viktor_inbound_messages
+             WHERE delivered_at IS NULL ORDER BY datetime(created_at), message_id LIMIT ?1",
+            Self::COLUMNS
+        ))?;
+        statement
+            .query_map([i64::try_from(limit).unwrap_or(i64::MAX)], Self::from_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    pub fn contains_thread(&self, thread_id: &str) -> Result<bool> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM viktor_inbound_messages WHERE thread_id = ?1)",
+            [thread_id],
+            |row| row.get(0),
+        )
+        .map_err(Into::into)
+    }
+
+    pub fn mark_delivery_error(&self, message_id: &str, error: &str) -> Result<()> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.execute(
+            "UPDATE viktor_inbound_messages SET last_error = ?2
+             WHERE message_id = ?1 AND delivered_at IS NULL",
+            params![message_id, error],
+        )?;
+        Ok(())
+    }
+
+    pub fn mark_delivered(
+        &self,
+        message_id: &str,
+        factory_session: Option<&str>,
+        notification_id: Option<i64>,
+    ) -> Result<()> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.execute(
+            "UPDATE viktor_inbound_messages SET delivered_at = ?2,
+                factory_session = ?3, notification_id = ?4, last_error = NULL
+             WHERE message_id = ?1 AND delivered_at IS NULL",
+            params![
+                message_id,
+                Utc::now().to_rfc3339(),
+                factory_session,
+                notification_id
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Atomically claim pending messages for direct SessionStart surfacing.
+    /// Every returned row is already receipted, so callers must render all of
+    /// them in the hook output.
+    pub fn surface_pending(
+        &self,
+        factory_session: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<ViktorInboundMessage>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        crate::shared_db::with_write_retry(|| {
+            let conn = crate::shared_db::lock_connection(&self.conn)?;
+            let tx = crate::shared_db::ImmediateTx::new(&conn)?;
+            let mut statement = tx.prepare(&format!(
+                "SELECT {} FROM viktor_inbound_messages
+                 WHERE delivered_at IS NULL ORDER BY datetime(created_at), message_id LIMIT ?1",
+                Self::COLUMNS
+            ))?;
+            let messages = statement
+                .query_map([i64::try_from(limit).unwrap_or(i64::MAX)], Self::from_row)?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            drop(statement);
+            let delivered_at = Utc::now().to_rfc3339();
+            for message in &messages {
+                tx.execute(
+                    "UPDATE viktor_inbound_messages SET delivered_at = ?2,
+                        factory_session = ?3, last_error = NULL
+                     WHERE message_id = ?1 AND delivered_at IS NULL",
+                    params![message.message_id, delivered_at, factory_session],
+                )?;
+            }
+            tx.commit()?;
+            Ok(messages)
+        })
+    }
+
+    pub fn get(&self, message_id: &str) -> Result<Option<ViktorInboundMessage>> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.query_row(
+            &format!(
+                "SELECT {} FROM viktor_inbound_messages WHERE message_id = ?1",
+                Self::COLUMNS
+            ),
+            [message_id],
+            Self::from_row,
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
+    const COLUMNS: &str = "message_id, thread_id, body, created_at, delivered_at,
+        factory_session, notification_id, last_error";
+
+    fn parse_datetime(value: String) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(&value)
+            .map(|value| value.with_timezone(&Utc))
+            .or_else(|_| {
+                chrono::NaiveDateTime::parse_from_str(&value, "%Y-%m-%d %H:%M:%S")
+                    .map(|value| Utc.from_utc_datetime(&value))
+            })
+            .unwrap_or_else(|_| Utc::now())
+    }
+
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ViktorInboundMessage> {
+        let delivered_at: Option<String> = row.get(4)?;
+        Ok(ViktorInboundMessage {
+            message_id: row.get(0)?,
+            thread_id: row.get(1)?,
+            body: row.get(2)?,
+            created_at: Self::parse_datetime(row.get(3)?),
+            delivered_at: delivered_at.map(Self::parse_datetime),
+            factory_session: row.get(5)?,
+            notification_id: row.get(6)?,
+            last_error: row.get(7)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inbound_messages_are_idempotent_and_surface_once() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = SqliteViktorInboundStore::open(temp.path()).unwrap();
+        assert!(store.record("thread-1", "message-1", "question").unwrap());
+        assert!(!store.record("thread-1", "message-1", "duplicate").unwrap());
+        assert!(store.contains_thread("thread-1").unwrap());
+        assert!(!store.contains_thread("thread-missing").unwrap());
+        store
+            .mark_delivery_error("message-1", "no live factory supervisor")
+            .unwrap();
+
+        let surfaced = store.surface_pending(Some("factory-1"), 8).unwrap();
+        assert_eq!(surfaced.len(), 1);
+        assert_eq!(surfaced[0].body, "question");
+        assert!(
+            store
+                .surface_pending(Some("factory-1"), 8)
+                .unwrap()
+                .is_empty()
+        );
+        let persisted = store.get("message-1").unwrap().unwrap();
+        assert!(persisted.delivered_at.is_some());
+        assert_eq!(persisted.factory_session.as_deref(), Some("factory-1"));
+        assert!(persisted.last_error.is_none());
+    }
+}

--- a/crates/cas-store/src/viktor_watch_store.rs
+++ b/crates/cas-store/src/viktor_watch_store.rs
@@ -215,6 +215,19 @@ impl SqliteViktorWatchStore {
             .map_err(Into::into)
     }
 
+    /// Any CAS-created watch, including a terminal one, proves that the thread
+    /// originated on the existing outbound path and must not be rediscovered
+    /// as a provider-initiated thread.
+    pub fn contains_thread(&self, thread_id: &str) -> Result<bool> {
+        let conn = crate::shared_db::lock_connection(&self.conn)?;
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM viktor_thread_watches WHERE thread_id = ?1)",
+            [thread_id],
+            |row| row.get(0),
+        )
+        .map_err(Into::into)
+    }
+
     pub fn record_poll(
         &self,
         id: i64,


### PR DESCRIPTION
## Summary

- discover Viktor-originated threads through the managed list_threads/list_messages gateway path when no CAS watch row exists
- durably deduplicate provider messages and route them to one live, factory-session-filtered supervisor with origin=viktor
- surface undeliverable questions once at the next supervisor SessionStart and retain the existing send_message reply path
- bound each 30-second discovery tick to one 32-thread scan, four message calls, and four seconds

## Verification

- cargo check -p cas --lib --tests
- scripts/run-scoped-tests.sh --proof -p cas --lib -E test(/viktor/) (9 passed; committed-diff surface covered)
- scripts/run-scoped-tests.sh -p cas-store --lib viktor_inbound_store (1 passed)
- scripts/run-scoped-tests.sh -p cas --test builtin_flavor_drift_test (9 passed)

Task: cas-edb8