### PR TITLE
feat(hooks): enforceable staging.scratch_root in the factory workspace contract

### DIFF
--- a/cas-cli/src/config/access/get.rs
+++ b/cas-cli/src/config/access/get.rs
@@ -80,6 +80,7 @@ impl Config {
             "staging.staging_dir" | "staging.large_artifact_dir" => {
                 Some(staging.staging_dir.unwrap_or_default())
             }
+            "staging.scratch_root" => Some(staging.scratch_root.unwrap_or_default()),
             "staging.tmpfs_warning_threshold_bytes" => {
                 Some(staging.tmpfs_warning_threshold_bytes.to_string())
             }

--- a/cas-cli/src/config/access/list.rs
+++ b/cas-cli/src/config/access/list.rs
@@ -170,6 +170,10 @@ impl Config {
                 staging.staging_dir.clone().unwrap_or_default(),
             ),
             (
+                "staging.scratch_root".to_string(),
+                staging.scratch_root.clone().unwrap_or_default(),
+            ),
+            (
                 "staging.tmpfs_warning_threshold_bytes".to_string(),
                 staging.tmpfs_warning_threshold_bytes.to_string(),
             ),

--- a/cas-cli/src/config/access/set.rs
+++ b/cas-cli/src/config/access/set.rs
@@ -285,6 +285,14 @@ impl Config {
                     Some(value.to_string())
                 };
             }
+            "staging.scratch_root" => {
+                let staging = self.staging.get_or_insert_with(StagingConfig::default);
+                staging.scratch_root = if value.is_empty() {
+                    None
+                } else {
+                    Some(value.to_string())
+                };
+            }
             "staging.tmpfs_warning_threshold_bytes" => {
                 let staging = self.staging.get_or_insert_with(StagingConfig::default);
                 staging.tmpfs_warning_threshold_bytes = value

--- a/cas-cli/src/config/meta/seed/hooks_and_code.rs
+++ b/cas-cli/src/config/meta/seed/hooks_and_code.rs
@@ -352,6 +352,23 @@ pub(super) fn register_hooks_and_code(registry: &mut ConfigRegistry) {
     });
 
     registry.register(ConfigMeta {
+        key: "staging.scratch_root",
+        section: "staging",
+        name: "Agent Scratch Root",
+        description: "Configured root for ephemeral agent writes. The PreToolUse workspace guard permits file and directory creation below this root, while writes outside the worktree, durable artifacts root, system temp directory, and explicit harness exceptions are denied.",
+        value_type: ConfigType::String,
+        default: "",
+        constraint: Constraint::None,
+        advanced: false,
+        requires_feature: None,
+        keywords: &["staging", "scratch", "workspace", "guardrail", "pretooluse", "agent", "temporary"],
+        use_cases: &[
+            "Keep agent-generated logs and temporary fixtures under one disk-backed root",
+            "Enforce a host-specific scratch location without moving source or durable proof",
+        ],
+    });
+
+    registry.register(ConfigMeta {
         key: "staging.tmpfs_warning_threshold_bytes",
         section: "staging",
         name: "tmpfs Warning Threshold",

--- a/cas-cli/src/config/meta/seed/sections.rs
+++ b/cas-cli/src/config/meta/seed/sections.rs
@@ -63,7 +63,7 @@ pub(super) fn add_section_descriptions(registry: &mut ConfigRegistry) {
     );
     registry.section_descriptions.insert(
         "staging",
-        "Durable staging paths and tmpfs write guardrails",
+        "Durable staging paths, agent scratch roots, and tmpfs write guardrails",
     );
     registry.section_descriptions.insert(
         "factory",

--- a/cas-cli/src/config/mod.rs
+++ b/cas-cli/src/config/mod.rs
@@ -82,8 +82,8 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub factory: Option<FactoryConfig>,
 
-    /// `[staging]` — durable staging path and tmpfs/ramfs warning thresholds
-    /// for hook-side large-write guardrails.
+    /// `[staging]` — durable staging, configured agent scratch paths, and
+    /// tmpfs/ramfs warning thresholds for hook-side write guardrails.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub staging: Option<StagingConfig>,
 

--- a/cas-cli/src/config/mod_tests.rs
+++ b/cas-cli/src/config/mod_tests.rs
@@ -131,9 +131,13 @@ fn config_set_supports_staging_keys_and_alias() {
     config
         .set("staging.tmpfs_warning_threshold_bytes", "2048")
         .unwrap();
+    config
+        .set("staging.scratch_root", "/mnt/agent-scratch")
+        .unwrap();
 
     let staging = config.staging.as_ref().expect("staging section");
     assert_eq!(staging.staging_dir.as_deref(), Some("/mnt/large-artifacts"));
+    assert_eq!(staging.scratch_root.as_deref(), Some("/mnt/agent-scratch"));
     assert_eq!(staging.tmpfs_warning_threshold_bytes, 2048);
 
     config.set("staging.staging_dir", "").unwrap();
@@ -142,6 +146,15 @@ fn config_set_supports_staging_keys_and_alias() {
             .staging
             .as_ref()
             .and_then(|staging| staging.staging_dir.as_deref()),
+        None
+    );
+
+    config.set("staging.scratch_root", "").unwrap();
+    assert_eq!(
+        config
+            .staging
+            .as_ref()
+            .and_then(|staging| staging.scratch_root.as_deref()),
         None
     );
 }

--- a/cas-cli/src/config/settings.rs
+++ b/cas-cli/src/config/settings.rs
@@ -229,6 +229,13 @@ pub struct StagingConfig {
     )]
     pub staging_dir: Option<String>,
 
+    /// Root for ephemeral agent-created files such as logs, generated fixtures,
+    /// and scratch checkouts. When configured, the PreToolUse workspace guard
+    /// permits writes below this root in addition to the worktree and durable
+    /// factory artifacts root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scratch_root: Option<String>,
+
     /// Warn when cumulative session writes or tmpfs usage growth crosses this
     /// many bytes on a tmpfs/ramfs-backed mount. Default: 1 GiB.
     #[serde(default = "default_tmpfs_warning_threshold_bytes")]
@@ -245,6 +252,7 @@ impl Default for StagingConfig {
     fn default() -> Self {
         Self {
             staging_dir: None,
+            scratch_root: None,
             tmpfs_warning_threshold_bytes: default_tmpfs_warning_threshold_bytes(),
         }
     }
@@ -1143,15 +1151,17 @@ mod tests {
             DEFAULT_TMPFS_WARNING_THRESHOLD_BYTES
         );
         assert_eq!(sc.staging_dir, None);
+        assert_eq!(sc.scratch_root, None);
     }
 
     #[test]
     fn staging_config_roundtrips_staging_dir_and_threshold() {
-        let toml_str = "[staging]\nstaging_dir = \"/mnt/durable/cas-staging\"\ntmpfs_warning_threshold_bytes = 2048\n";
+        let toml_str = "[staging]\nstaging_dir = \"/mnt/durable/cas-staging\"\nscratch_root = \"/mnt/durable/cas-scratch\"\ntmpfs_warning_threshold_bytes = 2048\n";
         let parsed: std::collections::HashMap<String, StagingConfig> =
             toml::from_str(toml_str).expect("valid toml");
         let sc = parsed.get("staging").expect("section present");
         assert_eq!(sc.staging_dir.as_deref(), Some("/mnt/durable/cas-staging"));
+        assert_eq!(sc.scratch_root.as_deref(), Some("/mnt/durable/cas-scratch"));
         assert_eq!(sc.tmpfs_warning_threshold_bytes, 2048);
     }
 

--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -289,8 +289,8 @@ pub fn handle_pre_tool_use(
 
     // Durable workspace contract (GH #196, GH #528). Factory file creation is
     // intentionally narrow: the checked-out worktree, a configured durable
-    // artifacts root, an optional configured scratch root, system temp, and
-    // the harness-provided scratchpad are sanctioned.
+    // artifacts root, an optional configured scratch root, and the
+    // harness-provided scratchpad are sanctioned.
     // Supervisors may also write the harness's per-project file-memory tree;
     // workers remain restricted to the original roots.
     // A scratchpad may itself be under /tmp, but it is explicitly ephemeral
@@ -316,7 +316,7 @@ pub fn handle_pre_tool_use(
             return Ok(HookOutput::with_pre_tool_permission(
                 "deny",
                 &format!(
-                    "🚫 FACTORY WORKSPACE CONTRACT: file creation outside the worktree, durable artifacts root, configured scratch root, system temp, or harness exceptions is blocked: {}. Use your worktree, `{}/<task-id>/` for durable proof{}; system temp is for tool-managed temporary files only.",
+                    "🚫 FACTORY WORKSPACE CONTRACT: file creation outside the worktree, durable artifacts root, configured scratch root, or harness exceptions is blocked: {}. Use your worktree, `{}/<task-id>/` for durable proof{}; only this session's harness scratchpad is sanctioned for ephemeral notes. Bare /tmp and stray $HOME files are not sanctioned.",
                     path.display(),
                     artifacts.display(),
                     scratch
@@ -1520,12 +1520,6 @@ fn unsanctioned_factory_path(
             scratch_root,
         )));
     }
-    // Do not turn a configured scratch root into a requirement for system
-    // tools. `std::env::temp_dir` respects the host's documented temp setup
-    // (`TMPDIR` et al.) and keeps explicit temp-file workflows working. It is
-    // deliberately kept separate: a test or unusual host can locate `$HOME`
-    // under `/tmp`, which must not turn arbitrary home writes into temp files.
-    let system_temp = lexically_normalize_path(std::env::temp_dir());
     for key in ["CAS_SCRATCHPAD", "CAS_SCRATCHPAD_PATH", "CLAUDE_SCRATCHPAD"] {
         if let Some(value) = std::env::var_os(key) {
             sanctioned.push(lexically_normalize_path(std::path::PathBuf::from(value)));
@@ -1545,12 +1539,10 @@ fn unsanctioned_factory_path(
         lexically_normalize_path(std::path::PathBuf::from(&input.cwd).join(raw_path))
     };
     let is_explicitly_sanctioned = sanctioned.iter().any(|root| path.starts_with(root));
-    let is_home_path = home.as_ref().is_some_and(|home| path.starts_with(home));
     if is_non_creation_stream_device(&path)
         || is_harness_session_scratchpad(&path, &input.session_id)
         || (is_supervisor && is_harness_file_memory_path(&path, home.as_deref()))
         || is_explicitly_sanctioned
-        || (!is_home_path && path.starts_with(&system_temp))
     {
         return None;
     }
@@ -1743,7 +1735,7 @@ mod workspace_contract_tests {
     }
 
     #[test]
-    fn system_temp_and_relative_worktree_writes_remain_sanctioned() {
+    fn relative_worktree_writes_remain_sanctioned_and_bare_tmp_is_denied() {
         let cwd = tempfile::tempdir().expect("worktree");
         let input = bash_input("true", cwd.path());
 
@@ -1762,8 +1754,8 @@ mod workspace_contract_tests {
                     .join("cas-3bd6-tool-temp.log")
                     .to_string_lossy(),
             ),
-            None,
-            "system temp is an explicit workspace-contract exception"
+            Some(std::env::temp_dir().join("cas-3bd6-tool-temp.log")),
+            "bare system temp must remain outside the workspace contract"
         );
     }
 }

--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -287,28 +287,39 @@ pub fn handle_pre_tool_use(
     // instead of calling open_*() directly, reducing ~11 SQLite connections to ~3-4.
     let mut stores = ToolHookStores::new(cas_root);
 
-    // Durable workspace contract (GH #196).  Factory file creation is
+    // Durable workspace contract (GH #196, GH #528). Factory file creation is
     // intentionally narrow: the checked-out worktree, a configured durable
-    // artifacts root, and the harness-provided scratchpad are sanctioned.
+    // artifacts root, an optional configured scratch root, system temp, and
+    // the harness-provided scratchpad are sanctioned.
     // Supervisors may also write the harness's per-project file-memory tree;
     // workers remain restricted to the original roots.
     // A scratchpad may itself be under /tmp, but it is explicitly ephemeral
     // and is rejected later if cited as close evidence.
     if is_factory_agent {
-        let factory = stores.config().factory();
+        let config = stores.config();
+        let factory = config.factory();
+        let scratch_root = config
+            .staging
+            .as_ref()
+            .and_then(|staging| staging.scratch_root.as_deref());
         if let Some(path) = factory_unsanctioned_write_path(
             input,
             &factory.artifacts_root,
+            scratch_root,
             crate::harness_policy::is_supervisor(input),
         ) {
-            let artifacts = crate::config::resolved_factory_artifacts_root(
-                factory.artifacts_root.as_deref(),
-            );
+            let artifacts =
+                crate::config::resolved_factory_artifacts_root(factory.artifacts_root.as_deref());
+            let scratch = scratch_root
+                .map(|root| format!(" or `{root}/...` for ephemeral scratch output"))
+                .unwrap_or_default();
             return Ok(HookOutput::with_pre_tool_permission(
                 "deny",
                 &format!(
-                    "🚫 FACTORY WORKSPACE CONTRACT: file creation outside the worktree, durable artifacts root, or harness scratchpad is blocked: {}. Use your worktree, `{}/<task-id>/` for durable proof, or the harness scratchpad only for ephemeral notes. Bare /tmp and stray $HOME files are not sanctioned.",
-                    path.display(), artifacts.display()
+                    "🚫 FACTORY WORKSPACE CONTRACT: file creation outside the worktree, durable artifacts root, configured scratch root, system temp, or harness exceptions is blocked: {}. Use your worktree, `{}/<task-id>/` for durable proof{}; system temp is for tool-managed temporary files only.",
+                    path.display(),
+                    artifacts.display(),
+                    scratch
                 ),
             ));
         }
@@ -1460,6 +1471,7 @@ fn is_harness_session_scratchpad(path: &std::path::Path, session_id: &str) -> bo
 fn factory_unsanctioned_write_path(
     input: &HookInput,
     configured_artifacts_root: &Option<String>,
+    configured_scratch_root: Option<&str>,
     is_supervisor: bool,
 ) -> Option<std::path::PathBuf> {
     let tool = input.tool_name.as_deref()?;
@@ -1479,43 +1491,91 @@ fn factory_unsanctioned_write_path(
     };
 
     raw_paths.into_iter().find_map(|raw_path| {
-        unsanctioned_factory_path(input, configured_artifacts_root, is_supervisor, &raw_path)
+        unsanctioned_factory_path(
+            input,
+            configured_artifacts_root,
+            configured_scratch_root,
+            is_supervisor,
+            &raw_path,
+        )
     })
 }
 
 fn unsanctioned_factory_path(
     input: &HookInput,
     configured_artifacts_root: &Option<String>,
+    configured_scratch_root: Option<&str>,
     is_supervisor: bool,
     raw_path: &str,
 ) -> Option<std::path::PathBuf> {
     let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
-    let mut sanctioned = vec![std::path::PathBuf::from(&input.cwd)];
-    sanctioned.push(crate::config::resolved_factory_artifacts_root(
-        configured_artifacts_root.as_deref(),
+    let mut sanctioned = vec![lexically_normalize_path(std::path::PathBuf::from(
+        &input.cwd,
+    ))];
+    sanctioned.push(lexically_normalize_path(
+        crate::config::resolved_factory_artifacts_root(configured_artifacts_root.as_deref()),
     ));
+    if let Some(scratch_root) = configured_scratch_root.filter(|root| !root.trim().is_empty()) {
+        sanctioned.push(lexically_normalize_path(std::path::PathBuf::from(
+            scratch_root,
+        )));
+    }
+    // Do not turn a configured scratch root into a requirement for system
+    // tools. `std::env::temp_dir` respects the host's documented temp setup
+    // (`TMPDIR` et al.) and keeps explicit temp-file workflows working. It is
+    // deliberately kept separate: a test or unusual host can locate `$HOME`
+    // under `/tmp`, which must not turn arbitrary home writes into temp files.
+    let system_temp = lexically_normalize_path(std::env::temp_dir());
     for key in ["CAS_SCRATCHPAD", "CAS_SCRATCHPAD_PATH", "CLAUDE_SCRATCHPAD"] {
         if let Some(value) = std::env::var_os(key) {
-            sanctioned.push(std::path::PathBuf::from(value));
+            sanctioned.push(lexically_normalize_path(std::path::PathBuf::from(value)));
         }
     }
 
-    let path = if let Some(suffix) = raw_path.strip_prefix("~/") {
+    let raw_path = if let Some(suffix) = raw_path.strip_prefix("~/") {
         home.as_ref()?.join(suffix)
     } else if let Some(suffix) = raw_path.strip_prefix("$HOME/") {
         home.as_ref()?.join(suffix)
     } else {
         std::path::PathBuf::from(raw_path)
     };
-    if !path.is_absolute()
-        || is_non_creation_stream_device(&path)
+    let path = if raw_path.is_absolute() {
+        lexically_normalize_path(raw_path)
+    } else {
+        lexically_normalize_path(std::path::PathBuf::from(&input.cwd).join(raw_path))
+    };
+    let is_explicitly_sanctioned = sanctioned.iter().any(|root| path.starts_with(root));
+    let is_home_path = home.as_ref().is_some_and(|home| path.starts_with(home));
+    if is_non_creation_stream_device(&path)
         || is_harness_session_scratchpad(&path, &input.session_id)
         || (is_supervisor && is_harness_file_memory_path(&path, home.as_deref()))
-        || sanctioned.iter().any(|root| path.starts_with(root))
+        || is_explicitly_sanctioned
+        || (!is_home_path && path.starts_with(&system_temp))
     {
         return None;
     }
     Some(path)
+}
+
+/// Normalize `.` and `..` without requiring the target to exist. Write
+/// guardrails decide before creation, so `canonicalize` would both fail for
+/// the common case and make a configured root vulnerable to `root/../escape`.
+fn lexically_normalize_path(path: std::path::PathBuf) -> std::path::PathBuf {
+    use std::path::Component;
+
+    let mut normalized = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    normalized
 }
 
 /// The Claude harness persists its direct file memory per project below
@@ -1632,11 +1692,79 @@ mod workspace_contract_tests {
         ] {
             let input = bash_input(command, cwd.path());
             assert_eq!(
-                factory_unsanctioned_write_path(&input, &None, false),
+                factory_unsanctioned_write_path(&input, &None, None, false),
                 Some(home.path().join(expected)),
                 "write must remain guarded: {command}"
             );
         }
+    }
+
+    #[test]
+    fn configured_scratch_root_allows_its_children_and_denies_escape() {
+        let cwd = tempfile::tempdir().expect("worktree");
+        let input = bash_input("true", cwd.path());
+        let scratch = std::path::PathBuf::from("/var/lib/cas-3bd6-scratch");
+        let scratch_root = scratch.to_string_lossy().to_string();
+        let outside = std::path::PathBuf::from("/var/lib/cas-3bd6-outside/stray.log");
+
+        assert_eq!(
+            unsanctioned_factory_path(
+                &input,
+                &None,
+                Some(&scratch_root),
+                false,
+                &scratch.join("logs/build.log").to_string_lossy(),
+            ),
+            None,
+            "configured scratch root must permit nested output"
+        );
+        assert_eq!(
+            unsanctioned_factory_path(
+                &input,
+                &None,
+                Some(&scratch_root),
+                false,
+                &scratch.join("../escape.log").to_string_lossy(),
+            ),
+            Some(scratch.parent().unwrap().join("escape.log")),
+            "a lexical parent traversal must not escape the configured root"
+        );
+        assert_eq!(
+            unsanctioned_factory_path(
+                &input,
+                &None,
+                Some(&scratch_root),
+                false,
+                &outside.to_string_lossy(),
+            ),
+            Some(outside),
+            "configured scratch enforcement must deny unrelated host paths"
+        );
+    }
+
+    #[test]
+    fn system_temp_and_relative_worktree_writes_remain_sanctioned() {
+        let cwd = tempfile::tempdir().expect("worktree");
+        let input = bash_input("true", cwd.path());
+
+        assert_eq!(
+            unsanctioned_factory_path(&input, &None, None, false, "relative-output.log"),
+            None,
+            "relative outputs resolve inside the current worktree"
+        );
+        assert_eq!(
+            unsanctioned_factory_path(
+                &input,
+                &None,
+                None,
+                false,
+                &std::env::temp_dir()
+                    .join("cas-3bd6-tool-temp.log")
+                    .to_string_lossy(),
+            ),
+            None,
+            "system temp is an explicit workspace-contract exception"
+        );
     }
 }
 


### PR DESCRIPTION
Agents can no longer scatter scratch files across $HOME: the PreToolUse workspace contract now accepts an optional `staging.scratch_root` config naming the single approved scratch location, allowing writes below it (with lexical `..` escapes denied) alongside the existing sanctioned set — worktree, durable artifacts root, system temp, harness exceptions. Hosts without the config keep today's behavior unchanged, and the denial message names every approved destination including the configured root.

Full config plumbing (get/set/list/meta/TOML roundtrip) and docs. Proof: workspace contract tests 6/6, config set/get, settings roundtrip.

Fixes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)