### PR TITLE
ci: defer required PR work to merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,6 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
-      || (github.event_name == 'pull_request'
-      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/')))
@@ -224,17 +222,16 @@ jobs:
             echo "::notice title=sccache stats::scripts/ci-sccache-summary.sh is absent at this checkout; skipping cache reporting."
           fi
 
-  # Required checks always start: path selection happens in steps, never with
-  # job-level `paths` filters, so their exact ruleset contexts keep reporting.
-  # A Rust-unaffected diff short-circuits Rust work only; hub-web-only diffs
-  # still run the Commander asset validation below.
+  # Full Fast Validation runs exactly once on GitHub's canonical merge-queue
+  # tree. The required rollup below emits a cheap hosted PR admission context,
+  # then this job family validates the tree that will actually land. This avoids
+  # compiling the PR head and its merge tree back-to-back without widening the
+  # self-hosted route beyond merge_group.
   fast-validation-preflight:
     name: Fast Validation — preflight (no test suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
-      || (github.event_name == 'pull_request'
-      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/')))
@@ -310,8 +307,6 @@ jobs:
     if: >-
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
-      || (github.event_name == 'pull_request'
-      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/'))))
@@ -464,8 +459,6 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
-      || (github.event_name == 'pull_request'
-      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/')))
@@ -540,8 +533,6 @@ jobs:
     if: >-
       always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
-      || (github.event_name == 'pull_request'
-      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/'))))
@@ -572,8 +563,6 @@ jobs:
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
-      || (github.event_name == 'pull_request'
-      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/')))
@@ -619,10 +608,10 @@ jobs:
             echo "::notice title=sccache stats::scripts/ci-sccache-summary.sh is absent at this checkout; skipping cache reporting."
           fi
 
-  # The repository ruleset requires this exact check name. It reports success
-  # only after preflight, all exhaustive nextest shards, and doctests pass.
-  # Queue (rather than cancel) matching head-SHA checks per cas-9eaf; because
-  # this fan-in does no compilation, a duplicate cannot inflate the PR path.
+  # The repository ruleset requires this exact check name. On merge_group it
+  # reports success only after preflight, all exhaustive nextest shards, and
+  # doctests pass. On a main PR it is a cheap hosted admission receipt; the
+  # canonical merged tree receives the exhaustive validation before it lands.
   fast-validation:
     name: Fast Validation
     if: >-
@@ -653,7 +642,13 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
+      - name: Admit protected PR to merge-queue validation
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Fast Validation is deferred to the canonical merge-queue tree."
+
       - name: Require every Fast Validation lane to pass
+        if: github.event_name != 'pull_request'
         env:
           PREFLIGHT: ${{ needs.fast-validation-preflight.result }}
           SUITE: ${{ needs.fast-validation-suite.result }}
@@ -722,7 +717,9 @@ jobs:
 
   # Keep this compile-only: --all-targets catches Darwin-only type errors in
   # production, test, example, and benchmark code without duplicating the full
-  # Linux test suite on a more expensive runner.
+  # Linux test suite on a more expensive runner. The full check runs on the
+  # canonical merge-queue tree; main PRs emit only a hosted admission receipt
+  # so their code is not compiled twice before it can enter that queue.
   macos-check:
     name: macOS Check
     if: >-
@@ -750,38 +747,53 @@ jobs:
     # Zig 0.15.2 cannot link its build runner with the Xcode 26.6 / macOS 26.5
     # SDK that macos-latest selected in 2026-07. Keep the known-good Xcode 26.3
     # / macOS 26.2 SDK explicit until Zig is upgraded and verified against it.
-    runs-on: macos-26
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'macos-26' }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
+      - name: Admit protected PR to merge-queue Darwin validation
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "macOS Check is deferred to the canonical merge-queue tree."
+
       - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
         with:
           submodules: recursive
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - id: classify-diff
+        if: github.event_name != 'pull_request'
         uses: ./.github/actions/classify-required-diff
         with:
           base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
 
       - name: Report Rust short-circuit
-        if: steps.classify-diff.outputs.rust-unaffected == 'true'
+        if: >-
+          github.event_name != 'pull_request'
+          && steps.classify-diff.outputs.rust-unaffected == 'true'
         run: echo "macOS Rust checks skipped for ${{ steps.classify-diff.outputs.class }} diff."
 
       - name: Install Rust
-        if: steps.classify-diff.outputs.rust-unaffected != 'true'
+        if: >-
+          github.event_name != 'pull_request'
+          && steps.classify-diff.outputs.rust-unaffected != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       # ghostty_vt_sys builds its native library with Zig even for cargo check.
       - name: Install Zig
-        if: steps.classify-diff.outputs.rust-unaffected != 'true'
+        if: >-
+          github.event_name != 'pull_request'
+          && steps.classify-diff.outputs.rust-unaffected != 'true'
         run: ./scripts/bootstrap-zig.sh
 
       # Zig discovers Darwin SDKs through xcrun, which follows DEVELOPER_DIR.
       # Keep this visible so runner-image/toolchain drift is diagnosable.
       - name: Report Apple and Zig toolchains
-        if: steps.classify-diff.outputs.rust-unaffected != 'true'
+        if: >-
+          github.event_name != 'pull_request'
+          && steps.classify-diff.outputs.rust-unaffected != 'true'
         run: |
           echo "DEVELOPER_DIR=$DEVELOPER_DIR"
           xcode-select --print-path
@@ -792,13 +804,17 @@ jobs:
           ./.context/zig/zig env
 
       - name: Setup sccache
-        if: steps.classify-diff.outputs.rust-unaffected != 'true'
+        if: >-
+          github.event_name != 'pull_request'
+          && steps.classify-diff.outputs.rust-unaffected != 'true'
         id: setup-sccache
         continue-on-error: true
         uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Probe sccache backend
-        if: steps.classify-diff.outputs.rust-unaffected != 'true'
+        if: >-
+          github.event_name != 'pull_request'
+          && steps.classify-diff.outputs.rust-unaffected != 'true'
         shell: bash
         run: |
           if [[ "${{ steps.setup-sccache.outcome }}" != "success" ]] || ! sccache --start-server; then
@@ -809,25 +825,23 @@ jobs:
           fi
 
       - name: Cache cargo
-        if: steps.classify-diff.outputs.rust-unaffected != 'true'
+        if: >-
+          github.event_name != 'pull_request'
+          && steps.classify-diff.outputs.rust-unaffected != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
 
       - name: Check workspace
-        if: steps.classify-diff.outputs.rust-unaffected != 'true'
+        if: >-
+          github.event_name != 'pull_request'
+          && steps.classify-diff.outputs.rust-unaffected != 'true'
         env:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: cargo check --workspace --all-targets
 
-      - name: Check (without MCP proxy)
-        if: steps.classify-diff.outputs.rust-unaffected != 'true'
-        env:
-          ZIG: ${{ github.workspace }}/.context/zig/zig
-        run: cargo check -p cas --no-default-features
-
       - name: Report sccache stats
-        if: always() && steps.classify-diff.outputs.rust-unaffected != 'true'
+        if: always() && github.event_name != 'pull_request' && steps.classify-diff.outputs.rust-unaffected != 'true'
         run: |
           # Version skew (cas-3e14): the workflow can come from a newer main
           # while the checkout is an older head that predates this script.

--- a/docs/branch-protection/README.md
+++ b/docs/branch-protection/README.md
@@ -10,8 +10,8 @@ The two required contexts are deliberately minimal, but neither removes coverage
 
 | Required context | Unique protection | Steady-state wall | Verdict |
 | --- | --- | --- | --- |
-| `Fast Validation` | Its rollup rejects a failed preflight, the full-suite fan-in (and every exhaustive nextest shard), **and doctests**. | Dominated by the suite archive build/shards; target is under five minutes after the self-hosted archive path. | Required. |
-| `macOS Check` | Darwin/Xcode/SDK compile surface that Linux does not exercise. | Measured about 4.2–4.3 minutes. | Required; no equivalent scoped macOS proof exists yet. |
+| `Fast Validation` | On the canonical `merge_group` tree, its rollup rejects a failed preflight, the full-suite fan-in (and every exhaustive nextest shard), **and doctests**. | Queue receipt 32367317728: 3m38 from merge-group start to the rollup. | Required; a main PR reports a cheap hosted admission context, then the merged tree receives the exhaustive check. |
+| `macOS Check` | On the canonical `merge_group` tree, Darwin/Xcode/SDK compilation that Linux does not exercise. | Queue receipt 32367317728: 4m43 before removing the duplicate no-MCP-proxy check. | Required; a main PR reports a cheap hosted admission context, then the merged tree receives the full Darwin compile. |
 
 `Fast Validation — doctests` is intentionally not a separate required context: the required
 `Fast Validation` fan-in already requires `fast-validation-docs` to succeed. Its coverage is
@@ -39,8 +39,11 @@ Verify afterwards, and roll back if needed:
 default branch if it is ever renamed. Substitute `"refs/heads/main"` if you prefer it pinned.
 
 The CI workflow must include the `merge_group` trigger and make both required contexts report
-on the synthetic merged-tree SHA. Without that trigger, merge-queue entries wait until their
-status-check timeout because no required context can report.
+on the synthetic merged-tree SHA. Main PR contexts are deliberately cheap hosted admissions:
+they let auto-merge enter the queue without compiling the PR head and the eventual merged tree
+back-to-back. The full Fast Validation and Darwin checks run only on the canonical merged tree
+before it lands. Without the `merge_group` trigger, entries wait until their status-check timeout
+because no required context can report.
 
 ### Validation performed
 
@@ -62,8 +65,8 @@ Live API application remains operator-visible and must be receipted.
 
 | Job (`name:`) | Triggers | Required? |
 | --- | --- | --- |
-| `Fast Validation` | `pull_request`, `merge_group`, push to `main`, schedule, dispatch | **Yes — the rollup, not the lower full-suite fan-in** |
-| `macOS Check` | `pull_request`, `merge_group`, push to `main`, schedule, dispatch | **Yes** — see below |
+| `Fast Validation` | Cheap hosted admission on `pull_request`; exhaustive rollup on `merge_group`, push to `main`, schedule, dispatch | **Yes — the rollup, not the lower full-suite fan-in** |
+| `macOS Check` | Cheap hosted admission on `pull_request`; Darwin compile on `merge_group`, push to `main`, schedule, dispatch | **Yes** — see below |
 | `Release-Profile & Build Guard (compile-only, no test suite)` | `if:` limits it to `schedule` or `refs/heads/main` | **No — must not be required** |
 
 **Release-Profile & Build Guard is excluded, and this is the load-bearing exclusion.** Its
@@ -73,10 +76,10 @@ permanently unmergeable. Its own renamed title already says it is compile-only w
 suite, so it is not the suite-executing gate anyway.
 
 **macOS Check is included**, per the standing "Linux-green ≠ merge-ready" discipline — macOS
-breakage has shipped before precisely because Linux was green. Two costs to accept knowingly:
-it runs on `macos-26` with a pinned Xcode 26.3 `DEVELOPER_DIR`, so runner or SDK trouble
-becomes a merge blocker, and macOS minutes are billed at a higher multiplier. If that proves
-too costly, drop it from the JSON — but drop it deliberately, not by forgetting it.
+breakage has shipped before precisely because Linux was green. Its full compile runs on
+`macos-26` with a pinned Xcode 26.3 `DEVELOPER_DIR` against the canonical merge-queue tree, so
+runner or SDK trouble remains a merge blocker. The PR admission job is hosted and intentionally
+does not claim Darwin coverage; it exists only to admit the PR to the tree that does provide it.
 
 ## 4. Factory flow
 

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -463,6 +463,24 @@ for job in "${required_pr_jobs[@]}"; do
     require_text "$block" 'cancel-in-progress: true' "$job releases runners held by its own superseded runs"
 done
 
+# Merge-queue latency contract (cas-6600): protected PRs emit both required
+# contexts quickly on hosted runners, then the canonical merge_group tree gets
+# the expensive Fast Validation and Darwin work. This retains coverage on the
+# exact tree that lands while avoiding a duplicate PR-head build.
+fast_admission="$(job_block fast-validation)"
+macos="$(job_block macos-check)"
+for job in fast-validation-runner-route fast-validation-preflight fast-validation-suite-build fast-validation-suite-shards fast-validation-suite fast-validation-docs; do
+    require_absent "$(job_block "$job")" "github.event_name == 'pull_request'" \
+        "$job defers exhaustive PR-head work to the merge queue"
+done
+require_text "$fast_admission" 'Admit protected PR to merge-queue validation' 'Fast Validation emits a PR admission receipt'
+require_text "$fast_admission" "if: github.event_name == 'pull_request'" 'Fast Validation admission is PR-only'
+require_text "$fast_admission" "if: github.event_name != 'pull_request'" 'Fast Validation only gates dependencies on the canonical tree'
+require_text "$macos" "github.event_name == 'pull_request' && 'ubuntu-latest' || 'macos-26'" 'macOS PR admission stays hosted while queue validation uses macOS'
+require_text "$macos" 'Admit protected PR to merge-queue Darwin validation' 'macOS Check emits a PR admission receipt'
+require_text "$macos" "github.event_name != 'pull_request'" 'macOS compilation is deferred to the canonical tree'
+require_absent "$macos" 'cargo check -p cas --no-default-features' 'macOS does not duplicate the Linux no-MCP-proxy build'
+
 preflight="$(job_block fast-validation-preflight)"
 suite="$(job_block fast-validation-suite)"
 suite_build="$(job_block fast-validation-suite-build)"
@@ -507,6 +525,7 @@ require_text "$suite" 'needs: fast-validation-suite-shards' 'required full-suite
 require_text "$suite" 'test "$SHARDS" = success' 'required full-suite context rejects failed shards'
 require_text "$(<"$makefile")" '../scripts/run-verified-tests.sh nextest run --workspace --no-fail-fast' 'local make test verifies CI workspace nextest scope'
 require_text "$docs" 'scripts/run-verified-tests.sh test -p cas --doc' 'doctest coverage remains in Fast Validation with an execution receipt'
+require_text "$preflight" 'cargo build -p cas --no-default-features' 'Linux preflight retains no-MCP-proxy compilation coverage'
 require_text "$(<"$real_store_guard")" 'run-verified-tests.sh' 'real-store guard requires an executed-test receipt'
 require_text "$(<"$migration_guard")" 'run-verified-tests.sh nextest run -p cas --test component_output_test' 'release migration snapshots require an executed-test receipt'
 if [[ -x "$verified" ]]; then


### PR DESCRIPTION
Moves exhaustive Fast Validation and Darwin compilation from the PR head to the canonical merge-queue tree, while required PR contexts remain short hosted admission receipts. Retains no-MCP-proxy coverage in Linux preflight and removes its duplicate macOS invocation.\n\nProof: scripts/test-ci-test-tiers.sh (469 passed, 0 failed); git diff --check.\n\nTask: cas-6600.