### PR TITLE
fix(worktree): GC refuses removal when external symlinks resolve into the worktree

### DIFF
--- a/cas-cli/src/cli/sweep.rs
+++ b/cas-cli/src/cli/sweep.rs
@@ -128,11 +128,7 @@ fn print_repo(report: &RepoSweepReport, _opts: SweepOptions) {
         "  → {} removed, {} skipped{}",
         report.removed_count(),
         report.skipped_count(),
-        if report.prune_ran {
-            ", prune ran"
-        } else {
-            ""
-        },
+        if report.prune_ran { ", prune ran" } else { "" },
     );
 }
 
@@ -143,6 +139,7 @@ fn badge(d: &Disposition) -> &'static str {
         Disposition::SkippedDirty { .. } => "[skip: dirty]   ",
         Disposition::SkippedUnmerged { .. } => "[skip: unmerged]",
         Disposition::SkippedDirtyUnmerged { .. } => "[skip: d+u]     ",
+        Disposition::SkippedExternalSymlinks { .. } => "[skip: links]   ",
         Disposition::WouldRemove => "[would remove]  ",
         Disposition::WouldSalvageAndRemove => "[would salvage] ",
         Disposition::Error { .. } => "[error]         ",
@@ -154,9 +151,9 @@ fn detail(d: &Disposition) -> Option<String> {
         Disposition::SalvagedAndRemoved { patch_path } => {
             Some(format!("patch: {}", patch_path.display()))
         }
-        Disposition::SkippedDirty { modified_files } => {
-            Some(format!("{modified_files} modified file(s); rerun with --salvage-dirty to capture"))
-        }
+        Disposition::SkippedDirty { modified_files } => Some(format!(
+            "{modified_files} modified file(s); rerun with --salvage-dirty to capture"
+        )),
         Disposition::SkippedUnmerged { unmerged_commits } => Some(format!(
             "{unmerged_commits} unmerged commit(s); merge or delete the branch first"
         )),
@@ -166,6 +163,15 @@ fn detail(d: &Disposition) -> Option<String> {
         } => Some(format!(
             "{modified_files} modified + {unmerged_commits} unmerged; \
              unmerged worktrees are never auto-removed"
+        )),
+        Disposition::SkippedExternalSymlinks { links } => Some(format!(
+            "{} live link(s) from primary node_modules resolve into this worktree; run the package-manager reinstall before retrying ({})",
+            links.len(),
+            links
+                .iter()
+                .map(|link| format!("{} -> {}", link.link.display(), link.target.display()))
+                .collect::<Vec<_>>()
+                .join(", ")
         )),
         Disposition::Error { reason } => Some(reason.clone()),
         _ => None,
@@ -213,7 +219,11 @@ fn append_log_line(line: &str) {
         return;
     }
     let path = logs.join("global-sweep.log");
-    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
         let _ = writeln!(f, "{line}");
     }
 }

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -3907,6 +3907,12 @@ impl CasService {
         // cas-b7dd (GH #88): processes still alive inside a worktree with no
         // live owner, plus registered servers whose session is gone.
         let orphan_processes = scan_orphan_processes(&self.inner.cas_root, &live_workers);
+        // GH #529: a pnpm virtual-store link can survive after its worktree
+        // does not. Surface that false-green condition in the regular factory
+        // report instead of relying on a later JS test runner to notice it.
+        let primary_checkout = self.inner.cas_root.parent().unwrap_or(&self.inner.cas_root);
+        let dangling_node_modules =
+            crate::worktree::scan_dangling_node_modules_symlinks(primary_checkout);
 
         let mut out = String::from("Factory GC Report\n=================\n");
         out.push_str(&format!(
@@ -3926,6 +3932,21 @@ impl CasService {
             orphan_processes.servers.len(),
             orphan_processes.reapable_count(),
         ));
+        if !dangling_node_modules.is_empty() {
+            out.push_str(
+                "\nDangling primary-checkout node_modules symlinks (JS install is broken):\n",
+            );
+            for link in &dangling_node_modules {
+                out.push_str(&format!(
+                    "  - {} -> {}\n",
+                    link.link.display(),
+                    link.target.display(),
+                ));
+            }
+            out.push_str(
+                "  Remediation: run the repository's locked package-manager install from the primary checkout before relying on JS/TS tests.\n",
+            );
+        }
         out.push_str(&orphan_processes.render());
         out.push_str(&artifact_report.render());
 

--- a/cas-cli/src/worktree/external_symlinks.rs
+++ b/cas-cli/src/worktree/external_symlinks.rs
@@ -71,8 +71,82 @@ pub fn scan_external_symlinks_into(worktree_path: &Path) -> Vec<ExternalSymlink>
     let mut found = Vec::new();
     let mut budget = MAX_SCAN_ENTRIES;
     for (root, max_depth) in roots {
-        scan_dir(&root, 0, max_depth, &worktree_canon, &mut found, &mut budget);
+        scan_dir(
+            &root,
+            0,
+            max_depth,
+            &worktree_canon,
+            &mut found,
+            &mut budget,
+        );
     }
+    found
+}
+
+/// Scan the primary checkout's dependency tree for live links into a worker
+/// worktree. pnpm's default virtual store is per-project, so its ordinary
+/// install path does not cross-link worktrees. This guard instead protects the
+/// non-default `virtualStoreDir`/global-store configuration or a manual
+/// relink that makes package entries resolve through a disposable worktree.
+/// Unlike the `$HOME` scan above, this root is deliberately JS-only: a
+/// repository without a root `package.json` is untouched.
+///
+/// This is a guard, not a repair. A package-manager reinstall is the only
+/// reliable way to reconstruct its chosen virtual-store layout; removing the
+/// worktree first turns that recoverable mistake into a silent broken install.
+pub fn scan_project_node_modules_symlinks_into(
+    worktree_path: &Path,
+    project_root: &Path,
+) -> Vec<ExternalSymlink> {
+    if !project_root.join("package.json").is_file() {
+        return Vec::new();
+    }
+    let Ok(worktree_canon) = worktree_path.canonicalize() else {
+        return Vec::new();
+    };
+
+    let mut found = Vec::new();
+    let mut budget = MAX_SCAN_ENTRIES;
+    scan_dir(
+        &project_root.join("node_modules"),
+        0,
+        MAX_SCAN_DEPTH,
+        &worktree_canon,
+        &mut found,
+        &mut budget,
+    );
+    found
+}
+
+/// A dangling link in the primary checkout's JavaScript dependency tree.
+/// `target` is the resolved lexical destination (which intentionally need not
+/// exist) so remediation can name the deleted worktree rather than merely the
+/// link itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DanglingNodeModulesSymlink {
+    pub link: PathBuf,
+    pub target: PathBuf,
+}
+
+/// Find broken symlinks beneath a primary checkout's `node_modules` tree.
+///
+/// The scan is bounded and skips non-JS repositories. It is intentionally a
+/// report-only detector: `pnpm install --frozen-lockfile` (or the repository's
+/// chosen package-manager equivalent) owns repair of its virtual store.
+pub fn scan_dangling_node_modules_symlinks(project_root: &Path) -> Vec<DanglingNodeModulesSymlink> {
+    if !project_root.join("package.json").is_file() {
+        return Vec::new();
+    }
+
+    let mut found = Vec::new();
+    let mut budget = MAX_SCAN_ENTRIES;
+    scan_dangling_dir(
+        &project_root.join("node_modules"),
+        0,
+        MAX_SCAN_DEPTH,
+        &mut found,
+        &mut budget,
+    );
     found
 }
 
@@ -122,6 +196,49 @@ fn scan_dir(
 
         if meta.is_dir() && depth < max_depth {
             scan_dir(&path, depth + 1, max_depth, worktree_canon, found, budget);
+        }
+    }
+}
+
+fn scan_dangling_dir(
+    dir: &Path,
+    depth: usize,
+    max_depth: usize,
+    found: &mut Vec<DanglingNodeModulesSymlink>,
+    budget: &mut usize,
+) {
+    if *budget == 0 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if *budget == 0 {
+            return;
+        }
+        *budget -= 1;
+        let path = entry.path();
+        let Ok(meta) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if meta.file_type().is_symlink() {
+            if path.canonicalize().is_err() {
+                let target = std::fs::read_link(&path)
+                    .map(|target| {
+                        if target.is_absolute() {
+                            target
+                        } else {
+                            path.parent().unwrap_or(dir).join(target)
+                        }
+                    })
+                    .unwrap_or_else(|_| PathBuf::from("<unreadable target>"));
+                found.push(DanglingNodeModulesSymlink { link: path, target });
+            }
+            continue;
+        }
+        if meta.is_dir() && depth < max_depth {
+            scan_dangling_dir(&path, depth + 1, max_depth, found, budget);
         }
     }
 }
@@ -214,7 +331,49 @@ mod tests {
             std::os::unix::fs::symlink(worktree.path().join("gone"), &link).unwrap();
 
             let found = scan_external_symlinks_into(worktree.path());
-            assert!(found.is_empty(), "a dangling link can't reference a live worktree: {found:?}");
+            assert!(
+                found.is_empty(),
+                "a dangling link can't reference a live worktree: {found:?}"
+            );
         });
+    }
+
+    #[test]
+    fn main_checkout_node_modules_link_into_worktree_is_detected() {
+        let project = TempDir::new().unwrap();
+        let worktree = TempDir::new().unwrap();
+        std::fs::write(project.path().join("package.json"), "{}").unwrap();
+        let target = worktree
+            .path()
+            .join("node_modules/.pnpm/pkg@1/node_modules/pkg");
+        std::fs::create_dir_all(&target).unwrap();
+        let link = project.path().join("node_modules/pkg");
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let found = scan_project_node_modules_symlinks_into(worktree.path(), project.path());
+        assert_eq!(found.len(), 1, "found: {found:?}");
+        assert_eq!(found[0].link, link);
+    }
+
+    #[test]
+    fn dangling_node_modules_link_is_reported_but_non_js_project_is_ignored() {
+        let project = TempDir::new().unwrap();
+        let link = project.path().join("node_modules/pkg");
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("/deleted/worktree/node_modules/pkg", &link).unwrap();
+
+        assert!(scan_dangling_node_modules_symlinks(project.path()).is_empty());
+        std::fs::write(project.path().join("package.json"), "{}").unwrap();
+        let found = scan_dangling_node_modules_symlinks(project.path());
+        assert_eq!(found.len(), 1, "found: {found:?}");
+        assert_eq!(found[0].link, link);
+        assert!(
+            found[0]
+                .target
+                .ends_with("deleted/worktree/node_modules/pkg")
+        );
     }
 }

--- a/cas-cli/src/worktree/manager/worker_ops.rs
+++ b/cas-cli/src/worktree/manager/worker_ops.rs
@@ -2,9 +2,13 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::types::Worktree;
-use crate::worktree::external_symlinks::{scan_external_symlinks_into, ExternalSymlink};
+use crate::worktree::external_symlinks::{
+    ExternalSymlink, scan_external_symlinks_into, scan_project_node_modules_symlinks_into,
+};
 use crate::worktree::git::GitOperations;
-use crate::worktree::manager::{WorktreeError, WorktreeManager, WorktreeResult, symlink_project_config};
+use crate::worktree::manager::{
+    WorktreeError, WorktreeManager, WorktreeResult, symlink_project_config,
+};
 
 /// Describes a worker worktree that was left on disk because it held uncommitted work.
 ///
@@ -54,6 +58,18 @@ pub struct CleanupReport {
 }
 
 impl WorktreeManager {
+    /// External-link guard shared by every manager-owned worktree deletion.
+    /// `$HOME` links and primary-checkout `node_modules` links have different
+    /// roots, so keep their scans separate and combine their named evidence.
+    fn inbound_symlinks(&self, worktree_path: &std::path::Path) -> Vec<ExternalSymlink> {
+        let mut links = scan_external_symlinks_into(worktree_path);
+        links.extend(scan_project_node_modules_symlinks_into(
+            worktree_path,
+            &self.repo_root,
+        ));
+        links
+    }
+
     /// Calculate the worktree path for a factory worker
     pub fn worktree_path_for_worker(&self, worker_name: &str) -> PathBuf {
         self.worktree_root().join(worker_name)
@@ -254,23 +270,22 @@ impl WorktreeManager {
                 // `force` — force means "bypass git dirty-tree protection",
                 // not "I'm aware this will orphan $HOME symlinks".
                 if worktree.path.exists() {
-                    let links = scan_external_symlinks_into(&worktree.path);
+                    let links = self.inbound_symlinks(&worktree.path);
                     if !links.is_empty() {
-                        report.external_symlinks_blocked.push(ExternalSymlinkWarning {
-                            worker_name: name.clone(),
-                            path: worktree.path.clone(),
-                            links,
-                        });
+                        report
+                            .external_symlinks_blocked
+                            .push(ExternalSymlinkWarning {
+                                worker_name: name.clone(),
+                                path: worktree.path.clone(),
+                                links,
+                            });
                         self.workers.insert(name, worktree);
                         continue;
                     }
                 }
 
                 if !force && worktree.path.exists() {
-                    let file_count = self
-                        .git
-                        .uncommitted_file_count(&worktree.path)
-                        .unwrap_or(0);
+                    let file_count = self.git.uncommitted_file_count(&worktree.path).unwrap_or(0);
                     if file_count > 0 {
                         report.dirty_deferred.push(DirtyWorktreeWarning {
                             worker_name: name.clone(),
@@ -304,7 +319,7 @@ impl WorktreeManager {
             // cas-df97: live external symlinks block regardless of `force`
             // — see the identical guard in cleanup_workers.
             if worktree.path.exists() {
-                let links = scan_external_symlinks_into(&worktree.path);
+                let links = self.inbound_symlinks(&worktree.path);
                 if !links.is_empty() {
                     let warning = ExternalSymlinkWarning {
                         worker_name: worker_name.to_string(),
@@ -355,10 +370,7 @@ impl WorktreeManager {
     /// [`RemoveOutcome::DirtyDeferred`] so the caller can warn and mark the
     /// worker for later salvage. Callers who need to force-remove a dirty
     /// tree should use [`WorktreeManager::remove_worker`] with `force = true`.
-    pub fn attempt_remove_worker(
-        &mut self,
-        worker_name: &str,
-    ) -> WorktreeResult<RemoveOutcome> {
+    pub fn attempt_remove_worker(&mut self, worker_name: &str) -> WorktreeResult<RemoveOutcome> {
         let mut worktree = match self.workers.remove(worker_name) {
             Some(wt) => wt,
             None => return Ok(RemoveOutcome::NotTracked),
@@ -369,7 +381,7 @@ impl WorktreeManager {
             // state — this is the actual production path
             // (finalize_worker_worktree) that the reported incident went
             // through.
-            let links = scan_external_symlinks_into(&worktree.path);
+            let links = self.inbound_symlinks(&worktree.path);
             if !links.is_empty() {
                 let warning = ExternalSymlinkWarning {
                     worker_name: worker_name.to_string(),
@@ -380,10 +392,7 @@ impl WorktreeManager {
                 return Ok(RemoveOutcome::ExternalSymlinksBlocked(warning));
             }
 
-            let file_count = self
-                .git
-                .uncommitted_file_count(&worktree.path)
-                .unwrap_or(0);
+            let file_count = self.git.uncommitted_file_count(&worktree.path).unwrap_or(0);
             if file_count > 0 {
                 let warning = DirtyWorktreeWarning {
                     worker_name: worker_name.to_string(),

--- a/cas-cli/src/worktree/mod.rs
+++ b/cas-cli/src/worktree/mod.rs
@@ -34,11 +34,14 @@ pub mod salvage;
 pub mod sweep;
 pub mod target_lock;
 
-pub use external_symlinks::{scan_external_symlinks_into, ExternalSymlink};
+pub use external_symlinks::{
+    DanglingNodeModulesSymlink, ExternalSymlink, scan_dangling_node_modules_symlinks,
+    scan_external_symlinks_into, scan_project_node_modules_symlinks_into,
+};
 pub use git::{GitError, GitOperations};
 pub(crate) use manager::WorktreeError;
 pub use manager::{
     CleanupReport, DirtyWorktreeWarning, ExternalSymlinkWarning, RemoveOutcome, WorktreeConfig,
     WorktreeManager, WorktreeResult, node_modules_setup_instruction, symlink_project_config,
 };
-pub use salvage::{salvage, SalvageError, SalvageOutcome, SkipReason};
+pub use salvage::{SalvageError, SalvageOutcome, SkipReason, salvage};

--- a/cas-cli/src/worktree/sweep.rs
+++ b/cas-cli/src/worktree/sweep.rs
@@ -18,7 +18,11 @@ use std::process::Command;
 use anyhow::Result;
 use tracing::{debug, warn};
 
-use crate::worktree::salvage::{self, SalvageOutcome};
+use crate::worktree::{
+    ExternalSymlink,
+    salvage::{self, SalvageOutcome},
+    scan_project_node_modules_symlinks_into,
+};
 
 pub mod opportunistic;
 
@@ -40,22 +44,36 @@ pub enum Disposition {
     /// Clean + merged → removed.
     Removed,
     /// Dirty; `--salvage-dirty` was set → salvage patch written then removed.
-    SalvagedAndRemoved { patch_path: PathBuf },
+    SalvagedAndRemoved {
+        patch_path: PathBuf,
+    },
     /// Dirty; `--salvage-dirty` was NOT set → skipped on disk.
-    SkippedDirty { modified_files: usize },
+    SkippedDirty {
+        modified_files: usize,
+    },
     /// Branch has commits not merged to the parent branch → skipped.
-    SkippedUnmerged { unmerged_commits: usize },
+    SkippedUnmerged {
+        unmerged_commits: usize,
+    },
     /// Dirty AND unmerged → skipped (reports both).
     SkippedDirtyUnmerged {
         modified_files: usize,
         unmerged_commits: usize,
+    },
+    /// A live symlink outside the worktree resolves into it. Removing the
+    /// worktree would convert a repairable package-manager mislink into a
+    /// broken checkout, so the operator must repair/reinstall first.
+    SkippedExternalSymlinks {
+        links: Vec<ExternalSymlink>,
     },
     /// Dry-run preview of what would happen without the flag.
     WouldRemove,
     WouldSalvageAndRemove,
     /// Worktree path vanished or is otherwise unreadable (reaped by another
     /// process mid-scan, permission error, etc.).
-    Error { reason: String },
+    Error {
+        reason: String,
+    },
 }
 
 impl Disposition {
@@ -65,6 +83,7 @@ impl Disposition {
             Disposition::SkippedDirty { .. }
                 | Disposition::SkippedUnmerged { .. }
                 | Disposition::SkippedDirtyUnmerged { .. }
+                | Disposition::SkippedExternalSymlinks { .. }
         )
     }
 
@@ -98,10 +117,16 @@ pub struct RepoSweepReport {
 
 impl RepoSweepReport {
     pub fn removed_count(&self) -> usize {
-        self.worktrees.iter().filter(|w| w.disposition.is_removed()).count()
+        self.worktrees
+            .iter()
+            .filter(|w| w.disposition.is_removed())
+            .count()
     }
     pub fn skipped_count(&self) -> usize {
-        self.worktrees.iter().filter(|w| w.disposition.is_skip()).count()
+        self.worktrees
+            .iter()
+            .filter(|w| w.disposition.is_skip())
+            .count()
     }
     pub fn bytes_reclaimed(&self) -> u64 {
         self.worktrees.iter().map(|w| w.bytes_reclaimed).sum()
@@ -145,10 +170,7 @@ pub fn sweep_one_repo(repo_root: &Path, opts: SweepOptions) -> RepoSweepReport {
     let entries = match std::fs::read_dir(&wt_root) {
         Ok(e) => e,
         Err(e) => {
-            report.repo_error = Some(format!(
-                "cannot read {}: {e}",
-                wt_root.display()
-            ));
+            report.repo_error = Some(format!("cannot read {}: {e}", wt_root.display()));
             return report;
         }
     };
@@ -307,6 +329,11 @@ fn sweep_one_worktree(
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("unknown");
+            let links = scan_project_node_modules_symlinks_into(worktree_path, repo_root);
+            if !links.is_empty() {
+                rec.disposition = Disposition::SkippedExternalSymlinks { links };
+                return rec;
+            }
             match salvage::salvage(worktree_path, repo_root, worker) {
                 Ok(Some(SalvageOutcome { patch_path, .. })) => {
                     let size = dir_size(worktree_path);
@@ -340,6 +367,11 @@ fn sweep_one_worktree(
             }
         }
         (false, false) => {
+            let links = scan_project_node_modules_symlinks_into(worktree_path, repo_root);
+            if !links.is_empty() {
+                rec.disposition = Disposition::SkippedExternalSymlinks { links };
+                return rec;
+            }
             if opts.dry_run {
                 rec.disposition = Disposition::WouldRemove;
                 return rec;
@@ -364,7 +396,9 @@ fn uncommitted_count(worktree_path: &Path) -> std::io::Result<usize> {
         .current_dir(worktree_path)
         .output()?;
     if !out.status.success() {
-        return Err(std::io::Error::other(String::from_utf8_lossy(&out.stderr).to_string()));
+        return Err(std::io::Error::other(
+            String::from_utf8_lossy(&out.stderr).to_string(),
+        ));
     }
     Ok(String::from_utf8_lossy(&out.stdout)
         .lines()

--- a/cas-cli/src/worktree/sweep/opportunistic.rs
+++ b/cas-cli/src/worktree/sweep/opportunistic.rs
@@ -31,7 +31,7 @@ use tracing::{debug, info, warn};
 use crate::config::WorktreesConfig;
 use crate::store::known_repos::host_cas_dir;
 use crate::worktree::discovery::list_tracked_repos;
-use crate::worktree::salvage;
+use crate::worktree::{ExternalSymlink, salvage, scan_project_node_modules_symlinks_into};
 
 /// Disposition for a single worktree encountered by the opportunistic
 /// sweep. Narrower than `sweep::Disposition` because the TTL path has
@@ -49,6 +49,10 @@ pub enum OpportunisticOutcome {
     },
     /// Path was a symlink — refused.
     RefusedSymlink,
+    /// A primary-checkout JavaScript dependency link resolves into this
+    /// disposable worktree. Preserve it until the package-manager install is
+    /// repaired rather than creating a dangling virtual-store entry.
+    InboundSymlinksBlocked { links: Vec<ExternalSymlink> },
     /// Something blew up partway through; string captures the reason.
     Error { reason: String },
 }
@@ -85,7 +89,9 @@ impl SweepSummary {
                     self.salvaged += 1;
                     self.bytes_freed = self.bytes_freed.saturating_add(*bytes_freed);
                 }
-                OpportunisticOutcome::RefusedSymlink | OpportunisticOutcome::Error { .. } => {
+                OpportunisticOutcome::RefusedSymlink
+                | OpportunisticOutcome::InboundSymlinksBlocked { .. }
+                | OpportunisticOutcome::Error { .. } => {
                     self.errors += 1
                 }
             }
@@ -282,6 +288,11 @@ fn classify_and_act(
         return Ok(OpportunisticOutcome::Young {
             age_secs: age.as_secs(),
         });
+    }
+
+    let links = scan_project_node_modules_symlinks_into(worktree_path, repo_root);
+    if !links.is_empty() {
+        return Ok(OpportunisticOutcome::InboundSymlinksBlocked { links });
     }
 
     let dirty = has_uncommitted_changes(worktree_path)?;

--- a/cas-cli/src/worktree/sweep/opportunistic/tests.rs
+++ b/cas-cli/src/worktree/sweep/opportunistic/tests.rs
@@ -97,6 +97,41 @@ fn reclaims_old_clean_worktree() {
     });
 }
 
+/// GH #529: the TTL-driven GC has a separate deletion path from the manual
+/// sweep. A live pnpm-style primary-checkout link into the aged worktree must
+/// block this path too, otherwise GC creates broken imports long after the
+/// linking mistake.
+#[cfg(unix)]
+#[test]
+fn preserves_old_worktree_linked_from_primary_node_modules() {
+    use std::os::unix::fs::symlink;
+
+    TestEnvGuard::run_with_temp_home(|home| {
+        ensure_host_schema().unwrap();
+        let repo = bootstrap_repo(home, "repo");
+        fs::write(repo.join("package.json"), "{}").unwrap();
+        let wt = add_worktree_aged(&repo, "pnpm-link", Duration::from_secs(48 * 3600));
+        let package = wt.join("node_modules/.pnpm/pkg@1/node_modules/pkg");
+        fs::create_dir_all(&package).unwrap();
+        let link = repo.join("node_modules/pkg");
+        fs::create_dir_all(link.parent().unwrap()).unwrap();
+        symlink(&package, &link).unwrap();
+        register(&repo);
+
+        let summary = run_forced(&ttl_zero()).unwrap();
+        let outcome = &summary.per_repo[0].entries[0].1;
+        match outcome {
+            OpportunisticOutcome::InboundSymlinksBlocked { links } => {
+                assert_eq!(links.len(), 1, "links: {links:?}");
+                assert_eq!(links[0].link, link);
+            }
+            other => panic!("expected inbound-link refusal, got {other:?}"),
+        }
+        assert!(wt.exists(), "worktree must survive the refusal");
+        assert!(link.exists(), "dependency link must remain live");
+    });
+}
+
 #[test]
 fn salvages_old_dirty_worktree() {
     TestEnvGuard::run_with_temp_home(|home| {
@@ -109,7 +144,10 @@ fn salvages_old_dirty_worktree() {
         let s = run_forced(&ttl_zero()).unwrap();
         assert_eq!(s.salvaged, 1);
         assert_eq!(s.reclaimed, 0);
-        assert!(!wt.exists(), "dirty old worktree must be removed after salvage");
+        assert!(
+            !wt.exists(),
+            "dirty old worktree must be removed after salvage"
+        );
         let salvage_dir = repo.join(".cas/salvage");
         let patches: Vec<_> = fs::read_dir(&salvage_dir)
             .unwrap()
@@ -209,7 +247,10 @@ fn cross_repo_iteration_continues_on_failure() {
 
         let s = run_forced(&ttl_zero()).unwrap();
         assert_eq!(s.repos_visited, 2);
-        assert_eq!(s.reclaimed, 1, "healthy repo swept despite unhealthy sibling");
+        assert_eq!(
+            s.reclaimed, 1,
+            "healthy repo swept despite unhealthy sibling"
+        );
         assert!(!wt_a.exists());
         let unhealthy_rec = s
             .per_repo

--- a/cas-cli/src/worktree/sweep/tests.rs
+++ b/cas-cli/src/worktree/sweep/tests.rs
@@ -10,9 +10,7 @@ use std::process::Command;
 
 use tempfile::TempDir;
 
-use crate::worktree::sweep::{
-    sweep_one_repo, Disposition, SweepOptions,
-};
+use crate::worktree::sweep::{Disposition, SweepOptions, sweep_one_repo};
 
 fn git(dir: &Path, args: &[&str]) -> std::process::Output {
     Command::new("git")
@@ -78,9 +76,46 @@ fn sweep_clean_merged_worktree_removes_it() {
     let report = sweep_one_repo(&repo, SweepOptions::default());
 
     assert_eq!(report.worktrees.len(), 1);
-    assert!(matches!(report.worktrees[0].disposition, Disposition::Removed));
+    assert!(matches!(
+        report.worktrees[0].disposition,
+        Disposition::Removed
+    ));
     assert!(!wt.exists(), "worktree dir must be gone");
     assert!(report.prune_ran, "prune must run when worktrees existed");
+}
+
+/// GH #529: pnpm's package entries are symlinks. If the primary checkout has
+/// been repointed into an otherwise clean worker's virtual store, the sweep
+/// must preserve the worktree rather than creating a quiet module-resolution
+/// failure after successful-looking tests.
+#[cfg(unix)]
+#[test]
+fn sweep_refuses_worktree_with_primary_node_modules_link_into_it() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let repo = bootstrap_repo(&temp);
+    fs::write(repo.join(".gitignore"), "node_modules/\n").unwrap();
+    git_ok(&repo, &["add", ".gitignore"]);
+    git_ok(&repo, &["commit", "-q", "-m", "ignore dependency trees"]);
+    std::fs::write(repo.join("package.json"), "{}").unwrap();
+    let wt = add_worktree(&repo, "pnpm-store");
+    let package = wt.join("node_modules/.pnpm/pkg@1/node_modules/pkg");
+    fs::create_dir_all(&package).unwrap();
+    let link = repo.join("node_modules/pkg");
+    fs::create_dir_all(link.parent().unwrap()).unwrap();
+    symlink(&package, &link).unwrap();
+
+    let report = sweep_one_repo(&repo, SweepOptions::default());
+    match &report.worktrees[0].disposition {
+        Disposition::SkippedExternalSymlinks { links } => {
+            assert_eq!(links.len(), 1, "links: {links:?}");
+            assert_eq!(links[0].link, link);
+        }
+        other => panic!("expected inbound-link refusal, got {other:?}"),
+    }
+    assert!(wt.exists(), "worktree must survive the refusal");
+    assert!(link.exists(), "primary checkout link must remain live");
 }
 
 #[test]
@@ -194,7 +229,13 @@ fn dry_run_makes_no_filesystem_changes() {
     assert!(clean.exists(), "dry run must not remove clean worktree");
     assert!(dirty.exists(), "dry run must not remove dirty worktree");
     assert!(
-        !repo.join(".cas/salvage").exists() || repo.join(".cas/salvage").read_dir().unwrap().next().is_none(),
+        !repo.join(".cas/salvage").exists()
+            || repo
+                .join(".cas/salvage")
+                .read_dir()
+                .unwrap()
+                .next()
+                .is_none(),
         "dry run must not write a salvage patch"
     );
     assert!(!report.prune_ran, "dry run must not invoke git prune");
@@ -283,7 +324,10 @@ fn unknown_parent_branch_produces_error_not_silent_delete() {
             "expected Error(parent branch), got {other:?} — worktree with committed work was classified as something else"
         ),
     }
-    assert!(wt.exists(), "worktree with committed work must NOT be removed");
+    assert!(
+        wt.exists(),
+        "worktree with committed work must NOT be removed"
+    );
 }
 
 #[test]
@@ -304,10 +348,7 @@ fn symlink_worktree_path_is_refused_not_followed() {
     symlink(&external, &link).unwrap();
 
     let report = sweep_one_repo(&repo, SweepOptions::default());
-    let sneaky_rec = report
-        .worktrees
-        .iter()
-        .find(|r| r.worktree_path == link);
+    let sneaky_rec = report.worktrees.iter().find(|r| r.worktree_path == link);
     if let Some(rec) = sneaky_rec {
         // If the sweep classified at all, it must be Error("symlink").
         match &rec.disposition {

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -437,9 +437,7 @@ fn integration_test_process_path_mutation_is_isolated() {
 
     let mut hits = Vec::new();
     visit(
-        cas::test_paths::crate_root()
-            .join("tests")
-            .as_path(),
+        cas::test_paths::crate_root().join("tests").as_path(),
         &mut hits,
     );
     assert!(
@@ -2135,7 +2133,10 @@ async fn cas_a736_worker_status_reconciles_the_full_terminal_relay_backlog() {
             .mark_suppressed(prompt_id, Some("historical lifecycle occurrence expired"))
             .expect("suppress historical relay");
     }
-    assert_eq!(queue.list_undelivered_lifecycle_relays(10).unwrap().len(), 10);
+    assert_eq!(
+        queue.list_undelivered_lifecycle_relays(10).unwrap().len(),
+        10
+    );
 
     let text = get_text(
         &env.service
@@ -2148,7 +2149,10 @@ async fn cas_a736_worker_status_reconciles_the_full_terminal_relay_backlog() {
         "the terminal backlog must fully self-reconcile rather than leave a banner: {text}"
     );
     assert!(
-        queue.list_undelivered_lifecycle_relays(10).unwrap().is_empty(),
+        queue
+            .list_undelivered_lifecycle_relays(10)
+            .unwrap()
+            .is_empty(),
         "a second status read must not reintroduce an acknowledged terminal relay"
     );
 }
@@ -4345,6 +4349,30 @@ async fn test_gc_report_shows_pending_prompts() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn test_gc_report_names_dangling_primary_node_modules_link() {
+    let env = FactoryTestEnv::new();
+    let repo = env.cas_root.parent().expect("CAS root has checkout parent");
+    std::fs::write(repo.join("package.json"), "{}").unwrap();
+    let link = repo.join("node_modules/backend");
+    std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink("/deleted/cassy-worktree/node_modules/backend", &link).unwrap();
+
+    let report = env
+        .service
+        .factory(Parameters(factory_req("gc_report")))
+        .await
+        .expect("gc report");
+    let text = get_text(&report);
+    assert!(
+        text.contains("Dangling primary-checkout node_modules symlinks"),
+        "{text}"
+    );
+    assert!(text.contains(&link.display().to_string()), "{text}");
+    assert!(text.contains("package-manager install"), "{text}");
+}
+
 #[tokio::test]
 async fn test_gc_artifacts_are_lifecycle_keyed_and_strays_are_review_only() {
     let env = FactoryTestEnv::new();
@@ -5785,11 +5813,7 @@ async fn test_worker_peer_message_does_not_confirm_supervisor_instruction() {
         ("CAS_FACTORY_SESSION", "peer-message-session"),
     ]);
     let env = FactoryTestEnv::new();
-    env.register_worker_with_id(
-        "test-agent-id",
-        "swift-fox",
-        Some("peer-message-session"),
-    );
+    env.register_worker_with_id("test-agent-id", "swift-fox", Some("peer-message-session"));
     env.register_worker_in_session("peer-worker", "peer-message-session");
     env.register_supervisor_in_session("supervisor", "peer-message-session");
     let instruction = env
@@ -7722,10 +7746,7 @@ async fn cas_dcf2_wake_starvation_is_top_line_status_not_a_lifecycle_relay_gh390
         .expect("enqueue");
     for _ in 0..3 {
         env.prompt_queue()
-            .record_wake_gate_decline(
-                message_id,
-                "pane has not been silent long enough",
-            )
+            .record_wake_gate_decline(message_id, "pane has not been silent long enough")
             .expect("record busy wake decline");
     }
     env.prompt_queue()
@@ -7840,8 +7861,9 @@ async fn cas4a27_supervisor_reply_is_linked_and_distinct_from_spawn_replay_gh334
             .expect("worker inbox poll"),
     );
     assert!(
-        text.contains(&format!("notification_id={spawn_id} origin=spawn-boilerplate"))
-            && text.contains("delivery=first-delivery"),
+        text.contains(&format!(
+            "notification_id={spawn_id} origin=spawn-boilerplate"
+        )) && text.contains("delivery=first-delivery"),
         "the delayed spawn brief needs machine-readable origin, ID, time, and delivery state: {text}"
     );
     assert!(


### PR DESCRIPTION
Worktree GC (manager, manual, and TTL/opportunistic paths) now refuses to remove a worktree when a live symlink from outside — notably the main checkout's node_modules/pnpm store links — resolves into it, reporting a new SkippedExternalSymlinks disposition with the offending links so the operator repairs/reinstalls first instead of inheriting 1900+ dangling links and false-green test runs. `gc_report` additionally inventories already-dangling JS dependency links loudly.

Non-JS repos are unaffected (scan is a no-op without node_modules). Proof: focused GC seam tests 4/4, gc_report integration 1/1, cargo check clean.

Fixes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)