### PR TITLE
fix: clarify Viktor operator key source

### DIFF
--- a/cas-cli/src/cli/viktor.rs
+++ b/cas-cli/src/cli/viktor.rs
@@ -142,7 +142,7 @@ pub fn execute(args: &ViktorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
             }
         );
         if !report.credential_present {
-            println!("  setup: cas viktor key");
+            println!("  setup: cas viktor key (paste a key from the Viktor operator)");
             println!("  key source: get an operator-issued key from the Viktor operator");
         } else {
             println!("  credential source: {}", report.credential_source);


### PR DESCRIPTION
Clarifies that Viktor provisioning
  credential: VIKTOR_API_KEY (not set)
  user config: /home/pippenz/.config/code-mode-mcp/config.toml
  project policy: none; managed user policy applies
  start: run cas serve without a project proxy config; startup refreshes the credential-reference-only managed Viktor upstream
  upstream: upstream absent (Backoff; connection_failed)
  watched runs pending: 0
  inbound questions pending: 0
  replies: run-starting calls are durably watched by CAS; replies and Viktor-originated questions arrive as inbound notifications (origin=viktor), and disconnected/no-live states remain durable instead of being dropped setup expects the key from the Viktor operator.\n\nFresh delivery anchor for cas-2fb63 after PR #552 merged.