### PR TITLE
fix(cas-update): lock the shared stable build worktree against concurrent runs

### DIFF
--- a/contrib/shell-helpers/cas-update
+++ b/contrib/shell-helpers/cas-update
@@ -53,6 +53,7 @@ SERVER_REGISTRY_ROOTS="${CAS_UPDATE_SERVER_REGISTRY_ROOTS:-}"
 WAIT_STEPS="${CAS_UPDATE_WAIT_STEPS:-20}"
 WAIT_SLEEP="${CAS_UPDATE_WAIT_SLEEP:-0.25}"
 BUILD_WORKTREE_DIR=""
+BUILD_WORKTREE_LOCK_DIR=""
 
 BRANCH="main"
 DO_BUILD=1
@@ -525,8 +526,9 @@ build_and_install() {
   if [ "$DO_PULL" = "1" ] && [ "$DRY_RUN" != "1" ]; then
     worktree_root="${CAS_UPDATE_WORKTREE_ROOT:-$(dirname "$source_root_abs")/.cas-update-worktrees}"
     mkdir -p "$worktree_root"
+    acquire_build_worktree_lock "$worktree_root" || return 1
     if ! prepare_build_worktree "$worktree_root" "$fetched_commit"; then
-      BUILD_WORKTREE_DIR=""
+      cleanup_build_worktree
       error "could not prepare detached build worktree"
       return 1
     fi
@@ -664,7 +666,48 @@ cleanup() {
 cleanup_build_worktree() {
   # The fetched-build worktree is deliberately persistent: Cargo fingerprints
   # workspace manifests by absolute path, so removing it defeats target reuse.
+  release_build_worktree_lock
   BUILD_WORKTREE_DIR=""
+}
+
+release_build_worktree_lock() {
+  [ -n "$BUILD_WORKTREE_LOCK_DIR" ] || return 0
+  # Never remove a lock that a newer updater acquired after ours became stale.
+  if [ "$(cat "$BUILD_WORKTREE_LOCK_DIR/pid" 2>/dev/null || true)" = "$$" ]; then
+    rm -rf "$BUILD_WORKTREE_LOCK_DIR"
+  fi
+  BUILD_WORKTREE_LOCK_DIR=""
+}
+
+acquire_build_worktree_lock() {
+  local worktree_root="$1" lock_dir holder_pid holder_started
+  lock_dir="$worktree_root/.cas-update.lock"
+
+  if mkdir "$lock_dir" 2>/dev/null; then
+    printf '%s\n' "$$" >"$lock_dir/pid"
+    date -u +%Y-%m-%dT%H:%M:%SZ >"$lock_dir/started_at"
+    BUILD_WORKTREE_LOCK_DIR="$lock_dir"
+    return 0
+  fi
+
+  holder_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+  holder_started="$(cat "$lock_dir/started_at" 2>/dev/null || true)"
+  if [[ "$holder_pid" =~ ^[0-9]+$ ]] && kill -0 "$holder_pid" 2>/dev/null; then
+    error "another cas-update holds $lock_dir (PID $holder_pid, started ${holder_started:-unknown}); refusing to reset the shared build worktree"
+    return 1
+  fi
+
+  warn "Recovering stale cas-update lock at $lock_dir (former PID ${holder_pid:-unknown}, started ${holder_started:-unknown})"
+  rm -rf "$lock_dir"
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    holder_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+    holder_started="$(cat "$lock_dir/started_at" 2>/dev/null || true)"
+    error "another cas-update acquired $lock_dir during stale-lock recovery (PID ${holder_pid:-unknown}, started ${holder_started:-unknown}); refusing to reset the shared build worktree"
+    return 1
+  fi
+  printf '%s\n' "$$" >"$lock_dir/pid"
+  date -u +%Y-%m-%dT%H:%M:%SZ >"$lock_dir/started_at"
+  BUILD_WORKTREE_LOCK_DIR="$lock_dir"
 }
 
 recreate_build_worktree() {

--- a/contrib/shell-helpers/tests/cas-update-test.sh
+++ b/contrib/shell-helpers/tests/cas-update-test.sh
@@ -136,6 +136,7 @@ make_build_fixture() {
   printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' \
     'printf "%s\\n" "$PWD" >>"$CAS_UPDATE_CARGO_LOG"' \
     'printf "%s\\n" "${ZIG:-}" >>"$CAS_UPDATE_ZIG_LOG"' \
+    'if [ -n "${CAS_UPDATE_CARGO_BLOCK_FILE:-}" ]; then touch "${CAS_UPDATE_CARGO_STARTED_FILE:?}"; while [ ! -f "$CAS_UPDATE_CARGO_BLOCK_FILE" ]; do sleep 0.05; done; fi' \
     'mkdir -p "$CARGO_TARGET_DIR/release-fast"' \
     'marker=checked-out' \
     '[ -f "$PWD/upstream-marker" ] && marker=fetched' \
@@ -154,6 +155,7 @@ run_build_case() {
     export CAS_UPDATE_WORKTREE_ROOT="$tmp/build-worktrees"
     export CAS_UPDATE_CARGO_LOG="$tmp/cargo.log"
     export CAS_UPDATE_ZIG_LOG="$tmp/zig.log"
+    export CAS_UPDATE_SOURCE_ONLY=1
     export PATH="$tmp/tools:$PATH"
     unset ZIG
     # shellcheck source=../cas-update
@@ -225,6 +227,50 @@ test_build_uses_detached_fetched_worktree() {
     && [ "$(git -C "$stable_worktree" rev-parse --is-inside-work-tree)" = true ]; then
     pass 'a corrupted stable worktree is recreated and the fetched build continues'
   else fail 'a corrupted stable worktree is recreated and the fetched build continues'; fi
+  rm -rf "$tmp"
+}
+
+test_stable_build_worktree_lock() {
+  local tmp out first_out second_out stable_worktree first_pid stable_head
+  tmp="$(make_build_fixture)"
+  out="$tmp/out"; first_out="$tmp/first-out"; second_out="$tmp/second-out"
+  stable_worktree="$tmp/build-worktrees/cas-update-build"
+
+  (
+    export CAS_UPDATE_CARGO_BLOCK_FILE="$tmp/release-first-build"
+    export CAS_UPDATE_CARGO_STARTED_FILE="$tmp/first-build-started"
+    run_build_case "$tmp" "$first_out" 1 1
+  ) &
+  first_pid=$!
+  for _ in $(seq 1 100); do [ -f "$tmp/first-build-started" ] && break; sleep 0.05; done
+
+  if [ ! -f "$tmp/first-build-started" ]; then
+    touch "$tmp/release-first-build"; wait "$first_pid" || true
+    fail 'concurrent update fixture reaches the in-flight build boundary'
+    rm -rf "$tmp"
+    return
+  fi
+  stable_head="$(git -C "$stable_worktree" rev-parse HEAD)"
+  if ! run_build_case "$tmp" "$second_out" 1 1 \
+    && [ "$(git -C "$stable_worktree" rev-parse HEAD)" = "$stable_head" ] \
+    && assert_contains "$second_out" 'another cas-update holds' \
+    && assert_contains "$second_out" 'refusing to reset the shared build worktree'; then
+    pass 'a concurrent cas-update refuses before it can reset the in-flight stable worktree'
+  else fail 'a concurrent cas-update refuses before it can reset the in-flight stable worktree'; fi
+
+  touch "$tmp/release-first-build"
+  if wait "$first_pid"; then
+    pass 'the winning cas-update finishes after its build gate releases'
+  else fail 'the winning cas-update finishes after its build gate releases'; fi
+
+  mkdir -p "$tmp/build-worktrees/.cas-update.lock"
+  printf '%s\n' 99999999 >"$tmp/build-worktrees/.cas-update.lock/pid"
+  printf '%s\n' 2000-01-01T00:00:00Z >"$tmp/build-worktrees/.cas-update.lock/started_at"
+  if run_build_case "$tmp" "$out" 1 1 \
+    && assert_contains "$out" 'Recovering stale cas-update lock' \
+    && [ ! -d "$tmp/build-worktrees/.cas-update.lock" ]; then
+    pass 'a dead lock holder is recovered without bricking later updates'
+  else fail 'a dead lock holder is recovered without bricking later updates'; fi
   rm -rf "$tmp"
 }
 
@@ -386,6 +432,7 @@ test_installer
 test_updater_ancestry_is_protected
 test_main_exit_and_help
 test_build_uses_detached_fetched_worktree
+test_stable_build_worktree_lock
 
 if [ "$failures" -ne 0 ]; then
   printf '%s of %s tests failed\n' "$failures" "$tests" >&2


### PR DESCRIPTION
A second concurrent `cas-update` run could reset the shared stable build worktree underneath an in-flight build. The updater now takes an atomic lock (mkdir + pid/started_at) on the worktree root: a live holder makes the second run refuse with a message naming the holder; a dead holder's lock is recovered with a re-race guard; release is pid-checked so a newer holder's lock is never removed.

Concurrent test coverage: an in-flight (deliberately blocked) build survives a second run's attempt untouched, the second run refuses with the holder message, and a stale dead-PID lock recovers without bricking later updates.

Fixes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)