### PR TITLE
Fix cas-c505 report embedding-cost baseline

### DIFF
--- a/docs/analysis/2026-08-17-historical-operational-vector-index.html
+++ b/docs/analysis/2026-08-17-historical-operational-vector-index.html
@@ -242,9 +242,9 @@
 
 </head>
 <body><a class="skip" href="#main">Skip to report</a><header><p>CAS operational intelligence · frozen evidence artifact</p></header><main id="main">
-<h1 id="historical-cas-operational-vector-index">Historical CAS
+<h1 id="historical-cassy-operational-vector-index">Historical Cassy
 operational vector index</h1>
-<p class="lead"><strong>Headline finding.</strong> Structural normalization removed <strong>92.17%</strong> of 1,033,752 candidate evidence chunks before embedding, turning 3.03 GB of CAS operational sources into 80,951 provenance-bearing semantic units without adding anything to live CAS search.</p>
+<p class="lead"><strong>Headline finding.</strong> Structural normalization removed <strong>92.17%</strong> of 1,033,752 candidate evidence chunks before embedding, turning 3.03 GB of Cassy operational sources into 80,951 provenance-bearing semantic units without adding anything to live Cassy search.</p>
 
 <div class="cards">
 <div class="card"><strong>3.03 GB</strong>eligible frozen source data<br><small>cut off 2026-08-17 13:44:57 UTC</small></div>
@@ -285,23 +285,25 @@ operational vector index</h1>
 <tr>
 <td>Estimated embedding tokens</td>
 <td style="text-align: right;">13,530,757</td>
-<td style="text-align: right;">unfiltered estimate¹</td>
-<td style="text-align: right;">-744,744,243</td>
+<td style="text-align: right;">758,141,679 unfiltered¹</td>
+<td style="text-align: right;">-744,610,922</td>
 <td style="text-align: right;">-98.22%</td>
 <td style="text-align: right;">54,123,027 retained characters</td>
 </tr>
 <tr>
 <td>Provider-list-price equivalent</td>
 <td style="text-align: right;">$1.759</td>
-<td style="text-align: right;">$97.27 unfiltered¹</td>
-<td style="text-align: right;">-$95.51</td>
-<td style="text-align: right;">-98.19%</td>
+<td style="text-align: right;">$98.56 unfiltered¹</td>
+<td style="text-align: right;">-$96.80</td>
+<td style="text-align: right;">-98.22%</td>
 <td style="text-align: right;">$0.13 / million tokens</td>
 </tr>
 </tbody>
 </table></div>
-<p>¹ The unfiltered estimate uses the deliberately conservative
-four-bytes-per-token approximation over 3.03 GB. It is a comparison
+<p>¹ The unfiltered comparison baseline is
+<code>3,032,566,716 eligible bytes / 4 bytes per token = 758,141,679 tokens</code>;
+at <code>$0.13 / million tokens</code>, that is <code>$98.56</code>
+before display rounding. It is a deliberately conservative comparison
 model, not a measured tokenizer count. Sources:
 <code>full-prepare.json</code>; <a
 href="https://platform.openai.com/docs/models/text-embedding-3-large">OpenAI's
@@ -392,7 +394,7 @@ filtering</h3>
 <td style="text-align: right;">637,929,328</td>
 </tr>
 <tr>
-<td>Claude CAS transcripts</td>
+<td>Claude Cassy transcripts</td>
 <td style="text-align: right;">628 files</td>
 <td style="text-align: right;">628 files</td>
 <td style="text-align: right;">464,310,658</td>
@@ -400,11 +402,11 @@ filtering</h3>
 <tr>
 <td>Codex transcript store</td>
 <td style="text-align: right;">2,018 files / 4,685,246,440 bytes</td>
-<td style="text-align: right;">821 CAS-cwd sessions</td>
+<td style="text-align: right;">821 Cassy-cwd sessions</td>
 <td style="text-align: right;">1,888,567,587</td>
 </tr>
 <tr>
-<td>Grok CAS transcript representations</td>
+<td>Grok Cassy transcript representations</td>
 <td style="text-align: right;">71 files / 100,708,411 bytes</td>
 <td style="text-align: right;">13 canonical
 <code>chat_history.jsonl</code> files</td>
@@ -464,7 +466,7 @@ knowledge, history, or code search.</p>
 <h3 id="privacy-and-embedding-receipt">Privacy and embedding
 receipt</h3>
 <p>The explicit task authorization covers one fixed historical embedding
-build. Text is redacted locally before the request. The CAS cloud
+build. Text is redacted locally before the request. The Cassy cloud
 contract maps <code>cas-embed-v1</code> to OpenAI
 <code>text-embedding-3-large</code> at 1,024 dimensions; the committed
 cloud response states that the endpoint persists neither text nor
@@ -714,8 +716,8 @@ candidate generator; hybrid/current-code evidence is the decision
 surface.</p>
 <h3 id="cross-channel-association">Cross-channel association</h3>
 <p>The frozen operational index is intentionally only one evidence
-channel. The labeled queries were also checked against the existing CAS
-surfaces:</p>
+channel. The labeled queries were also checked against the existing
+Cassy surfaces:</p>
 <div class="table-wrap"><table>
 <thead>
 <tr>
@@ -877,7 +879,7 @@ this cutoff artifact.</li>
 <li><strong>Corpus growth:</strong> the task was estimated at about 1
 GB; the fixed-cutoff eligible corpus is 3.03 GB because Codex and
 factory history grew after task creation. The inventory states both the
-discovery population and the selected CAS population.</li>
+discovery population and the selected Cassy population.</li>
 <li><strong>Snapshot time versus row update time:</strong> cutoff
 filters are applied to event creation timestamps. A row created before
 the cutoff but mutated between the cutoff and filesystem copy may
@@ -888,7 +890,8 @@ reliable timestamps. They preserve session/source provenance and an
 <code>unattributed</code> epoch instead of a fabricated timestamp.</li>
 <li><strong>Approximate tokens and list price:</strong> token count uses
 characters divided by four and cost uses the direct provider list price.
-The CAS service may meter differently; both are labeled estimates.</li>
+The Cassy service may meter differently; both are labeled
+estimates.</li>
 <li><strong>Dense similarity is non-causal:</strong> high cosine
 similarity associates descriptions, not mechanisms. Recommendations
 require corroboration from SQL, current code, task/issue state, and
@@ -941,7 +944,7 @@ evidence kept separate (<a
 href="https://arxiv.org/abs/2506.03691">LogSage, arXiv:2506.03691</a>).
 The price receipt uses the official OpenAI model page for
 <code>text-embedding-3-large</code>, retrieved 2026-08-17. These sources
-informed the method; all CAS findings above come from the frozen local
+informed the method; all Cassy findings above come from the frozen local
 corpus and committed code/history channels.</p>
 </main><footer><p>Markdown source: <a href="2026-08-17-historical-operational-vector-index.md">2026-08-17-historical-operational-vector-index.md</a>. Offline, dependency-free rendering.</p></footer></body>
 </html>

--- a/docs/analysis/2026-08-17-historical-operational-vector-index.md
+++ b/docs/analysis/2026-08-17-historical-operational-vector-index.md
@@ -15,10 +15,10 @@
 |---|---:|---:|---:|---:|---:|
 | Eligible source bytes | 3,032,566,716 | 1,000,000,000 task estimate | +2,032,566,716 | +203.26% | 1 snapshot + 1,510 files |
 | Unique chunks sent for embedding | 80,951 | 1,033,752 candidates | -952,801 | -92.17% | 1,033,752 candidates |
-| Estimated embedding tokens | 13,530,757 | unfiltered estimate¹ | -744,744,243 | -98.22% | 54,123,027 retained characters |
-| Provider-list-price equivalent | $1.759 | $97.27 unfiltered¹ | -$95.51 | -98.19% | $0.13 / million tokens |
+| Estimated embedding tokens | 13,530,757 | 758,141,679 unfiltered¹ | -744,610,922 | -98.22% | 54,123,027 retained characters |
+| Provider-list-price equivalent | $1.759 | $98.56 unfiltered¹ | -$96.80 | -98.22% | $0.13 / million tokens |
 
-¹ The unfiltered estimate uses the deliberately conservative four-bytes-per-token approximation over 3.03 GB. It is a comparison model, not a measured tokenizer count. Sources: `full-prepare.json`; [OpenAI's `text-embedding-3-large` model page](https://platform.openai.com/docs/models/text-embedding-3-large), checked 2026-08-17.
+¹ The unfiltered comparison baseline is `3,032,566,716 eligible bytes / 4 bytes per token = 758,141,679 tokens`; at `$0.13 / million tokens`, that is `$98.56` before display rounding. It is a deliberately conservative comparison model, not a measured tokenizer count. Sources: `full-prepare.json`; [OpenAI's `text-embedding-3-large` model page](https://platform.openai.com/docs/models/text-embedding-3-large), checked 2026-08-17.
 
 <figure aria-describedby="reduction-summary">
 <svg viewBox="0 0 820 180" role="img" aria-labelledby="reduction-title reduction-desc">

--- a/docs/analysis/scripts/test_render_historical_vector_report.py
+++ b/docs/analysis/scripts/test_render_historical_vector_report.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 ANALYSIS_DIR = Path(__file__).parents[1]
 SOURCE = ANALYSIS_DIR / "2026-08-17-historical-operational-vector-index.md"
+CHECKED_HTML = ANALYSIS_DIR / "2026-08-17-historical-operational-vector-index.html"
 RENDERER = Path(__file__).with_name("render_historical_vector_report.py")
 
 
@@ -56,6 +57,11 @@ class HistoricalVectorReportTests(unittest.TestCase):
         for cell in expected_cells:
             self.assertIn(cell, rendered)
         self.assertIn("3,032,566,716 eligible bytes / 4 bytes per token", rendered)
+
+        checked_html = CHECKED_HTML.read_text()
+        for cell in expected_cells:
+            self.assertIn(cell, checked_html)
+        self.assertIn("3,032,566,716 eligible bytes / 4 bytes per token", checked_html)
 
 
 if __name__ == "__main__":

--- a/docs/analysis/scripts/test_render_historical_vector_report.py
+++ b/docs/analysis/scripts/test_render_historical_vector_report.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Regression coverage for the cas-c505 report summary arithmetic."""
+
+from decimal import Decimal, ROUND_HALF_UP
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ANALYSIS_DIR = Path(__file__).parents[1]
+SOURCE = ANALYSIS_DIR / "2026-08-17-historical-operational-vector-index.md"
+RENDERER = Path(__file__).with_name("render_historical_vector_report.py")
+
+
+class HistoricalVectorReportTests(unittest.TestCase):
+    def test_embedding_summary_uses_one_reproducible_baseline(self):
+        eligible_bytes = Decimal("3032566716")
+        current_tokens = Decimal("13530757")
+        price_per_million = Decimal("0.13")
+        baseline_tokens = eligible_bytes / 4
+        baseline_cost = baseline_tokens * price_per_million / Decimal("1000000")
+        token_delta = current_tokens - baseline_tokens
+        cost_delta = current_tokens * price_per_million / Decimal("1000000") - baseline_cost
+        reduction = token_delta / baseline_tokens * 100
+
+        self.assertEqual(baseline_tokens, Decimal("758141679"))
+        self.assertEqual(baseline_cost.quantize(Decimal("0.01"), ROUND_HALF_UP), Decimal("98.56"))
+        self.assertEqual(token_delta, Decimal("-744610922"))
+        self.assertEqual(cost_delta.quantize(Decimal("0.01"), ROUND_HALF_UP), Decimal("-96.80"))
+        self.assertEqual(reduction.quantize(Decimal("0.01"), ROUND_HALF_UP), Decimal("-98.22"))
+
+        source = SOURCE.read_text()
+        expected_cells = (
+            "758,141,679 unfiltered¹",
+            "-744,610,922",
+            "-98.22%",
+            "$98.56 unfiltered¹",
+            "-$96.80",
+        )
+        for cell in expected_cells:
+            self.assertIn(cell, source)
+        self.assertIn(
+            "3,032,566,716 eligible bytes / 4 bytes per token = 758,141,679 tokens",
+            source,
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "report.html"
+            subprocess.run(
+                [sys.executable, str(RENDERER), str(SOURCE), str(output)], check=True
+            )
+            rendered = output.read_text()
+
+        for cell in expected_cells:
+            self.assertIn(cell, rendered)
+        self.assertIn("3,032,566,716 eligible bytes / 4 bytes per token", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #456

Corrects the stated unfiltered token and provider-price comparison baseline, regenerates the HTML report, and adds arithmetic/render regression coverage.