### PR TITLE
fix(commander): FACTORY/TASKS panes derive epic liveness from task status, not residual queue rows

### DIFF
--- a/cas-cli/src/ui/factory/director/factory_radar.rs
+++ b/cas-cli/src/ui/factory/director/factory_radar.rs
@@ -315,8 +315,7 @@ const MAX_UNFOCUSED_EPIC_ROWS: usize = 4;
 /// per frame (the exact pattern cas-eb7f deduped next door in the TASKS
 /// panel).
 fn unfocused_live_epic_groups(data: &DirectorData) -> Vec<cas_factory::EpicGroup> {
-    data.tasks_by_epic()
-        .0
+    data.live_epic_groups()
         .into_iter()
         .filter(|group| {
             crate::ui::factory::director::tasks::epic_is_renderable_source_blind(
@@ -438,7 +437,7 @@ fn render_unfocused_overview(
             .iter()
             .filter(|t| t.status == TaskStatus::InProgress)
             .count();
-        let queued = group.subtasks.len().saturating_sub(active);
+        let queued = group.subtasks.iter().filter(|task| task.status == TaskStatus::Open).count();
         let counts = format!("  {active} active, {queued} queued");
         let title_budget = (area.width as usize)
             .saturating_sub(group.epic.id.len() + 4 + counts.len())
@@ -606,7 +605,7 @@ fn render_summary_bar(
     let queue_count = data
         .ready_tasks
         .iter()
-        .filter(|t| t.status == TaskStatus::Open)
+        .filter(|task| data.is_live_queue_task(task))
         .count();
     let blocked_count = data
         .in_progress_tasks
@@ -1058,6 +1057,27 @@ mod tests {
             !text.contains("No focused epic"),
             "bare dead-zone placeholder must not render when live epics exist: {text}"
         );
+    }
+
+    #[test]
+    fn factory_radar_ignores_closed_epic_residue_and_counts_only_live_queue_tasks() {
+        let mut data = data_with_two_live_epics();
+        data.ready_tasks.push(subtask("cas-closed-child", "Stale queued child", TaskStatus::Open, "cas-closed", None));
+        data.epic_tasks.push(task("cas-closed", "Closed epic with residual queue row", TaskStatus::Closed, TaskType::Epic));
+        data.epic_tasks.push(task("cas-empty", "Open epic without children", TaskStatus::Open, TaskType::Epic));
+
+        let backend = TestBackend::new(100, 16);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = ActiveTheme::default();
+        terminal.draw(|frame| {
+            render_with_focus(frame, frame.area(), &data, &theme, None, None, false, None, "supervisor", false);
+        }).unwrap();
+
+        let text = buffer_text(&terminal);
+        assert!(text.contains("Live epics (3):"), "wrong liveness set: {text}");
+        assert!(text.contains("cas-empty"), "open empty epic must render: {text}");
+        assert!(!text.contains("cas-closed"), "closed epic and its residual child must not render: {text}");
+        assert!(text.contains("Queue 2"), "terminal residue inflated queue: {text}");
     }
 
     /// cas-582d AC3: unfocused with no session-visible live epics still

--- a/cas-cli/src/ui/factory/director/tasks.rs
+++ b/cas-cli/src/ui/factory/director/tasks.rs
@@ -32,7 +32,7 @@ impl ScopedTaskView {
         // hint leaked a cross-project epic's id/title whenever the session
         // shared a Cassy project's task DB with another session/project.
         let unfocused_live_epics = if focused_epic_id.is_none() {
-            epic_groups
+            data.live_epic_groups()
                 .iter()
                 .filter(|group| epic_is_renderable_source_blind(data, &group.epic.id))
                 .map(|group| (group.epic.id.clone(), group.epic.title.clone()))
@@ -598,6 +598,18 @@ mod tests {
         // caller relies on `epic_groups` instead.
         let focused = ScopedTaskView::new(&data, Some("cas-focused"));
         assert!(focused.unfocused_live_epics.is_empty());
+    }
+
+    #[test]
+    fn scoped_task_view_unfocused_hint_excludes_closed_parent_residue() {
+        let mut data = data_for_scoping();
+        data.epic_tasks.iter_mut().find(|epic| epic.id == "cas-focused").expect("fixture includes focused epic").status = TaskStatus::Closed;
+        data.epic_tasks.push(task("cas-empty-open", "Open epic without child rows", TaskType::Epic, None, None));
+
+        let scoped = ScopedTaskView::new(&data, None);
+        let hint_ids: Vec<_> = scoped.unfocused_live_epics.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(hint_ids, vec!["cas-empty-open"]);
+        assert!(!hint_ids.contains(&"cas-focused"), "an Open child cannot make a Closed parent epic live again");
     }
 
     /// cas-6185c AC1: THE regression this fix-round exists for — the

--- a/crates/cas-factory/src/director.rs
+++ b/crates/cas-factory/src/director.rs
@@ -683,6 +683,58 @@ impl DirectorData {
 
         (groups, standalone)
     }
+
+    /// Epics that are live enough to appear in an unfocused factory overview.
+    ///
+    /// A residual Open child must never resurrect a terminal parent epic in a
+    /// pane. Conversely, an Open/InProgress epic remains useful orientation
+    /// even before its first child has been created, so it is retained with an
+    /// empty subtask list.
+    pub fn live_epic_groups(&self) -> Vec<EpicGroup> {
+        let (groups, _) = self.tasks_by_epic();
+        let mut grouped: HashMap<String, EpicGroup> = groups
+            .into_iter()
+            .map(|group| (group.epic.id.clone(), group))
+            .collect();
+
+        let mut live_groups: Vec<EpicGroup> = self
+            .epic_tasks
+            .iter()
+            .filter(|epic| matches!(epic.status, TaskStatus::Open | TaskStatus::InProgress))
+            .map(|epic| {
+                grouped.remove(&epic.id).unwrap_or_else(|| EpicGroup {
+                    epic: epic.clone(),
+                    subtasks: Vec::new(),
+                    has_active: false,
+                })
+            })
+            .collect();
+
+        live_groups.sort_by(|a, b| {
+            group_recency(b)
+                .cmp(&group_recency(a))
+                .then_with(|| a.has_active.cmp(&b.has_active).reverse())
+                .then_with(|| a.epic.priority.0.cmp(&b.epic.priority.0))
+                .then_with(|| a.epic.id.cmp(&b.epic.id))
+        });
+
+        live_groups
+    }
+
+    /// Whether an Open task belongs in the FACTORY queue counter.
+    ///
+    /// Standalone tasks are queueable on their own. Epic children require a
+    /// currently live parent; this prevents stale child rows from a Closed or
+    /// Cancelled epic inflating the actionable queue.
+    pub fn is_live_queue_task(&self, task: &TaskSummary) -> bool {
+        task.status == TaskStatus::Open
+            && task.epic.as_ref().is_none_or(|epic_id| {
+                self.epic_tasks.iter().any(|epic| {
+                    epic.id == *epic_id
+                        && matches!(epic.status, TaskStatus::Open | TaskStatus::InProgress)
+                })
+            })
+    }
 }
 
 /// Newest `updated_at` across an epic group (the epic row and all of its
@@ -1108,5 +1160,49 @@ mod tests {
             worker_summary.pending_supervisor_messages, 0,
             "a backed-off supervisor row must not permanently latch the idle transition"
         );
+    }
+
+    #[test]
+    fn live_epic_groups_exclude_terminal_parent_residue_and_keep_empty_open_epics() {
+        fn summary(id: &str, status: TaskStatus, task_type: TaskType, epic: Option<&str>) -> TaskSummary {
+            TaskSummary {
+                id: id.to_string(),
+                title: id.to_string(),
+                status,
+                priority: Priority::MEDIUM,
+                assignee: None,
+                task_type,
+                epic: epic.map(str::to_string),
+                branch: None,
+                updated_at: None,
+                epic_verification_owner: None,
+            }
+        }
+
+        let terminal_child = summary("cas-closed-child", TaskStatus::Open, TaskType::Task, Some("cas-closed"));
+        let live_child = summary("cas-open-child", TaskStatus::Open, TaskType::Task, Some("cas-open"));
+        let data = DirectorData {
+            ready_tasks: vec![terminal_child.clone(), live_child.clone()],
+            in_progress_tasks: Vec::new(),
+            epic_tasks: vec![
+                summary("cas-closed", TaskStatus::Closed, TaskType::Epic, None),
+                summary("cas-open", TaskStatus::Open, TaskType::Epic, None),
+                summary("cas-empty", TaskStatus::InProgress, TaskType::Epic, None),
+            ],
+            agents: Vec::new(),
+            activity: Vec::new(),
+            agent_id_to_name: HashMap::new(),
+            changes: Vec::new(),
+            git_loaded: false,
+            reminders: Vec::new(),
+            epic_closed_counts: HashMap::new(),
+        };
+
+        let live_groups = data.live_epic_groups();
+        let live_ids: Vec<_> = live_groups.iter().map(|group| group.epic.id.as_str()).collect();
+        assert_eq!(live_ids, vec!["cas-empty", "cas-open"]);
+        assert!(live_groups.iter().any(|group| group.epic.id == "cas-empty" && group.subtasks.is_empty()));
+        assert!(!data.is_live_queue_task(&terminal_child));
+        assert!(data.is_live_queue_task(&live_child));
     }
 }


### PR DESCRIPTION
Commander's FACTORY pane no longer lists long-closed epics as "Live epics" with phantom queued counts: a shared `live_epic_groups()` projection makes the parent epic's task status (Open/InProgress, plus explicit focus) authoritative for liveness, keeps open epics visible even with zero children, and excludes children of terminal or missing parents from the FACTORY Queue counter. The TASKS pane's unfocused hint consumes the same projection, so a stale Open child can no longer resurrect a Closed parent in either pane.

Regression tests pin the incident shapes: closed-epic residue with queued children renders not-live, and an empty open epic renders live.

Fixes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)