### PR TITLE
fix: return committed epic close receipt

### DIFF
--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -1973,6 +1973,12 @@ impl CasCore {
         // to take over must update epic_verification_owner first (or act
         // as the owner). Prevents a mis-routed director completion prompt
         // from racing the owning supervisor on `task close`.
+        // The stranded-branch override can carry a branch verdict for every
+        // child in a large epic. Keep that audit payload out of the close
+        // critical path: the compact closed row is the durable outcome the
+        // caller needs before its MCP deadline, and the full narrative is
+        // appended from a detached task after that row commits.
+        let mut deferred_epic_override_note = None;
         if task.task_type == TaskType::Epic {
             if let Some(ref owner) = task.epic_verification_owner {
                 let caller_id = self.get_agent_id().ok();
@@ -2179,9 +2185,11 @@ impl CasCore {
                                 SupervisorAuthorityError::Store(error) => format!(
                                     "EPIC CLOSE OVERRIDE REJECTED: supervisor authority could not be checked ({error})."
                                 ),
-                                SupervisorAuthorityError::NotRegistered { caller_id, error } => format!(
-                                    "EPIC CLOSE OVERRIDE REJECTED: caller `{caller_id}` is not a registered supervisor ({error})."
-                                ),
+                                SupervisorAuthorityError::NotRegistered { caller_id, error } => {
+                                    format!(
+                                        "EPIC CLOSE OVERRIDE REJECTED: caller `{caller_id}` is not a registered supervisor ({error})."
+                                    )
+                                }
                                 SupervisorAuthorityError::NotLive(caller) => format!(
                                     "EPIC CLOSE OVERRIDE REJECTED: only a live registered supervisor may use stranded_branch_override. Caller `{}` has role {}.",
                                     caller.name, caller.role
@@ -2189,24 +2197,22 @@ impl CasCore {
                             }));
                         }
                     };
-                    // The waived gate output is stored verbatim: it already
-                    // names every branch and the measured verdict behind it, so
-                    // the note records what was actually true at override time
-                    // rather than only what the supervisor asserted.
-                    append_close_decision_note(
-                        task_store.as_ref(),
-                        &mut task,
-                        &format!(
-                            "decision: supervisor `{caller_name}` (role {caller_role}) overrode \
+                    // The waived gate output is stored verbatim, but not before
+                    // the close commit. A large epic can have dozens of verdicts;
+                    // synchronously copying the resulting multi-kilobyte task
+                    // notes row made the MCP response miss its 55s deadline
+                    // (GH #515). The detached append below is idempotent and runs
+                    // only after the Closed row is durable.
+                    deferred_epic_override_note = Some(format!(
+                        "decision: supervisor `{caller_name}` (role {caller_role}) overrode \
                              the epic stranded-branch gate for `{epic_id}`.\n\
                              Inspection narrative: {narrative}\n\
                              Waived gate output follows verbatim, including every measured \
                              branch verdict:\n{msg}",
-                            caller_name = caller.name,
-                            caller_role = caller.role,
-                            epic_id = req.id,
-                        ),
-                    );
+                        caller_name = caller.name,
+                        caller_role = caller.role,
+                        epic_id = req.id,
+                    ));
                 }
             }
         }
@@ -4337,6 +4343,11 @@ impl CasCore {
             data: None,
         })?;
 
+        let epic_override_note_pending = deferred_epic_override_note.is_some();
+        if let Some(note) = deferred_epic_override_note {
+            append_close_decision_note_detached(task_store.clone(), task.id.clone(), note);
+        }
+
         // Artifacts are validated under this task's configured durable root
         // before they can become receipt evidence. Index every supported text
         // artifact at the same close boundary; a search failure must never
@@ -4693,7 +4704,7 @@ impl CasCore {
             String::new()
         };
 
-        Ok(Self::success(format_close_success_message(
+        let mut receipt = format_close_success_message(
             &req.id,
             &task.title,
             &verification_note,
@@ -4703,7 +4714,13 @@ impl CasCore {
             &epic_close_msg,
             commit_nudge_msg,
             &auto_unblock_msg,
-        )))
+        );
+        if epic_override_note_pending {
+            receipt.push_str(
+                "\n\nReceipt: epic close committed. The full stranded-branch override narrative is queued as a durable decision note.",
+            );
+        }
+        Ok(Self::success(receipt))
     }
 
     /// Resolve the filesystem path for the **worker's isolated
@@ -9486,6 +9503,56 @@ fn append_close_decision_note(task_store: &dyn cas_store::TaskStore, task: &mut 
             "failed to persist close decision note"
         );
     }
+}
+
+/// Append a non-critical close audit payload after the terminal task row has
+/// committed. Dropping the request future (for example at the MCP 55s
+/// deadline) must not cancel this work: the caller already has a durable close
+/// outcome and can safely re-query while the note is written.
+fn append_close_decision_note_detached(
+    task_store: std::sync::Arc<dyn cas_store::TaskStore>,
+    task_id: String,
+    note: String,
+) {
+    tokio::spawn(async move {
+        let log_task_id = task_id.clone();
+        // The close transaction can still be releasing SQLite's write lock
+        // when this detached task wakes. Retry the idempotent append rather
+        // than silently dropping the audit narrative on that normal race.
+        for attempt in 1..=3 {
+            let store = task_store.clone();
+            let id = task_id.clone();
+            let note = note.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let mut task = store.get(&id)?;
+                if task.notes.contains(&note) {
+                    return Ok::<(), cas_store::StoreError>(());
+                }
+                let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M");
+                let formatted = format!("[{timestamp}] {note}");
+                task.notes = if task.notes.is_empty() {
+                    formatted
+                } else {
+                    format!("{}\n\n{formatted}", task.notes)
+                };
+                task.updated_at = chrono::Utc::now();
+                store.update(&task).map(|_| ())
+            })
+            .await;
+            match result {
+                Ok(Ok(())) => return,
+                Ok(Err(error)) if attempt == 3 => {
+                    tracing::warn!(task_id = %log_task_id, error = %error, "failed to append deferred epic close decision note after retries")
+                }
+                Err(error) if attempt == 3 => {
+                    tracing::warn!(task_id = %log_task_id, error = %error, "deferred epic close decision note task failed after retries")
+                }
+                Ok(Err(error)) => tracing::debug!(task_id = %log_task_id, attempt, error = %error, "retrying deferred epic close decision note"),
+                Err(error) => tracing::debug!(task_id = %log_task_id, attempt, error = %error, "retrying failed deferred epic close decision note task"),
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25 * attempt)).await;
+        }
+    });
 }
 
 fn commit_receipt_rejection(receipt: &str, parent_branch: &str, reason: &str) -> String {
@@ -15419,6 +15486,63 @@ mod code_review_gate_tests {
             code_review_findings: None,
             search_manifest: None,
             commit_receipt: None,
+        }
+    }
+
+    /// GH #515: a large epic override must commit its compact close outcome
+    /// without waiting for a note that contains every child verdict. This is
+    /// the isolated persistence half of the incident shape: 31 child rows,
+    /// each with a deliberately large verdict, are rendered as one audit note
+    /// and written only after the caller-facing path has returned.
+    #[tokio::test]
+    async fn large_epic_override_narrative_is_detached_and_lands_durably_gh_515() {
+        let cas_root = tempfile::tempdir().expect("temporary Cassy root");
+        let task_store = crate::store::open_task_store(cas_root.path()).expect("task store");
+        task_store.init().expect("initialize task store");
+
+        let mut epic = Task::new("cas-gh-515".to_string(), "large override epic".to_string());
+        epic.task_type = TaskType::Epic;
+        epic.status = TaskStatus::Closed;
+        task_store.add(&epic).expect("add closed epic");
+
+        let verdicts = (0..31)
+            .map(|child| {
+                format!(
+                    "| cas-child-{child:02} | factory/worker-{child:02} | verdict: {} |",
+                    "content evolved after integration; ".repeat(256)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let note = format!(
+            "decision: supervisor `test` overrode the epic stranded-branch gate for `cas-gh-515`.\n\
+             Inspection narrative: compared all 31 branches with their landed target paths.\n\
+             Waived gate output follows verbatim, including every measured branch verdict:\n{verdicts}"
+        );
+        assert!(
+            note.len() > 200_000,
+            "fixture must retain the incident's large-note shape"
+        );
+
+        let started = std::time::Instant::now();
+        append_close_decision_note_detached(task_store.clone(), epic.id.clone(), note.clone());
+        let schedule_elapsed = started.elapsed();
+        assert!(
+            schedule_elapsed < std::time::Duration::from_millis(100),
+            "the committed close path must only schedule the large note, took {schedule_elapsed:?}"
+        );
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let persisted = task_store.get(&epic.id).expect("read epic");
+            if persisted.notes.contains(&verdicts) {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "deferred override narrative did not land within the bounded regression window"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
     }
 

--- a/cas-cli/src/mcp/tools/service/server_handler.rs
+++ b/cas-cli/src/mcp/tools/service/server_handler.rs
@@ -141,6 +141,10 @@ impl ServerHandler for CasService {
             let start = std::time::Instant::now();
             let tool_name = request.name.clone();
             let request_id = format!("{}", context.id);
+            // Keep enough of the request to distinguish a committed task close
+            // from an unknown write when the response deadline wins the race.
+            // `ToolCallContext` consumes `request` below.
+            let timeout_arguments = request.arguments.clone();
             info!(method = "tools/call", tool = %tool_name, id = %request_id, "MCP call_tool START");
             let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
 
@@ -160,11 +164,13 @@ impl ServerHandler for CasService {
                 }
                 Err(_) => {
                     warn!(method = "tools/call", tool = %tool_name, id = %request_id, "MCP tool call TIMED OUT after 55s — handler hung");
+                    let mutation_outcome =
+                        self.mutation_timeout_outcome(&tool_name, timeout_arguments.as_ref());
                     Err(rmcp::ErrorData {
                         code: rmcp::model::ErrorCode::INTERNAL_ERROR,
                         message: format!(
-                            "Tool '{}' timed out after 55s. This is a Cassy server bug — please report it.",
-                            tool_name
+                            "Tool '{}' timed out after 55s. This is a Cassy server bug — please report it. Mutation outcome: {}",
+                            tool_name, mutation_outcome
                         ).into(),
                         data: None,
                     })
@@ -173,5 +179,72 @@ impl ServerHandler for CasService {
 
             result
         }
+    }
+}
+
+impl CasService {
+    /// A response-layer timeout cancels the handler, but a synchronous store
+    /// write may have committed just before that cancellation. Never leave a
+    /// caller guessing whether retrying a mutating request would duplicate it.
+    fn mutation_timeout_outcome(
+        &self,
+        tool_name: &str,
+        arguments: Option<&serde_json::Map<String, serde_json::Value>>,
+    ) -> String {
+        let action = arguments
+            .and_then(|args| args.get("action"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+
+        if !potentially_mutating_call(tool_name, action) {
+            return "not applicable (the timed-out call was read-only)".to_string();
+        }
+
+        // Task close is the dangerous retry shape: its postcondition is cheap
+        // and authoritative, so report it rather than a vague generic hint.
+        if tool_name == "task"
+            && action == "close"
+            && let Some(task_id) = arguments
+                .and_then(|args| args.get("id"))
+                .and_then(serde_json::Value::as_str)
+        {
+            if let Ok(store) = self.inner.open_task_store()
+                && let Ok(task) = store.get(task_id)
+                && task.status == crate::types::TaskStatus::Closed
+            {
+                return format!(
+                    "COMMITTED (task `{task_id}` is Closed; do not retry close, re-query task state)"
+                );
+            }
+        }
+
+        "UNKNOWN (the response deadline elapsed before Cassy could confirm a committed write; re-query state before retrying)".to_string()
+    }
+}
+
+fn potentially_mutating_call(tool_name: &str, action: &str) -> bool {
+    match tool_name {
+        "task" => !matches!(
+            action,
+            "show" | "list" | "ready" | "blocked" | "dep_list" | "available" | "mine"
+        ),
+        "memory" => !matches!(action, "get" | "list" | "recent"),
+        "rule" | "skill" | "spec" | "verification" | "coordination" | "system" | "team"
+        | "pattern" | "knowledge" => !matches!(action, "show" | "list" | "status" | "members"),
+        // Unknown tool/action schemas must be treated as write-capable: an
+        // optimistic "not committed" answer would invite a duplicate write.
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::potentially_mutating_call;
+
+    #[test]
+    fn timeout_backstop_never_treats_task_close_as_read_only() {
+        assert!(potentially_mutating_call("task", "close"));
+        assert!(!potentially_mutating_call("task", "show"));
+        assert!(potentially_mutating_call("unknown_future_tool", "anything"));
     }
 }

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -88,6 +88,143 @@ async fn test_0447_brief_task_start_returns_only_own_notes_and_is_size_bounded()
     );
 }
 
+/// GH #515: close must publish the committed epic outcome before a huge
+/// stranded-branch audit payload is written. The fixture has 31 child lanes
+/// and a 200 KB supervisor narrative, the incident shape that previously
+/// exhausted the MCP response budget.
+#[tokio::test]
+async fn epic_override_close_returns_compact_receipt_before_large_note_gh_515() {
+    let (temp, service) = setup_cas();
+    let cas_dir = temp.path().join(".cas");
+    let task_store = open_task_store(&cas_dir).expect("task store");
+    let agent_store = open_agent_store(&cas_dir).expect("agent store");
+    let session_id = format!("test-session-{}", std::process::id());
+    let mut supervisor = agent_store.get(&session_id).expect("registered caller");
+    supervisor.role = cas::types::AgentRole::Supervisor;
+    agent_store.update(&supervisor).expect("make caller supervisor");
+
+    let git = |args: &[&str]| {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(temp.path())
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .output()
+            .expect("run git");
+        assert!(output.status.success(), "git {args:?}: {output:?}");
+    };
+    git(&["init", "-q", "-b", "main"]);
+    std::fs::write(temp.path().join("seed.txt"), "seed\n").expect("write seed");
+    git(&["add", "seed.txt"]);
+    git(&["commit", "-q", "-m", "seed"]);
+
+    let epic = service
+        .cas_task_create(Parameters(TaskCreateRequest {
+            depth: Some("light".to_string()),
+            title: "large override epic".to_string(),
+            description: None,
+            priority: 2,
+            task_type: "epic".to_string(),
+            labels: None,
+            notes: None,
+            blocked_by: None,
+            design: None,
+            acceptance_criteria: None,
+            external_ref: None,
+            assignee: None,
+            demo_statement: None,
+            execution_note: None,
+            epic: None,
+        }))
+        .await
+        .expect("create epic");
+    let epic_id = extract_task_id(&extract_text(epic))
+        .expect("epic id")
+        .to_string();
+    let mut stored_epic = task_store.get(&epic_id).expect("stored epic");
+    stored_epic.branch = Some("main".to_string());
+    task_store.update(&stored_epic).expect("set epic branch");
+
+    for child in 0..31 {
+        let worker = format!("worker-{child:02}");
+        git(&["checkout", "-q", "-b", &format!("factory/{worker}"), "main"]);
+        let file = format!("lane-{child:02}.txt");
+        std::fs::write(temp.path().join(&file), format!("lane {child}\n")).expect("write lane");
+        git(&["add", &file]);
+        git(&["commit", "-q", "-m", &format!("lane {child}")]);
+        git(&["checkout", "-q", "main"]);
+
+        let child_task = service
+            .cas_task_create(Parameters(TaskCreateRequest {
+                epic: Some(epic_id.clone()),
+                ..basic_create(&format!("child {child}"), None)
+            }))
+            .await
+            .expect("create child");
+        let child_id = extract_task_id(&extract_text(child_task))
+            .expect("child id")
+            .to_string();
+        let mut stored_child = task_store.get(&child_id).expect("stored child");
+        stored_child.status = cas::types::TaskStatus::Closed;
+        stored_child.assignee = Some(worker);
+        task_store.update(&stored_child).expect("close child fixture");
+    }
+
+    let narrative = format!(
+        "GH515-NARRATIVE-START: I diffed each of the 31 child branches against main and recorded the measured result. {} GH515-NARRATIVE-END",
+        "evidence retained for each branch; ".repeat(7_000)
+    );
+    assert!(narrative.len() > 200_000, "large-narrative precondition");
+    let started = std::time::Instant::now();
+    let close = service
+        .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: Some(narrative.clone()),
+            id: epic_id.clone(),
+            reason: Some("override incident-shaped epic close".to_string()),
+            bypass_code_review: None,
+            code_review_findings: None,
+            search_manifest: None,
+            commit_receipt: None,
+        }))
+        .await
+        .expect("close epic");
+    let elapsed = started.elapsed();
+    let receipt = extract_text(close);
+    assert!(
+        receipt.contains("Closed task:") && receipt.contains("epic close committed"),
+        "close must return the compact committed receipt: {receipt}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "close waited for the large note instead of returning its committed receipt: {elapsed:?}"
+    );
+    assert_eq!(
+        task_store.get(&epic_id).expect("closed epic").status,
+        cas::types::TaskStatus::Closed,
+        "the terminal mutation must commit before the compact receipt"
+    );
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let stored = task_store.get(&epic_id).expect("read closed epic");
+        if stored.notes.contains("GH515-NARRATIVE-START")
+            && stored.notes.contains("GH515-NARRATIVE-END")
+            && stored.notes.len() >= narrative.len()
+        {
+            break;
+        }
+        let current = task_store.get(&epic_id).expect("read current epic");
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the full override narrative must land durably after the compact close receipt; task notes contain {} bytes",
+            current.notes.len()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
 #[tokio::test]
 async fn test_task_show() {
     let (_temp, service) = setup_cas();


### PR DESCRIPTION
Fixes #515\n\nEpic close now commits before deferring large override narratives, returns a compact receipt, and reports committed/unknown state on response-layer timeouts.