### PR TITLE
fix(factory): relay every stopped worker incident to the supervisor

### DIFF
--- a/cas-cli/src/mcp/tools/service/agent_search_system/supervisor_queue.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/supervisor_queue.rs
@@ -36,7 +36,7 @@ pub(crate) fn acknowledge_linked_lifecycle_notification(
         // this bridge does not recognise them, `message_ack notification_id`
         // acknowledges only the durable row and leaves the linked prompt
         // relay visible in every later worker_status response.
-        "worker_idle" | "worker_stalled" => {
+        "worker_idle" | "worker_stalled" | "worker_delivery_stalled" | "worker_unavailable" => {
             format!("worker-attention-outbox:{notification_id}")
         }
         _ => return Ok(None),
@@ -375,7 +375,7 @@ mod cas_20ac_ack_tests {
         let durable_id = supervisor_queue
             .notify(
                 "supervisor-id",
-                "worker_idle",
+                "worker_delivery_stalled",
                 r#"{"worker":"quiet-ibis"}"#,
                 NotificationPriority::High,
             )
@@ -385,10 +385,10 @@ mod cas_20ac_ack_tests {
                 &format!("lifecycle-wake:worker-attention:{durable_id}"),
                 "supervisor",
                 &format!(
-                    "<worker-attention kind=\"worker_idle\" worker=\"quiet-ibis\" notification_id=\"{durable_id}\">\\nidle\\n</worker-attention>"
+                    "<worker-attention kind=\"worker_delivery_stalled\" worker=\"quiet-ibis\" notification_id=\"{durable_id}\">\\ndelivery stalled\\n</worker-attention>"
                 ),
                 None,
-                Some("worker_idle: quiet-ibis"),
+                Some("worker_delivery_stalled: quiet-ibis"),
                 Some(NotificationPriority::High),
                 &format!("worker-attention-outbox:{durable_id}"),
             )

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -6919,6 +6919,15 @@ pub(crate) fn default_codex_sessions_dir() -> Option<std::path::PathBuf> {
 /// machine-readable exhausted-credit state in the same bounded tail. A generic
 /// error, an old rate-limit record, or an unresolved rollout is not enough to
 /// declare a live worker unavailable.
+pub(crate) fn worker_reports_usage_limit(
+    cas_root: &std::path::Path,
+    agent: &cas_types::Agent,
+) -> bool {
+    let cli = worker_cli_from_agent(agent);
+    let rollout = worker_transcript_path_for_agent(cas_root, agent);
+    codex_rollout_reports_usage_limit(rollout.as_deref(), cli)
+}
+
 fn codex_rollout_reports_usage_limit(
     rollout: Option<&std::path::Path>,
     cli: cas_mux::SupervisorCli,
@@ -10993,8 +11002,12 @@ effort = "high"
             "codex-kind-owl-71-session".to_string(),
             "kind-owl-71".to_string(),
         );
-        agent.metadata.insert("worker_cli".to_string(), "codex".to_string());
-        agent.metadata.insert("clone_path".to_string(), clone.to_string());
+        agent
+            .metadata
+            .insert("worker_cli".to_string(), "codex".to_string());
+        agent
+            .metadata
+            .insert("clone_path".to_string(), clone.to_string());
         agent
             .metadata
             .insert("worker_account_dir".to_string(), account_dir.to_string());

--- a/cas-cli/src/prompt_revalidation.rs
+++ b/cas-cli/src/prompt_revalidation.rs
@@ -467,7 +467,9 @@ pub(crate) fn parse_worker_attention_envelope(prompt: &str) -> bool {
     tag.starts_with("<worker-attention ")
         && matches!(
             xml_attribute(tag, "kind"),
-            Some("worker_idle" | "worker_stalled")
+            Some(
+                "worker_idle" | "worker_stalled" | "worker_delivery_stalled" | "worker_unavailable"
+            )
         )
         && xml_attribute(tag, "worker").is_some_and(|value| !value.is_empty())
         && xml_attribute(tag, "notification_id").is_some_and(|value| value.parse::<i64>().is_ok())
@@ -1494,6 +1496,12 @@ mod cas_3dcb_worker_died_relay_tests {
         assert!(is_supervisor_wake_envelope(&relay()));
         assert!(is_supervisor_wake_envelope(
             "<worker-attention kind=\"worker_stalled\" worker=\"calm-owl\" notification_id=\"42\">\nbody</worker-attention>"
+        ));
+        assert!(is_supervisor_wake_envelope(
+            "<worker-attention kind=\"worker_delivery_stalled\" worker=\"calm-owl\" notification_id=\"42\">\nbody</worker-attention>"
+        ));
+        assert!(is_supervisor_wake_envelope(
+            "<worker-attention kind=\"worker_unavailable\" worker=\"calm-owl\" notification_id=\"42\">\nbody</worker-attention>"
         ));
         assert!(is_supervisor_wake_envelope(
             "<task-lifecycle transition=\"task_awaiting_merge\" task_id=\"cas-1\" old=\"in_progress\" \

--- a/cas-cli/src/ui/factory/daemon/fork_first.rs
+++ b/cas-cli/src/ui/factory/daemon/fork_first.rs
@@ -566,6 +566,8 @@ impl DaemonInitPhase {
             teams,
             notify_rx,
             dead_workers: std::collections::HashSet::new(),
+            reported_unavailable_workers: std::collections::HashSet::new(),
+            last_usage_limit_scan: None,
             cancelled_spawns: std::collections::HashSet::new(),
             last_idle_message_times: HashMap::new(),
             lifecycle_redelivery_attempts: HashMap::new(),

--- a/cas-cli/src/ui/factory/daemon/mod.rs
+++ b/cas-cli/src/ui/factory/daemon/mod.rs
@@ -233,6 +233,12 @@ pub struct FactoryDaemon {
     notify_rx: Option<cas_factory::DaemonNotifier>,
     /// Workers that have been shut down or crashed — their queued messages are dropped.
     dead_workers: std::collections::HashSet<String>,
+    /// Workers whose harness has reported a terminal unavailable state in the
+    /// current session. One supervisor relay per episode; removal permits a
+    /// later recovered-and-exhausted worker to surface again.
+    reported_unavailable_workers: std::collections::HashSet<String>,
+    /// Last bounded rollout scan for terminal harness availability evidence.
+    last_usage_limit_scan: Option<Instant>,
     /// In-flight spawns cancelled by a shutdown that targeted that specific
     /// generation. Entries are consumed when the matching spawn task finishes.
     cancelled_spawns: std::collections::HashSet<String>,

--- a/cas-cli/src/ui/factory/daemon/process.rs
+++ b/cas-cli/src/ui/factory/daemon/process.rs
@@ -335,6 +335,8 @@ pub async fn run_daemon_after_fork(
         teams,
         notify_rx,
         dead_workers: std::collections::HashSet::new(),
+        reported_unavailable_workers: std::collections::HashSet::new(),
+        last_usage_limit_scan: None,
         cancelled_spawns: std::collections::HashSet::new(),
         last_idle_message_times: HashMap::new(),
         lifecycle_redelivery_attempts: HashMap::new(),

--- a/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
@@ -7,11 +7,6 @@ fn enqueue_worker_attention_relay(
     cas_dir: &std::path::Path,
     event: &crate::ui::factory::director::DirectorEvent,
 ) {
-    use crate::mcp::tools::core::task::lifecycle::supervisor_push::{
-        LIFECYCLE_WAKE_SOURCE_PREFIX, resolve_owning_supervisor,
-    };
-    use cas_store::{NotificationPriority, NotifyIdempotentResult};
-
     let (kind, worker, task_id, elapsed_secs) = match event {
         crate::ui::factory::director::DirectorEvent::WorkerIdle {
             worker,
@@ -30,6 +25,68 @@ fn enqueue_worker_attention_relay(
         ),
         _ => return,
     };
+    let detail = match (kind, task_id, elapsed_secs) {
+        ("worker_stalled", Some(task), Some(elapsed)) => format!(
+            "Worker {worker} is stalled on {task} after {}m without activity.",
+            elapsed / 60
+        ),
+        _ => format!("Worker {worker} is idle with no active task and needs supervisor attention."),
+    };
+    enqueue_worker_attention_relay_detail(cas_dir, kind, worker, task_id, elapsed_secs, &detail);
+}
+
+/// Persist one confirmed worker stoppage through the same durable supervisor
+/// relay used by director-detected idle and stall events.  This is deliberately
+/// narrower than a normal-message delivery failure: callers invoke it only
+/// after a bounded wake retry has also produced no pane output.
+pub(super) fn enqueue_worker_delivery_stalled_relay(
+    cas_dir: &std::path::Path,
+    worker: &str,
+    message_id: i64,
+) {
+    let detail = format!(
+        "Worker {worker} produced no pane output after normal message {message_id} and its bounded retry."
+    );
+    enqueue_worker_attention_relay_detail(
+        cas_dir,
+        "worker_delivery_stalled",
+        worker,
+        None,
+        None,
+        &detail,
+    );
+}
+
+/// Surface a terminal harness-side refusal even when its MCP child continues
+/// heartbeating. The evidence is collected from the harness artifact, not
+/// inferred from heartbeat age.
+pub(super) fn enqueue_worker_unavailable_relay(cas_dir: &std::path::Path, worker: &str) {
+    let detail = format!(
+        "Worker {worker}'s harness reported a terminal unavailable state while its process may still heartbeat."
+    );
+    enqueue_worker_attention_relay_detail(
+        cas_dir,
+        "worker_unavailable",
+        worker,
+        None,
+        None,
+        &detail,
+    );
+}
+
+fn enqueue_worker_attention_relay_detail(
+    cas_dir: &std::path::Path,
+    kind: &str,
+    worker: &str,
+    task_id: Option<&str>,
+    elapsed_secs: Option<u64>,
+    detail: &str,
+) {
+    use crate::mcp::tools::core::task::lifecycle::supervisor_push::{
+        LIFECYCLE_WAKE_SOURCE_PREFIX, resolve_owning_supervisor,
+    };
+    use cas_store::{NotificationPriority, NotifyIdempotentResult};
+
     let factory_session = std::env::var("CAS_FACTORY_SESSION").ok();
     let Ok(agent_store) = crate::store::open_agent_store(cas_dir) else {
         tracing::warn!("worker attention relay skipped: agent store unavailable");
@@ -58,6 +115,7 @@ fn enqueue_worker_attention_relay(
         "worker": worker,
         "task_id": task_id,
         "elapsed_secs": elapsed_secs,
+        "detail": detail,
         "factory_session": factory_session,
         "occurrence": occurrence,
     })
@@ -86,13 +144,6 @@ fn enqueue_worker_attention_relay(
     let Ok(prompt_queue) = crate::store::open_prompt_queue_store(cas_dir) else {
         tracing::error!(worker = %worker, kind, notification_id, "worker attention relay left pending: prompt queue unavailable");
         return;
-    };
-    let detail = match (kind, task_id, elapsed_secs) {
-        ("worker_stalled", Some(task), Some(elapsed)) => format!(
-            "Worker {worker} is stalled on {task} after {}m without activity.",
-            elapsed / 60
-        ),
-        _ => format!("Worker {worker} is idle with no active task and needs supervisor attention."),
     };
     let body = format!(
         "<worker-attention kind=\"{kind}\" worker=\"{worker}\" notification_id=\"{notification_id}\">\n{detail}\nRun `coordination action=worker_status` and reassign or recover the worker as needed.\n</worker-attention>"
@@ -161,6 +212,8 @@ mod worker_attention_tests {
                 active_task: None,
             },
         );
+        enqueue_worker_delivery_stalled_relay(&cas_dir, "silent-codex", 42);
+        enqueue_worker_unavailable_relay(&cas_dir, "limited-codex");
         enqueue_worker_attention_relay(
             &cas_dir,
             &crate::ui::factory::director::DirectorEvent::WorkerStalled {
@@ -173,7 +226,7 @@ mod worker_attention_tests {
 
         let queue = crate::store::open_prompt_queue_store(&cas_dir).unwrap();
         let rows = queue.peek_all(10).unwrap();
-        assert_eq!(rows.len(), 2);
+        assert_eq!(rows.len(), 4);
         assert!(rows.iter().all(|row| {
             row.target == "supervisor"
                 && crate::mcp::tools::core::task::lifecycle::supervisor_push::is_lifecycle_wake_source(&row.source)
@@ -185,6 +238,16 @@ mod worker_attention_tests {
         );
         assert!(rows.iter().any(|row| {
             row.prompt.contains("kind=\"worker_stalled\"") && row.prompt.contains("cas-d4ae")
+        }));
+        assert!(rows.iter().any(|row| {
+            row.prompt.contains("kind=\"worker_delivery_stalled\"")
+                && row.prompt.contains("silent-codex")
+                && row.prompt.contains("normal message 42")
+        }));
+        assert!(rows.iter().any(|row| {
+            row.prompt.contains("kind=\"worker_unavailable\"")
+                && row.prompt.contains("limited-codex")
+                && row.prompt.contains("terminal unavailable state")
         }));
     }
 }
@@ -377,6 +440,8 @@ impl FactoryDaemon {
             teams,
             notify_rx,
             dead_workers: std::collections::HashSet::new(),
+            reported_unavailable_workers: std::collections::HashSet::new(),
+            last_usage_limit_scan: None,
             cancelled_spawns: std::collections::HashSet::new(),
             last_idle_message_times: HashMap::new(),
             lifecycle_redelivery_attempts: HashMap::new(),
@@ -718,6 +783,7 @@ impl FactoryDaemon {
 
                     // Send notifications for detected events
                     self.app.notify_events(&delivery_events);
+                    self.relay_usage_limited_workers();
 
                     // cas-d4ae: the detector has already emitted exactly one
                     // event for this idle/stall episode and the app just

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -1304,6 +1304,56 @@ pub(crate) struct InboxDeferredWrite {
 }
 
 impl FactoryDaemon {
+    /// Relay a terminal Codex account-limit record once per unavailable
+    /// episode. Codex keeps its MCP child alive after this terminal harness
+    /// refusal, so heartbeat alone would hide the stopped worker indefinitely.
+    pub(super) fn relay_usage_limited_workers(&mut self) {
+        const USAGE_LIMIT_SCAN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+        let now = std::time::Instant::now();
+        if self
+            .last_usage_limit_scan
+            .is_some_and(|last| now.saturating_duration_since(last) < USAGE_LIMIT_SCAN_INTERVAL)
+        {
+            return;
+        }
+        self.last_usage_limit_scan = Some(now);
+
+        let Ok(agents) = crate::store::open_agent_store(self.app.cas_dir()) else {
+            return;
+        };
+        let Ok(active) = agents.list(Some(cas_types::AgentStatus::Active)) else {
+            return;
+        };
+        let workers: std::collections::HashSet<&str> =
+            self.app.worker_names().iter().map(String::as_str).collect();
+        let unavailable: std::collections::HashSet<String> = active
+            .iter()
+            .filter(|agent| {
+                agent.role == cas_types::AgentRole::Worker
+                    && agent.factory_session.as_deref() == Some(self.session_name.as_str())
+                    && workers.contains(agent.name.as_str())
+                    && crate::mcp::tools::service::factory_ops::worker_reports_usage_limit(
+                        self.app.cas_dir(),
+                        agent,
+                    )
+            })
+            .map(|agent| agent.name.clone())
+            .collect();
+        self.reported_unavailable_workers
+            .retain(|worker| unavailable.contains(worker));
+        for worker in unavailable {
+            if self.reported_unavailable_workers.insert(worker.clone()) {
+                super::lifecycle::enqueue_worker_unavailable_relay(self.app.cas_dir(), &worker);
+                tracing::warn!(
+                    target: "cas::coordination",
+                    stage = "worker_usage_limited",
+                    worker = %worker,
+                    "terminal harness availability record relayed to supervisor"
+                );
+            }
+        }
+    }
+
     /// Bounce aged direct messages to their original sender. The prompt store
     /// owns the read/ack race and one-shot marker; this daemon layer adds the
     /// live recipient harness and the authoritative delivery-state context.
@@ -1427,8 +1477,19 @@ impl FactoryDaemon {
                 }
                 NormalDeliveryProbeAction::FlagSupervisor => {
                     self.normal_delivery_probes.remove(&row_id);
+                    // A normal message that was transport-delivered, then
+                    // ignored across the bounded retry window is worker-health
+                    // evidence, not merely an informational inbox row. Route it
+                    // through the durable worker-attention outbox so every
+                    // harness reaches the owning supervisor without a manual
+                    // worker_status poll (cas-986a).
+                    super::lifecycle::enqueue_worker_delivery_stalled_relay(
+                        self.app.cas_dir(),
+                        &pane,
+                        row_id,
+                    );
                     let notice = format!(
-                        "<system-notice>Normal message {row_id} to '{target}' was transport-delivered, then produced no pane output for two watchdog windows. A single normal nudge was attempted; no urgent escalation was sent.</system-notice>"
+                        "<system-notice>Normal message {row_id} to '{target}' was transport-delivered, then produced no pane output for two watchdog windows. A single normal nudge was attempted; a durable worker-attention relay was sent to the supervisor; no urgent escalation was sent.</system-notice>"
                     );
                     if let Err(error) = queue.enqueue_with_session(
                         "delivery-watchdog",


### PR DESCRIPTION
Two worker-stoppage classes previously died in non-durable notices; both now route through the durable worker-attention outbox:

- A normal message that is transport-delivered but produces no pane output across the bounded 120s retry + 120s observation window now emits a durable `worker_delivery_stalled` supervisor relay instead of only an ordinary queue note.
- A 60-second daemon scan detects artifact-proven Codex terminal usage-limit records (the harness keeps its MCP child heartbeating through this state, so heartbeat age alone hides it) and emits exactly one `worker_unavailable` relay per continuous episode, with recovery re-arming the relay.

ACK bridge and wake-envelope parser accept both new kinds. Codex hung-turn root evidence: unframed large PTY bursts swallow the trailing CR into the composer (cas-mux/src/harness.rs:42-70); bracketed paste is the standing mitigation.

Scoped proof: worker_attention_tests 2/2, wake corroboration + ACK-bridge + watchdog-backoff regressions all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)