### PR TITLE
chore(release): prepare v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-08-19
+
+### Added
+- **Factory workers now surface Viktor-originated questions to a live supervisor.** Incoming conversations are persisted and deduplicated, and remain visible for the next supervisor when no live session is available.
+- **Cassy can use an alternate worker account without losing its isolated project context.** Each worker now resolves its own project history and hooks instead of inheriting another checkout's state.
+
+### Changed
+- **Merge-queue validation now uses the trusted self-hosted route where appropriate, while the required validation set stays intentionally small and explicit.**
+- **Worker guidance is more concise and scannable, with evidence-first progress updates and clearer handoff expectations.**
+
+### Fixed
+- **Factory spawning and delivery are more reliable.** Workers retain refreshed local epic bases when publication is unavailable, reject unsafe branch-reference state, and handle Codex account, liveness, and terminal-limit conditions more accurately.
+- **Task completion and test evidence are stricter and clearer.** Cassy prevents misleading green test receipts, preserves merge and review gates, and repairs the urgent-stop review path.
+- **Viktor restart and archive handling now fail visibly and recover safely, reducing silent loss of pending replies and queued work.**
+
 ## [3.1.0] - 2026-08-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"


### PR DESCRIPTION
Prepares the v3.2.0 release by updating all package versions and Cargo.lock, plus a user-facing changelog entry for the current reliability and factory wave. This branch was reset to current main before the isolated release commit.