### PR TITLE
fix(cloud): adopt server-resolved canonical id at registration; explicit pin authoritative (GH #531)

### DIFF
--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -2663,20 +2663,30 @@ pub fn ensure_team_project_registration(
         .ok()
         .and_then(|root| crate::cloud::normalized_git_remote_for_push(&root));
 
-    let registration = crate::cloud::TeamRegistration::new(
-        &cloud_config.endpoint,
-        token,
-        &team_id,
-        &canonical_id,
-    )
-    .with_git_remote(git_remote.as_deref());
+    let registration =
+        crate::cloud::TeamRegistration::new(&cloud_config.endpoint, token, &team_id, &canonical_id)
+            .with_git_remote(git_remote.as_deref());
 
     match registration.ensure() {
         Ok(outcome) => {
+            let effective_id = match outcome.adopted_canonical_id() {
+                Some(adopted) => {
+                    crate::cloud::set_canonical_id_in_config_toml(cas_root, adopted)?;
+                    crate::cloud::invalidate_cached_project_id();
+                    tracing::info!(
+                        sent_canonical_id = %canonical_id,
+                        adopted_canonical_id = %adopted,
+                        "adopted server-resolved canonical project id during registration"
+                    );
+                    adopted.to_string()
+                }
+                None => canonical_id.clone(),
+            };
             if let Some(q) = queue.as_ref() {
-                let _ = q.set_metadata(&cache_key, &chrono::Utc::now().to_rfc3339());
+                let effective_cache_key = team_registration_metadata_key(&team_id, &effective_id);
+                let _ = q.set_metadata(&effective_cache_key, &chrono::Utc::now().to_rfc3339());
             }
-            report_team_registration(cli, &team_id, &canonical_id, &outcome)?;
+            report_team_registration(cli, &team_id, &effective_id, &outcome)?;
             Ok(())
         }
         Err(failure) => {
@@ -2723,6 +2733,7 @@ fn report_team_registration(
                     "canonical_id": canonical_id,
                     "registered": true,
                     "newly_registered": outcome.newly_registered(),
+                    "adopted_canonical_id": outcome.adopted_canonical_id(),
                     "project_uuid": outcome.project_uuid(),
                 }
             })
@@ -2740,6 +2751,16 @@ fn report_team_registration(
         fmt.write_colored("  \u{2713} ", success_color)?;
         fmt.write_raw(&format!(
             "Registered project {canonical_id} with team {team_id}"
+        ))?;
+        fmt.newline()?;
+    } else if outcome.adopted_canonical_id().is_some() {
+        let theme = ActiveTheme::default();
+        let mut out = io::stdout();
+        let mut fmt = Formatter::stdout(&mut out, theme);
+        let success_color = fmt.theme().palette.status_success;
+        fmt.write_colored("  ✓ ", success_color)?;
+        fmt.write_raw(&format!(
+            "Adopted team project id {canonical_id} (server-resolved existing bucket)"
         ))?;
         fmt.newline()?;
     }

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -3006,6 +3006,22 @@ mod tests {
     }
 
     #[test]
+    fn adopt_is_case_insensitive_on_remote_when_unpinned() {
+        // The server lowercases git remotes; a fresh clone of a mixed-case
+        // organization must still adopt its server-resolved bucket.
+        assert_eq!(
+            should_adopt_canonical_id(
+                Some("github.com/Richards-LLC/ozer-health"),
+                Some("github.com/richards-llc/ozer-health"),
+                Some("ozer"),
+                None,
+            )
+            .as_deref(),
+            Some("ozer"),
+        );
+    }
+
+    #[test]
     fn explicit_pin_blocks_adoption_even_when_remote_matches() {
         // `[project] canonical_id` is authoritative. The later team-push
         // path must not undo a server-resolved legacy bucket pin by re-homing

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -326,7 +326,8 @@ pub fn normalize_git_remote_url(url: &str) -> Option<String> {
 ///  - the local remote equals the returned `git_remote` (case-insensitive —
 ///    the server lowercases per its `normalizeGitRemote` rule, while our
 ///    [`normalize_git_remote_url`] preserves the original case),
-///  - the returned id differs from the current pin (otherwise it is a no-op).
+///  - no explicit config pin exists. A pin is authoritative, whether set by
+///    `cas cloud project set` or by verified registration-time adoption.
 ///
 /// The git-remote equality gate is the safety property: it prevents a shared
 /// machine whose `origin` differs from the returned project from being silently
@@ -346,14 +347,10 @@ pub fn should_adopt_canonical_id(
     if !local.eq_ignore_ascii_case(resp_remote) {
         return None;
     }
-    let canonical = normalize_project_canonical_id(canonical)?;
-    if current_pin
-        .and_then(normalize_project_canonical_id)
-        .is_some_and(|pin| pin == canonical)
-    {
-        return None; // already pinned correctly — no-op
+    if current_pin.is_some() {
+        return None;
     }
-    Some(canonical)
+    normalize_project_canonical_id(canonical)
 }
 
 /// Derive the canonical project ID from a `.cas` directory path.
@@ -3009,18 +3006,18 @@ mod tests {
     }
 
     #[test]
-    fn adopt_is_case_insensitive_on_remote() {
-        // Our normalize preserves case (Richards-LLC); the server lowercases.
-        // Equality must still hold so mixed-case orgs adopt correctly.
+    fn explicit_pin_blocks_adoption_even_when_remote_matches() {
+        // `[project] canonical_id` is authoritative. The later team-push
+        // path must not undo a server-resolved legacy bucket pin by re-homing
+        // it to the remote-form identity.
         assert_eq!(
             should_adopt_canonical_id(
                 Some("github.com/Richards-LLC/ozer-health"),
                 Some("github.com/richards-llc/ozer-health"),
                 Some("ozer"),
                 Some("github.com/Richards-LLC/ozer-health"),
-            )
-            .as_deref(),
-            Some("ozer"),
+            ),
+            None,
         );
     }
 

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -1817,10 +1817,7 @@ mod tests {
         let _guard = TestEnvGuard::new();
         let mut project = logged_in_project();
         let user = user_with_teams(
-            &[
-                ("team-a", "alpha", "Alpha"),
-                ("team-b", "beta", "Beta"),
-            ],
+            &[("team-a", "alpha", "Alpha"), ("team-b", "beta", "Beta")],
             Some("team-b"),
         );
 
@@ -2742,7 +2739,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_folder_slug_reconciles_to_this_repositories_remote_identity() {
+    fn explicit_pin_wins_even_when_it_equals_the_repo_name() {
         let temp = TempDir::new().unwrap();
         let cas_dir = git_project_with_remote(
             temp.path(),
@@ -2753,8 +2750,8 @@ mod tests {
 
         assert_eq!(
             resolve_canonical_id(&cas_dir).as_deref(),
-            Some("github.com/richards-llc/gabber-studio"),
-            "the old bare folder slug and both remote spellings must share one identity",
+            Some("gabber-studio"),
+            "an explicit pin is the source of truth, even when it equals the repo name",
         );
     }
 

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -121,17 +121,10 @@ pub fn resolve_canonical_id(cas_root: &Path) -> Option<String> {
 /// [`resolve_canonical_id`] plus the step that produced the value.
 pub fn resolve_canonical_id_with_source(cas_root: &Path) -> Option<(String, CanonicalIdSource)> {
     if let Some(id) = canonical_id_from_config_toml(cas_root) {
-        // Reconcile the legacy folder-name value used by older clients with
-        // the current remote-derived identity. This is deliberately narrow:
-        // an intentional server-assigned pin such as `team-alpha` remains a
-        // pin unless it is exactly this repository's final remote segment.
-        if let Some(remote) = derive_canonical_id_from_git_remote(cas_root)
-            .and_then(|remote| normalize_project_canonical_id(&remote))
-        {
-            if legacy_slug_matches_remote(&id, &remote) {
-                return Some((remote, CanonicalIdSource::ConfigToml));
-            }
-        }
+        // A config pin is authoritative. Registration reconciles an unpinned
+        // remote-derived id with the server and writes the server-resolved
+        // bucket here; rewriting that pin afterwards disconnects the client
+        // from legacy bare-slug buckets because team pull matches verbatim.
         return Some((id, CanonicalIdSource::ConfigToml));
     }
     if let Some(id) = derive_canonical_id_from_git_remote(cas_root)
@@ -178,13 +171,6 @@ pub fn normalize_project_canonical_id(value: &str) -> Option<String> {
         .or_else(|| normalize_git_remote_url(&trimmed.to_ascii_lowercase()))
         .unwrap_or_else(|| trimmed.to_string());
     Some(normalized.trim_matches('/').to_ascii_lowercase())
-}
-
-fn legacy_slug_matches_remote(legacy: &str, remote: &str) -> bool {
-    let Some(last_segment) = remote.rsplit('/').next() else {
-        return false;
-    };
-    legacy == last_segment && !legacy.contains('/')
 }
 
 /// Write `[project] canonical_id = "<value>"` to `<cas_root>/config.toml`,

--- a/cas-cli/src/cloud/team_registration.rs
+++ b/cas-cli/src/cloud/team_registration.rs
@@ -51,21 +51,36 @@ pub enum RegistrationOutcome {
     AlreadyRegistered { project_uuid: String },
     /// The project was missing and the server accepted + confirmed it.
     Registered { project_uuid: String },
+    /// The registration push resolved to an existing project under a different
+    /// canonical id. The caller must persist this id before the same sync run
+    /// performs its regular team push and pull.
+    AdoptedExisting {
+        project_uuid: String,
+        canonical_id: String,
+    },
 }
 
 impl RegistrationOutcome {
     /// Server-side UUID of the team project.
     pub fn project_uuid(&self) -> &str {
         match self {
-            Self::AlreadyRegistered { project_uuid } | Self::Registered { project_uuid } => {
-                project_uuid
-            }
+            Self::AlreadyRegistered { project_uuid }
+            | Self::Registered { project_uuid }
+            | Self::AdoptedExisting { project_uuid, .. } => project_uuid,
         }
     }
 
     /// `true` when this run created the registration (worth telling the user).
     pub fn newly_registered(&self) -> bool {
         matches!(self, Self::Registered { .. })
+    }
+
+    /// The server-resolved id that must be pinned for future sync operations.
+    pub fn adopted_canonical_id(&self) -> Option<&str> {
+        match self {
+            Self::AdoptedExisting { canonical_id, .. } => Some(canonical_id),
+            _ => None,
+        }
     }
 }
 
@@ -83,7 +98,11 @@ pub struct RegistrationFailure {
 
 impl fmt::Display for RegistrationFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}\n  Failing interaction: {}", self.reason, self.interaction)
+        write!(
+            f,
+            "{}\n  Failing interaction: {}",
+            self.reason, self.interaction
+        )
     }
 }
 
@@ -116,12 +135,7 @@ pub struct TeamRegistration<'a> {
 
 impl<'a> TeamRegistration<'a> {
     /// Build a registration for `canonical_id` against `team_id`.
-    pub fn new(
-        endpoint: &'a str,
-        token: &'a str,
-        team_id: &'a str,
-        canonical_id: &'a str,
-    ) -> Self {
+    pub fn new(endpoint: &'a str, token: &'a str, team_id: &'a str, canonical_id: &'a str) -> Self {
         Self {
             endpoint,
             token,
@@ -159,24 +173,41 @@ impl<'a> TeamRegistration<'a> {
     /// Returns `Ok` only when the *server* lists the project — a 2xx on the
     /// registration write is not treated as proof on its own.
     pub fn ensure(&self) -> Result<RegistrationOutcome, RegistrationFailure> {
-        if let Some(project_uuid) = self.lookup()? {
+        if let Some(project_uuid) = self.lookup(self.canonical_id)? {
             return Ok(RegistrationOutcome::AlreadyRegistered { project_uuid });
         }
 
-        let register_status = self.register()?;
+        let (register_status, resolved_id) = self.register()?;
+        let expected_id = resolved_id.as_deref().unwrap_or(self.canonical_id);
 
-        match self.lookup()? {
-            Some(project_uuid) => Ok(RegistrationOutcome::Registered { project_uuid }),
+        match self.lookup(expected_id)? {
+            Some(project_uuid) if expected_id == self.canonical_id => {
+                Ok(RegistrationOutcome::Registered { project_uuid })
+            }
+            Some(project_uuid) => Ok(RegistrationOutcome::AdoptedExisting {
+                project_uuid,
+                canonical_id: expected_id.to_string(),
+            }),
             None => Err(RegistrationFailure {
-                reason: format!(
-                    "Project '{}' is still not registered with team {} on {} after the \
-                     registration request succeeded. The server accepted the write but does \
-                     not list the project, so team memories and team pushes for this project \
-                     cannot work. This is a server-side defect — report the interaction below.",
-                    self.canonical_id, self.team_id, self.endpoint
-                ),
+                reason: if expected_id == self.canonical_id {
+                    format!(
+                        "Project '{}' is still not registered with team {} on {} after the \
+                         registration request succeeded. The server accepted the write but does \
+                         not list the project, so team memories and team pushes for this project \
+                         cannot work. This is a server-side defect — report the interaction below.",
+                        self.canonical_id, self.team_id, self.endpoint
+                    )
+                } else {
+                    format!(
+                        "The server resolved project '{}' to '{}' during registration, but \
+                         team {} on {} did not list the resolved project afterward. The client \
+                         will not adopt '{}' until that verification succeeds.",
+                        self.canonical_id, expected_id, self.team_id, self.endpoint, expected_id,
+                    )
+                },
                 interaction: format!(
-                    "POST {} (body: {{\"entries\":[],\"project_canonical_id\":\"{}\"{}}}) -> {}; \
+                    "POST {} (body: {{\"entries\":[],\"project_canonical_id\":\"{}\"{}}}) -> {} \
+                     (resolved canonical_id: {}); \
                      GET {} -> 200 but no project with canonical_id \"{}\"",
                     self.push_url(),
                     self.canonical_id,
@@ -185,16 +216,17 @@ impl<'a> TeamRegistration<'a> {
                         None => String::new(),
                     },
                     register_status,
+                    resolved_id.as_deref().unwrap_or("<absent>"),
                     self.projects_url(),
-                    self.canonical_id,
+                    expected_id,
                 ),
             }),
         }
     }
 
     /// `GET /api/teams/{teamId}/projects` → the project UUID when the team
-    /// already knows this canonical id.
-    fn lookup(&self) -> Result<Option<String>, RegistrationFailure> {
+    /// already knows `canonical_id`.
+    fn lookup(&self, canonical_id: &str) -> Result<Option<String>, RegistrationFailure> {
         let url = self.projects_url();
         let response = ureq::get(&url)
             .set("Authorization", &format!("Bearer {}", self.token))
@@ -260,13 +292,14 @@ impl<'a> TeamRegistration<'a> {
         Ok(parsed
             .projects
             .into_iter()
-            .find(|p| p.canonical_id == self.canonical_id)
+            .find(|p| p.canonical_id == canonical_id)
             .map(|p| p.id))
     }
 
     /// `POST /api/teams/{teamId}/sync/push` with no rows — the server's
-    /// project-registration path. Returns the accepted status code.
-    fn register(&self) -> Result<u16, RegistrationFailure> {
+    /// project-registration path. Returns its status plus the canonical id the
+    /// server resolved the push into, if provided in the response body.
+    fn register(&self) -> Result<(u16, Option<String>), RegistrationFailure> {
         let url = self.push_url();
 
         let mut payload = serde_json::Map::new();
@@ -303,7 +336,18 @@ impl<'a> TeamRegistration<'a> {
             Ok(resp) => {
                 let status = resp.status();
                 if (200..300).contains(&status) {
-                    return Ok(status);
+                    let body = resp.into_string().unwrap_or_default();
+                    let resolved_id = serde_json::from_str::<serde_json::Value>(&body)
+                        .ok()
+                        .and_then(|value| {
+                            value
+                                .get("canonical_id")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::trim)
+                                .filter(|id| !id.is_empty())
+                                .map(str::to_owned)
+                        });
+                    return Ok((status, resolved_id));
                 }
                 let body = resp.into_string().unwrap_or_default();
                 Err(self.register_failure(&url, status, &body))
@@ -392,5 +436,14 @@ mod tests {
         };
         assert_eq!(fresh.project_uuid(), "p-2");
         assert!(fresh.newly_registered());
+        assert_eq!(fresh.adopted_canonical_id(), None);
+
+        let adopted = RegistrationOutcome::AdoptedExisting {
+            project_uuid: "p-3".to_string(),
+            canonical_id: "legacy-slug".to_string(),
+        };
+        assert_eq!(adopted.project_uuid(), "p-3");
+        assert!(!adopted.newly_registered());
+        assert_eq!(adopted.adopted_canonical_id(), Some("legacy-slug"));
     }
 }

--- a/cas-cli/tests/team_registration_test.rs
+++ b/cas-cli/tests/team_registration_test.rs
@@ -22,11 +22,16 @@ mod common;
 use common::{TEST_TEAM, make_cli_json, make_cloud_config};
 
 use cas::cli::cloud::{CloudSyncArgs, ensure_team_project_registration, execute_sync};
-use cas::cloud::{CloudConfig, SyncQueue, TeamInfo, get_project_canonical_id};
+use cas::cloud::{
+    CloudConfig, EntityType, SyncOperation, SyncQueue, TeamInfo, canonical_id_from_config_toml,
+    get_project_canonical_id, set_canonical_id_in_config_toml,
+};
 use cas::store::{
     open_commit_link_store, open_event_store, open_file_change_store, open_prompt_store,
     open_rule_store, open_skill_store, open_spec_store, open_store, open_task_store,
 };
+use flate2::read::GzDecoder;
+use std::io::Read;
 use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -141,6 +146,15 @@ fn team_push_ok_body() -> serde_json::Value {
     })
 }
 
+fn decode_gzip_json(body: &[u8]) -> serde_json::Value {
+    let mut decoder = GzDecoder::new(body);
+    let mut decoded = Vec::new();
+    decoder
+        .read_to_end(&mut decoded)
+        .expect("team request must be gzip-compressed JSON");
+    serde_json::from_slice(&decoded).expect("team request must decode as JSON")
+}
+
 /// THE regression test for the reported defect: the server accepts everything
 /// but never lists the project. Before the fix this was a green, exit-0 sync;
 /// now `execute_sync` fails with a non-zero exit and names the real reason.
@@ -218,7 +232,9 @@ async fn sync_fails_loud_when_server_never_registers_the_project() {
     let queue = SyncQueue::open(&cas_root).unwrap();
     assert_eq!(
         queue
-            .get_metadata(&format!("team_project_registered_{TEST_TEAM}_{expected_id}"))
+            .get_metadata(&format!(
+                "team_project_registered_{TEST_TEAM}_{expected_id}"
+            ))
             .unwrap(),
         None,
         "a failed registration must never be recorded as confirmed"
@@ -276,10 +292,264 @@ async fn registration_creates_the_project_when_the_team_does_not_know_it() {
     let queue = SyncQueue::open(&cas_root).unwrap();
     assert!(
         queue
-            .get_metadata(&format!("team_project_registered_{TEST_TEAM}_{expected_id}"))
+            .get_metadata(&format!(
+                "team_project_registered_{TEST_TEAM}_{expected_id}"
+            ))
             .unwrap()
             .is_some(),
         "a confirmed registration must be cached so steady-state syncs stay cheap"
+    );
+}
+
+/// A server can resolve the registration push to an existing legacy-slug
+/// bucket by its git remote. The client must verify and adopt *that* id, not
+/// retry its sent remote-shaped id and call the server broken.
+#[tokio::test]
+async fn registration_adopts_the_server_resolved_existing_bucket() {
+    let server = MockServer::start().await;
+    let sent_id = "github.com/richards-llc/gabber-studio";
+    let resolved_id = "gabber-studio";
+
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_project_list_body()))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "canonical_id": resolved_id,
+            "synced": { "entries": 0, "tasks": 0, "rules": 0, "skills": 0 },
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_list_body(resolved_id)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let endpoint = server.uri();
+    let outcome = tokio::task::spawn_blocking(move || {
+        cas::cloud::TeamRegistration::new(&endpoint, "test-token", TEST_TEAM, sent_id).ensure()
+    })
+    .await
+    .unwrap()
+    .expect("the resolved existing bucket must be treated as a successful registration");
+
+    assert_eq!(outcome.project_uuid(), "project-uuid-1");
+    assert!(
+        !outcome.newly_registered(),
+        "mapping to an existing server bucket must not be reported as creating a new one"
+    );
+    assert!(
+        format!("{outcome:?}").contains("AdoptedExisting"),
+        "the outcome must preserve that the server resolved a different canonical id: {outcome:?}"
+    );
+}
+
+/// A divergent server response is an identity-resolution result, not evidence
+/// of a server-side defect. If its listed bucket disappears between the push
+/// and the verification GET, name the resolved id honestly for recovery.
+#[tokio::test]
+async fn divergent_registration_failure_names_resolved_id_without_blame() {
+    let server = MockServer::start().await;
+    let sent_id = "github.com/richards-llc/gabber-studio";
+    let resolved_id = "gabber-studio";
+
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_project_list_body()))
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "canonical_id": resolved_id,
+            "synced": { "entries": 0, "tasks": 0, "rules": 0, "skills": 0 },
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let endpoint = server.uri();
+    let failure = tokio::task::spawn_blocking(move || {
+        cas::cloud::TeamRegistration::new(&endpoint, "test-token", TEST_TEAM, sent_id)
+            .ensure()
+            .expect_err("missing resolved bucket must fail registration")
+    })
+    .await
+    .unwrap();
+    let message = failure.to_string();
+
+    assert!(
+        message.contains(resolved_id),
+        "failure must name the resolved id: {message}"
+    );
+    assert!(
+        !message.contains("server-side defect"),
+        "a divergent response is not proof of a server-side defect: {message}"
+    );
+}
+
+/// End-to-end regression coverage for the live outage shape: an explicit
+/// remote-form pin, a pre-contract bare-slug bucket, and a queued team row.
+/// The same sync run must re-home its cache/config before team push and pull.
+#[tokio::test]
+async fn sync_adopts_resolved_id_before_its_team_push_and_pull() {
+    let server = MockServer::start().await;
+    let sent_id = "github.com/richards-llc/gabber-studio";
+    let resolved_id = "gabber-studio";
+
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_project_list_body()))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_list_body(resolved_id)))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "canonical_id": resolved_id,
+            "synced": { "entries": 1, "tasks": 0, "rules": 0, "skills": 0,
+                "sessions": 0, "verifications": 0, "events": 0, "prompts": 0,
+                "file_changes": 0, "commit_links": 0, "agents": 0, "worktrees": 0 },
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/push"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/sync/pull"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": [], "tasks": [], "rules": [], "skills": [], "specs": [],
+            "events": [], "prompts": [], "file_changes": [], "commit_links": [],
+            "knowledge_pages": [], "pulled_at": "2026-08-18T00:00:00Z",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/api/teams/{TEST_TEAM}/sync/pull")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": [], "tasks": [], "rules": [], "skills": [],
+            "pulled_at": "2026-08-18T00:00:00Z", "team_id": TEST_TEAM, "status": "ok",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = make_cas_root();
+    let cas_root = tmp.path().to_path_buf();
+    init_all_stores_at(&cas_root);
+    set_canonical_id_in_config_toml(&cas_root, sent_id).unwrap();
+    let config = make_cloud_config(server.uri());
+    config.save_to_cas_dir(&cas_root).unwrap();
+    let queue = SyncQueue::open(&cas_root).unwrap();
+    queue
+        .enqueue_for_team(
+            EntityType::Entry,
+            "legacy-id-proof-entry",
+            SyncOperation::Upsert,
+            Some(r#"{"id":"legacy-id-proof-entry","scope":"project","content":"proof"}"#),
+            TEST_TEAM,
+        )
+        .unwrap();
+
+    let _env = ScopedEnv::set(&[
+        ("CAS_ROOT", &cas_root.to_string_lossy()),
+        (
+            "CAS_USER_CLOUD_JSON",
+            "/nonexistent/cas-test-isolation/cloud.json",
+        ),
+    ]);
+    assert_eq!(
+        project_id(),
+        sent_id,
+        "prime the process cache with the sent id"
+    );
+
+    let args = CloudSyncArgs {
+        dry_run: false,
+        rehome: false,
+        full: false,
+    };
+    let cli = make_cli_json();
+    let cas_root_owned = cas_root.clone();
+    tokio::task::spawn_blocking(move || execute_sync(&args, &cli, &cas_root_owned))
+        .await
+        .unwrap()
+        .expect("the same sync run must finish against the resolved bucket");
+
+    assert_eq!(
+        canonical_id_from_config_toml(&cas_root).as_deref(),
+        Some(resolved_id),
+        "registration must persist the server-resolved canonical id"
+    );
+    assert_eq!(
+        get_project_canonical_id().as_deref(),
+        Some(resolved_id),
+        "registration must invalidate the stale process cache before team sync"
+    );
+    assert!(
+        queue
+            .get_metadata(&format!(
+                "team_project_registered_{TEST_TEAM}_{resolved_id}"
+            ))
+            .unwrap()
+            .is_some(),
+        "registration cache must be keyed by the adopted id"
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let team_push_ids: Vec<_> = requests
+        .iter()
+        .filter(|request| {
+            request.method.as_str() == "POST" && request.url.path() == team_push_path()
+        })
+        .map(|request| {
+            decode_gzip_json(&request.body)["project_canonical_id"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+    assert_eq!(
+        team_push_ids,
+        vec![sent_id, resolved_id],
+        "registration sends the original id once; the queued team push in the same run must use the adopted id"
+    );
+    let team_pull = requests
+        .iter()
+        .find(|request| {
+            request.method.as_str() == "GET"
+                && request.url.path() == format!("/api/teams/{TEST_TEAM}/sync/pull")
+        })
+        .expect("sync must perform the team pull");
+    assert_eq!(
+        team_pull
+            .url
+            .query_pairs()
+            .find(|(key, _)| key == "project_id")
+            .map(|(_, value)| value.into_owned())
+            .as_deref(),
+        Some(resolved_id),
+        "same-run team pull must use the adopted id"
     );
 }
 
@@ -522,7 +792,9 @@ async fn sync_adopts_the_resolvable_team_without_any_manual_team_command() {
         "sync must persist the adopted team scope"
     );
     assert_eq!(
-        saved.active_team_id_with_user_config(Some(&user_cfg)).as_deref(),
+        saved
+            .active_team_id_with_user_config(Some(&user_cfg))
+            .as_deref(),
         Some(TEST_TEAM),
         "the adopted scope must resolve to the user's team"
     );
@@ -533,7 +805,9 @@ async fn sync_adopts_the_resolvable_team_without_any_manual_team_command() {
     let queue = SyncQueue::open(&cas_root).unwrap();
     assert!(
         queue
-            .get_metadata(&format!("team_project_registered_{TEST_TEAM}_{expected_id}"))
+            .get_metadata(&format!(
+                "team_project_registered_{TEST_TEAM}_{expected_id}"
+            ))
             .unwrap()
             .is_some(),
         "the adopted team must end the sync with a confirmed registration"


### PR DESCRIPTION
Fixes #531.

Cloud sync deadlock introduced by d4cb1362 (cas-4328): team registration ignored the server-resolved `canonical_id` in the push response, then demanded the *sent* id in `/projects` and aborted every sync (gabber-studio down since 2026-08-18; cas-src queue at 617 failed).

**Was →** `register()` discarded the response body; `ensure()` looked up the sent id and aborted with a false "server-side defect" message; the cas-4328 legacy-slug reconcile silently rewrote an explicit `[project] canonical_id` pin back to remote form, neutralizing `cas cloud project set`.

**Now →** `ensure()` parses the resolved `canonical_id` from the registration push response, verifies *that* id against `/projects`, and returns `AdoptedExisting`; the caller pins it (`set_canonical_id_in_config_toml` + `invalidate_cached_project_id`) so the **same run's** team push and pull hit the real bucket. An explicit pin is now authoritative (reconcile dropped; `should_adopt_canonical_id` never overrides a pin). Divergence failures name the resolved id instead of blaming the server.

Test-first: failing tests landed in 8cb4e786 before production commits. End-to-end wiremock test asserts registration sends the original id once, then queued team push + team pull use the adopted id, and config/cache/metadata are re-homed within one run.

Verified: `cargo check -p cas --lib --tests` clean; `team_registration_test` 11/11; `cloud::config` lib 95/95 (independently re-run by supervisor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)