### PR TITLE
Fix macOS release onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Knowledge stays local-first: the SQLite metadata and markdown bodies are the sou
 ## Quick Start
 
 ```bash
-# Install (Linux x86_64)
+# Install (Linux x86_64 or macOS Apple Silicon)
 curl -fsSL https://raw.githubusercontent.com/Richards-LLC/cassy/main/scripts/cas-install.sh | bash
 
 # Initialize in your project — writes .mcp.json, .claude/settings.json hooks,
@@ -202,7 +202,14 @@ Installs the latest release binary to `~/.local/bin/cas`. Override with `CAS_INS
 
 ### macOS (Apple Silicon)
 
-The installer script is Linux-only today. Releases publish a macOS ARM64 tarball — grab `cas-aarch64-apple-darwin.tar.gz` from [Releases](https://github.com/Richards-LLC/cassy/releases) and drop `cas` on your `PATH`, or build from source. A full from-zero Mac walkthrough lives in [docs/onboarding/macbook-from-zero.md](docs/onboarding/macbook-from-zero.md).
+```bash
+curl -fsSL https://raw.githubusercontent.com/Richards-LLC/cassy/main/scripts/cas-install.sh | bash
+```
+
+The installer downloads the release asset for Apple Silicon and clears its
+macOS quarantine attribute after installation. Intel Macs do not have a
+published release asset; build from source instead. A full from-zero Mac
+walkthrough lives in [docs/onboarding/macbook-from-zero.md](docs/onboarding/macbook-from-zero.md).
 
 ### Build from source
 

--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -218,6 +218,7 @@ test-ci-tiers:
 	cd .. && ./scripts/test-release-published-receipt.sh
 	cd .. && ./scripts/test-check-release-preflight.sh
 	cd .. && ./scripts/test-check-release-host.sh
+	cd .. && ./scripts/test-cas-install.sh
 	cd .. && ./scripts/test-check-release-migration-snapshots.sh
 
 # Type check

--- a/docs/onboarding/2026-08-17-mac-setup-petra-stella.md
+++ b/docs/onboarding/2026-08-17-mac-setup-petra-stella.md
@@ -1,8 +1,8 @@
 # Cassy on a Mac from zero — Petra Stella team member guide
 
-Date: 2026-08-17 · Revised 2026-08-18 after a clean-install run found the step order, `cas cloud team`, and `cas update --user` claims wrong · Verified against: Cassy v2.72.0 (released 2026-08-17), `cas` CLI help and measured command behaviour on a live install · Audience: a new Petra Stella team member with an Apple Silicon Mac and terminal comfort.
+Date: 2026-08-17 · Revised 2026-08-20 for the supported macOS release installer and documented team-membership flow · Audience: a new Petra Stella team member with an Apple Silicon Mac and terminal comfort.
 
-**Time: about 15 minutes**, none of it compiling. This uses the published release binary, not a source build. (The older `docs/onboarding/macbook-from-zero.md` is the source-build path for people hacking on Cassy itself; it predates current releases — see Known gaps.)
+**Time: about 15 minutes**, none of it compiling. This uses the published release binary, not a source build. The [MacBook from zero guide](macbook-from-zero.md) has the same binary fast path plus the contributor source-build path.
 
 ---
 
@@ -28,22 +28,20 @@ Steps 1 and 2 are safe to paste twice: each `~/.zprofile` line is appended only 
 
 ## 2. Install the Cassy binary
 
-> **Heads-up (gap #469):** the documented one-liner installer (`cas-install.sh`) currently refuses macOS even though macOS builds ship with every release. Until that fix lands, download the release asset directly:
-
 ```bash
-mkdir -p ~/.local/bin && cd "$(mktemp -d)"
-curl -fsSL -o cas.tar.gz \
-  https://github.com/Richards-LLC/cassy/releases/latest/download/cas-aarch64-apple-darwin.tar.gz
-tar -xzf cas.tar.gz
-mv cas ~/.local/bin/cas && chmod +x ~/.local/bin/cas
-xattr -d com.apple.quarantine ~/.local/bin/cas 2>/dev/null || true  # Gatekeeper
-grep -qxF 'export PATH=$HOME/.local/bin:$PATH' ~/.zprofile 2>/dev/null \
-  || echo 'export PATH=$HOME/.local/bin:$PATH' >> ~/.zprofile
-export PATH=$HOME/.local/bin:$PATH   # this shell; ~/.zprofile covers new ones
-cas --version                        # expect: cas 2.72.0 (or newer)
+curl -fsSL https://raw.githubusercontent.com/Richards-LLC/cassy/main/scripts/cas-install.sh | bash
 ```
 
-The block used to end with `exec zsh -l`, which replaced the shell mid-paste so the lines after it never ran. `export PATH=…` does the same job for the current shell and lets the rest of the block finish. New terminals pick the PATH up from `~/.zprofile`.
+The installer prints a PATH fix if `~/.local/bin` is absent from your shell.
+Apply it for this shell, then confirm the installed release:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+cas --version
+```
+
+It also clears the downloaded binary's `com.apple.quarantine` attribute, so no
+manual Gatekeeper command is necessary.
 
 ## 3. One-time Cassy setup
 
@@ -115,6 +113,17 @@ Since v2.72.0 sync is also honest: it prints a summary of any task-status change
 - **Pulling the team pool:** happens automatically with sync; `cas cloud team-memories` forces an immediate incremental pull for the current project (`--full` re-pulls everything, `--dry-run` previews).
 - Memories are project-scoped by the project's canonical slug, which auto-derives from the git remote — so `cas init` in a shared repo is all it takes for your context to line up with the team's.
 
+### Adding a new team member
+
+`cas cloud team` selects an existing membership; it cannot invite or grant one.
+Before a new teammate starts setup, a current Petra Stella Cloud team
+administrator must add the teammate's Cassy Cloud account email to the team.
+After that, the teammate runs `cas login --token <their-personal-api-key>` and,
+inside an initialized shared project, `cas cloud team show`. If they belong to
+multiple teams, they select this one with `cas cloud team set
+<team-slug-or-uuid>` and run `cas cloud sync`. If `team show` reports no team,
+the administrator should recheck the account email and membership.
+
 ## 7. Per project
 
 Run this from inside the project, never from your home directory — `cas init` scaffolds `.cas/`, `CLAUDE.md`, `.gitignore`, `.mcp.json` and `scripts/` into whatever directory you are standing in. (After v2.72.0 it refuses to do that in `$HOME` and tells you to `cd` first; on 2.72.0 itself it does it silently.)
@@ -140,12 +149,6 @@ Then start working: bare `cas` launches the factory TUI with defaults.
 - Hub unreachable from hub.petrastella.io → `cas hub service status`; confirm Tailscale is connected; re-pair if the Commander shows "Machine needs pairing".
 - Anything else → `cas doctor` first, then ask in #cas-internal.
 
-## Known gaps (filed 2026-08-17)
-
-- **[#469](https://github.com/Richards-LLC/cassy/issues/469)** `cas-install.sh` rejects macOS — the reason this guide hand-downloads the release asset. When fixed, step 2 collapses to one curl|bash line.
-- **[#470](https://github.com/Richards-LLC/cassy/issues/470)** the older from-zero doc is source-build-only with stale claims about release channels; this guide supersedes it for non-contributors.
-- **[#471](https://github.com/Richards-LLC/cassy/issues/471)** there is no CLI or documented flow for the *admin* side of team invites — a Petra Stella admin must invite your account in the Cassy Cloud web UI before `cas cloud team show` will show the team.
-
 ---
 
-Provenance: commands and flags verified against `cas 2.71.0/2.72.0` `--help` output and `cas config` defaults on the machine `soundwave-linux` (2026-08-17); release asset names and checksums from the published v2.72.0 GitHub release; memory-sharing semantics from the Cassy memory MCP contract and `cas memory`/`cas cloud team-memories` CLI. The 2026-08-18 revision additionally measured each step's real behaviour outside and inside a project (`cas login --token`, `cas whoami`, `cas cloud team show`, `cas cloud status`, `cas doctor`, `cas init`) and read `sync_user_builtins` in `cas-cli/src/cli/update.rs` for the `--user` claim.
+Provenance: current release assets include `cas-aarch64-apple-darwin.tar.gz`; the installer and its macOS flow are covered by `scripts/test-cas-install.sh`. Team selection is verified against the `cas cloud team` CLI contract: it resolves cached memberships but does not expose an invite mutation.

--- a/docs/onboarding/macbook-from-zero.md
+++ b/docs/onboarding/macbook-from-zero.md
@@ -1,14 +1,67 @@
 # MacBook from zero to Cassy
 
-End-to-end setup for installing Cassy on a Mac **from `Richards-LLC/cassy`**, built from source. Assumes you are comfortable with a terminal but have never installed Cassy or Claude Code before.
+End-to-end setup for installing Cassy on a Mac. Most people should use the
+published Apple Silicon release below; the source-build path remains for Cassy
+contributors.
 
-> **What this is not.** This guide does not use the legacy public `install.sh` or Homebrew paths, which distributed **v1.0** (2026-03-12) and **v0.2.1** respectively — months behind the development tip at the time. It intentionally builds from the current source repository instead.
-
-> **Hard requirement:** Apple Silicon Mac (M1 / M2 / M3 / M4). The build itself works on Intel Mac, but the vendored Ghostty terminal renderer and several profiling paths are tested only on `aarch64-apple-darwin`. If you're on Intel, expect to debug.
+> **Release requirement:** Apple Silicon Mac (M1 / M2 / M3 / M4). Cassy publishes
+> `aarch64-apple-darwin` release assets, not Intel macOS assets. Intel Mac users
+> must use the contributor build path and should expect to debug its less-tested
+> renderer and profiling paths.
 
 ---
 
-## What you'll end up with
+## Fast path — install the published binary (about 5 minutes)
+
+On an Apple Silicon Mac, this is the normal installation path. It downloads the
+current GitHub Release, installs `cas` at `~/.local/bin/cas`, and clears the
+macOS quarantine attribute so Gatekeeper does not block the first run.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Richards-LLC/cassy/main/scripts/cas-install.sh | bash
+
+# The installer prints a PATH fix if needed. For this shell, if it did:
+export PATH="$HOME/.local/bin:$PATH"
+cas --version
+```
+
+Initialize a project and verify it before configuring any integrations:
+
+```bash
+cd /path/to/your/repo
+cas init
+cas doctor
+```
+
+For Cassy Cloud, sign in once per machine, then confirm team scope from inside
+the initialized project:
+
+```bash
+cas login --token <YOUR-PERSONAL-API-KEY>
+cas cloud team show
+cas cloud sync
+```
+
+### Add a teammate to Cassy Cloud
+
+There is no `cas cloud team invite` command because the Cloud membership API is
+administrator-owned. The working flow is:
+
+1. The teammate gives their Cassy Cloud account email to a current team
+   administrator.
+2. The administrator adds that account to the team in Petra Stella Cloud. This
+   authorization step must happen before the teammate can use team data.
+3. The teammate runs `cas login --token <their-personal-api-key>` and, from an
+   initialized shared project, runs `cas cloud team show`. If membership was
+   just changed, logging in again refreshes the cached memberships.
+4. If there is more than one team, the teammate selects the shared team with
+   `cas cloud team set <team-slug-or-uuid>`, then runs `cas cloud sync`.
+
+`cas cloud team` only selects from the account's existing memberships; it never
+creates or grants a membership. If step 3 still reports no team, the
+administrator needs to confirm that the account email and team are correct.
+
+## Contributor path — build from source
 
 - `cas` binary built from your fork at `~/.local/bin/cas`
 - Claude Code installed and configured to talk to `cas` over MCP

--- a/scripts/cas-install.sh
+++ b/scripts/cas-install.sh
@@ -52,21 +52,37 @@ detect_platform() {
 
   case "$os" in
     Linux)  os="unknown-linux-gnu" ;;
+    Darwin) os="apple-darwin" ;;
     *)
       error "Unsupported OS: $os"
-      error "Cassy currently only supports Linux. macOS/Windows support is planned."
+      error "Cassy supports Linux x86_64 and macOS on Apple Silicon."
       exit 1
       ;;
   esac
 
   case "$arch" in
     x86_64|amd64) arch="x86_64" ;;
+    arm64|aarch64)
+      if [ "$os" = "apple-darwin" ]; then
+        arch="aarch64"
+      else
+        error "Unsupported architecture: $arch"
+        error "Cassy currently publishes Linux x86_64 and macOS Apple Silicon binaries."
+        exit 1
+      fi
+      ;;
     *)
       error "Unsupported architecture: $arch"
-      error "Cassy currently only supports x86_64. ARM64 support is planned."
+      error "Cassy currently publishes Linux x86_64 and macOS Apple Silicon binaries."
       exit 1
       ;;
   esac
+
+  if [ "$os" = "apple-darwin" ] && [ "$arch" != "aarch64" ]; then
+    error "Unsupported architecture: $arch"
+    error "Cassy publishes a macOS Apple Silicon binary only; Intel Macs must build from source."
+    exit 1
+  fi
 
   PLATFORM="${arch}-${os}"
 }
@@ -184,7 +200,9 @@ download_and_install() {
 
   local tmp_dir
   tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "$tmp_dir"' EXIT
+  # Capture the path while the local exists; an EXIT trap that expands
+  # `$tmp_dir` later fails under `set -u` after this function has returned.
+  trap "rm -rf -- $(printf '%q' "$tmp_dir")" EXIT
 
   local archive_path="${tmp_dir}/${asset_name}"
 
@@ -215,6 +233,13 @@ download_and_install() {
     sudo install -m 755 "${tmp_dir}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
   else
     install -m 755 "${tmp_dir}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+  fi
+
+  # GitHub-downloaded binaries can retain the quarantine attribute on macOS.
+  # Clearing it is harmless when the attribute is absent and lets the first
+  # `cas` invocation proceed without a Gatekeeper rejection.
+  if [ "$(uname -s)" = "Darwin" ] && command -v xattr &>/dev/null; then
+    xattr -d com.apple.quarantine "${INSTALL_DIR}/${BINARY_NAME}" 2>/dev/null || true
   fi
 }
 

--- a/scripts/test-cas-install.sh
+++ b/scripts/test-cas-install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Fixture test for the portable installer. No network access or real install.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+installer="$script_dir/cas-install.sh"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+mkdir -p "$tmpdir/bin" "$tmpdir/install" "$tmpdir/archive"
+cat >"$tmpdir/archive/cas" <<'EOF'
+#!/usr/bin/env bash
+echo 'cas fixture version'
+EOF
+chmod +x "$tmpdir/archive/cas"
+tar -czf "$tmpdir/release.tar.gz" -C "$tmpdir/archive" cas
+
+cat >"$tmpdir/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  -s) printf '%s\n' "${FIXTURE_OS:?}" ;;
+  -m) printf '%s\n' "${FIXTURE_ARCH:?}" ;;
+  *) exit 2 ;;
+esac
+EOF
+
+cat >"$tmpdir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FIXTURE_CURL_LOG:?}"
+output=''
+while (($#)); do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ -n "$output" ]]; then
+  cp "${FIXTURE_ARCHIVE:?}" "$output"
+else
+  printf '%s\n' '{"tag_name":"v9.9.9"}'
+fi
+EOF
+
+cat >"$tmpdir/bin/xattr" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FIXTURE_XATTR_LOG:?}"
+EOF
+chmod +x "$tmpdir/bin/uname" "$tmpdir/bin/curl" "$tmpdir/bin/xattr"
+
+darwin_output="$(
+  PATH="$tmpdir/bin:/usr/bin:/bin" \
+  FIXTURE_OS=Darwin \
+  FIXTURE_ARCH=arm64 \
+  FIXTURE_ARCHIVE="$tmpdir/release.tar.gz" \
+  FIXTURE_CURL_LOG="$tmpdir/curl.log" \
+  FIXTURE_XATTR_LOG="$tmpdir/xattr.log" \
+  CAS_INSTALL_DIR="$tmpdir/install" \
+  CAS_REPO=fixture/cassy \
+  "$installer"
+)"
+grep -qF 'Platform: aarch64-apple-darwin' <<<"$darwin_output"
+grep -qF 'cas fixture version' <<<"$darwin_output"
+test -x "$tmpdir/install/cas"
+grep -qF 'cas-aarch64-apple-darwin.tar.gz' "$tmpdir/curl.log"
+grep -qF -- "-d com.apple.quarantine $tmpdir/install/cas" "$tmpdir/xattr.log"
+echo 'ok   macOS Apple Silicon installs the published Darwin asset and clears quarantine'
+
+set +e
+intel_output="$(PATH="$tmpdir/bin:/usr/bin:/bin" FIXTURE_OS=Darwin FIXTURE_ARCH=x86_64 "$installer" 2>&1)"
+intel_status=$?
+set -e
+test "$intel_status" -ne 0
+grep -qF 'macOS Apple Silicon binary only; Intel Macs must build from source' <<<"$intel_output"
+echo 'ok   macOS Intel names the source-build path instead of selecting a missing asset'
+
+echo 'PASS: portable installer macOS behavior verified.'


### PR DESCRIPTION
Fixes #469
Fixes #470
Fixes #471

- installs the Apple Silicon release asset and clears Gatekeeper quarantine
- adds the binary fast path and administrator-to-teammate membership flow
- adds a fixture test wired into the release guard lane