### PR TITLE
fix(ci): prevent stale sccache probe failures (cas-065a)

### DIFF
--- a/.github/workflows/merge-queue-watchdog.yml
+++ b/.github/workflows/merge-queue-watchdog.yml
@@ -1,0 +1,24 @@
+name: Merge queue watchdog
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel-stale-merge-group-runs:
+    name: Cancel stale merge-queue runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cancel runs exceeding twice the suite-build p95
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Successful suite builds measured 288–576s; 20m exceeds 2x p95.
+          CASSY_MERGE_GROUP_HANG_SECONDS: '1200'
+        run: ./scripts/cancel-stale-merge-group-runs.sh

--- a/docs/ci/self-hosted-runner-pilot.md
+++ b/docs/ci/self-hosted-runner-pilot.md
@@ -31,8 +31,11 @@ independent restrictions:
    repository `push` trigger for `main`, `epic/**`, and `factory/**`. It has no
    pull-request, pull-request-target, workflow-run, comment, or dispatch event.
 2. The `cassy-public-trusted` organization runner group selects only repository
-   `Richards-LLC/cassy` and only this workflow at an explicit canonical branch
-   ref. The pilot ref is replaced by `refs/heads/main` after landing.
+   `Richards-LLC/cassy`; it deliberately has `restricted_to_workflows=false`.
+   GitHub matches that policy against the synthetic
+   `refs/heads/gh-readonly-queue/...` ref for `merge_group`, not `main`, and
+   selected-workflow wildcards are rejected. A `ci.yml@refs/heads/main`
+   restriction therefore makes a self-hosted queue job unclaimable.
 3. The job repeats the canonical repository, non-fork, push-event, and trusted
    ref conditions in a server-evaluated job `if` before runner assignment. The
    same guard requires repository variable `CASSY_SELF_HOSTED_PILOT=enabled`;
@@ -43,8 +46,10 @@ Fork pull requests continue to run only the existing GitHub-hosted required
 checks. The CI route selects the box only when `github.event_name` is
 `merge_group` and the explicit control variable is enabled; the route job does
 not check out source, and the archive job repeats the selected-mode guard.
-Approval of a fork workflow does not grant it the selected runner group. Do not
-weaken any of the three restrictions independently.
+Approval of a fork workflow does not grant it the selected runner group. The
+queue route's no-checkout selector, `merge_group`-only archive guard, canonical
+repository check, non-fork check, queue-ref check, and explicit readiness
+variable are all required; do not weaken them independently.
 
 ## Availability and isolation
 
@@ -77,6 +82,10 @@ GitHub listener, outside Runner.Worker's per-step process tracking; starting it
 inside one workflow step causes the runner to reap it before Cargo's next step.
 The launch wrapper then uses GitHub's `bin/runsvc.sh`, which translates systemd
 termination into the listener signal that closes the remote session cleanly.
+`SCCACHE_IDLE_TIMEOUT=0` is committed in the unit: the server must not
+self-terminate after ten minutes of queue inactivity. The incident-only debug
+drop-in is not a provisioned dependency; inspect the journal or reproduce with
+the committed unit instead.
 The pilot workflow explicitly clears `RUSTC_WRAPPER` for its first measured
 receipt. The private cache is a later optimization, never a lane prerequisite.
 It also points `TMPDIR` at GitHub Runner's disk-backed temporary directory;
@@ -86,11 +95,18 @@ nextest's default archive extraction used the unit's private tmpfs-backed
 ## Provision and audit
 
 Create `cassy-public-trusted` before registration with selected repository
-`Richards-LLC/cassy`, `allows_public_repositories=true`,
-`restricted_to_workflows=true`, and exactly one selected workflow:
+`Richards-LLC/cassy`, `allows_public_repositories=true`, and
+`restricted_to_workflows=false`. This is intentional: GitHub cannot match a
+selected workflow pinned to `main` against merge-queue refs and rejects a
+queue-ref wildcard. The checked-in CI route is the compensating boundary.
 
-```text
-Richards-LLC/cassy/.github/workflows/self-hosted-fast-validation.yml@refs/heads/main
+After updating an existing group, read it back before enabling the route:
+
+```bash
+gh api --method PATCH orgs/Richards-LLC/actions/runner-groups/GROUP_ID \\
+  -f restricted_to_workflows=false
+gh api orgs/Richards-LLC/actions/runner-groups/GROUP_ID \\
+  --jq '{restricted_to_workflows, selected_workflows}'
 ```
 
 Generate a short-lived organization registration token, then run from a trusted

--- a/docs/ci/self-hosted-runner-pilot.md
+++ b/docs/ci/self-hosted-runner-pilot.md
@@ -85,7 +85,12 @@ termination into the listener signal that closes the remote session cleanly.
 `SCCACHE_IDLE_TIMEOUT=0` is committed in the unit: the server must not
 self-terminate after ten minutes of queue inactivity. The incident-only debug
 drop-in is not a provisioned dependency; inspect the journal or reproduce with
-the committed unit instead.
+the committed unit instead. The unit also sets `CARGO_CACHE_RUSTC_INFO=0`.
+Cargo's otherwise persistent `CARGO_TARGET_DIR/.rustc_info.json` had retained
+a failed `sccache rustc -vV` response and replayed it in later jobs without a
+new request reaching the healthy server. Disabling only that version-probe
+cache retains the shared target artifacts while making each job re-check the
+live compiler/cache path.
 The pilot workflow explicitly clears `RUSTC_WRAPPER` for its first measured
 receipt. The private cache is a later optimization, never a lane prerequisite.
 It also points `TMPDIR` at GitHub Runner's disk-backed temporary directory;

--- a/ops/systemd/cassy-actions-runner.service
+++ b/ops/systemd/cassy-actions-runner.service
@@ -31,6 +31,8 @@ Environment=SCCACHE_DIR=/var/lib/cassy-actions/cache/sccache
 # runner traffic and statistics inside this service account.
 Environment=SCCACHE_SERVER_PORT=4227
 Environment=SCCACHE_CACHE_SIZE=50G
+# Keep the private server alive across idle merge-queue periods.
+Environment=SCCACHE_IDLE_TIMEOUT=0
 Environment=CARGO_BUILD_JOBS=12
 Environment=RUSTC_WRAPPER=sccache
 Environment=PATH=/var/lib/cassy-actions/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/ops/systemd/cassy-actions-runner.service
+++ b/ops/systemd/cassy-actions-runner.service
@@ -33,6 +33,11 @@ Environment=SCCACHE_SERVER_PORT=4227
 Environment=SCCACHE_CACHE_SIZE=50G
 # Keep the private server alive across idle merge-queue periods.
 Environment=SCCACHE_IDLE_TIMEOUT=0
+# Cargo otherwise persists a failed sccache rustc probe in
+# CARGO_TARGET_DIR/.rustc_info.json and replays it in later jobs without
+# contacting the now-healthy server. The saved target artifacts remain shared;
+# this only repeats Cargo's inexpensive rustc version probe per invocation.
+Environment=CARGO_CACHE_RUSTC_INFO=0
 Environment=CARGO_BUILD_JOBS=12
 Environment=RUSTC_WRAPPER=sccache
 Environment=PATH=/var/lib/cassy-actions/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/scripts/cancel-stale-merge-group-runs.sh
+++ b/scripts/cancel-stale-merge-group-runs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Cancel merge-queue workflow runs that exceed twice the observed suite-build
+# p95. A vanished queue entry otherwise leaves its self-hosted claim occupied.
+set -euo pipefail
+
+repository="${GITHUB_REPOSITORY:-Richards-LLC/cassy}"
+hang_seconds="${CASSY_MERGE_GROUP_HANG_SECONDS:-1200}"
+now_epoch="${CASSY_NOW_EPOCH:-$(date -u +%s)}"
+
+if [[ ! "$repository" =~ ^[^/]+/[^/]+$ ]]; then
+    echo "GITHUB_REPOSITORY must be an owner/repository slug" >&2
+    exit 2
+fi
+if [[ ! "$hang_seconds" =~ ^[0-9]+$ ]] || (( hang_seconds == 0 )); then
+    echo "CASSY_MERGE_GROUP_HANG_SECONDS must be a positive integer" >&2
+    exit 2
+fi
+if [[ ! "$now_epoch" =~ ^[0-9]+$ ]]; then
+    echo "CASSY_NOW_EPOCH must be epoch seconds" >&2
+    exit 2
+fi
+
+runs="$(gh api "repos/$repository/actions/runs?event=merge_group&status=in_progress&per_page=100")"
+while IFS=$'\t' read -r run_id started_at head_branch; do
+    [[ -n "$run_id" && "$started_at" != null ]] || continue
+    started_epoch="$(date -u -d "$started_at" +%s)"
+    age_seconds=$((now_epoch - started_epoch))
+    (( age_seconds > hang_seconds )) || continue
+    printf 'cancelling stale merge_group run=%s age_seconds=%s threshold_seconds=%s ref=%s\n' \\
+        "$run_id" "$age_seconds" "$hang_seconds" "$head_branch"
+    gh api --method POST "repos/$repository/actions/runs/$run_id/cancel" >/dev/null
+done < <(jq -r '.workflow_runs[] | [.id, (.run_started_at // .created_at), .head_branch] | @tsv' <<<"$runs")

--- a/scripts/cancel-stale-merge-group-runs.sh
+++ b/scripts/cancel-stale-merge-group-runs.sh
@@ -20,13 +20,15 @@ if [[ ! "$now_epoch" =~ ^[0-9]+$ ]]; then
     exit 2
 fi
 
-runs="$(gh api "repos/$repository/actions/runs?event=merge_group&status=in_progress&per_page=100")"
-while IFS=$'\t' read -r run_id started_at head_branch; do
+in_progress_runs="$(gh api "repos/$repository/actions/runs?event=merge_group&status=in_progress&per_page=100")"
+queued_runs="$(gh api "repos/$repository/actions/runs?event=merge_group&status=queued&per_page=100")"
+runs="$(jq -s '{workflow_runs: map(.workflow_runs[]) }' <<<"$in_progress_runs" <<<"$queued_runs")"
+while IFS=$'\t' read -r run_id started_at head_branch status; do
     [[ -n "$run_id" && "$started_at" != null ]] || continue
     started_epoch="$(date -u -d "$started_at" +%s)"
     age_seconds=$((now_epoch - started_epoch))
     (( age_seconds > hang_seconds )) || continue
-    printf 'cancelling stale merge_group run=%s age_seconds=%s threshold_seconds=%s ref=%s\n' \\
-        "$run_id" "$age_seconds" "$hang_seconds" "$head_branch"
+    printf 'cancelling stale merge_group run=%s status=%s age_seconds=%s threshold_seconds=%s ref=%s\n' \
+        "$run_id" "$status" "$age_seconds" "$hang_seconds" "$head_branch"
     gh api --method POST "repos/$repository/actions/runs/$run_id/cancel" >/dev/null
-done < <(jq -r '.workflow_runs[] | [.id, (.run_started_at // .created_at), .head_branch] | @tsv' <<<"$runs")
+done < <(jq -r '.workflow_runs[] | [.id, (.run_started_at // .created_at), .head_branch, .status] | @tsv' <<<"$runs")

--- a/scripts/cancel-stale-merge-group-runs.sh
+++ b/scripts/cancel-stale-merge-group-runs.sh
@@ -22,7 +22,7 @@ fi
 
 in_progress_runs="$(gh api "repos/$repository/actions/runs?event=merge_group&status=in_progress&per_page=100")"
 queued_runs="$(gh api "repos/$repository/actions/runs?event=merge_group&status=queued&per_page=100")"
-runs="$(jq -s '{workflow_runs: map(.workflow_runs[]) }' <<<"$in_progress_runs" <<<"$queued_runs")"
+runs="$(printf '%s\n%s\n' "$in_progress_runs" "$queued_runs" | jq -s '{workflow_runs: map(.workflow_runs[]) }')"
 while IFS=$'\t' read -r run_id started_at head_branch status; do
     [[ -n "$run_id" && "$started_at" != null ]] || continue
     started_epoch="$(date -u -d "$started_at" +%s)"

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -15,6 +15,7 @@ real_store_guard="$repo_root/scripts/check-real-store-untouched.sh"
 migration_guard="$repo_root/scripts/check-release-migration-snapshots.sh"
 watchdog="$repo_root/.github/workflows/merge-queue-watchdog.yml"
 watchdog_script="$repo_root/scripts/cancel-stale-merge-group-runs.sh"
+runner_unit="$repo_root/ops/systemd/cassy-actions-runner.service"
 
 pass=0
 fail=0
@@ -137,6 +138,10 @@ pilot_doc="$(<"$repo_root/docs/ci/self-hosted-runner-pilot.md")"
 require_text "$pilot_doc" 'restricted_to_workflows=false' 'runner-group policy permits synthetic merge-queue refs'
 require_text "$pilot_doc" 'refs/heads/gh-readonly-queue/...' 'pilot documents queue-ref mismatch'
 require_text "$pilot_doc" 'selected-workflow wildcards are rejected' 'pilot records GitHub wildcard limitation'
+require_text "$pilot_doc" 'CARGO_CACHE_RUSTC_INFO=0' 'pilot documents Cargo rustc-info cache containment'
+
+runner_unit_text="$(<"$runner_unit")"
+require_text "$runner_unit_text" 'Environment=CARGO_CACHE_RUSTC_INFO=0' 'runner does not persist failed sccache rustc probes across jobs'
 
 if [[ -x "$watchdog_script" ]]; then
     watchdog_text="$(<"$watchdog")"

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -146,6 +146,7 @@ if [[ -x "$watchdog_script" ]]; then
     require_text "$watchdog_text" "CASSY_MERGE_GROUP_HANG_SECONDS: '1200'" 'watchdog pins a 20-minute 2x-p95 threshold'
     require_text "$watchdog_script_text" 'event=merge_group&status=in_progress' 'watchdog inspects in-progress merge-group runs'
     require_text "$watchdog_script_text" 'event=merge_group&status=queued' 'watchdog also reclaims queued pre-claim starvation'
+    require_text "$watchdog_script_text" "printf '%s\\n%s\\n'" 'watchdog combines in-progress and queued API responses'
     require_text "$watchdog_script_text" '.run_started_at // .created_at' 'watchdog measures queued starvation from queue creation'
     require_text "$watchdog_script_text" 'actions/runs/$run_id/cancel' 'watchdog cancels stale runs by id'
     require_text "$watchdog_script_text" 'age_seconds > hang_seconds' 'watchdog does not cancel at or below threshold'

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -144,7 +144,9 @@ if [[ -x "$watchdog_script" ]]; then
     require_text "$watchdog_text" "cron: '*/5 * * * *'" 'merge-queue watchdog runs at GitHub’s five-minute floor'
     require_text "$watchdog_text" 'actions: write' 'merge-queue watchdog may cancel an orphaned run'
     require_text "$watchdog_text" "CASSY_MERGE_GROUP_HANG_SECONDS: '1200'" 'watchdog pins a 20-minute 2x-p95 threshold'
-    require_text "$watchdog_script_text" 'event=merge_group&status=in_progress' 'watchdog inspects only active merge-group runs'
+    require_text "$watchdog_script_text" 'event=merge_group&status=in_progress' 'watchdog inspects in-progress merge-group runs'
+    require_text "$watchdog_script_text" 'event=merge_group&status=queued' 'watchdog also reclaims queued pre-claim starvation'
+    require_text "$watchdog_script_text" '.run_started_at // .created_at' 'watchdog measures queued starvation from queue creation'
     require_text "$watchdog_script_text" 'actions/runs/$run_id/cancel' 'watchdog cancels stale runs by id'
     require_text "$watchdog_script_text" 'age_seconds > hang_seconds' 'watchdog does not cancel at or below threshold'
 else

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -13,6 +13,8 @@ makefile="$repo_root/cas-cli/Makefile"
 verified="$repo_root/scripts/run-verified-tests.sh"
 real_store_guard="$repo_root/scripts/check-real-store-untouched.sh"
 migration_guard="$repo_root/scripts/check-release-migration-snapshots.sh"
+watchdog="$repo_root/.github/workflows/merge-queue-watchdog.yml"
+watchdog_script="$repo_root/scripts/cancel-stale-merge-group-runs.sh"
 
 pass=0
 fail=0
@@ -130,6 +132,25 @@ require_text "$self_hosted_text" 'TMPDIR: ${{ runner.temp }}' 'self-hosted pilot
 require_absent "$self_hosted_text" 'cargo nextest run' 'self-hosted pilot leaves suite execution on hosted runners'
 require_absent "$self_hosted_text" '--partition' 'self-hosted pilot does not duplicate hosted shard execution'
 require_absent "$(<"$ruleset")" 'Self-hosted pilot' 'self-hosted pilot is not a required status check'
+
+pilot_doc="$(<"$repo_root/docs/ci/self-hosted-runner-pilot.md")"
+require_text "$pilot_doc" 'restricted_to_workflows=false' 'runner-group policy permits synthetic merge-queue refs'
+require_text "$pilot_doc" 'refs/heads/gh-readonly-queue/...' 'pilot documents queue-ref mismatch'
+require_text "$pilot_doc" 'selected-workflow wildcards are rejected' 'pilot records GitHub wildcard limitation'
+
+if [[ -x "$watchdog_script" ]]; then
+    watchdog_text="$(<"$watchdog")"
+    watchdog_script_text="$(<"$watchdog_script")"
+    require_text "$watchdog_text" "cron: '*/5 * * * *'" 'merge-queue watchdog runs at GitHub’s five-minute floor'
+    require_text "$watchdog_text" 'actions: write' 'merge-queue watchdog may cancel an orphaned run'
+    require_text "$watchdog_text" "CASSY_MERGE_GROUP_HANG_SECONDS: '1200'" 'watchdog pins a 20-minute 2x-p95 threshold'
+    require_text "$watchdog_script_text" 'event=merge_group&status=in_progress' 'watchdog inspects only active merge-group runs'
+    require_text "$watchdog_script_text" 'actions/runs/$run_id/cancel' 'watchdog cancels stale runs by id'
+    require_text "$watchdog_script_text" 'age_seconds > hang_seconds' 'watchdog does not cancel at or below threshold'
+else
+    printf 'FAIL merge-queue watchdog script is executable\n'
+    fail=$((fail + 1))
+fi
 
 suite_build="$(job_block fast-validation-suite-build)"
 suite_shards="$(job_block fast-validation-suite-shards)"


### PR DESCRIPTION
AC1 containment for the merge-queue sccache outage: a stale cached rustc-version response in the runner's persistent cargo-target `.rustc_info.json` replays the failed sccache probe on every merge-group build — deterministically reproduced 5/5 with the file present, 0 failures with it moved aside, re-fails on restore. This eliminates the TCP/TasksMax hypotheses.

Containment: `CARGO_CACHE_RUSTC_INFO=0` in the committed runner unit, rationale in the pilot doc, tier-contract pin (396 passed / 0 failed).

Lands behind #535 (lane bypass) and #534 (group policy + watchdog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)