### PR TITLE
fix: audit terminal task reopens

### DIFF
--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -815,7 +815,13 @@ impl CloudSyncer {
         // historical backfill (GH #192). Once a project has established a
         // watermark, retain the existing behavior: healthy empty incremental
         // pulls advance to the server clock.
-        if (had_prior_watermark || result.total_pulled() > 0)
+        // A locally-retained conflict (including a terminal-row rejection) is
+        // still a successfully consumed, project-scoped server row. Advance
+        // past it so an unattributed reopen is journaled once rather than
+        // fetched and rejected forever. Foreign/malformed rows never reach
+        // `conflicts_resolved`, so the GH #192 empty/wrong-bucket safeguard
+        // remains intact.
+        if (had_prior_watermark || result.total_pulled() > 0 || result.conflicts_resolved > 0)
             && let Some(pulled_at) = body.pulled_at
         {
             let _ = self.queue.set_metadata("last_pull_at", &pulled_at);

--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -368,10 +368,11 @@ fn rejects_terminal_regression(local: &Task, remote: &Task) -> bool {
     !has_explicit_remote_reopen(remote, local.closed_at)
 }
 
-/// Cassy's `task reopen` action writes `[YYYY-mm-dd HH:MM] Reopened: <reason>`
-/// into the task's replicated note timeline. Treat that timestamped record as
-/// the reopening event; a bare active task row, even one with a newer
-/// `updated_at`, is not authorization to undo a close/cancellation.
+/// Cassy's `task reopen` action writes `[YYYY-mm-dd HH:MM] Reopened:
+/// actor=<agent> reason=<reason>` into the task's replicated note timeline.
+/// Treat that timestamped, attributed record as the reopening event; a bare
+/// active task row, even one with a newer `updated_at`, is not authorization to
+/// undo a close/cancellation.
 fn has_explicit_remote_reopen(
     remote: &Task,
     local_closed_at: Option<chrono::DateTime<chrono::Utc>>,
@@ -384,7 +385,17 @@ fn has_explicit_remote_reopen(
         else {
             return false;
         };
-        if !event.trim_start().starts_with("Reopened:") {
+        let Some(audit) = event.trim_start().strip_prefix("Reopened:") else {
+            return false;
+        };
+        let Some((actor, reason)) = audit
+            .trim()
+            .strip_prefix("actor=")
+            .and_then(|audit| audit.split_once(" reason="))
+        else {
+            return false;
+        };
+        if actor.trim().is_empty() || reason.trim().is_empty() {
             return false;
         }
         let Ok(timestamp) = chrono::NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%d %H:%M")
@@ -2082,7 +2093,7 @@ mod web_close_tests {
         remote.close_reason = None;
         remote.updated_at = chrono::Utc::now() + chrono::Duration::minutes(1);
         remote.notes = format!(
-            "[{}] Reopened: regression found after deployment",
+            "[{}] Reopened: actor=remote-supervisor reason=regression found after deployment",
             chrono::Utc::now().format("%Y-%m-%d %H:%M")
         );
         assert!(matches!(
@@ -2099,7 +2110,41 @@ mod web_close_tests {
         assert!(
             reopened
                 .notes
-                .contains("prior_close_reason=original delivery merged")
+            .contains("prior_close_reason=original delivery merged")
+        );
+    }
+
+    #[test]
+    fn terminal_sync_rejects_unattributed_reopen_note() {
+        let temp = TempDir::new().unwrap();
+        let cas_dir = init_cas_dir(temp.path()).unwrap();
+        let store = open_task_store(&cas_dir).unwrap();
+        let queue = Arc::new(SyncQueue::open(&cas_dir).unwrap());
+        queue.init().unwrap();
+        let syncer = CloudSyncer::new(queue, CloudConfig::default(), CloudSyncerConfig::default());
+
+        let mut local = Task::new("cas-unattributed-reopen".into(), "closed task".into());
+        local.status = TaskStatus::Closed;
+        local.closed_at = Some(chrono::Utc::now() - chrono::Duration::hours(1));
+        store.add(&local).unwrap();
+
+        let mut remote = local.clone();
+        remote.status = TaskStatus::Open;
+        remote.closed_at = None;
+        remote.updated_at = chrono::Utc::now() + chrono::Duration::minutes(1);
+        remote.notes = format!(
+            "[{}] Reopened: regression found after deployment",
+            chrono::Utc::now().format("%Y-%m-%d %H:%M")
+        );
+
+        assert!(matches!(
+            syncer.upsert_task(&*store, remote, "sync-unattributed", "personal_pull"),
+            Ok(UpsertResult::Skipped)
+        ));
+        assert_eq!(
+            store.get("cas-unattributed-reopen").unwrap().status,
+            TaskStatus::Closed,
+            "sync must not accept a terminal exit lacking actor and reason"
         );
     }
 }

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -5171,6 +5171,17 @@ impl CasCore {
         }
 
         let old_status = task.status;
+        let reason = req
+            .reason
+            .as_deref()
+            .map(str::trim)
+            .filter(|reason| !reason.is_empty())
+            .ok_or_else(|| {
+                Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    "task reopen rejected: a non-empty reason is required to preserve the terminal-state audit trail",
+                )
+            })?;
         task.status = TaskStatus::Open;
         if matches!(old_status, TaskStatus::Closed | TaskStatus::Cancelled) {
             // cas-cd24: closed-specific resets stay gated to the closed
@@ -5192,38 +5203,40 @@ impl CasCore {
         }
         task.updated_at = chrono::Utc::now();
 
-        // cas-cd24: capture the reopen/unblock reason on the audit trail —
-        // previously silently dropped (the dispatcher discarded `reason`
-        // for this action entirely; see `TaskRequest` -> `IdRequest` in
-        // `service/core.rs` before this fix). Mirrors the close-path
-        // `close_reason`/note pattern above in `cas_task_close`.
-        if let Some(reason) = &req.reason {
-            let timestamp = task.updated_at.format("%Y-%m-%d %H:%M");
-            let verb = if fresh_scope_dispatch.is_some() && old_status != TaskStatus::Closed {
-                "Review scope reset"
-            } else if old_status == TaskStatus::Blocked {
-                "Unblocked"
-            } else {
-                "Reopened"
-            };
-            let reopen_note = format!("[{timestamp}] {verb}: {reason}");
-            if task.notes.is_empty() {
-                task.notes = reopen_note;
-            } else {
-                task.notes = format!("{}\n\n{}", task.notes, reopen_note);
-            }
-        }
-
+        let actor_id = self.get_agent_id().map_err(|error| {
+            Self::error(
+                ErrorCode::INVALID_PARAMS,
+                format!("task reopen rejected: attributed actor is unavailable: {error}"),
+            )
+        })?;
         let actor = self
-            .get_agent_id()
-            .ok()
-            .and_then(|id| {
-                self.open_agent_store()
-                    .ok()
-                    .and_then(|s| s.get(&id).ok())
-                    .map(|a| a.name)
-            })
-            .unwrap_or_else(|| "unknown".into());
+            .open_agent_store()?
+            .get(&actor_id)
+            .map_err(|error| {
+                Self::error(
+                    ErrorCode::INVALID_PARAMS,
+                    format!("task reopen rejected: attributed actor is unavailable: {error}"),
+                )
+            })?;
+        // Terminal exits must be independently intelligible after replication:
+        // the actor and the reason are both embedded in the note, rather than
+        // relying on ephemeral caller context or a generic updated_at stamp.
+        let timestamp = task.updated_at.format("%Y-%m-%d %H:%M");
+        let verb = if fresh_scope_dispatch.is_some() && old_status != TaskStatus::Closed {
+            "Review scope reset"
+        } else if old_status == TaskStatus::Blocked {
+            "Unblocked"
+        } else {
+            "Reopened"
+        };
+        let actor = format!("{} ({})", actor.name, actor.id).replace(['\n', '\r'], " ");
+        let reason = reason.replace(['\n', '\r'], " ");
+        let reopen_note = format!("[{timestamp}] {verb}: actor={actor} reason={reason}");
+        if task.notes.is_empty() {
+            task.notes = reopen_note;
+        } else {
+            task.notes = format!("{}\n\n{}", task.notes, reopen_note);
+        }
         // cas-ec74: the two atomic reopen paths below write `task.updated_at`
         // through verbatim (it is their optimistic-concurrency key), so this
         // occurrence is correct for them. The plain `update()` path re-stamps

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -548,11 +548,18 @@ impl CasCore {
                 data: None,
             });
         }
-        let reopening_closed = task.status == TaskStatus::Closed
-            && req
-                .status
-                .as_deref()
-                .is_some_and(|status| status.eq_ignore_ascii_case(&TaskStatus::Open.to_string()));
+        if task.is_terminal() && req.status.is_some() {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from(format!(
+                    "TASK UPDATE REJECTED: terminal task {} may change status only through task \
+                     action=reopen with a non-empty reason so supervisor authority and the \
+                     attributed audit trail are recorded atomically.",
+                    task.id
+                )),
+                data: None,
+            });
+        }
         if req
             .status
             .as_deref()
@@ -582,22 +589,20 @@ impl CasCore {
                 data: None,
             });
         }
-        if !reopening_closed {
-            if let Err(message) = super::lifecycle::proof_scope::guard_task_proof_scope(
-                &self.cas_root,
-                &task,
-                super::lifecycle::proof_scope::ProofScopeOperation::TaskUpdate {
-                    request: &req,
-                    target_repo_supplied: target_repo.is_some(),
-                    target_branch_supplied: target_branch.is_some(),
-                },
-            ) {
-                return Err(McpError {
-                    code: ErrorCode::INVALID_PARAMS,
-                    message: Cow::from(message.to_string()),
-                    data: None,
-                });
-            }
+        if let Err(message) = super::lifecycle::proof_scope::guard_task_proof_scope(
+            &self.cas_root,
+            &task,
+            super::lifecycle::proof_scope::ProofScopeOperation::TaskUpdate {
+                request: &req,
+                target_repo_supplied: target_repo.is_some(),
+                target_branch_supplied: target_branch.is_some(),
+            },
+        ) {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from(message.to_string()),
+                data: None,
+            });
         }
         // Resolving an existing work target is necessary only when this call
         // changes its branch. Unrelated task fields (notably the first
@@ -1166,10 +1171,6 @@ impl CasCore {
                 task.status = new_status;
                 changes.push("status");
             }
-            if reopening_closed {
-                task.closed_at = None;
-                task.deliverables.factory_branch_anchor = None;
-            }
         }
 
         // Captured before `req.epic` is consumed below — the blocked_by guard
@@ -1611,7 +1612,7 @@ mod status_transition_tests {
     use crate::mcp::tools::core::task::lifecycle::close_ops::{
         EpicCloseGateOutcome, run_epic_close_merge_gate,
     };
-    use cas_types::{Task, TaskStatus, TaskType};
+    use cas_types::{Agent, Task, TaskStatus, TaskType};
     use tempfile::TempDir;
 
     fn git(repo: &std::path::Path, args: &[&str]) -> String {
@@ -1630,7 +1631,7 @@ mod status_transition_tests {
     }
 
     #[tokio::test]
-    async fn task_update_closed_to_in_progress_clears_factory_branch_anchor() {
+    async fn task_update_rejects_terminal_status_changes_and_reopen_clears_factory_branch_anchor() {
         let temp = TempDir::new().unwrap();
         let repo = temp.path();
         git(repo, &["init", "-q", "-b", "main"]);
@@ -1652,6 +1653,12 @@ mod status_transition_tests {
         let core = CasCore::with_daemon(cas_dir, None, None);
         let store = core.open_task_store().unwrap();
         store.init().unwrap();
+        let agent_store = core.open_agent_store().unwrap();
+        agent_store.init().unwrap();
+        agent_store
+            .add(&Agent::new("supervisor-agent".into(), "supervisor".into()))
+            .unwrap();
+        core.set_agent_id_for_testing("supervisor-agent".into());
 
         let mut task = Task::new("cas-anchor".into(), "Anchored closed task".into());
         task.status = TaskStatus::Closed;
@@ -1666,10 +1673,32 @@ mod status_transition_tests {
             "status": "in_progress"
         }))
         .unwrap();
-        core.cas_task_update(Parameters(req)).await.unwrap();
+        let error = core
+            .cas_task_update(Parameters(req))
+            .await
+            .expect_err("generic update must not silently reopen a terminal task");
+        assert!(error.message.contains("action=reopen"), "{}", error.message);
+        assert_eq!(store.get("cas-anchor").unwrap().status, TaskStatus::Closed);
+
+        // The attributed supervisor-only reopen path remains the sanctioned
+        // way to start a fresh close cycle.
+        unsafe {
+            std::env::set_var("CAS_AGENT_ROLE", "supervisor");
+        }
+        core.cas_task_reopen(Parameters(TaskReopenRequest {
+            id: "cas-anchor".into(),
+            reason: Some("delivery needs a fresh review cycle".into()),
+        }))
+        .await
+        .unwrap();
+        unsafe {
+            std::env::remove_var("CAS_AGENT_ROLE");
+        }
 
         let updated = store.get("cas-anchor").unwrap();
-        assert_eq!(updated.status, TaskStatus::InProgress);
+        assert_eq!(updated.status, TaskStatus::Open);
+        assert!(updated.notes.contains("actor=supervisor (supervisor-agent)"));
+        assert!(updated.notes.contains("reason=delivery needs a fresh review cycle"));
         assert!(
             updated.deliverables.factory_branch_anchor.is_none(),
             "a Closed -> non-Closed transition must invalidate the prior close cycle's anchor"

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -627,8 +627,6 @@ impl CasCore {
         let prior_assignee = task.assignee.clone();
 
         let mut changes = Vec::new();
-        let mut atomic_parent_dependency = cas_store::ParentDependencyUpdate::Unchanged;
-
         if let Some(title) = req.title {
             task.title = title;
             changes.push("title");
@@ -1239,28 +1237,23 @@ impl CasCore {
                 None => existing_parent_deps.is_empty(),
             };
             if !already_matches {
-                if reopening_closed {
-                    atomic_parent_dependency =
-                        cas_store::ParentDependencyUpdate::Replace(replacement);
-                } else {
-                    for dep in existing_parent_deps {
-                        task_store
-                            .remove_dependency(&req.id, &dep.to_id)
-                            .map_err(|e| McpError {
-                                code: ErrorCode::INTERNAL_ERROR,
-                                message: Cow::from(format!(
-                                    "Failed to remove existing epic dependency: {e}"
-                                )),
-                                data: None,
-                            })?;
-                    }
-                    if let Some(dep) = replacement.as_ref() {
-                        task_store.add_dependency(dep).map_err(|e| McpError {
+                for dep in existing_parent_deps {
+                    task_store
+                        .remove_dependency(&req.id, &dep.to_id)
+                        .map_err(|e| McpError {
                             code: ErrorCode::INTERNAL_ERROR,
-                            message: Cow::from(format!("Failed to add epic dependency: {e}")),
+                            message: Cow::from(format!(
+                                "Failed to remove existing epic dependency: {e}"
+                            )),
                             data: None,
                         })?;
-                    }
+                }
+                if let Some(dep) = replacement.as_ref() {
+                    task_store.add_dependency(dep).map_err(|e| McpError {
+                        code: ErrorCode::INTERNAL_ERROR,
+                        message: Cow::from(format!("Failed to add epic dependency: {e}")),
+                        data: None,
+                    })?;
                 }
                 changes.push("epic");
             }
@@ -1298,22 +1291,6 @@ impl CasCore {
                 return Err(McpError {
                     code: ErrorCode::INVALID_PARAMS,
                     message: Cow::from(format!("Task {} cannot block itself.", req.id)),
-                    data: None,
-                });
-            }
-
-            // Reopening rewrites the task atomically as Open; a fresh blocker
-            // would immediately contradict that status. Reject the combination
-            // explicitly rather than persisting an Open-but-blocked task.
-            if reopening_closed {
-                return Err(McpError {
-                    code: ErrorCode::INVALID_PARAMS,
-                    message: Cow::from(
-                        "blocked_by cannot be combined with reopening a closed task \
-                         (status=open). Reopen first, then add blockers with a second \
-                         `update blocked_by=...` call."
-                            .to_string(),
-                    ),
                     data: None,
                 });
             }
@@ -1476,66 +1453,13 @@ impl CasCore {
                 })
                 .unwrap_or_else(|| "unknown".into())
         });
-        let lifecycle_outbox = if reopening_closed {
-            let actor = lifecycle_actor.as_deref().unwrap_or("unknown");
-            let agent_store = self.open_agent_store().map_err(|error| McpError {
-                code: ErrorCode::INTERNAL_ERROR,
-                message: Cow::from(format!("Failed to prepare reopen lifecycle: {error}")),
-                data: None,
-            })?;
-            let occurrence = crate::mcp::tools::core::task::lifecycle::supervisor_push::occurrence_from_updated_at(task.updated_at);
-            let outbox = crate::mcp::tools::core::task::lifecycle::supervisor_push::prepare_task_lifecycle_outbox(
-                agent_store.as_ref(),
-                &task.id,
-                &task.title,
-                TaskStatus::Closed,
-                TaskStatus::Open,
-                actor,
-                None,
-                crate::mcp::tools::core::task::lifecycle::supervisor_push::LifecycleTransition::ReadyReopened,
-                &occurrence,
-            );
-            if outbox.is_some() {
-                crate::store::open_supervisor_queue_store(&self.cas_root).map_err(|error| {
-                    McpError {
-                        code: ErrorCode::INTERNAL_ERROR,
-                        message: Cow::from(format!(
-                            "Failed to initialize reopen lifecycle outbox: {error}"
-                        )),
-                        data: None,
-                    }
-                })?;
-            }
-            outbox
-        } else {
-            None
-        };
-
-        if reopening_closed {
-            cas_store::reopen_closed_task_atomic(
-                &self.cas_root,
-                &task,
-                original_updated_at,
-                atomic_parent_dependency,
-                lifecycle_outbox.as_ref(),
-            )
-            .map_err(|e| McpError {
-                code: ErrorCode::INTERNAL_ERROR,
-                message: Cow::from(format!("Failed to atomically reopen task: {e}")),
-                data: None,
-            })?;
-        } else {
-            // cas-ec74: adopt the store-owned stamp so the lifecycle occurrence
-            // pushed below matches the persisted row. (The `reopening_closed`
-            // branch above goes through `reopen_exact_with_conn`, which writes
-            // `task.updated_at` through verbatim as its optimistic-concurrency
-            // key, so its occurrence is already consistent.)
-            task.updated_at = task_store.update(&task).map_err(|e| McpError {
-                code: ErrorCode::INTERNAL_ERROR,
-                message: Cow::from(format!("Failed to update: {e}")),
-                data: None,
-            })?;
-        }
+        // cas-ec74: adopt the store-owned stamp so the lifecycle occurrence
+        // pushed below matches the persisted row.
+        task.updated_at = task_store.update(&task).map_err(|e| McpError {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: Cow::from(format!("Failed to update: {e}")),
+            data: None,
+        })?;
 
         // cas-062d: push blocked / ready-reopened transitions.
         if let Some((old_st, new_st)) = lifecycle_status_change {
@@ -1656,7 +1580,7 @@ mod status_transition_tests {
         let agent_store = core.open_agent_store().unwrap();
         agent_store.init().unwrap();
         agent_store
-            .add(&Agent::new("supervisor-agent".into(), "supervisor".into()))
+            .register(&Agent::new("supervisor-agent".into(), "supervisor".into()))
             .unwrap();
         core.set_agent_id_for_testing("supervisor-agent".into());
 

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -549,6 +549,24 @@ impl CasCore {
             });
         }
         if task.is_terminal() && req.status.is_some() {
+            if task.status == TaskStatus::Closed
+                && req
+                    .blocked_by
+                    .as_deref()
+                    .is_some_and(|blocked_by| !blocked_by.trim().is_empty())
+            {
+                return Err(McpError {
+                    code: ErrorCode::INVALID_PARAMS,
+                    message: Cow::from(format!(
+                        "TASK UPDATE REJECTED: reopening a closed task {} cannot be combined \
+                         with blocked_by. Use task action=reopen with a non-empty reason so \
+                         supervisor authority and the attributed audit trail are recorded, then \
+                         add blockers with a separate update call.",
+                        task.id
+                    )),
+                    data: None,
+                });
+            }
             return Err(McpError {
                 code: ErrorCode::INVALID_PARAMS,
                 message: Cow::from(format!(
@@ -1621,8 +1639,16 @@ mod status_transition_tests {
 
         let updated = store.get("cas-anchor").unwrap();
         assert_eq!(updated.status, TaskStatus::Open);
-        assert!(updated.notes.contains("actor=supervisor (supervisor-agent)"));
-        assert!(updated.notes.contains("reason=delivery needs a fresh review cycle"));
+        assert!(
+            updated
+                .notes
+                .contains("actor=supervisor (supervisor-agent)")
+        );
+        assert!(
+            updated
+                .notes
+                .contains("reason=delivery needs a fresh review cycle")
+        );
         assert!(
             updated.deliverables.factory_branch_anchor.is_none(),
             "a Closed -> non-Closed transition must invalidate the prior close cycle's anchor"

--- a/cas-cli/src/mcp/tools/types/task.rs
+++ b/cas-cli/src/mcp/tools/types/task.rs
@@ -297,11 +297,11 @@ pub struct TaskReopenRequest {
     #[schemars(description = "Task ID to reopen")]
     pub id: String,
 
-    /// Reopen reason (cas-cd24)
+    /// Required reopen reason (cas-b4fc)
     #[schemars(
-        description = "Reason for reopening (e.g. why a blocker was withdrawn or a \
-                       closed task needs rework). Recorded on the task's audit \
-                       trail as a note."
+        description = "Required reason for reopening (e.g. why a blocker was withdrawn or a \
+                       closed task needs rework). Recorded with the acting agent on the task's \
+                       audit trail as a note."
     )]
     #[serde(default)]
     pub reason: Option<String>,

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -437,9 +437,7 @@ fn integration_test_process_path_mutation_is_isolated() {
 
     let mut hits = Vec::new();
     visit(
-        cas::test_paths::crate_root()
-            .join("tests")
-            .as_path(),
+        cas::test_paths::crate_root().join("tests").as_path(),
         &mut hits,
     );
     assert!(
@@ -2135,7 +2133,10 @@ async fn cas_a736_worker_status_reconciles_the_full_terminal_relay_backlog() {
             .mark_suppressed(prompt_id, Some("historical lifecycle occurrence expired"))
             .expect("suppress historical relay");
     }
-    assert_eq!(queue.list_undelivered_lifecycle_relays(10).unwrap().len(), 10);
+    assert_eq!(
+        queue.list_undelivered_lifecycle_relays(10).unwrap().len(),
+        10
+    );
 
     let text = get_text(
         &env.service
@@ -2148,7 +2149,10 @@ async fn cas_a736_worker_status_reconciles_the_full_terminal_relay_backlog() {
         "the terminal backlog must fully self-reconcile rather than leave a banner: {text}"
     );
     assert!(
-        queue.list_undelivered_lifecycle_relays(10).unwrap().is_empty(),
+        queue
+            .list_undelivered_lifecycle_relays(10)
+            .unwrap()
+            .is_empty(),
         "a second status read must not reintroduce an acknowledged terminal relay"
     );
 }
@@ -5785,11 +5789,7 @@ async fn test_worker_peer_message_does_not_confirm_supervisor_instruction() {
         ("CAS_FACTORY_SESSION", "peer-message-session"),
     ]);
     let env = FactoryTestEnv::new();
-    env.register_worker_with_id(
-        "test-agent-id",
-        "swift-fox",
-        Some("peer-message-session"),
-    );
+    env.register_worker_with_id("test-agent-id", "swift-fox", Some("peer-message-session"));
     env.register_worker_in_session("peer-worker", "peer-message-session");
     env.register_supervisor_in_session("supervisor", "peer-message-session");
     let instruction = env
@@ -6554,7 +6554,7 @@ async fn test_062d_lifecycle_reopen_pushes_ready() {
         .inner
         .cas_task_reopen(Parameters(cas::mcp::tools::TaskReopenRequest {
             id: "cas-062d-reopen".to_string(),
-            reason: None,
+            reason: Some("new ready cycle after supervisor review".to_string()),
         }))
         .await
         .expect("reopen should succeed");
@@ -7722,10 +7722,7 @@ async fn cas_dcf2_wake_starvation_is_top_line_status_not_a_lifecycle_relay_gh390
         .expect("enqueue");
     for _ in 0..3 {
         env.prompt_queue()
-            .record_wake_gate_decline(
-                message_id,
-                "pane has not been silent long enough",
-            )
+            .record_wake_gate_decline(message_id, "pane has not been silent long enough")
             .expect("record busy wake decline");
     }
     env.prompt_queue()
@@ -7840,8 +7837,9 @@ async fn cas4a27_supervisor_reply_is_linked_and_distinct_from_spawn_replay_gh334
             .expect("worker inbox poll"),
     );
     assert!(
-        text.contains(&format!("notification_id={spawn_id} origin=spawn-boilerplate"))
-            && text.contains("delivery=first-delivery"),
+        text.contains(&format!(
+            "notification_id={spawn_id} origin=spawn-boilerplate"
+        )) && text.contains("delivery=first-delivery"),
         "the delayed spawn brief needs machine-readable origin, ID, time, and delivery state: {text}"
     );
     assert!(

--- a/cas-cli/tests/mcp_tools_test/task_tools/cancellation.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/cancellation.rs
@@ -293,6 +293,9 @@ async fn registered_supervisor_can_reopen_cancelled_task_and_clear_outcome() {
     assert!(
         reopened
             .notes
-            .contains("Reopened: actor=test-agent reason=replacement was reverted")
+            .contains("Reopened: actor=test-agent (test-session-")
+            && reopened.notes.contains(") reason=replacement was reverted"),
+        "reopen audit must retain both the registered actor identity and reason: {:?}",
+        reopened.notes
     );
 }

--- a/cas-cli/tests/mcp_tools_test/task_tools/cancellation.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/cancellation.rs
@@ -139,7 +139,7 @@ async fn cancel_refuses_blank_reason_without_mutation() {
 }
 
 #[tokio::test]
-async fn direct_status_updates_cannot_cancel_or_reopen_cancelled_work() {
+async fn direct_status_updates_cannot_change_terminal_work() {
     let (temp, core) = setup_cas();
     let _env_lock = env_test_lock();
     let cas_dir = temp.path().join(".cas");
@@ -186,6 +186,28 @@ async fn direct_status_updates_cannot_cancel_or_reopen_cancelled_work() {
         persisted.terminal_outcome,
         Some(TaskTerminalOutcome::Cancelled { .. })
     ));
+
+    let mut closed = Task::new(
+        "cas-closed-update-bypass".into(),
+        "guard terminal reopen verb".into(),
+    );
+    closed.status = TaskStatus::Closed;
+    closed.closed_at = Some(chrono::Utc::now());
+    store.add(&closed).unwrap();
+    let direct_closed_reopen: TaskUpdateRequest = serde_json::from_value(serde_json::json!({
+        "id": closed.id,
+        "status": "in_progress"
+    }))
+    .unwrap();
+    let error = core
+        .cas_task_update(Parameters(direct_closed_reopen))
+        .await
+        .expect_err("direct Closed -> active update must use the attributed reopen action");
+    assert!(error.message.contains("action=reopen"), "{}", error.message);
+    assert_eq!(
+        store.get("cas-closed-update-bypass").unwrap().status,
+        TaskStatus::Closed
+    );
 }
 
 #[tokio::test]
@@ -271,6 +293,6 @@ async fn registered_supervisor_can_reopen_cancelled_task_and_clear_outcome() {
     assert!(
         reopened
             .notes
-            .contains("Reopened: replacement was reverted")
+            .contains("Reopened: actor=test-agent reason=replacement was reverted")
     );
 }

--- a/cas-cli/tests/mcp_tools_test/task_tools/dependencies.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/dependencies.rs
@@ -668,6 +668,7 @@ async fn task_update_blocked_by_rejects_the_epic_set_in_the_same_call() {
 #[tokio::test]
 async fn task_update_blocked_by_is_rejected_when_reopening_a_closed_task() {
     let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
     let task_store = open_task_store(&temp.path().join(".cas")).expect("task store");
     let service = cas::mcp::CasService::new(core, None);
 
@@ -701,15 +702,22 @@ async fn task_update_blocked_by_is_rejected_when_reopening_a_closed_task() {
         "a rejected reopen+blocked_by call must not write any dependency"
     );
 
-    // Reopen first, then add the blocker: the documented two-call path works.
+    // Reopen first through the attributed supervisor-only action, then add
+    // the blocker: the documented two-call path works.
+    unsafe {
+        std::env::set_var("CAS_AGENT_ROLE", "supervisor");
+    }
     service
         .task(Parameters(task_req(serde_json::json!({
-            "action": "update",
+            "action": "reopen",
             "id": dependent_id,
-            "status": "open",
+            "reason": "dependency review requires a fresh work cycle",
         }))))
         .await
-        .expect("reopen should succeed on its own");
+        .expect("attributed supervisor reopen should succeed on its own");
+    unsafe {
+        std::env::remove_var("CAS_AGENT_ROLE");
+    }
     service
         .task(Parameters(task_req(serde_json::json!({
             "action": "update",

--- a/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
@@ -605,7 +605,7 @@ async fn test_supervisor_can_reopen_closed_task() {
         let text = extract_text(
             core.cas_task_reopen(Parameters(TaskReopenRequest {
                 id: id.clone(),
-                reason: None,
+                reason: Some("post-close regression requires rework".to_string()),
             }))
             .await
             .expect("supervisor reopen should succeed"),
@@ -626,6 +626,39 @@ async fn test_supervisor_can_reopen_closed_task() {
         TaskStatus::Open,
         "supervisor reopen must transition the task back to Open"
     );
+    assert!(task.notes.contains("actor=test-agent"), "{:?}", task.notes);
+    assert!(
+        task.notes
+            .contains("reason=post-close regression requires rework"),
+        "{:?}",
+        task.notes
+    );
+}
+
+#[tokio::test]
+async fn test_supervisor_reopen_terminal_task_requires_non_empty_reason() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    let task_store = open_task_store(&cas_dir).unwrap();
+    let id = create_started_and_closed_light_task(&core, "terminal reopen reason required").await;
+
+    unsafe {
+        std::env::set_var("CAS_AGENT_ROLE", "supervisor");
+    }
+    let error = core
+        .cas_task_reopen(Parameters(TaskReopenRequest {
+            id: id.clone(),
+            reason: Some("   ".to_string()),
+        }))
+        .await
+        .expect_err("terminal reopen without a reason must be rejected");
+    unsafe {
+        std::env::remove_var("CAS_AGENT_ROLE");
+    }
+
+    assert!(error.message.contains("non-empty reason"), "{}", error.message);
+    assert_eq!(task_store.get(&id).unwrap().status, TaskStatus::Closed);
 }
 
 /// cas-cd24 AC1: `reopen` on a Blocked task transitions it to Open and
@@ -721,7 +754,7 @@ async fn test_cd24_closed_reopen_still_clears_closed_at() {
         }
         core.cas_task_reopen(Parameters(TaskReopenRequest {
             id: id.clone(),
-            reason: None,
+            reason: Some("preserve close metadata regression coverage".to_string()),
         }))
         .await
         .expect("supervisor reopen should succeed");

--- a/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
@@ -125,7 +125,10 @@ async fn test_light_depth_solo_close_skips_verification_jail() {
     let task_store = open_task_store(&cas_dir).unwrap();
 
     let created = core
-        .cas_task_create(Parameters(create_req("light task — solo close", Some("light"))))
+        .cas_task_create(Parameters(create_req(
+            "light task — solo close",
+            Some("light"),
+        )))
         .await
         .expect("task_create should succeed");
     let id = extract_task_id(&extract_text(created))
@@ -144,7 +147,8 @@ async fn test_light_depth_solo_close_skips_verification_jail() {
             bypass_code_review: None,
             code_review_findings: None,
             search_manifest: None,
-            commit_receipt: None,        }))
+            commit_receipt: None,
+        }))
         .await
         .expect("task_close should return a result"),
     );
@@ -250,7 +254,10 @@ async fn test_deep_depth_solo_close_still_arms_verification_jail() {
     let task_store = open_task_store(&cas_dir).unwrap();
 
     let created = core
-        .cas_task_create(Parameters(create_req("deep task — solo close", Some("deep"))))
+        .cas_task_create(Parameters(create_req(
+            "deep task — solo close",
+            Some("deep"),
+        )))
         .await
         .expect("task_create should succeed");
     let id = extract_task_id(&extract_text(created))
@@ -269,7 +276,8 @@ async fn test_deep_depth_solo_close_still_arms_verification_jail() {
             bypass_code_review: None,
             code_review_findings: None,
             search_manifest: None,
-            commit_receipt: None,        }))
+            commit_receipt: None,
+        }))
         .await
         .expect("task_close should return a result"),
     );
@@ -306,7 +314,10 @@ async fn test_unset_depth_solo_close_still_arms_verification_jail() {
     let task_store = open_task_store(&cas_dir).unwrap();
 
     let created = core
-        .cas_task_create(Parameters(create_req("unset-depth task — solo close", None)))
+        .cas_task_create(Parameters(create_req(
+            "unset-depth task — solo close",
+            None,
+        )))
         .await
         .expect("task_create should succeed");
     let id = extract_task_id(&extract_text(created))
@@ -325,7 +336,8 @@ async fn test_unset_depth_solo_close_still_arms_verification_jail() {
             bypass_code_review: None,
             code_review_findings: None,
             search_manifest: None,
-            commit_receipt: None,        }))
+            commit_receipt: None,
+        }))
         .await
         .expect("task_close should return a result"),
     );
@@ -533,7 +545,8 @@ async fn create_started_and_closed_light_task(core: &CasCore, title: &str) -> St
             bypass_code_review: None,
             code_review_findings: None,
             search_manifest: None,
-            commit_receipt: None,        }))
+            commit_receipt: None,
+        }))
         .await
         .expect("task_close should return a result"),
     );
@@ -560,7 +573,7 @@ async fn test_worker_cannot_reopen_closed_task() {
     let result = core
         .cas_task_reopen(Parameters(TaskReopenRequest {
             id: id.clone(),
-            reason: None,
+            reason: Some("worker requests a fresh review cycle".to_string()),
         }))
         .await;
 
@@ -657,7 +670,11 @@ async fn test_supervisor_reopen_terminal_task_requires_non_empty_reason() {
         std::env::remove_var("CAS_AGENT_ROLE");
     }
 
-    assert!(error.message.contains("non-empty reason"), "{}", error.message);
+    assert!(
+        error.message.contains("non-empty reason"),
+        "{}",
+        error.message
+    );
     assert_eq!(task_store.get(&id).unwrap().status, TaskStatus::Closed);
 }
 
@@ -674,7 +691,10 @@ async fn test_cd24_supervisor_can_reopen_blocked_task_with_reason() {
     let task_store = open_task_store(&cas_dir).unwrap();
 
     let created = core
-        .cas_task_create(Parameters(create_req("blocked reopen with reason", Some("light"))))
+        .cas_task_create(Parameters(create_req(
+            "blocked reopen with reason",
+            Some("light"),
+        )))
         .await
         .expect("task_create should succeed");
     let id = extract_task_id(&extract_text(created))
@@ -698,7 +718,10 @@ async fn test_cd24_supervisor_can_reopen_blocked_task_with_reason() {
         let text = extract_text(
             core.cas_task_reopen(Parameters(TaskReopenRequest {
                 id: id.clone(),
-                reason: Some("Withdrew the iOS background-auto-start AC — Apple does not permit it.".to_string()),
+                reason: Some(
+                    "Withdrew the iOS background-auto-start AC — Apple does not permit it."
+                        .to_string(),
+                ),
             }))
             .await
             .expect("supervisor reopen of a blocked task should succeed"),
@@ -720,7 +743,8 @@ async fn test_cd24_supervisor_can_reopen_blocked_task_with_reason() {
         "reopen must transition a Blocked task to Open"
     );
     assert!(
-        task.notes.contains("Withdrew the iOS background-auto-start AC"),
+        task.notes
+            .contains("Withdrew the iOS background-auto-start AC"),
         "reopen reason must be captured in the audit trail (task.notes): {:?}",
         task.notes
     );
@@ -802,7 +826,7 @@ async fn test_cd24_reopen_rejects_other_statuses_and_names_alternative() {
         let r = core
             .cas_task_reopen(Parameters(TaskReopenRequest {
                 id: id.clone(),
-                reason: None,
+                reason: Some("exercise nonterminal reopen rejection".to_string()),
             }))
             .await;
         unsafe {
@@ -856,7 +880,10 @@ async fn test_start_on_closed_message_is_worker_appropriate() {
                 "worker-facing start-on-closed message should direct to the supervisor: {msg}"
             );
         }
-        Ok(ok) => panic!("expected start-on-closed to fail, got: {}", extract_text(ok)),
+        Ok(ok) => panic!(
+            "expected start-on-closed to fail, got: {}",
+            extract_text(ok)
+        ),
     }
 }
 
@@ -894,6 +921,9 @@ async fn test_start_on_closed_message_is_supervisor_appropriate() {
                 "supervisor-facing message should not use the worker refusal wording: {msg}"
             );
         }
-        Ok(ok) => panic!("expected start-on-closed to fail, got: {}", extract_text(ok)),
+        Ok(ok) => panic!(
+            "expected start-on-closed to fail, got: {}",
+            extract_text(ok)
+        ),
     }
 }

--- a/cas-cli/tests/mcp_tools_test/task_tools/reopen_atomicity.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/reopen_atomicity.rs
@@ -1,5 +1,5 @@
 use crate::support::*;
-use cas::mcp::tools::{TaskReopenRequest, TaskUpdateRequest};
+use cas::mcp::tools::TaskReopenRequest;
 use cas::store::{
     open_agent_store, open_event_store, open_recording_store, open_supervisor_queue_store,
     open_task_store, open_verification_store,
@@ -47,7 +47,6 @@ struct ClosedFixture {
     service: cas::mcp::CasCore,
     task_id: String,
     old_epic_id: String,
-    new_epic_id: String,
     dispatch_id: String,
 }
 
@@ -77,13 +76,6 @@ impl ClosedFixture {
         );
         old_epic.task_type = cas::types::TaskType::Epic;
         task_store.add(&old_epic).expect("old epic");
-        let mut new_epic = Task::new(
-            format!("cas-new-epic-{suffix}"),
-            "Replacement parent epic".to_string(),
-        );
-        new_epic.task_type = cas::types::TaskType::Epic;
-        task_store.add(&new_epic).expect("new epic");
-
         let mut task = Task::new(
             format!("cas-reopen-{suffix}"),
             "Failure-atomic reopen".to_string(),
@@ -139,7 +131,6 @@ impl ClosedFixture {
             service,
             task_id: task.id,
             old_epic_id: old_epic.id,
-            new_epic_id: new_epic.id,
             dispatch_id: dispatch.id,
         }
     }
@@ -148,25 +139,10 @@ impl ClosedFixture {
         self.temp.path().join(".cas")
     }
 
-    fn update_request(&self) -> TaskUpdateRequest {
-        TaskUpdateRequest {
-            blocked_by: None,
+    fn reopen_request(&self) -> TaskReopenRequest {
+        TaskReopenRequest {
             id: self.task_id.clone(),
-            title: None,
-            notes: None,
-            priority: None,
-            labels: None,
-            description: None,
-            design: None,
-            acceptance_criteria: None,
-            demo_statement: None,
-            execution_note: None,
-            external_ref: None,
-            assignee: None,
-            status: Some("open".to_string()),
-            epic: Some(self.new_epic_id.clone()),
-            epic_verification_owner: None,
-            depth: None,
+            reason: Some("exercise atomic terminal reopen".to_string()),
         }
     }
 }
@@ -230,7 +206,7 @@ fn install_failure(conn: &Connection, name: &str, body: &str) {
 }
 
 #[tokio::test]
-async fn update_reopen_rolls_back_every_later_write_and_retries_idempotently() {
+async fn reopen_rolls_back_every_later_write_and_retries_idempotently() {
     let fixture = ClosedFixture::new("update");
     let _env_lock = env_test_lock();
     let _env = EnvGuard::set(&[
@@ -253,13 +229,6 @@ async fn update_reopen_rolls_back_every_later_write_and_retries_idempotently() {
             format!("BEFORE UPDATE ON tasks WHEN OLD.id = '{}'", fixture.task_id),
         ),
         (
-            "fail_reopen_dependency",
-            format!(
-                "BEFORE DELETE ON dependencies WHEN OLD.from_id = '{}'",
-                fixture.task_id
-            ),
-        ),
-        (
             "fail_reopen_event",
             format!(
                 "BEFORE INSERT ON events WHEN NEW.entity_id = '{}'",
@@ -277,7 +246,7 @@ async fn update_reopen_rolls_back_every_later_write_and_retries_idempotently() {
         install_failure(&conn, name, &body);
         let result = fixture
             .service
-            .cas_task_update(Parameters(fixture.update_request()))
+            .cas_task_reopen(Parameters(fixture.reopen_request()))
             .await;
         assert!(result.is_err(), "{name} must surface");
         conn.execute_batch(&format!("DROP TRIGGER {name};"))
@@ -287,7 +256,7 @@ async fn update_reopen_rolls_back_every_later_write_and_retries_idempotently() {
 
     fixture
         .service
-        .cas_task_update(Parameters(fixture.update_request()))
+        .cas_task_reopen(Parameters(fixture.reopen_request()))
         .await
         .expect("retry after failures");
     let after = snapshot(&fixture);
@@ -300,7 +269,7 @@ async fn update_reopen_rolls_back_every_later_write_and_retries_idempotently() {
         .get_dependencies(&fixture.task_id)
         .expect("parents");
     assert_eq!(parents.len(), 1);
-    assert_eq!(parents[0].to_id, fixture.new_epic_id);
+    assert_eq!(parents[0].to_id, fixture.old_epic_id);
     assert_eq!(
         cas_store::get_verification_dispatch(&fixture.cas_dir(), &fixture.dispatch_id)
             .expect("dispatch")
@@ -310,10 +279,10 @@ async fn update_reopen_rolls_back_every_later_write_and_retries_idempotently() {
 
     let retry = fixture
         .service
-        .cas_task_update(Parameters(fixture.update_request()))
+        .cas_task_reopen(Parameters(fixture.reopen_request()))
         .await
-        .expect("exact update retry");
-    assert!(extract_text(retry).contains("No changes specified"));
+        .expect("exact reopen retry");
+    assert!(extract_text(retry).contains("idempotently"));
     assert_eq!(
         snapshot(&fixture),
         after,

--- a/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
@@ -3355,7 +3355,7 @@ async fn test_reopened_task_does_not_reuse_stale_anchor_cas_cf64() {
             service
                 .cas_task_reopen(Parameters(TaskReopenRequest {
                     id: id_a.clone(),
-                    reason: None,
+                    reason: Some("new commit requires a fresh close cycle".to_string()),
                 }))
                 .await
                 .expect("reopen returns"),

--- a/cas-cli/tests/pull_watermark_recovery_test.rs
+++ b/cas-cli/tests/pull_watermark_recovery_test.rs
@@ -15,7 +15,7 @@ use cas::store::{
     open_rule_store_local, open_skill_store_local, open_spec_store, open_store_local,
     open_task_store_local,
 };
-use cas::types::{Entry, EntryType, Scope};
+use cas::types::{Entry, EntryType, Scope, Task, TaskStatus};
 use wiremock::matchers::{method, path, query_param, query_param_is_missing};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -154,5 +154,132 @@ async fn empty_first_pull_then_corrected_bucket_backfills_without_metadata_surge
         queue.get_metadata("last_pull_at").unwrap().as_deref(),
         Some("2026-08-09T18:10:00Z"),
         "once a project has a successful watermark, empty incremental pulls still advance it"
+    );
+}
+
+/// cas-b4fc / GH #516: a terminal task rejected for an unattributed remote
+/// reopen must be durably journaled and must advance the pull watermark.  The
+/// following incremental pull therefore cannot receive that old bad row again.
+#[tokio::test]
+async fn unattributed_terminal_reopen_is_journaled_once_and_not_retried_next_pull() {
+    let server = MockServer::start().await;
+    let project_id = cas::cloud::get_project_canonical_id()
+        .expect("test must run inside a project with a canonical id");
+    let initial_pulled_at = "2026-08-20T15:10:00Z";
+
+    let mut remote = Task::new(
+        "cas-unattributed-two-cycle".to_string(),
+        "remote zombie reopen".to_string(),
+    );
+    remote.status = TaskStatus::Open;
+    remote.updated_at = chrono::Utc::now() + chrono::Duration::minutes(1);
+    remote.notes = "[2026-08-20 15:09] Reopened: missing audit fields".to_string();
+    let mut remote_json = serde_json::to_value(remote).unwrap();
+    remote_json["project_id"] = serde_json::json!(project_id);
+    remote_json["project_canonical_id"] = serde_json::json!(project_id);
+
+    Mock::given(method("GET"))
+        .and(path("/api/sync/pull"))
+        .and(query_param("project_id", project_id.as_str()))
+        .and(query_param_is_missing("since"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": [], "tasks": [remote_json], "rules": [], "skills": [],
+            "specs": [], "events": [], "prompts": [],
+            "file_changes": [], "commit_links": [],
+            "pulled_at": initial_pulled_at,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/sync/pull"))
+        .and(query_param("project_id", project_id.as_str()))
+        .and(query_param("since", initial_pulled_at))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": [], "tasks": [], "rules": [], "skills": [],
+            "specs": [], "events": [], "prompts": [],
+            "file_changes": [], "commit_links": [],
+            "pulled_at": "2026-08-20T15:11:00Z",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cas_root = tmp.path().join(".cas");
+    std::fs::create_dir_all(&cas_root).unwrap();
+    let store = open_store_local(&cas_root).unwrap();
+    let task_store = open_task_store_local(&cas_root).unwrap();
+    let rule_store = open_rule_store_local(&cas_root).unwrap();
+    let skill_store = open_skill_store_local(&cas_root).unwrap();
+    let spec_store = open_spec_store(&cas_root).unwrap();
+    let event_store = open_event_store(&cas_root).unwrap();
+    let prompt_store = open_prompt_store(&cas_root).unwrap();
+    let file_change_store = open_file_change_store(&cas_root).unwrap();
+    let commit_link_store = open_commit_link_store(&cas_root).unwrap();
+    let queue = Arc::new(SyncQueue::open(&cas_root).unwrap());
+    queue.init().unwrap();
+
+    let mut local = Task::new(
+        "cas-unattributed-two-cycle".to_string(),
+        "locally closed task".to_string(),
+    );
+    local.status = TaskStatus::Closed;
+    local.closed_at = Some(
+        chrono::DateTime::parse_from_rfc3339("2026-08-20T15:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+    );
+    task_store.add(&local).unwrap();
+
+    let syncer = CloudSyncer::new(
+        Arc::clone(&queue),
+        CloudConfig {
+            endpoint: server.uri(),
+            token: Some("test-token".to_string()),
+            ..Default::default()
+        },
+        CloudSyncerConfig::default(),
+    );
+    let pull = || {
+        syncer.pull(
+            store.as_ref(),
+            task_store.as_ref(),
+            rule_store.as_ref(),
+            skill_store.as_ref(),
+            spec_store.as_ref(),
+            event_store.as_ref(),
+            prompt_store.as_ref(),
+            file_change_store.as_ref(),
+            commit_link_store.as_ref(),
+        )
+    };
+
+    let rejected = pull().expect("unattributed reopen response is handled");
+    assert_eq!(rejected.conflicts_resolved, 1);
+    let conflicts = queue.list_conflicts(10).unwrap();
+    assert_eq!(conflicts.len(), 1);
+    assert_eq!(conflicts[0].strategy, "terminal_status_guard");
+    assert_eq!(
+        queue.get_metadata("last_pull_at").unwrap().as_deref(),
+        Some(initial_pulled_at),
+        "the rejected row still advances the successful pull watermark"
+    );
+    assert_eq!(
+        task_store.get("cas-unattributed-two-cycle").unwrap().status,
+        TaskStatus::Closed,
+    );
+
+    let next_cycle = pull().expect("incremental follow-up pull succeeds");
+    assert_eq!(next_cycle.conflicts_resolved, 0);
+    assert_eq!(
+        queue.list_conflicts(10).unwrap().len(),
+        1,
+        "the rejected terminal reopen is journaled once, not retried"
+    );
+    assert_eq!(
+        queue.get_metadata("last_pull_at").unwrap().as_deref(),
+        Some("2026-08-20T15:11:00Z"),
+        "the healthy second cycle advances from the rejected row's watermark"
     );
 }


### PR DESCRIPTION
Fixes #516

Prevents generic status updates from exiting terminal task states, keeps attributed supervisor reopen as the sanctioned path, rejects unattributed terminal rows during cloud pull, and advances the watermark after the durable conflict journal so rejected rows do not recur.