### PR TITLE
fix(factory): make worker attention relays durable

### DIFF
--- a/cas-cli/src/mcp/tools/service/agent_search_system/supervisor_queue.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/supervisor_queue.rs
@@ -430,4 +430,43 @@ mod cas_20ac_ack_tests {
             "an acknowledged worker-attention relay must remain absent after a store reopen"
         );
     }
+
+    #[test]
+    fn every_worker_attention_kind_acks_its_linked_prompt() {
+        for kind in [
+            "worker_idle",
+            "worker_stalled",
+            "worker_delivery_stalled",
+            "worker_unavailable",
+        ] {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let prompt_queue = open_prompt_queue_store(temp.path()).expect("prompt queue");
+            let supervisor_queue =
+                open_supervisor_queue_store(temp.path()).expect("supervisor queue");
+            let durable_id = supervisor_queue
+                .notify("supervisor-id", kind, "{}", NotificationPriority::High)
+                .expect("durable notice");
+            let prompt_id = match prompt_queue
+                .enqueue_idempotent(
+                    &format!("lifecycle-wake:worker-attention:{durable_id}"),
+                    "supervisor",
+                    &format!(
+                        "<worker-attention kind=\"{kind}\" worker=\"quiet-ibis\" notification_id=\"{durable_id}\">\\nrelay\\n</worker-attention>"
+                    ),
+                    None,
+                    Some(&format!("{kind}: quiet-ibis")),
+                    Some(NotificationPriority::High),
+                    &format!("worker-attention-outbox:{durable_id}"),
+                )
+                .expect("linked prompt")
+            {
+                EnqueueIdempotentResult::Created(id) | EnqueueIdempotentResult::AlreadyExists(id) => id,
+            };
+
+            let ack = acknowledge_linked_lifecycle_notification(temp.path(), durable_id)
+                .expect("ack bridge")
+                .expect("attention event must be bridged");
+            assert_eq!(ack.prompt_id, Some(prompt_id), "{kind}");
+        }
+    }
 }

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -6923,39 +6923,95 @@ pub(crate) fn worker_reports_usage_limit(
     cas_root: &std::path::Path,
     agent: &cas_types::Agent,
 ) -> bool {
+    matches!(
+        worker_usage_limit_evidence(cas_root, agent),
+        UsageLimitEvidence::Limited { .. }
+    )
+}
+
+/// The rollout scanner has three states.  In particular, an unreadable or
+/// unresolved rollout is not a recovery: callers retain a previously-open
+/// episode until they have affirmative later-turn evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum UsageLimitEvidence {
+    Limited { first_evidence: String },
+    Recovered,
+    Unavailable,
+}
+
+pub(crate) fn worker_usage_limit_evidence(
+    cas_root: &std::path::Path,
+    agent: &cas_types::Agent,
+) -> UsageLimitEvidence {
     let cli = worker_cli_from_agent(agent);
     let rollout = worker_transcript_path_for_agent(cas_root, agent);
-    codex_rollout_reports_usage_limit(rollout.as_deref(), cli)
+    codex_rollout_usage_limit_evidence(rollout.as_deref(), cli)
 }
 
 fn codex_rollout_reports_usage_limit(
     rollout: Option<&std::path::Path>,
     cli: cas_mux::SupervisorCli,
 ) -> bool {
+    matches!(
+        codex_rollout_usage_limit_evidence(rollout, cli),
+        UsageLimitEvidence::Limited { .. }
+    )
+}
+
+fn codex_rollout_usage_limit_evidence(
+    rollout: Option<&std::path::Path>,
+    cli: cas_mux::SupervisorCli,
+) -> UsageLimitEvidence {
     if cli != cas_mux::SupervisorCli::Codex {
-        return false;
+        return UsageLimitEvidence::Recovered;
     }
     let Some(rollout) = rollout else {
-        return false;
+        return UsageLimitEvidence::Unavailable;
     };
     let Ok(metadata) = std::fs::metadata(rollout) else {
-        return false;
+        return UsageLimitEvidence::Unavailable;
     };
     const TAIL_BYTES: u64 = 256 * 1024;
     let start = metadata.len().saturating_sub(TAIL_BYTES);
     let Ok(mut file) = std::fs::File::open(rollout) else {
-        return false;
+        return UsageLimitEvidence::Unavailable;
     };
     use std::io::{Read, Seek, SeekFrom};
     if file.seek(SeekFrom::Start(start)).is_err() {
-        return false;
+        return UsageLimitEvidence::Unavailable;
     }
     let mut tail = String::new();
     if file.read_to_string(&mut tail).is_err() {
-        return false;
+        return UsageLimitEvidence::Unavailable;
     }
-    tail.contains("You've hit your usage limit")
-        && (tail.contains("\"has_credits\":false") || tail.contains("\"has_credits\": false"))
+    // Rollouts are append-only JSONL.  A limit line that is followed by a
+    // successful terminal turn is historical rollout text, not a live outage.
+    // Keep the record timestamp (or its byte offset as a legacy fallback) as
+    // the durable episode identity used by daemon restarts and retry keys.
+    let mut latest_terminal = None;
+    for (line_index, line) in tail.lines().enumerate() {
+        let limited = line.contains("You've hit your usage limit")
+            && (line.contains("\"has_credits\":false") || line.contains("\"has_credits\": false"));
+        let completed = line.contains("\"type\":\"task_complete\"")
+            || line.contains("\"type\": \"task_complete\"");
+        if limited {
+            let timestamp = serde_json::from_str::<serde_json::Value>(line)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("timestamp")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_owned)
+                })
+                .unwrap_or_else(|| format!("tail-{}", start + line_index as u64));
+            latest_terminal = Some(UsageLimitEvidence::Limited {
+                first_evidence: timestamp,
+            });
+        } else if completed {
+            latest_terminal = Some(UsageLimitEvidence::Recovered);
+        }
+    }
+    latest_terminal.unwrap_or(UsageLimitEvidence::Recovered)
 }
 
 fn synthesized_codex_transcript_path(clone_path: &str, session_id: &str) -> String {
@@ -8506,6 +8562,37 @@ mod tests {
             Some(rollout.path()),
             cas_mux::SupervisorCli::Claude
         ));
+    }
+
+    #[test]
+    fn codex_usage_limit_requires_the_latest_terminal_rollout_outcome() {
+        let rollout = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            rollout.path(),
+            concat!(
+                r#"{"timestamp":"2026-08-20T12:00:00Z","type":"event_msg","payload":{"type":"task_complete","error":"You've hit your usage limit","rate_limits":{"credits":{"has_credits":false}}}}"#,
+                "\n",
+                r#"{"timestamp":"2026-08-20T12:01:00Z","type":"event_msg","payload":{"type":"task_complete"}}"#,
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            codex_rollout_usage_limit_evidence(Some(rollout.path()), cas_mux::SupervisorCli::Codex),
+            UsageLimitEvidence::Recovered,
+            "a later successful terminal turn clears historical rollout text"
+        );
+
+        std::fs::write(
+            rollout.path(),
+            r#"{"timestamp":"2026-08-20T12:02:00Z","type":"event_msg","payload":{"type":"task_complete","error":"You've hit your usage limit","rate_limits":{"credits":{"has_credits":false}}}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            codex_rollout_usage_limit_evidence(Some(rollout.path()), cas_mux::SupervisorCli::Codex),
+            UsageLimitEvidence::Limited {
+                first_evidence: "2026-08-20T12:02:00Z".to_string(),
+            }
+        );
     }
 
     /// cas-4a5e: a typo'd/missing codex config_dir must fail with a message

--- a/cas-cli/src/ui/factory/daemon/fork_first.rs
+++ b/cas-cli/src/ui/factory/daemon/fork_first.rs
@@ -566,7 +566,7 @@ impl DaemonInitPhase {
             teams,
             notify_rx,
             dead_workers: std::collections::HashSet::new(),
-            reported_unavailable_workers: std::collections::HashSet::new(),
+            reported_unavailable_workers: std::collections::HashMap::new(),
             last_usage_limit_scan: None,
             cancelled_spawns: std::collections::HashSet::new(),
             last_idle_message_times: HashMap::new(),

--- a/cas-cli/src/ui/factory/daemon/mod.rs
+++ b/cas-cli/src/ui/factory/daemon/mod.rs
@@ -236,7 +236,10 @@ pub struct FactoryDaemon {
     /// Workers whose harness has reported a terminal unavailable state in the
     /// current session. One supervisor relay per episode; removal permits a
     /// later recovered-and-exhausted worker to surface again.
-    reported_unavailable_workers: std::collections::HashSet<String>,
+    /// Agent generation -> stable evidence occurrence.  This survives a
+    /// transient unreadable rollout in-process; the relay's idempotency key
+    /// reconstructs the same episode after a daemon restart.
+    reported_unavailable_workers: std::collections::HashMap<String, String>,
     /// Last bounded rollout scan for terminal harness availability evidence.
     last_usage_limit_scan: Option<Instant>,
     /// In-flight spawns cancelled by a shutdown that targeted that specific

--- a/cas-cli/src/ui/factory/daemon/process.rs
+++ b/cas-cli/src/ui/factory/daemon/process.rs
@@ -335,7 +335,7 @@ pub async fn run_daemon_after_fork(
         teams,
         notify_rx,
         dead_workers: std::collections::HashSet::new(),
-        reported_unavailable_workers: std::collections::HashSet::new(),
+        reported_unavailable_workers: std::collections::HashMap::new(),
         last_usage_limit_scan: None,
         cancelled_spawns: std::collections::HashSet::new(),
         last_idle_message_times: HashMap::new(),

--- a/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
@@ -6,7 +6,7 @@ use crate::ui::factory::daemon::imports::*;
 fn enqueue_worker_attention_relay(
     cas_dir: &std::path::Path,
     event: &crate::ui::factory::director::DirectorEvent,
-) {
+) -> WorkerAttentionRelayOutcome {
     let (kind, worker, task_id, elapsed_secs) = match event {
         crate::ui::factory::director::DirectorEvent::WorkerIdle {
             worker,
@@ -23,7 +23,7 @@ fn enqueue_worker_attention_relay(
             Some(task_id.as_str()),
             Some(*elapsed_secs),
         ),
-        _ => return,
+        _ => return WorkerAttentionRelayOutcome::NotApplicable,
     };
     let detail = match (kind, task_id, elapsed_secs) {
         ("worker_stalled", Some(task), Some(elapsed)) => format!(
@@ -32,7 +32,15 @@ fn enqueue_worker_attention_relay(
         ),
         _ => format!("Worker {worker} is idle with no active task and needs supervisor attention."),
     };
-    enqueue_worker_attention_relay_detail(cas_dir, kind, worker, task_id, elapsed_secs, &detail);
+    enqueue_worker_attention_relay_detail(
+        cas_dir,
+        kind,
+        worker,
+        task_id,
+        elapsed_secs,
+        &detail,
+        &format!("{kind}:{worker}:{}", task_id.unwrap_or("")),
+    )
 }
 
 /// Persist one confirmed worker stoppage through the same durable supervisor
@@ -43,7 +51,7 @@ pub(super) fn enqueue_worker_delivery_stalled_relay(
     cas_dir: &std::path::Path,
     worker: &str,
     message_id: i64,
-) {
+) -> WorkerAttentionRelayOutcome {
     let detail = format!(
         "Worker {worker} produced no pane output after normal message {message_id} and its bounded retry."
     );
@@ -54,13 +62,18 @@ pub(super) fn enqueue_worker_delivery_stalled_relay(
         None,
         None,
         &detail,
-    );
+        &format!("delivery:{message_id}"),
+    )
 }
 
 /// Surface a terminal harness-side refusal even when its MCP child continues
 /// heartbeating. The evidence is collected from the harness artifact, not
 /// inferred from heartbeat age.
-pub(super) fn enqueue_worker_unavailable_relay(cas_dir: &std::path::Path, worker: &str) {
+pub(super) fn enqueue_worker_unavailable_relay(
+    cas_dir: &std::path::Path,
+    worker: &str,
+    occurrence: &str,
+) -> WorkerAttentionRelayOutcome {
     let detail = format!(
         "Worker {worker}'s harness reported a terminal unavailable state while its process may still heartbeat."
     );
@@ -71,7 +84,18 @@ pub(super) fn enqueue_worker_unavailable_relay(cas_dir: &std::path::Path, worker
         None,
         None,
         &detail,
-    );
+        occurrence,
+    )
+}
+
+/// A relay is consumed by an in-memory detector only after both durable lanes
+/// are confirmed. `Pending` deliberately leaves that detector eligible for a
+/// retry; the occurrence key makes the replay idempotent after a partial write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorkerAttentionRelayOutcome {
+    Persisted { notification_id: i64 },
+    Pending,
+    NotApplicable,
 }
 
 fn enqueue_worker_attention_relay_detail(
@@ -81,7 +105,8 @@ fn enqueue_worker_attention_relay_detail(
     task_id: Option<&str>,
     elapsed_secs: Option<u64>,
     detail: &str,
-) {
+    occurrence: &str,
+) -> WorkerAttentionRelayOutcome {
     use crate::mcp::tools::core::task::lifecycle::supervisor_push::{
         LIFECYCLE_WAKE_SOURCE_PREFIX, resolve_owning_supervisor,
     };
@@ -90,25 +115,23 @@ fn enqueue_worker_attention_relay_detail(
     let factory_session = std::env::var("CAS_FACTORY_SESSION").ok();
     let Ok(agent_store) = crate::store::open_agent_store(cas_dir) else {
         tracing::warn!("worker attention relay skipped: agent store unavailable");
-        return;
+        return WorkerAttentionRelayOutcome::Pending;
     };
     let Some(supervisor) =
         resolve_owning_supervisor(agent_store.as_ref(), factory_session.as_deref())
     else {
-        return;
+        return WorkerAttentionRelayOutcome::Pending;
     };
     let Ok(supervisor_queue) = crate::store::open_supervisor_queue_store(cas_dir) else {
         tracing::warn!(worker = %worker, kind, "worker attention relay skipped: supervisor queue unavailable");
-        return;
+        return WorkerAttentionRelayOutcome::Pending;
     };
-    // The event detector emits once per episode. The timestamp distinguishes a
-    // later recovered-and-stalled episode while the queue dedupes retries of
-    // this exact durable occurrence.
-    let occurrence = chrono::Utc::now().to_rfc3339();
+    // `occurrence` identifies the detected episode, not this delivery attempt.
+    // A retry after a durable-only write must reuse it across daemon restarts.
     let key = format!(
         "worker-attention:{}:{kind}:{worker}:{}:{occurrence}",
         factory_session.as_deref().unwrap_or(""),
-        task_id.unwrap_or("")
+        occurrence
     );
     let payload = serde_json::json!({
         "kind": kind,
@@ -129,21 +152,25 @@ fn enqueue_worker_attention_relay_detail(
     ) {
         Ok(NotifyIdempotentResult::Created(id)) => id,
         Ok(NotifyIdempotentResult::AlreadyExists {
-            id: _,
+            id,
             prompt_delivered: true,
-        }) => return,
+        }) => {
+            return WorkerAttentionRelayOutcome::Persisted {
+                notification_id: id,
+            };
+        }
         Ok(NotifyIdempotentResult::AlreadyExists {
             id,
             prompt_delivered: false,
         }) => id,
         Err(error) => {
             tracing::error!(worker = %worker, kind, %error, "worker attention relay durable enqueue failed");
-            return;
+            return WorkerAttentionRelayOutcome::Pending;
         }
     };
     let Ok(prompt_queue) = crate::store::open_prompt_queue_store(cas_dir) else {
         tracing::error!(worker = %worker, kind, notification_id, "worker attention relay left pending: prompt queue unavailable");
-        return;
+        return WorkerAttentionRelayOutcome::Pending;
     };
     let body = format!(
         "<worker-attention kind=\"{kind}\" worker=\"{worker}\" notification_id=\"{notification_id}\">\n{detail}\nRun `coordination action=worker_status` and reassign or recover the worker as needed.\n</worker-attention>"
@@ -159,11 +186,13 @@ fn enqueue_worker_attention_relay_detail(
         &format!("worker-attention-outbox:{notification_id}"),
     ) {
         tracing::error!(worker = %worker, kind, notification_id, %error, "worker attention relay prompt enqueue failed");
-        return;
+        return WorkerAttentionRelayOutcome::Pending;
     }
     if let Err(error) = supervisor_queue.mark_prompt_delivered(notification_id) {
         tracing::warn!(notification_id, %error, "worker attention relay prompt stamp failed; idempotent replay remains safe");
+        return WorkerAttentionRelayOutcome::Pending;
     }
+    WorkerAttentionRelayOutcome::Persisted { notification_id }
 }
 
 #[cfg(test)]
@@ -205,16 +234,21 @@ mod worker_attention_tests {
         let cas_dir = crate::store::init_cas_dir(temp.path()).unwrap();
         register_supervisor(&cas_dir, "worker-attention-test");
 
-        enqueue_worker_attention_relay(
+        let _ = enqueue_worker_attention_relay(
             &cas_dir,
             &crate::ui::factory::director::DirectorEvent::WorkerIdle {
                 worker: "calm-owl".to_string(),
                 active_task: None,
             },
         );
-        enqueue_worker_delivery_stalled_relay(&cas_dir, "silent-codex", 42);
-        enqueue_worker_unavailable_relay(&cas_dir, "limited-codex");
-        enqueue_worker_attention_relay(
+        let _ = enqueue_worker_delivery_stalled_relay(&cas_dir, "silent-codex", 42);
+        let _ = enqueue_worker_unavailable_relay(&cas_dir, "limited-codex", "episode-1");
+        let replay = enqueue_worker_unavailable_relay(&cas_dir, "limited-codex", "episode-1");
+        assert!(matches!(
+            replay,
+            WorkerAttentionRelayOutcome::Persisted { .. }
+        ));
+        let _ = enqueue_worker_attention_relay(
             &cas_dir,
             &crate::ui::factory::director::DirectorEvent::WorkerStalled {
                 worker: "steady-otter".to_string(),
@@ -226,7 +260,7 @@ mod worker_attention_tests {
 
         let queue = crate::store::open_prompt_queue_store(&cas_dir).unwrap();
         let rows = queue.peek_all(10).unwrap();
-        assert_eq!(rows.len(), 4);
+        assert_eq!(rows.len(), 4, "a persisted occurrence replays idempotently");
         assert!(rows.iter().all(|row| {
             row.target == "supervisor"
                 && crate::mcp::tools::core::task::lifecycle::supervisor_push::is_lifecycle_wake_source(&row.source)
@@ -440,7 +474,7 @@ impl FactoryDaemon {
             teams,
             notify_rx,
             dead_workers: std::collections::HashSet::new(),
-            reported_unavailable_workers: std::collections::HashSet::new(),
+            reported_unavailable_workers: std::collections::HashMap::new(),
             last_usage_limit_scan: None,
             cancelled_spawns: std::collections::HashSet::new(),
             last_idle_message_times: HashMap::new(),

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -1090,6 +1090,10 @@ pub(super) fn normal_delivery_probe_action(
     }
 }
 
+fn normal_delivery_probe_targets_worker(pane: &str, target: &str, supervisor_pane: &str) -> bool {
+    pane != supervisor_pane && target != "supervisor"
+}
+
 /// cas-ac7e (GH #130): an urgent row whose payload has been typed into a pane
 /// and whose wake is still unproven.
 #[derive(Debug, Clone)]
@@ -1326,28 +1330,48 @@ impl FactoryDaemon {
         };
         let workers: std::collections::HashSet<&str> =
             self.app.worker_names().iter().map(String::as_str).collect();
-        let unavailable: std::collections::HashSet<String> = active
-            .iter()
-            .filter(|agent| {
-                agent.role == cas_types::AgentRole::Worker
-                    && agent.factory_session.as_deref() == Some(self.session_name.as_str())
-                    && workers.contains(agent.name.as_str())
-                    && crate::mcp::tools::service::factory_ops::worker_reports_usage_limit(
-                        self.app.cas_dir(),
-                        agent,
-                    )
-            })
-            .map(|agent| agent.name.clone())
-            .collect();
-        self.reported_unavailable_workers
-            .retain(|worker| unavailable.contains(worker));
-        for worker in unavailable {
-            if self.reported_unavailable_workers.insert(worker.clone()) {
-                super::lifecycle::enqueue_worker_unavailable_relay(self.app.cas_dir(), &worker);
+        for agent in active.iter().filter(|agent| {
+            agent.role == cas_types::AgentRole::Worker
+                && agent.factory_session.as_deref() == Some(self.session_name.as_str())
+                && workers.contains(agent.name.as_str())
+        }) {
+            match crate::mcp::tools::service::factory_ops::worker_usage_limit_evidence(
+                self.app.cas_dir(),
+                agent,
+            ) {
+                crate::mcp::tools::service::factory_ops::UsageLimitEvidence::Recovered => {
+                    // Only affirmative newer terminal completion closes an
+                    // episode. A failed rollout read must not reset dedupe.
+                    self.reported_unavailable_workers.remove(&agent.id);
+                }
+                crate::mcp::tools::service::factory_ops::UsageLimitEvidence::Unavailable => {}
+                crate::mcp::tools::service::factory_ops::UsageLimitEvidence::Limited {
+                    first_evidence,
+                } => {
+                    let occurrence = format!("{}:{first_evidence}", agent.id);
+                    if self.reported_unavailable_workers.get(&agent.id) == Some(&occurrence) {
+                        continue;
+                    }
+                    if matches!(
+                        super::lifecycle::enqueue_worker_unavailable_relay(
+                            self.app.cas_dir(),
+                            &agent.name,
+                            &occurrence,
+                        ),
+                        super::lifecycle::WorkerAttentionRelayOutcome::Persisted { .. }
+                    ) {
+                        self.reported_unavailable_workers
+                            .insert(agent.id.clone(), occurrence);
+                    } else {
+                        continue;
+                    }
+                }
+            }
+            if self.reported_unavailable_workers.contains_key(&agent.id) {
                 tracing::warn!(
                     target: "cas::coordination",
                     stage = "worker_usage_limited",
-                    worker = %worker,
+                    worker = %agent.name,
                     "terminal harness availability record relayed to supervisor"
                 );
             }
@@ -1476,18 +1500,38 @@ impl FactoryDaemon {
                     );
                 }
                 NormalDeliveryProbeAction::FlagSupervisor => {
-                    self.normal_delivery_probes.remove(&row_id);
+                    // A supervisor pane is not a worker-health incident. The
+                    // probe was created via an alias, so guard both the pane
+                    // and addressed target before emitting worker wording.
+                    if !normal_delivery_probe_targets_worker(
+                        &pane,
+                        &target,
+                        self.app.supervisor_name(),
+                    ) {
+                        self.normal_delivery_probes.remove(&row_id);
+                        continue;
+                    }
                     // A normal message that was transport-delivered, then
                     // ignored across the bounded retry window is worker-health
                     // evidence, not merely an informational inbox row. Route it
                     // through the durable worker-attention outbox so every
                     // harness reaches the owning supervisor without a manual
                     // worker_status poll (cas-986a).
-                    super::lifecycle::enqueue_worker_delivery_stalled_relay(
+                    let relay = super::lifecycle::enqueue_worker_delivery_stalled_relay(
                         self.app.cas_dir(),
                         &pane,
                         row_id,
                     );
+                    if !matches!(
+                        relay,
+                        super::lifecycle::WorkerAttentionRelayOutcome::Persisted { .. }
+                    ) {
+                        // The durable/prompt outbox has not confirmed this
+                        // incident. Keep the probe so the next sweep retries
+                        // with its stable message-id occurrence key.
+                        continue;
+                    }
+                    self.normal_delivery_probes.remove(&row_id);
                     let notice = format!(
                         "<system-notice>Normal message {row_id} to '{target}' was transport-delivered, then produced no pane output for two watchdog windows. A single normal nudge was attempted; a durable worker-attention relay was sent to the supervisor; no urgent escalation was sent.</system-notice>"
                     );
@@ -9214,5 +9258,26 @@ mod urgent_wake_probe_tests {
             NormalDeliveryProbeAction::Observed,
             "any post-delivery pane output closes the watchdog"
         );
+    }
+
+    #[test]
+    fn normal_delivery_watchdog_never_labels_the_supervisor_as_a_worker() {
+        use super::normal_delivery_probe_targets_worker;
+
+        assert!(!normal_delivery_probe_targets_worker(
+            "supervisor-pane",
+            "worker",
+            "supervisor-pane"
+        ));
+        assert!(!normal_delivery_probe_targets_worker(
+            "supervisor-pane",
+            "supervisor",
+            "other-supervisor-pane"
+        ));
+        assert!(normal_delivery_probe_targets_worker(
+            "quiet-ibis",
+            "quiet-ibis",
+            "supervisor-pane"
+        ));
     }
 }


### PR DESCRIPTION
Hardens the worker-stoppage relays shipped in #542 against the failure modes found in review:

- The relay helper now returns Persisted/Pending; usage-limit episodes are marked reported and delivery probes retired only after the durable notification is confirmed, with a stable occurrence key so partial delivery retries idempotently.
- Usage-limit evidence is parsed as ordered rollout records: a limit line followed by a later successful terminal turn reads as Recovered, an unreadable rollout reads as Unavailable (not recovery), and episodes are identified by record timestamp rather than a boolean.
- The delivery watchdog can no longer label the supervisor pane as a stalled worker.
- ACK-bridge coverage extends to all four worker-attention kinds.

Scoped proof: 4/4 focused tests (ordered rollout outcome, idempotent durable replay, all-kind ACK bridge, supervisor exclusion); cargo check -p cas --lib --tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)