### PR TITLE
chore(release): prepare v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-08-19
+
+### Fixed
+- **Cloud sync no longer deadlocks on projects whose team bucket predates the git-remote identity contract.** Team registration now adopts the server-resolved canonical project id from the registration response, verifies it, and pins it so the same sync run pushes and pulls against the real bucket. Previously every sync aborted with a misleading "server-side defect" error (gabber-studio was down for two days; any legacy-slug project on a fresh checkout was affected).
+- **`cas cloud project set` is authoritative again.** An explicit `[project] canonical_id` pin is no longer silently rewritten to the remote-derived form, and the later team-push adoption path never overrides an existing pin.
+- **Registration failure messages now name the server-resolved canonical id** instead of wrongly blaming the server when identity resolution diverges.
+
 ## [3.2.0] - 2026-08-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"


### PR DESCRIPTION
Version bump + CHANGELOG for v3.3.0 — the cloud sync canonical-id deadlock fix (GH #531, PR #532).

🤖 Generated with [Claude Code](https://claude.com/claude-code)