### PR TITLE
ci: reclaim superseded heavy and stale queued runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ on:
   push:
     branches:
       - main
+      - staging
       - "epic/**"
       - "factory/**"
     tags:
@@ -669,7 +670,14 @@ jobs:
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
-      && github.ref == 'refs/heads/main')
+      && (github.ref == 'refs/heads/main'
+      || github.ref == 'refs/heads/staging'))
+    # Keep each heavy lane separate, but collapse superseded commits on the
+    # same integration ref. Event type keeps scheduled/manual runs independent
+    # of a rapid main or staging push.
+    concurrency:
+      group: heavy-tier-clippy-${{ github.event_name }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -883,7 +891,13 @@ jobs:
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
-      && github.ref == 'refs/heads/main')
+      && (github.ref == 'refs/heads/main'
+      || github.ref == 'refs/heads/staging'))
+    # See clippy: a newer integration commit cancels only this lane's stale
+    # work, while scheduled/manual work uses an event-distinct group.
+    concurrency:
+      group: heavy-tier-test-compile-guard-${{ github.event_name }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -942,6 +956,9 @@ jobs:
     name: Panic Isolation — release profile (named subset, not the suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    concurrency:
+      group: heavy-tier-panic-isolation-release-${{ github.event_name }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -976,6 +993,9 @@ jobs:
     name: Panic Isolation — release-fast profile (named subset, not the suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    concurrency:
+      group: heavy-tier-panic-isolation-release-fast-${{ github.event_name }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1018,6 +1038,9 @@ jobs:
     name: Build Benchmark & Timings (measurement only, no test suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    concurrency:
+      group: heavy-tier-build-benchmark-${{ github.event_name }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     # DELIBERATELY UNCACHED — the one compiling job exempt from the compiler
     # cache contract at the top of this file. It measures a genuinely cold

--- a/.github/workflows/stale-queued-run-watchdog.yml
+++ b/.github/workflows/stale-queued-run-watchdog.yml
@@ -1,0 +1,25 @@
+name: Stale queued-run watchdog
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel-stale-non-merge-group-queued-runs:
+    name: Cancel stale non-merge-group queued runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cancel queued runs exceeding normal scheduling time
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Twenty minutes is well above ordinary queue scheduling, yet
+          # promptly reclaims the 13-day release/main/PR starvation class.
+          CASSY_NON_MERGE_GROUP_QUEUE_SECONDS: '1200'
+        run: ./scripts/cancel-stale-non-merge-group-queued-runs.sh

--- a/scripts/cancel-stale-non-merge-group-queued-runs.sh
+++ b/scripts/cancel-stale-non-merge-group-queued-runs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Reclaim queued workflow runs that have outlived normal scheduling. Merge
+# queue runs have a distinct orphan policy in cas-065a and are intentionally
+# excluded here.
+set -euo pipefail
+
+repository="${GITHUB_REPOSITORY:-Richards-LLC/cassy}"
+queue_seconds="${CASSY_NON_MERGE_GROUP_QUEUE_SECONDS:-1200}"
+now_epoch="${CASSY_NOW_EPOCH:-$(date -u +%s)}"
+
+if [[ ! "$repository" =~ ^[^/]+/[^/]+$ ]]; then
+    echo "GITHUB_REPOSITORY must be an owner/repository slug" >&2
+    exit 2
+fi
+if [[ ! "$queue_seconds" =~ ^[0-9]+$ ]] || (( queue_seconds == 0 )); then
+    echo "CASSY_NON_MERGE_GROUP_QUEUE_SECONDS must be a positive integer" >&2
+    exit 2
+fi
+if [[ ! "$now_epoch" =~ ^[0-9]+$ ]]; then
+    echo "CASSY_NOW_EPOCH must be epoch seconds" >&2
+    exit 2
+fi
+
+queued_runs="$(gh api "repos/$repository/actions/runs?status=queued&per_page=100")"
+while IFS=$'\t' read -r run_id created_at event head_branch; do
+    [[ -n "$run_id" && "$created_at" != null ]] || continue
+    # cas-065a owns merge_group queue/orphan reclamation. Keeping that event
+    # out of this broader stale-queue sweep prevents duelling cancellers.
+    [[ "$event" != merge_group ]] || continue
+    if ! created_epoch="$(date -u -d "$created_at" +%s 2>/dev/null)"; then
+        printf 'skipping queued run=%s with invalid created_at=%s\n' "$run_id" "$created_at" >&2
+        continue
+    fi
+    age_seconds=$((now_epoch - created_epoch))
+    (( age_seconds > queue_seconds )) || continue
+
+    # The list endpoint is eventually consistent. Re-read status so a run
+    # claimed or cancelled between list and action is never cancelled again.
+    current_status="$(gh api "repos/$repository/actions/runs/$run_id" --jq '.status')"
+    if [[ "$current_status" != queued ]]; then
+        printf 'skipping no-longer-queued run=%s current_status=%s\n' "$run_id" "$current_status"
+        continue
+    fi
+
+    printf 'cancelling stale queued run=%s event=%s age_seconds=%s threshold_seconds=%s ref=%s\n' \
+        "$run_id" "$event" "$age_seconds" "$queue_seconds" "$head_branch"
+    gh api --method POST "repos/$repository/actions/runs/$run_id/cancel" >/dev/null
+done < <(jq -r '.workflow_runs[] | [.id, .created_at, .event, .head_branch] | @tsv' <<<"$queued_runs")

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -16,6 +16,8 @@ migration_guard="$repo_root/scripts/check-release-migration-snapshots.sh"
 watchdog="$repo_root/.github/workflows/merge-queue-watchdog.yml"
 watchdog_script="$repo_root/scripts/cancel-stale-merge-group-runs.sh"
 runner_unit="$repo_root/ops/systemd/cassy-actions-runner.service"
+stale_queue_watchdog="$repo_root/.github/workflows/stale-queued-run-watchdog.yml"
+stale_queue_script="$repo_root/scripts/cancel-stale-non-merge-group-queued-runs.sh"
 
 pass=0
 fail=0
@@ -509,6 +511,119 @@ for job in panic-isolation-release panic-isolation-release-fast build-benchmark;
     require_absent "$block" 'refs/heads/main' "$job does not consume runners on ordinary main pushes"
     require_absent "$block" "github.event_name == 'pull_request'" "$job does not delay PR validation"
 done
+
+# Heavy validation must run only at protected integration points. A second
+# merge to main/staging must cancel each individual heavy lane from the older
+# tree, without ever sharing a concurrency group with schedule/dispatch work.
+require_text "$ci_text" '- staging' 'CI accepts staging integration pushes'
+heavy_job_contract_holds() {
+    local block="$1" group="$2"
+    [[ "$block" == *"group: $group"* ]] \
+        && [[ "$block" == *'cancel-in-progress: true'* ]] \
+        && [[ "$block" != *'refs/heads/epic/'* ]] \
+        && [[ "$block" != *'refs/heads/factory/'* ]]
+}
+
+for job in clippy test-compile-guard panic-isolation-release panic-isolation-release-fast build-benchmark; do
+    block="$(job_block "$job")"
+    group="heavy-tier-$job-\${{ github.event_name }}-\${{ github.ref }}"
+    require_text "$block" "group: $group" "$job uses an event- and ref-keyed heavy-tier group"
+    require_text "$block" 'cancel-in-progress: true' "$job cancels a superseded heavy run"
+    require_text "$block" 'github.event_name' "$job keeps scheduled/dispatch work separate from push work"
+
+    # Mutation coverage: each broken form must fail the same contract rather
+    # than merely relying on a reviewer to notice a missing YAML line.
+    missing_group="${block//group: $group/}"
+    if heavy_job_contract_holds "$missing_group" "$group"; then
+        printf 'FAIL heavy-tier mutation removes concurrency group: %s\n' "$job"
+        fail=$((fail + 1))
+    else
+        printf 'ok   heavy-tier mutation catches removed concurrency group: %s\n' "$job"
+        pass=$((pass + 1))
+    fi
+    flipped_cancel="${block/cancel-in-progress: true/cancel-in-progress: false}"
+    if heavy_job_contract_holds "$flipped_cancel" "$group"; then
+        printf 'FAIL heavy-tier mutation flips cancellation: %s\n' "$job"
+        fail=$((fail + 1))
+    else
+        printf 'ok   heavy-tier mutation catches disabled cancellation: %s\n' "$job"
+        pass=$((pass + 1))
+    fi
+    epic_trigger="$block"$'\n'"      || startsWith(github.ref, 'refs/heads/epic/')"
+    if heavy_job_contract_holds "$epic_trigger" "$group"; then
+        printf 'FAIL heavy-tier mutation adds epic trigger: %s\n' "$job"
+        fail=$((fail + 1))
+    else
+        printf 'ok   heavy-tier mutation catches epic trigger: %s\n' "$job"
+        pass=$((pass + 1))
+    fi
+done
+
+for job in clippy test-compile-guard; do
+    block="$(job_block "$job")"
+    require_text "$block" "refs/heads/staging" "$job runs heavy validation on staging pushes"
+done
+
+# Stale QUEUED runs are a separate starvation class from cas-065a's
+# merge_group orphan watchdog. This sweep sees every queued event, excludes
+# merge_group, and rechecks the run before cancelling an eventually-consistent
+# list result.
+if [[ -x "$stale_queue_script" ]]; then
+    stale_watchdog_text="$(<"$stale_queue_watchdog")"
+    stale_queue_script_text="$(<"$stale_queue_script")"
+    require_text "$stale_watchdog_text" "cron: '*/5 * * * *'" 'stale queued-run watchdog uses GitHub’s five-minute floor'
+    require_text "$stale_watchdog_text" 'actions: write' 'stale queued-run watchdog may cancel a stranded run'
+    require_text "$stale_watchdog_text" "CASSY_NON_MERGE_GROUP_QUEUE_SECONDS: '1200'" 'stale queued-run watchdog pins a 20-minute threshold'
+    require_text "$stale_queue_script_text" 'actions/runs?status=queued' 'stale queued-run watchdog reads queued runs of every event'
+    require_text "$stale_queue_script_text" '[[ "$event" != merge_group ]]' 'stale queued-run watchdog excludes cas-065a merge-group scope'
+    require_text "$stale_queue_script_text" "gh api \"repos/\$repository/actions/runs/\$run_id\" --jq '.status'" 'stale queued-run watchdog rechecks status before cancellation'
+    require_text "$stale_queue_script_text" 'age_seconds > queue_seconds' 'stale queued-run watchdog preserves runs at or below its threshold'
+    require_text "$stale_queue_script_text" 'actions/runs/$run_id/cancel' 'stale queued-run watchdog cancels by run id'
+
+    stale_tmp="$(mktemp -d)"
+    mkdir -p "$stale_tmp/bin"
+    cat >"$stale_tmp/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${FAKE_GH_LOG:?}"
+if [[ "$*" == *'actions/runs?status=queued&per_page=100'* ]]; then
+    cat <<'JSON'
+{"workflow_runs":[
+  {"id":101,"created_at":"1970-01-01T00:00:00Z","event":"push","head_branch":"main"},
+  {"id":102,"created_at":"1970-01-01T00:00:00Z","event":"merge_group","head_branch":"gh-readonly-queue/main/pr-1"},
+  {"id":103,"created_at":"1970-01-01T00:30:00Z","event":"pull_request","head_branch":"feature"},
+  {"id":104,"created_at":"1970-01-01T00:00:00Z","event":"workflow_dispatch","head_branch":"main"}
+]}
+JSON
+elif [[ "$*" == *'actions/runs/101'*'--jq .status'* ]]; then
+    printf '%s\n' queued
+elif [[ "$*" == *'actions/runs/104'*'--jq .status'* ]]; then
+    printf '%s\n' completed
+elif [[ "$*" == *'--method POST'*'actions/runs/101/cancel'* ]]; then
+    exit 0
+else
+    printf 'unexpected fake gh invocation: %s\n' "$*" >&2
+    exit 2
+fi
+EOF
+    chmod +x "$stale_tmp/bin/gh"
+    stale_output="$stale_tmp/output"
+    if GITHUB_REPOSITORY=example/repo CASSY_NOW_EPOCH=2000 FAKE_GH_LOG="$stale_tmp/gh.log" \
+        PATH="$stale_tmp/bin:$PATH" "$stale_queue_script" >"$stale_output" 2>&1; then
+        require_text "$(<"$stale_output")" 'cancelling stale queued run=101 event=push' 'stale queued push run is cancelled'
+        require_text "$(<"$stale_output")" 'skipping no-longer-queued run=104 current_status=completed' 'stale list entry is rechecked before cancellation'
+        require_absent "$(<"$stale_tmp/gh.log")" 'actions/runs/102' 'merge-group candidate is left to cas-065a'
+        require_absent "$(<"$stale_tmp/gh.log")" 'actions/runs/103' 'fresh queued run is retained'
+        require_text "$(<"$stale_tmp/gh.log")" 'actions/runs/101/cancel' 'stale queued push run receives a cancel request'
+        require_absent "$(<"$stale_tmp/gh.log")" 'actions/runs/104/cancel' 'status-raced queued run is not cancelled'
+    else
+        printf 'FAIL stale queued-run watchdog executes against queued-run fixture\n'
+        fail=$((fail + 1))
+    fi
+    rm -rf "$stale_tmp"
+else
+    printf 'FAIL stale queued-run watchdog script is executable\n'
+    fail=$((fail + 1))
+fi
 
 receipt_job="$(job_block record-pr-validation)"
 require_text "$ci_text" 'actions: read' 'CI may query validation receipt artifacts'


### PR DESCRIPTION
Rapid main/staging merges no longer stack ~50-minute heavy-tier validations of dead trees: Clippy, Test Compile Guard, both Panic Isolation profiles, and Build Benchmark now carry per-lane concurrency groups keyed by event and ref with cancel-in-progress, so a newer integration commit cancels only its own lane's superseded work while scheduled/manual runs stay independent.

A new 5-minute stale-queued-run watchdog cancels non-merge-group runs queued longer than 20 minutes (the class that starved two release publications for 13 days), explicitly excluding merge_group runs, whose orphan policy lives in the cas-065a watchdog.

Tier contract extended with mutation coverage: 455 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)