### PR TITLE
fix(ci): raise runner task budget for sccache

### DIFF
--- a/docs/ci/self-hosted-runner-pilot.md
+++ b/docs/ci/self-hosted-runner-pilot.md
@@ -74,8 +74,11 @@ The listener runs as the non-login `cassy-actions` system account under
 toolchain, and sccache live under `/var/lib/cassy-actions`, never under `.cas`
 or the factory worktrees. The unit has no privileges or Docker access, applies
 systemd filesystem/device/kernel hardening, uses `nice=10` and best-effort
-`ionice=7`, and caps Cargo at 12 jobs. One listener and one workflow concurrency
-group enforce host job concurrency 1. The runner uses dedicated sccache port
+`ionice=7`, caps Cargo at 12 jobs, and reserves 2,048 cgroup task slots. This
+does not raise compilation concurrency: it prevents sccache plus 12 parallel
+rustc/linker process trees from exhausting the distro's 512-task service
+default and returning `EAGAIN` while spawning a compiler. One listener and one
+workflow concurrency group enforce host job concurrency 1. The runner uses dedicated sccache port
 4227; the default port belongs to the operator's cache server and must not be
 shared across Unix users. The systemd launch wrapper starts sccache before the
 GitHub listener, outside Runner.Worker's per-step process tracking; starting it
@@ -151,7 +154,8 @@ gh api orgs/Richards-LLC/actions/runner-groups
 gh api orgs/Richards-LLC/actions/runner-groups/GROUP_ID/repositories
 gh api orgs/Richards-LLC/actions/runner-groups/GROUP_ID/runners
 systemctl show cassy-actions-runner.service \
-  -p User -p Group -p Nice -p CPUWeight -p IOWeight -p ReadWritePaths
+  -p User -p Group -p Nice -p CPUWeight -p IOWeight -p TasksCurrent -p TasksMax \
+  -p ReadWritePaths
 ```
 
 To demonstrate hosted fallback, stop the service, push a Rust-touched commit on

--- a/ops/systemd/cassy-actions-runner.service
+++ b/ops/systemd/cassy-actions-runner.service
@@ -20,7 +20,11 @@ KillMode=mixed
 Nice=10
 CPUWeight=25
 IOWeight=25
-TasksMax=512
+# A 12-way cold Rust compile uses the sccache server plus enough rustc/linker
+# threads to exhaust the distro's 512-task default. Keep the CPU cap below,
+# but leave four times that many cgroup task slots so sccache can spawn rustc
+# during the archive's parallel fan-out (cas-aada).
+TasksMax=2048
 Environment=HOME=/var/lib/cassy-actions
 Environment=CARGO_HOME=/var/lib/cassy-actions/.cargo
 Environment=RUSTUP_HOME=/var/lib/cassy-actions/.rustup

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -161,6 +161,8 @@ require_text "$pilot_doc" 'CARGO_CACHE_RUSTC_INFO=0' 'pilot documents Cargo rust
 runner_unit_text="$(<"$runner_unit")"
 require_text "$runner_unit_text" 'Environment=CARGO_CACHE_RUSTC_INFO=0' 'runner does not persist failed sccache rustc probes across jobs'
 require_text "$runner_unit_text" 'Environment=SCCACHE_IDLE_TIMEOUT=0' 'runner keeps its private sccache server alive between merge-queue jobs'
+require_text "$runner_unit_text" 'TasksMax=2048' 'runner reserves enough cgroup task slots for parallel sccache compiler spawns'
+require_text "$pilot_doc" '2,048 cgroup task slots' 'pilot documents the parallel sccache task-slot budget'
 
 if [[ -x "$watchdog_script" ]]; then
     watchdog_text="$(<"$watchdog")"


### PR DESCRIPTION
Raises the trusted runner cgroup task budget from 512 to 2048 while retaining CARGO_BUILD_JOBS=12 and the merge-queue sccache fail-open bypass.\n\nEvidence: controlled sccache archive completed with 2048 slots; live service readback confirms TasksMax=2048. Tier contract: 488 passed, 0 failed.\n\nCloses cas-aada.