### PR TITLE
fix(ci): harden watchdog cancellation safety

### DIFF
--- a/.github/workflows/merge-queue-watchdog.yml
+++ b/.github/workflows/merge-queue-watchdog.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Cancel runs exceeding twice the suite-build p95
         env:
           GH_TOKEN: ${{ github.token }}
-          # Successful suite builds measured 288–576s; 20m exceeds 2x p95.
-          CASSY_MERGE_GROUP_HANG_SECONDS: '1200'
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          CASSY_WATCHDOG_DRY_RUN: 'false'
         run: ./scripts/cancel-stale-merge-group-runs.sh

--- a/.github/workflows/stale-queued-run-watchdog.yml
+++ b/.github/workflows/stale-queued-run-watchdog.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Cancel queued runs exceeding normal scheduling time
         env:
           GH_TOKEN: ${{ github.token }}
-          # Twenty minutes is well above ordinary queue scheduling, yet
-          # promptly reclaims the 13-day release/main/PR starvation class.
-          CASSY_NON_MERGE_GROUP_QUEUE_SECONDS: '1200'
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          CASSY_WATCHDOG_DRY_RUN: 'false'
         run: ./scripts/cancel-stale-non-merge-group-queued-runs.sh

--- a/scripts/cancel-stale-merge-group-runs.sh
+++ b/scripts/cancel-stale-merge-group-runs.sh
@@ -3,32 +3,48 @@
 # p95. A vanished queue entry otherwise leaves its self-hosted claim occupied.
 set -euo pipefail
 
-repository="${GITHUB_REPOSITORY:-Richards-LLC/cassy}"
-hang_seconds="${CASSY_MERGE_GROUP_HANG_SECONDS:-1200}"
-now_epoch="${CASSY_NOW_EPOCH:-$(date -u +%s)}"
-
-if [[ ! "$repository" =~ ^[^/]+/[^/]+$ ]]; then
-    echo "GITHUB_REPOSITORY must be an owner/repository slug" >&2
-    exit 2
-fi
-if [[ ! "$hang_seconds" =~ ^[0-9]+$ ]] || (( hang_seconds == 0 )); then
-    echo "CASSY_MERGE_GROUP_HANG_SECONDS must be a positive integer" >&2
-    exit 2
-fi
-if [[ ! "$now_epoch" =~ ^[0-9]+$ ]]; then
-    echo "CASSY_NOW_EPOCH must be epoch seconds" >&2
-    exit 2
-fi
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=watchdog-policy.sh
+source "$script_dir/watchdog-policy.sh"
+watchdog_policy_init
+repository="$WATCHDOG_REPOSITORY"
+hang_seconds="$WATCHDOG_THRESHOLD_SECONDS"
+now_epoch="$WATCHDOG_NOW_EPOCH"
 
 in_progress_runs="$(gh api "repos/$repository/actions/runs?event=merge_group&status=in_progress&per_page=100")"
 queued_runs="$(gh api "repos/$repository/actions/runs?event=merge_group&status=queued&per_page=100")"
 runs="$(printf '%s\n%s\n' "$in_progress_runs" "$queued_runs" | jq -s '{workflow_runs: map(.workflow_runs[]) }')"
-while IFS=$'\t' read -r run_id started_at head_branch status; do
-    [[ -n "$run_id" && "$started_at" != null ]] || continue
-    started_epoch="$(date -u -d "$started_at" +%s)"
+archive_job='Fast Validation — suite archive build'
+archive_job_state() {
+    gh api "repos/$repository/actions/runs/$1/jobs?filter=latest&per_page=100" \
+        | jq -r --arg name "$archive_job" \
+            '(.jobs | map(select(.name == $name)) | first) as $job
+             | if $job == null then empty else [$job.status, ($job.started_at // $job.created_at)] | @tsv end'
+}
+
+while IFS=$'\t' read -r run_id workflow_name head_branch run_status; do
+    [[ -n "$run_id" && "$workflow_name" == CI ]] || continue
+    job_state="$(archive_job_state "$run_id")"
+    IFS=$'\t' read -r job_status started_at <<<"$job_state"
+    [[ "$job_status" == queued || "$job_status" == in_progress ]] || continue
+    if ! started_epoch="$(date -u -d "$started_at" +%s 2>/dev/null)"; then
+        printf 'skipping merge_group run=%s with invalid archive time=%s\n' "$run_id" "$started_at" >&2
+        continue
+    fi
     age_seconds=$((now_epoch - started_epoch))
     (( age_seconds > hang_seconds )) || continue
-    printf 'cancelling stale merge_group run=%s status=%s age_seconds=%s threshold_seconds=%s ref=%s\n' \
-        "$run_id" "$status" "$age_seconds" "$hang_seconds" "$head_branch"
-    gh api --method POST "repos/$repository/actions/runs/$run_id/cancel" >/dev/null
-done < <(jq -r '.workflow_runs[] | [.id, (.run_started_at // .created_at), .head_branch, .status] | @tsv' <<<"$runs")
+    current_status="$(gh api "repos/$repository/actions/runs/$run_id" --jq '.status')"
+    if [[ "$current_status" != queued && "$current_status" != in_progress ]]; then
+        printf 'skipping inactive merge_group run=%s current_status=%s\n' "$run_id" "$current_status"
+        continue
+    fi
+    current_job_state="$(archive_job_state "$run_id")"
+    IFS=$'\t' read -r current_job_status _ <<<"$current_job_state"
+    if [[ "$current_job_status" != queued && "$current_job_status" != in_progress ]]; then
+        printf 'skipping inactive archive job for run=%s current_status=%s\n' "$run_id" "$current_job_status"
+        continue
+    fi
+    printf 'cancelling stale merge_group run=%s status=%s job_status=%s age_seconds=%s threshold_seconds=%s ref=%s\n' \
+        "$run_id" "$run_status" "$current_job_status" "$age_seconds" "$hang_seconds" "$head_branch"
+    watchdog_cancel_run "$run_id"
+done < <(jq -r '.workflow_runs[] | [.id, .name, .head_branch, .status] | @tsv' <<<"$runs")

--- a/scripts/cancel-stale-non-merge-group-queued-runs.sh
+++ b/scripts/cancel-stale-non-merge-group-queued-runs.sh
@@ -4,22 +4,13 @@
 # excluded here.
 set -euo pipefail
 
-repository="${GITHUB_REPOSITORY:-Richards-LLC/cassy}"
-queue_seconds="${CASSY_NON_MERGE_GROUP_QUEUE_SECONDS:-1200}"
-now_epoch="${CASSY_NOW_EPOCH:-$(date -u +%s)}"
-
-if [[ ! "$repository" =~ ^[^/]+/[^/]+$ ]]; then
-    echo "GITHUB_REPOSITORY must be an owner/repository slug" >&2
-    exit 2
-fi
-if [[ ! "$queue_seconds" =~ ^[0-9]+$ ]] || (( queue_seconds == 0 )); then
-    echo "CASSY_NON_MERGE_GROUP_QUEUE_SECONDS must be a positive integer" >&2
-    exit 2
-fi
-if [[ ! "$now_epoch" =~ ^[0-9]+$ ]]; then
-    echo "CASSY_NOW_EPOCH must be epoch seconds" >&2
-    exit 2
-fi
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=watchdog-policy.sh
+source "$script_dir/watchdog-policy.sh"
+watchdog_policy_init
+repository="$WATCHDOG_REPOSITORY"
+queue_seconds="$WATCHDOG_THRESHOLD_SECONDS"
+now_epoch="$WATCHDOG_NOW_EPOCH"
 
 queued_runs="$(gh api "repos/$repository/actions/runs?status=queued&per_page=100")"
 while IFS=$'\t' read -r run_id created_at event head_branch; do
@@ -44,5 +35,5 @@ while IFS=$'\t' read -r run_id created_at event head_branch; do
 
     printf 'cancelling stale queued run=%s event=%s age_seconds=%s threshold_seconds=%s ref=%s\n' \
         "$run_id" "$event" "$age_seconds" "$queue_seconds" "$head_branch"
-    gh api --method POST "repos/$repository/actions/runs/$run_id/cancel" >/dev/null
+    watchdog_cancel_run "$run_id"
 done < <(jq -r '.workflow_runs[] | [.id, .created_at, .event, .head_branch] | @tsv' <<<"$queued_runs")

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -18,6 +18,8 @@ watchdog_script="$repo_root/scripts/cancel-stale-merge-group-runs.sh"
 runner_unit="$repo_root/ops/systemd/cassy-actions-runner.service"
 stale_queue_watchdog="$repo_root/.github/workflows/stale-queued-run-watchdog.yml"
 stale_queue_script="$repo_root/scripts/cancel-stale-non-merge-group-queued-runs.sh"
+watchdog_policy="$repo_root/scripts/watchdog-policy.sh"
+watchdog_behavior_test="$repo_root/scripts/test-watchdog-scripts.sh"
 
 pass=0
 fail=0
@@ -158,18 +160,23 @@ require_text "$pilot_doc" 'CARGO_CACHE_RUSTC_INFO=0' 'pilot documents Cargo rust
 
 runner_unit_text="$(<"$runner_unit")"
 require_text "$runner_unit_text" 'Environment=CARGO_CACHE_RUSTC_INFO=0' 'runner does not persist failed sccache rustc probes across jobs'
+require_text "$runner_unit_text" 'Environment=SCCACHE_IDLE_TIMEOUT=0' 'runner keeps its private sccache server alive between merge-queue jobs'
 
 if [[ -x "$watchdog_script" ]]; then
     watchdog_text="$(<"$watchdog")"
     watchdog_script_text="$(<"$watchdog_script")"
     require_text "$watchdog_text" "cron: '*/5 * * * *'" 'merge-queue watchdog runs at GitHub’s five-minute floor'
     require_text "$watchdog_text" 'actions: write' 'merge-queue watchdog may cancel an orphaned run'
-    require_text "$watchdog_text" "CASSY_MERGE_GROUP_HANG_SECONDS: '1200'" 'watchdog pins a 20-minute 2x-p95 threshold'
+    require_text "$watchdog_text" 'run: ./scripts/cancel-stale-merge-group-runs.sh' 'merge-queue watchdog invokes its cancellation script'
+    require_text "$watchdog_text" 'GITHUB_REPOSITORY: ${{ github.repository }}' 'merge-queue watchdog passes its explicit repository'
+    require_text "$watchdog_text" "CASSY_WATCHDOG_DRY_RUN: 'false'" 'merge-queue watchdog disables dry-run in scheduled execution'
     require_text "$watchdog_script_text" 'event=merge_group&status=in_progress' 'watchdog inspects in-progress merge-group runs'
     require_text "$watchdog_script_text" 'event=merge_group&status=queued' 'watchdog also reclaims queued pre-claim starvation'
     require_text "$watchdog_script_text" "printf '%s\\n%s\\n'" 'watchdog combines in-progress and queued API responses'
-    require_text "$watchdog_script_text" '.run_started_at // .created_at' 'watchdog measures queued starvation from queue creation'
-    require_text "$watchdog_script_text" 'actions/runs/$run_id/cancel' 'watchdog cancels stale runs by id'
+    require_text "$watchdog_script_text" 'Fast Validation — suite archive build' 'watchdog scopes merge-group cancellation to the archive job'
+    require_text "$watchdog_script_text" '.name == $name' 'watchdog scopes merge-group cancellation to CI workflow jobs'
+    require_text "$watchdog_script_text" 'current_job_status' 'watchdog rechecks archive job state before cancellation'
+    require_text "$(<"$watchdog_policy")" 'actions/runs/$run_id/cancel' 'watchdog cancels stale runs by id'
     require_text "$watchdog_script_text" 'age_seconds > hang_seconds' 'watchdog does not cancel at or below threshold'
 else
     printf 'FAIL merge-queue watchdog script is executable\n'
@@ -652,12 +659,14 @@ if [[ -x "$stale_queue_script" ]]; then
     stale_queue_script_text="$(<"$stale_queue_script")"
     require_text "$stale_watchdog_text" "cron: '*/5 * * * *'" 'stale queued-run watchdog uses GitHub’s five-minute floor'
     require_text "$stale_watchdog_text" 'actions: write' 'stale queued-run watchdog may cancel a stranded run'
-    require_text "$stale_watchdog_text" "CASSY_NON_MERGE_GROUP_QUEUE_SECONDS: '1200'" 'stale queued-run watchdog pins a 20-minute threshold'
+    require_text "$stale_watchdog_text" 'run: ./scripts/cancel-stale-non-merge-group-queued-runs.sh' 'stale queued-run watchdog invokes its cancellation script'
+    require_text "$stale_watchdog_text" 'GITHUB_REPOSITORY: ${{ github.repository }}' 'stale queued-run watchdog passes its explicit repository'
+    require_text "$stale_watchdog_text" "CASSY_WATCHDOG_DRY_RUN: 'false'" 'stale queued-run watchdog disables dry-run in scheduled execution'
     require_text "$stale_queue_script_text" 'actions/runs?status=queued' 'stale queued-run watchdog reads queued runs of every event'
     require_text "$stale_queue_script_text" '[[ "$event" != merge_group ]]' 'stale queued-run watchdog excludes cas-065a merge-group scope'
     require_text "$stale_queue_script_text" "gh api \"repos/\$repository/actions/runs/\$run_id\" --jq '.status'" 'stale queued-run watchdog rechecks status before cancellation'
     require_text "$stale_queue_script_text" 'age_seconds > queue_seconds' 'stale queued-run watchdog preserves runs at or below its threshold'
-    require_text "$stale_queue_script_text" 'actions/runs/$run_id/cancel' 'stale queued-run watchdog cancels by run id'
+    require_text "$(<"$watchdog_policy")" 'actions/runs/$run_id/cancel' 'stale queued-run watchdog cancels by id'
 
     stale_tmp="$(mktemp -d)"
     mkdir -p "$stale_tmp/bin"
@@ -683,6 +692,7 @@ else
     printf 'unexpected fake gh invocation: %s\n' "$*" >&2
     exit 2
 fi
+
 EOF
     chmod +x "$stale_tmp/bin/gh"
     stale_output="$stale_tmp/output"
@@ -701,6 +711,23 @@ EOF
     rm -rf "$stale_tmp"
 else
     printf 'FAIL stale queued-run watchdog script is executable\n'
+    fail=$((fail + 1))
+fi
+
+if [[ -x "$watchdog_policy" && -x "$watchdog_behavior_test" ]]; then
+    require_text "$(<"$watchdog_policy")" 'CASSY_WATCHDOG_STALE_SECONDS:-1200' 'both watchdogs share one threshold authority'
+    require_absent "$watchdog_text$stale_watchdog_text" '1200' 'watchdog workflows do not duplicate the threshold'
+    require_absent "$(<"$watchdog_policy")$watchdog_text$stale_watchdog_text" 'CASSY_MERGE_GROUP_HANG_SECONDS' 'legacy merge-group threshold has no second authority'
+    require_absent "$(<"$watchdog_policy")$watchdog_text$stale_watchdog_text" 'CASSY_NON_MERGE_GROUP_QUEUE_SECONDS' 'legacy queued threshold has no second authority'
+    if "$watchdog_behavior_test"; then
+        printf 'ok   watchdog behavior fixtures pass for both scripts\n'
+        pass=$((pass + 1))
+    else
+        printf 'FAIL watchdog behavior fixtures pass for both scripts\n'
+        fail=$((fail + 1))
+    fi
+else
+    printf 'FAIL watchdog policy and behavior fixtures are executable\n'
     fail=$((fail + 1))
 fi
 

--- a/scripts/test-watchdog-scripts.sh
+++ b/scripts/test-watchdog-scripts.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Behavioral fixtures for both GitHub Actions cancellation watchdogs.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+merge_script="$repo_root/scripts/cancel-stale-merge-group-runs.sh"
+queued_script="$repo_root/scripts/cancel-stale-non-merge-group-queued-runs.sh"
+pass=0
+fail=0
+
+expect_text() {
+    local haystack="$1" needle="$2" label="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        printf 'ok   %s\n' "$label"; pass=$((pass + 1))
+    else
+        printf 'FAIL %s (missing %s)\n' "$label" "$needle" >&2; fail=$((fail + 1))
+    fi
+}
+
+expect_absent() {
+    local haystack="$1" needle="$2" label="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then
+        printf 'FAIL %s (unexpected %s)\n' "$label" "$needle" >&2; fail=$((fail + 1))
+    else
+        printf 'ok   %s\n' "$label"; pass=$((pass + 1))
+    fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+cat >"$tmp/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FAKE_GH_LOG:?}"
+case "$*" in
+  *'event=merge_group&status=in_progress&per_page=100'*)
+    printf '%s\n' '{"workflow_runs":[{"id":201,"name":"CI","run_started_at":"1970-01-01T00:00:00Z","created_at":"1970-01-01T00:00:00Z","head_branch":"queue","status":"in_progress"},{"id":202,"name":"CI","run_started_at":"1970-01-01T00:31:00Z","created_at":"1970-01-01T00:31:00Z","head_branch":"fresh","status":"in_progress"},{"id":203,"name":"Other workflow","run_started_at":"1970-01-01T00:00:00Z","created_at":"1970-01-01T00:00:00Z","head_branch":"other","status":"in_progress"}]}' ;;
+  *'event=merge_group&status=queued&per_page=100'*)
+    printf '%s\n' '{"workflow_runs":[{"id":204,"name":"CI","run_started_at":null,"created_at":"1970-01-01T00:00:00Z","head_branch":"queued","status":"queued"},{"id":205,"name":"CI","run_started_at":null,"created_at":"1970-01-01T00:00:00Z","head_branch":"raced","status":"queued"}]}' ;;
+  *'actions/runs?status=queued&per_page=100'*)
+    printf '%s\n' '{"workflow_runs":[{"id":101,"created_at":"1970-01-01T00:00:00Z","event":"push","head_branch":"main"},{"id":102,"created_at":"1970-01-01T00:00:00Z","event":"merge_group","head_branch":"queue"},{"id":103,"created_at":"1970-01-01T00:31:00Z","event":"pull_request","head_branch":"fresh"},{"id":104,"created_at":"1970-01-01T00:00:00Z","event":"workflow_dispatch","head_branch":"raced"},{"id":105,"created_at":"not-a-date","event":"push","head_branch":"invalid"}]}' ;;
+  *'actions/runs/201/jobs?filter=latest&per_page=100'*|*'actions/runs/204/jobs?filter=latest&per_page=100'*)
+    printf '%s\n' '{"jobs":[{"name":"Fast Validation — suite archive build","status":"in_progress","started_at":"1970-01-01T00:00:00Z","created_at":"1970-01-01T00:00:00Z"}]}' ;;
+  *'actions/runs/202/jobs?filter=latest&per_page=100'*)
+    printf '%s\n' '{"jobs":[{"name":"Fast Validation — suite archive build","status":"in_progress","started_at":"1970-01-01T00:31:00Z","created_at":"1970-01-01T00:31:00Z"}]}' ;;
+  *'actions/runs/205/jobs?filter=latest&per_page=100'*)
+    count_file="${FAKE_GH_STATE:?}/205-count"; count=0; [[ -f "$count_file" ]] && count="$(<"$count_file")"; echo $((count + 1)) >"$count_file"
+    if (( count == 0 )); then status=queued; else status=completed; fi
+    printf '{"jobs":[{"name":"Fast Validation — suite archive build","status":"%s","started_at":null,"created_at":"1970-01-01T00:00:00Z"}]}' "$status" ;;
+  *'actions/runs/201 --jq .status'*) printf 'in_progress\n' ;;
+  *'actions/runs/204 --jq .status'*) printf 'queued\n' ;;
+  *'actions/runs/205 --jq .status'*) printf 'queued\n' ;;
+  *'actions/runs/101 --jq .status'*) printf 'queued\n' ;;
+  *'actions/runs/104 --jq .status'*) printf 'completed\n' ;;
+  *'--method POST'*'actions/runs/'*) exit 0 ;;
+  *) printf 'unexpected fake gh invocation: %s\n' "$*" >&2; exit 2 ;;
+esac
+EOF
+chmod +x "$tmp/bin/gh"
+
+run_env=(GITHUB_REPOSITORY=example/repo CASSY_NOW_EPOCH=2000 FAKE_GH_LOG="$tmp/gh.log" FAKE_GH_STATE="$tmp/state" PATH="$tmp/bin:$PATH")
+mkdir -p "$tmp/state"
+merge_output="$tmp/merge-output"
+if env "${run_env[@]}" "$merge_script" >"$merge_output" 2>&1; then
+    merge_text="$(<"$merge_output")"; gh_log="$(<"$tmp/gh.log")"
+    expect_text "$merge_text" 'cancelling stale merge_group run=201' 'merge watchdog cancels stale in-progress CI archive job'
+    expect_text "$merge_text" 'cancelling stale merge_group run=204' 'merge watchdog falls back to created_at for queued archive job'
+    expect_text "$merge_text" 'skipping inactive archive job for run=205' 'merge watchdog tolerates a job completing mid-sweep'
+    expect_absent "$gh_log" 'actions/runs/202/cancel' 'merge watchdog preserves fresh archive job'
+    expect_absent "$gh_log" 'actions/runs/203/jobs' 'merge watchdog ignores non-CI merge-group workflows'
+    expect_absent "$gh_log" 'actions/runs/205/cancel' 'merge watchdog does not cancel a completed job'
+else
+    printf 'FAIL merge watchdog fixture exits successfully\n' >&2
+    cat "$merge_output" >&2
+    fail=$((fail + 1))
+fi
+
+: >"$tmp/gh.log"
+queued_output="$tmp/queued-output"
+if env "${run_env[@]}" "$queued_script" >"$queued_output" 2>&1; then
+    queued_text="$(<"$queued_output")"; gh_log="$(<"$tmp/gh.log")"
+    expect_text "$queued_text" 'cancelling stale queued run=101 event=push' 'queued watchdog cancels stale non-merge-group run'
+    expect_text "$queued_text" 'skipping no-longer-queued run=104 current_status=completed' 'queued watchdog tolerates a run completing mid-sweep'
+    expect_text "$queued_text" 'skipping queued run=105 with invalid created_at=not-a-date' 'queued watchdog guards invalid dates'
+    expect_absent "$gh_log" 'actions/runs/102' 'queued watchdog leaves merge-group scope alone'
+    expect_absent "$gh_log" 'actions/runs/103' 'queued watchdog preserves threshold-fresh run'
+    expect_text "$gh_log" 'actions/runs/101/cancel' 'queued watchdog sends cancel only after status re-read'
+else
+    printf 'FAIL queued watchdog fixture exits successfully\n' >&2; fail=$((fail + 1))
+fi
+
+for script in "$merge_script" "$queued_script"; do
+    dry_output="$tmp/$(basename "$script").dry-output"
+    if env "${run_env[@]}" CASSY_WATCHDOG_DRY_RUN=true "$script" >"$dry_output" 2>&1; then
+        if [[ "$script" == "$merge_script" ]]; then run_id=201; else run_id=101; fi
+        expect_text "$(<"$dry_output")" "dry-run would cancel run=$run_id" "$(basename "$script") dry-run reports without posting"
+    else
+        printf 'FAIL %s dry-run fixture exits successfully\n' "$(basename "$script")" >&2; fail=$((fail + 1))
+    fi
+done
+
+for script in "$merge_script" "$queued_script"; do
+    if env -u GITHUB_REPOSITORY CASSY_NOW_EPOCH=2000 "$script" >/dev/null 2>&1; then
+        printf 'FAIL %s rejects missing repository\n' "$(basename "$script")" >&2; fail=$((fail + 1))
+    elif [[ $? -eq 2 ]]; then
+        printf 'ok   %s requires an explicit repository\n' "$(basename "$script")"; pass=$((pass + 1))
+    else
+        printf 'FAIL %s missing repository exits 2\n' "$(basename "$script")" >&2; fail=$((fail + 1))
+    fi
+    if env GITHUB_REPOSITORY=example/repo CASSY_WATCHDOG_STALE_SECONDS=invalid "$script" >/dev/null 2>&1; then
+        printf 'FAIL %s rejects invalid threshold\n' "$(basename "$script")" >&2; fail=$((fail + 1))
+    elif [[ $? -eq 2 ]]; then
+        printf 'ok   %s invalid threshold exits 2\n' "$(basename "$script")"; pass=$((pass + 1))
+    else
+        printf 'FAIL %s invalid threshold exits 2\n' "$(basename "$script")" >&2; fail=$((fail + 1))
+    fi
+done
+
+printf 'test result: %s passed; %s failed\n' "$pass" "$fail"
+(( fail == 0 ))

--- a/scripts/watchdog-policy.sh
+++ b/scripts/watchdog-policy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Shared safety policy for GitHub Actions watchdogs. Successful suite archive
+# builds measured 288–576s, so this 20-minute limit stays above twice that p95.
+# Keep the timeout here so each watchdog uses the same reviewed value instead
+# of drifting independently.
+
+watchdog_policy_init() {
+    WATCHDOG_REPOSITORY="${GITHUB_REPOSITORY:-}"
+    WATCHDOG_THRESHOLD_SECONDS="${CASSY_WATCHDOG_STALE_SECONDS:-1200}"
+    WATCHDOG_NOW_EPOCH="${CASSY_NOW_EPOCH:-$(date -u +%s)}"
+    WATCHDOG_DRY_RUN="${CASSY_WATCHDOG_DRY_RUN:-false}"
+
+    if [[ ! "$WATCHDOG_REPOSITORY" =~ ^[^/]+/[^/]+$ ]]; then
+        echo "GITHUB_REPOSITORY must be an explicit owner/repository slug" >&2
+        exit 2
+    fi
+    if [[ ! "$WATCHDOG_THRESHOLD_SECONDS" =~ ^[0-9]+$ ]] || (( WATCHDOG_THRESHOLD_SECONDS == 0 )); then
+        echo "CASSY_WATCHDOG_STALE_SECONDS must be a positive integer" >&2
+        exit 2
+    fi
+    if [[ ! "$WATCHDOG_NOW_EPOCH" =~ ^[0-9]+$ ]]; then
+        echo "CASSY_NOW_EPOCH must be epoch seconds" >&2
+        exit 2
+    fi
+    if [[ "$WATCHDOG_DRY_RUN" != true && "$WATCHDOG_DRY_RUN" != false ]]; then
+        echo "CASSY_WATCHDOG_DRY_RUN must be true or false" >&2
+        exit 2
+    fi
+}
+
+watchdog_cancel_run() {
+    local run_id="$1"
+    if [[ "$WATCHDOG_DRY_RUN" == true ]]; then
+        printf 'dry-run would cancel run=%s\n' "$run_id"
+    elif ! gh api --method POST "repos/$WATCHDOG_REPOSITORY/actions/runs/$run_id/cancel" >/dev/null; then
+        # A run can complete after its final status read.  Do not abandon the
+        # sweep merely because GitHub rejects that now-stale cancellation.
+        printf 'unable to cancel run=%s; it may already be complete\n' "$run_id" >&2
+    fi
+}


### PR DESCRIPTION
## Summary\n- unify both watchdog scripts behind an explicit-repository, dry-run-safe policy\n- scope merge-queue cancellation to CI suite-archive jobs with final status re-reads\n- add fixed-clock fake-gh behavioral coverage and pin both workflow invocations\n\n## Verification\n- scripts/test-watchdog-scripts.sh (18 passed)\n- scripts/test-ci-test-tiers.sh (486 passed)