### PR TITLE
fix(factory): durable relay when a delivery PR is ejected from the merge queue

### DIFF
--- a/cas-cli/src/ui/factory/daemon/runtime/ci_watch.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/ci_watch.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use cas_store::{NotificationPriority, PromptQueueStore};
 use serde::Deserialize;
 
-use crate::bounded_process::{run_command, Deadline};
+use crate::bounded_process::{Deadline, run_command};
 
 /// The GitHub Actions polling cadence.  A factory uses at most 60 list calls
 /// per hour; failed runs add one jobs call and one optional log lookup.
@@ -66,6 +66,7 @@ pub(crate) trait CiTransport {
     fn completed_runs(&self) -> Result<Vec<CiRun>, CiWatchError>;
     fn failing_job(&self, run_id: u64) -> Result<String, CiWatchError>;
     fn failed_log(&self, run_id: u64) -> Result<Option<String>, CiWatchError>;
+    fn merge_queue_pull_requests(&self) -> Result<Vec<MergeQueuePullRequest>, CiWatchError>;
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -76,6 +77,41 @@ pub(crate) struct CiRun {
     pub html_url: String,
     pub status: String,
     pub conclusion: Option<String>,
+    #[serde(default)]
+    pub event: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AwaitingMergeDelivery {
+    pub task_id: String,
+    pub worker: String,
+    pub branch: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct MergeQueuePullRequest {
+    pub number: u64,
+    #[serde(rename = "headRefName")]
+    pub head_branch: String,
+    #[serde(rename = "isInMergeQueue")]
+    pub is_in_merge_queue: bool,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MergeQueueEjection {
+    pub task_id: String,
+    pub worker: String,
+    pub pr_number: u64,
+    pub failed_run_id: Option<u64>,
+    pub occurrence: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct MergeQueuePoll {
+    pub queued_prs: BTreeSet<u64>,
+    pub ejections: Vec<MergeQueueEjection>,
 }
 
 #[derive(Deserialize)]
@@ -92,6 +128,27 @@ struct JobsResponse {
 struct CiJob {
     name: String,
     conclusion: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct MergeQueueGraphqlResponse {
+    data: MergeQueueGraphqlData,
+}
+
+#[derive(Deserialize)]
+struct MergeQueueGraphqlData {
+    repository: MergeQueueRepository,
+}
+
+#[derive(Deserialize)]
+struct MergeQueueRepository {
+    #[serde(rename = "pullRequests")]
+    pull_requests: MergeQueuePullRequests,
+}
+
+#[derive(Deserialize)]
+struct MergeQueuePullRequests {
+    nodes: Vec<MergeQueuePullRequest>,
 }
 
 /// Real, bounded `gh` transport.  The watcher intentionally uses the CLI so
@@ -215,6 +272,98 @@ impl CiTransport for GhCiTransport {
         ])?;
         Ok((!log.is_empty()).then_some(log))
     }
+
+    fn merge_queue_pull_requests(&self) -> Result<Vec<MergeQueuePullRequest>, CiWatchError> {
+        let repo = crate::cli::integrate::github::RepoRef::from_owner_slash_repo(&self.repo)
+            .ok_or_else(|| {
+                CiWatchError::Unavailable(
+                    "invalid GitHub repository for merge-queue watcher".to_string(),
+                )
+            })?;
+        let query = "query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { pullRequests(first: 100, states: OPEN) { nodes { number headRefName isInMergeQueue updatedAt } } } }";
+        let response: MergeQueueGraphqlResponse = self.gh_json(&[
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={query}"),
+            "-F".to_string(),
+            format!("owner={}", repo.owner),
+            "-F".to_string(),
+            format!("name={}", repo.repo),
+        ])?;
+        Ok(response.data.repository.pull_requests.nodes)
+    }
+}
+
+fn merge_group_pr_number(branch: &str) -> Option<u64> {
+    let (_, suffix) = branch.rsplit_once("/pr-")?;
+    suffix.split_once('-')?.0.parse().ok()
+}
+
+/// The queue snapshot is intentionally small: one GraphQL open-PR listing and
+/// the existing completed-runs listing per minute. A delivery is ejected when
+/// its open PR leaves a previously-observed queue, or when a failed
+/// `merge_group` run proves that ejection after a daemon restart.
+pub(crate) fn collect_merge_queue_ejections(
+    transport: &dyn CiTransport,
+    deliveries: &[AwaitingMergeDelivery],
+    previously_queued: &BTreeSet<u64>,
+) -> Result<MergeQueuePoll, CiWatchError> {
+    let pulls = transport.merge_queue_pull_requests()?;
+    let runs = transport.completed_runs()?;
+    let mut failed_runs = BTreeMap::<u64, u64>::new();
+    for run in runs {
+        if run.event == "merge_group"
+            && run.conclusion.as_deref() == Some("failure")
+            && let Some(pr) = merge_group_pr_number(&run.head_branch)
+        {
+            failed_runs
+                .entry(pr)
+                .and_modify(|current| *current = (*current).max(run.id))
+                .or_insert(run.id);
+        }
+    }
+
+    let mut poll = MergeQueuePoll::default();
+    for delivery in deliveries {
+        let Some(pr) = pulls.iter().find(|pr| pr.head_branch == delivery.branch) else {
+            // A normally merged PR leaves the open-PR listing; it is never an ejection.
+            continue;
+        };
+        if pr.is_in_merge_queue {
+            poll.queued_prs.insert(pr.number);
+            continue;
+        }
+        let failed_run_id = failed_runs.get(&pr.number).copied();
+        if !previously_queued.contains(&pr.number) && failed_run_id.is_none() {
+            continue;
+        }
+        // A prior observed queue membership starts a fresh episode even when
+        // GitHub still lists the previous red run. This re-arms an admin
+        // dequeue/auto-merge disarm after a requeue; a restart without that
+        // in-memory observation instead keys directly to the failed run.
+        let occurrence = if previously_queued.contains(&pr.number) {
+            format!(
+                "queue-exit:{}:{}",
+                pr.updated_at,
+                failed_run_id
+                    .map(|run_id| format!("merge-group-run:{run_id}"))
+                    .unwrap_or_else(|| "no-failed-run".to_string())
+            )
+        } else {
+            failed_run_id
+                .map(|run_id| format!("merge-group-run:{run_id}"))
+                .expect("failed run required without an observed queue membership")
+        };
+        poll.ejections.push(MergeQueueEjection {
+            task_id: delivery.task_id.clone(),
+            worker: delivery.worker.clone(),
+            pr_number: pr.number,
+            failed_run_id,
+            occurrence,
+        });
+    }
+    Ok(poll)
 }
 
 /// Keep only the latest completed failure for each watched branch.
@@ -361,6 +510,7 @@ mod tests {
 
     struct FakeTransport {
         runs: Vec<CiRun>,
+        pulls: Vec<MergeQueuePullRequest>,
         job: String,
         log: Option<String>,
         calls: Cell<u8>,
@@ -377,6 +527,9 @@ mod tests {
         fn failed_log(&self, _: u64) -> Result<Option<String>, CiWatchError> {
             Ok(self.log.clone())
         }
+        fn merge_queue_pull_requests(&self) -> Result<Vec<MergeQueuePullRequest>, CiWatchError> {
+            Ok(self.pulls.clone())
+        }
     }
 
     fn run(branch: &str, conclusion: Option<&str>) -> CiRun {
@@ -391,6 +544,16 @@ mod tests {
             html_url: format!("https://github.test/org/repo/actions/runs/{id}"),
             status: "completed".to_string(),
             conclusion: conclusion.map(str::to_string),
+            event: "push".to_string(),
+        }
+    }
+
+    fn pull(number: u64, branch: &str, queued: bool, updated_at: &str) -> MergeQueuePullRequest {
+        MergeQueuePullRequest {
+            number,
+            head_branch: branch.to_string(),
+            is_in_merge_queue: queued,
+            updated_at: updated_at.to_string(),
         }
     }
 
@@ -398,6 +561,7 @@ mod tests {
     fn failed_completed_live_lane_emits_a_relay_with_job_and_test() {
         let transport = FakeTransport {
             runs: vec![run("factory/bright-otter", Some("failure"))],
+            pulls: Vec::new(),
             job: "Fast Validation".to_string(),
             log: Some("test contract_conflict_regression ... FAILED".to_string()),
             calls: Cell::new(0),
@@ -420,6 +584,7 @@ mod tests {
                 run_with("main", "stale-red", 41, Some("failure")),
                 run_with("main", "current-green", 42, Some("success")),
             ],
+            pulls: Vec::new(),
             job: "should not run".to_string(),
             log: None,
             calls: Cell::new(0),
@@ -440,6 +605,7 @@ mod tests {
                 run_with("main", "middle-red", 41, Some("failure")),
                 run_with("main", "current-red", 42, Some("failure")),
             ],
+            pulls: Vec::new(),
             job: "Fast Validation".to_string(),
             log: None,
             calls: Cell::new(0),
@@ -522,6 +688,7 @@ mod tests {
     fn green_runs_are_silent_without_expensive_job_lookup() {
         let transport = FakeTransport {
             runs: vec![run("main", Some("success"))],
+            pulls: Vec::new(),
             job: "should not run".to_string(),
             log: None,
             calls: Cell::new(0),
@@ -529,6 +696,101 @@ mod tests {
         let failures = collect_failures(&transport, &BTreeSet::from(["main".to_string()])).unwrap();
         assert!(failures.is_empty());
         assert_eq!(transport.calls.get(), 0);
+    }
+
+    #[test]
+    fn failed_merge_group_ejection_is_once_per_episode_and_rearms_on_requeue() {
+        let delivery = AwaitingMergeDelivery {
+            task_id: "cas-fc35".to_string(),
+            worker: "fast-jaguar-59".to_string(),
+            branch: "factory/fast-jaguar-59".to_string(),
+        };
+        let mut failed = run_with(
+            "gh-readonly-queue/main/pr-556-base",
+            "queue-sha",
+            901,
+            Some("failure"),
+        );
+        failed.event = "merge_group".to_string();
+        let ejected = FakeTransport {
+            runs: vec![failed.clone()],
+            pulls: vec![pull(556, &delivery.branch, false, "2026-08-20T15:32:03Z")],
+            job: String::new(),
+            log: None,
+            calls: Cell::new(0),
+        };
+        let first = collect_merge_queue_ejections(
+            &ejected,
+            std::slice::from_ref(&delivery),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert_eq!(first.ejections.len(), 1);
+        assert_eq!(first.ejections[0].failed_run_id, Some(901));
+        assert_eq!(first.ejections[0].occurrence, "merge-group-run:901");
+
+        let requeued = FakeTransport {
+            runs: vec![failed],
+            pulls: vec![pull(556, &delivery.branch, true, "2026-08-20T15:40:00Z")],
+            job: String::new(),
+            log: None,
+            calls: Cell::new(0),
+        };
+        let queued = collect_merge_queue_ejections(
+            &requeued,
+            std::slice::from_ref(&delivery),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert!(queued.ejections.is_empty(), "normal requeue must be silent");
+        assert_eq!(queued.queued_prs, BTreeSet::from([556]));
+
+        let mut second_failed = run_with(
+            "gh-readonly-queue/main/pr-556-next-base",
+            "queue-sha-2",
+            902,
+            Some("failure"),
+        );
+        second_failed.event = "merge_group".to_string();
+        let re_ejected = FakeTransport {
+            runs: vec![second_failed],
+            pulls: vec![pull(556, &delivery.branch, false, "2026-08-20T15:42:00Z")],
+            job: String::new(),
+            log: None,
+            calls: Cell::new(0),
+        };
+        let second =
+            collect_merge_queue_ejections(&re_ejected, &[delivery], &queued.queued_prs).unwrap();
+        assert_eq!(second.ejections.len(), 1);
+        assert_eq!(second.ejections[0].failed_run_id, Some(902));
+        assert_ne!(
+            first.ejections[0].occurrence,
+            second.ejections[0].occurrence
+        );
+
+        let normal_merge = FakeTransport {
+            runs: Vec::new(),
+            pulls: Vec::new(),
+            job: String::new(),
+            log: None,
+            calls: Cell::new(0),
+        };
+        let normal_delivery = AwaitingMergeDelivery {
+            task_id: "cas-fc35".to_string(),
+            worker: "fast-jaguar-59".to_string(),
+            branch: "factory/fast-jaguar-59".to_string(),
+        };
+        assert!(
+            collect_merge_queue_ejections(
+                &normal_merge,
+                &[normal_delivery],
+                &BTreeSet::from([556]),
+            )
+            .unwrap()
+            .ejections
+            .is_empty(),
+            "a normally merged PR must not relay"
+        );
     }
 
     #[test]
@@ -544,6 +806,11 @@ mod tests {
                 unreachable!()
             }
             fn failed_log(&self, _: u64) -> Result<Option<String>, CiWatchError> {
+                unreachable!()
+            }
+            fn merge_queue_pull_requests(
+                &self,
+            ) -> Result<Vec<MergeQueuePullRequest>, CiWatchError> {
                 unreachable!()
             }
         }

--- a/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
@@ -88,6 +88,141 @@ pub(super) fn enqueue_worker_unavailable_relay(
     )
 }
 
+/// A parked delivery whose PR was ejected must wake the supervisor *and* put
+/// a durable instruction in the delivering worker's inbox. The occurrence is
+/// a failed merge-group run ID when available, so a requeue naturally arms a
+/// new episode while repeated polls/restarts stay idempotent.
+pub(super) fn enqueue_merge_queue_ejection_relay(
+    cas_dir: &std::path::Path,
+    task_id: &str,
+    worker: &str,
+    pr_number: u64,
+    failed_run_id: Option<u64>,
+    occurrence: &str,
+) -> WorkerAttentionRelayOutcome {
+    use crate::mcp::tools::core::task::lifecycle::supervisor_push::{
+        LIFECYCLE_WAKE_SOURCE_PREFIX, resolve_owning_supervisor,
+    };
+    use cas_store::{NotificationPriority, NotifyIdempotentResult};
+
+    let factory_session = std::env::var("CAS_FACTORY_SESSION").ok();
+    let Ok(agent_store) = crate::store::open_agent_store(cas_dir) else {
+        return WorkerAttentionRelayOutcome::Pending;
+    };
+    let Some(supervisor) =
+        resolve_owning_supervisor(agent_store.as_ref(), factory_session.as_deref())
+    else {
+        return WorkerAttentionRelayOutcome::Pending;
+    };
+    let detail = match failed_run_id {
+        Some(run_id) => format!(
+            "Delivery PR #{pr_number} for {task_id} left the merge queue after failed merge_group run {run_id}."
+        ),
+        None => format!(
+            "Delivery PR #{pr_number} for {task_id} left the merge queue without merging (dequeued or auto-merge disarmed)."
+        ),
+    };
+    let key = format!(
+        "merge-queue-ejection:{}:{task_id}:{pr_number}:{occurrence}",
+        factory_session.as_deref().unwrap_or("")
+    );
+    let Ok(supervisor_queue) = crate::store::open_supervisor_queue_store(cas_dir) else {
+        return WorkerAttentionRelayOutcome::Pending;
+    };
+    let payload = serde_json::json!({
+        "kind": "merge_queue_ejected",
+        "worker": worker,
+        "task_id": task_id,
+        "pr_number": pr_number,
+        "failed_run_id": failed_run_id,
+        "detail": detail,
+        "occurrence": occurrence,
+    })
+    .to_string();
+    let notification_id = match supervisor_queue.notify_idempotent(
+        &supervisor.agent_id,
+        "merge_queue_ejected",
+        &payload,
+        NotificationPriority::High,
+        &key,
+    ) {
+        Ok(NotifyIdempotentResult::Created(id)) => id,
+        Ok(NotifyIdempotentResult::AlreadyExists {
+            id,
+            prompt_delivered: true,
+        }) => {
+            return WorkerAttentionRelayOutcome::Persisted {
+                notification_id: id,
+            };
+        }
+        Ok(NotifyIdempotentResult::AlreadyExists {
+            id,
+            prompt_delivered: false,
+        }) => id,
+        Err(error) => {
+            tracing::error!(task_id, pr_number, %error, "merge-queue ejection durable enqueue failed");
+            return WorkerAttentionRelayOutcome::Pending;
+        }
+    };
+    let Ok(prompt_queue) = crate::store::open_prompt_queue_store(cas_dir) else {
+        return WorkerAttentionRelayOutcome::Pending;
+    };
+    let supervisor_body = format!(
+        "<worker-attention kind=\"merge_queue_ejected\" worker=\"{worker}\" task_id=\"{task_id}\" notification_id=\"{notification_id}\">\n{detail}\nInspect the failed run and requeue or request changes.\n</worker-attention>"
+    );
+    let source = format!("{LIFECYCLE_WAKE_SOURCE_PREFIX}worker-attention:{notification_id}");
+    if prompt_queue.enqueue_idempotent(
+        &source,
+        "supervisor",
+        &supervisor_body,
+        factory_session.as_deref(),
+        Some(&format!("merge queue ejected: {task_id}")),
+        Some(NotificationPriority::High),
+        &format!("merge-queue-ejection-outbox:{notification_id}"),
+    ).is_err() || prompt_queue.enqueue_idempotent(
+        "merge-queue-ejection",
+        worker,
+        &format!("{detail}\nWait for the supervisor's merge recovery instructions before starting other work."),
+        factory_session.as_deref(),
+        Some(&format!("merge queue ejected: {task_id}")),
+        Some(NotificationPriority::High),
+        &format!("merge-queue-ejection-worker:{key}"),
+    ).is_err() {
+        return WorkerAttentionRelayOutcome::Pending;
+    }
+    let Ok(task_store) = crate::store::open_task_store(cas_dir) else {
+        return WorkerAttentionRelayOutcome::Pending;
+    };
+    let Ok(mut task) = task_store.get(task_id) else {
+        return WorkerAttentionRelayOutcome::Pending;
+    };
+    let marker = format!("merge-queue-ejection occurrence={occurrence}");
+    if !task.notes.contains(&marker) {
+        let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M");
+        let note = format!("[{timestamp}] 🚫 BLOCKER {detail} ({marker}).");
+        task.notes = if task.notes.is_empty() {
+            note
+        } else {
+            format!("{}\n\n{note}", task.notes)
+        };
+        task.updated_at = chrono::Utc::now();
+        if let Err(error) = task_store.update(&task) {
+            tracing::warn!(task_id, %error, "merge-queue ejection task note write failed");
+            return WorkerAttentionRelayOutcome::Pending;
+        }
+    }
+    // Keep the durable outbox replayable until the task-note receipt exists;
+    // otherwise a one-off store failure would leave an alert with no audit
+    // trail while future polls short-circuited as already delivered.
+    if supervisor_queue
+        .mark_prompt_delivered(notification_id)
+        .is_err()
+    {
+        return WorkerAttentionRelayOutcome::Pending;
+    }
+    WorkerAttentionRelayOutcome::Persisted { notification_id }
+}
+
 /// A relay is consumed by an in-memory detector only after both durable lanes
 /// are confirmed. `Pending` deliberately leaves that detector eligible for a
 /// retry; the occurrence key makes the replay idempotent after a partial write.
@@ -283,6 +418,68 @@ mod worker_attention_tests {
                 && row.prompt.contains("limited-codex")
                 && row.prompt.contains("terminal unavailable state")
         }));
+    }
+
+    #[test]
+    fn merge_queue_ejection_relays_to_supervisor_and_worker_once_and_notes_task() {
+        let _env = crate::test_support::TestEnvGuard::with_vars(&[(
+            "CAS_FACTORY_SESSION",
+            "merge-queue-ejection-test",
+        )]);
+        let temp = tempfile::TempDir::new().unwrap();
+        let cas_dir = crate::store::init_cas_dir(temp.path()).unwrap();
+        register_supervisor(&cas_dir, "merge-queue-ejection-test");
+        let task_store = crate::store::open_task_store(&cas_dir).unwrap();
+        let mut task = cas_types::Task::new("cas-fc35".to_string(), "parked delivery".to_string());
+        task.status = cas_types::TaskStatus::AwaitingMerge;
+        task.assignee = Some("fast-jaguar-59".to_string());
+        task_store.add(&task).unwrap();
+
+        let first = enqueue_merge_queue_ejection_relay(
+            &cas_dir,
+            "cas-fc35",
+            "fast-jaguar-59",
+            556,
+            Some(32386300052),
+            "merge-group-run:32386300052",
+        );
+        let replay = enqueue_merge_queue_ejection_relay(
+            &cas_dir,
+            "cas-fc35",
+            "fast-jaguar-59",
+            556,
+            Some(32386300052),
+            "merge-group-run:32386300052",
+        );
+        assert!(matches!(
+            first,
+            WorkerAttentionRelayOutcome::Persisted { .. }
+        ));
+        assert!(matches!(
+            replay,
+            WorkerAttentionRelayOutcome::Persisted { .. }
+        ));
+        let queue = crate::store::open_prompt_queue_store(&cas_dir).unwrap();
+        let rows = queue.peek_all(10).unwrap();
+        assert_eq!(
+            rows.len(),
+            2,
+            "one supervisor relay plus one worker inbox row"
+        );
+        assert!(rows.iter().any(|row| row.target == "supervisor"
+            && row.prompt.contains("failed merge_group run 32386300052")));
+        assert!(
+            rows.iter()
+                .any(|row| row.target == "fast-jaguar-59" && row.prompt.contains("PR #556"))
+        );
+        let persisted = task_store.get("cas-fc35").unwrap();
+        assert_eq!(
+            persisted
+                .notes
+                .matches("merge-queue-ejection occurrence=merge-group-run:32386300052")
+                .count(),
+            1
+        );
     }
 }
 
@@ -575,9 +772,21 @@ impl FactoryDaemon {
             .checked_sub(super::ci_watch::CI_WATCH_INTERVAL)
             .unwrap_or_else(std::time::Instant::now);
         let mut ci_watch_task: Option<
-            JoinHandle<Result<Vec<super::ci_watch::CiFailure>, super::ci_watch::CiWatchError>>,
+            JoinHandle<
+                Result<
+                    (
+                        Vec<super::ci_watch::CiFailure>,
+                        super::ci_watch::MergeQueuePoll,
+                    ),
+                    super::ci_watch::CiWatchError,
+                >,
+            >,
         > = None;
         let mut ci_watch_unavailable_reported = false;
+        // Queue membership is intentionally process-local: the durable relay
+        // key is the recovery boundary. A failed merge_group run also lets the
+        // first poll after a daemon restart recover a real ejection.
+        let mut last_merge_queue_membership = std::collections::BTreeSet::new();
         let refresh_interval = Duration::from_secs(2);
         let poll_interval = Duration::from_millis(100);
 
@@ -701,6 +910,28 @@ impl FactoryDaemon {
                     && last_ci_watch.elapsed() >= super::ci_watch::CI_WATCH_INTERVAL
                 {
                     let project = self.app.project_path().to_path_buf();
+                    let deliveries = crate::store::open_task_store(self.app.cas_dir())
+                        .ok()
+                        .and_then(|store| {
+                            store.list(Some(cas_types::TaskStatus::AwaitingMerge)).ok()
+                        })
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter_map(|task| {
+                            let worker = task.assignee?;
+                            let branch = task
+                                .deliverables
+                                .parked_branch
+                                .or(task.branch)
+                                .unwrap_or_else(|| format!("factory/{worker}"));
+                            Some(super::ci_watch::AwaitingMergeDelivery {
+                                task_id: task.id,
+                                worker,
+                                branch,
+                            })
+                        })
+                        .collect::<Vec<_>>();
+                    let previously_queued = last_merge_queue_membership.clone();
                     let mut watched_branches =
                         std::collections::BTreeSet::from(["main".to_string()]);
                     if let Some(manager) = self.app.worktree_manager() {
@@ -723,7 +954,14 @@ impl FactoryDaemon {
                     }
                     ci_watch_task = Some(tokio::task::spawn_blocking(move || {
                         let transport = super::ci_watch::GhCiTransport::from_project(&project)?;
-                        super::ci_watch::collect_failures(&transport, &watched_branches)
+                        let failures =
+                            super::ci_watch::collect_failures(&transport, &watched_branches)?;
+                        let queue_poll = super::ci_watch::collect_merge_queue_ejections(
+                            &transport,
+                            &deliveries,
+                            &previously_queued,
+                        )?;
+                        Ok((failures, queue_poll))
                     }));
                     last_ci_watch = std::time::Instant::now();
                 }
@@ -731,8 +969,35 @@ impl FactoryDaemon {
                 if ci_watch_task.as_ref().is_some_and(JoinHandle::is_finished) {
                     let task = ci_watch_task.take().expect("checked above");
                     match task.await {
-                        Ok(Ok(failures)) => {
+                        Ok(Ok((failures, queue_poll))) => {
                             ci_watch_unavailable_reported = false;
+                            last_merge_queue_membership = queue_poll.queued_prs;
+                            for ejection in queue_poll.ejections {
+                                match enqueue_merge_queue_ejection_relay(
+                                    self.app.cas_dir(),
+                                    &ejection.task_id,
+                                    &ejection.worker,
+                                    ejection.pr_number,
+                                    ejection.failed_run_id,
+                                    &ejection.occurrence,
+                                ) {
+                                    WorkerAttentionRelayOutcome::Persisted { notification_id } => {
+                                        tracing::warn!(
+                                            task_id = %ejection.task_id,
+                                            pr_number = ejection.pr_number,
+                                            failed_run_id = ?ejection.failed_run_id,
+                                            notification_id,
+                                            "queued durable merge-queue ejection relay for supervisor and worker"
+                                        )
+                                    }
+                                    WorkerAttentionRelayOutcome::Pending => tracing::warn!(
+                                        task_id = %ejection.task_id,
+                                        pr_number = ejection.pr_number,
+                                        "merge-queue ejection relay remains pending"
+                                    ),
+                                    WorkerAttentionRelayOutcome::NotApplicable => {}
+                                }
+                            }
                             if !failures.is_empty() {
                                 match crate::store::open_prompt_queue_store(self.app.cas_dir()) {
                                     Ok(queue) => {


### PR DESCRIPTION
An awaiting_merge task whose delivery PR fails its merge_group run (or is otherwise dequeued unmerged) no longer waits in silence: the existing once-per-minute bounded CI watcher now also snapshots merge-queue membership via one GraphQL call, and a detected ejection pushes an episode-keyed durable supervisor notification (ACK-bridged), a worker inbox message, and a task note carrying the failed run id. Re-queueing re-arms the episode; normal merges relay nothing.

Born from today's live incident: PRs #556/#557 dropped silently while their delivering workers sat parked. Seam regression proof 2/2 with a faked transport; cargo check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)