### PR TITLE
ci: skip duplicate main queue validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,36 @@ jobs:
             echo 'mode=hosted' >> "$GITHUB_OUTPUT"
           fi
 
+  # A merge queue validates a synthetic tree, then GitHub pushes that exact
+  # tree to main. Re-running the Fast Validation family on that push wastes
+  # hosted capacity without adding coverage. This gate is fail-closed: direct
+  # pushes, bypass merges, lookup failures, and any different tree run the
+  # complete suite normally.
+  fast-validation-main-push-dedupe:
+    name: Fast Validation — main-push tree dedupe
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'merge_group'
+      || (github.event_name == 'push'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/')))
+    runs-on: ubuntu-latest
+    outputs:
+      run-fast-validation: ${{ steps.tree-dedupe.outputs.run-fast-validation }}
+      validating-run-id: ${{ steps.tree-dedupe.outputs.validating-run-id }}
+      prior-run-url: ${{ steps.tree-dedupe.outputs.prior-run-url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - id: tree-dedupe
+        name: Check for successful merge-queue validation of this tree
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/check-ci-merge-queue-validation.sh
+
   # Factory pushes and PRs that do not target the protected default branch get
   # one cheap target-scoped lane. Main PRs use the full required lanes below;
   # do not spend an additional runner on this redundant subset there.
@@ -230,11 +260,13 @@ jobs:
   fast-validation-preflight:
     name: Fast Validation — preflight (no test suite)
     if: >-
-      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      needs.fast-validation-main-push-dedupe.outputs.run-fast-validation == 'true'
+      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/tags/')))
+      || startsWith(github.ref, 'refs/tags/'))))
+    needs: fast-validation-main-push-dedupe
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -305,7 +337,8 @@ jobs:
   fast-validation-suite-build:
     name: Fast Validation — suite archive build
     if: >-
-      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      needs.fast-validation-main-push-dedupe.outputs.run-fast-validation == 'true'
+      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
@@ -315,7 +348,7 @@ jobs:
       && github.repository == 'Richards-LLC/cassy'
       && github.event.repository.fork == false
       && vars.CASSY_MERGE_QUEUE_SELF_HOSTED == 'enabled'))
-    needs: fast-validation-runner-route
+    needs: [fast-validation-runner-route, fast-validation-main-push-dedupe]
     runs-on: ${{ fromJSON(needs.fast-validation-runner-route.outputs.runner) }}
     steps:
       - uses: actions/checkout@v4
@@ -455,12 +488,13 @@ jobs:
   fast-validation-suite-shards:
     name: Fast Validation — suite shard ${{ matrix.shard }}/3
     if: >-
-      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      needs.fast-validation-main-push-dedupe.outputs.run-fast-validation == 'true'
+      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/tags/')))
-    needs: fast-validation-suite-build
+      || startsWith(github.ref, 'refs/tags/'))))
+    needs: [fast-validation-suite-build, fast-validation-main-push-dedupe]
     strategy:
       fail-fast: false
       matrix:
@@ -516,12 +550,13 @@ jobs:
   fast-validation-suite:
     name: Fast Validation — full suite
     if: >-
-      always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      always() && needs.fast-validation-main-push-dedupe.outputs.run-fast-validation == 'true'
+      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/'))))
-    needs: fast-validation-suite-shards
+    needs: [fast-validation-suite-shards, fast-validation-main-push-dedupe]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -546,11 +581,13 @@ jobs:
   fast-validation-docs:
     name: Fast Validation — doctests
     if: >-
-      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      needs.fast-validation-main-push-dedupe.outputs.run-fast-validation == 'true'
+      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/tags/')))
+      || startsWith(github.ref, 'refs/tags/'))))
+    needs: fast-validation-main-push-dedupe
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -608,6 +645,7 @@ jobs:
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/'))))
     needs:
+      - fast-validation-main-push-dedupe
       - fast-validation-preflight
       - fast-validation-suite
       - fast-validation-docs
@@ -633,7 +671,9 @@ jobs:
           echo "Fast Validation is deferred to the canonical merge-queue tree."
 
       - name: Require every Fast Validation lane to pass
-        if: github.event_name != 'pull_request'
+        if: >-
+          github.event_name != 'pull_request'
+          && needs.fast-validation-main-push-dedupe.outputs.run-fast-validation == 'true'
         env:
           PREFLIGHT: ${{ needs.fast-validation-preflight.result }}
           SUITE: ${{ needs.fast-validation-suite.result }}
@@ -642,6 +682,45 @@ jobs:
           test "$PREFLIGHT" = success
           test "$SUITE" = success
           test "$DOCS" = success
+
+      - name: Report successful merge-queue validation reused by this main push
+        if: >-
+          github.event_name == 'push'
+          && github.ref == 'refs/heads/main'
+          && needs.fast-validation-main-push-dedupe.outputs.run-fast-validation == 'false'
+        run: |
+          echo "::notice title=Fast Validation deduplicated::Skipped the main-push suite because merge-queue run ${{ needs.fast-validation-main-push-dedupe.outputs.validating-run-id }} already validated this exact tree: ${{ needs.fast-validation-main-push-dedupe.outputs.prior-run-url }}"
+          echo "Fast Validation reused successful merge-queue run [${{ needs.fast-validation-main-push-dedupe.outputs.validating-run-id }}](${{ needs.fast-validation-main-push-dedupe.outputs.prior-run-url }})." >> "$GITHUB_STEP_SUMMARY"
+
+      # This artifact is published only after the merge-group Fast Validation
+      # fan-in passes. A later main push may reuse it only after the workflow
+      # itself concludes successfully, so it cannot turn a partial queue run
+      # into a false green shortcut.
+      - uses: actions/checkout@v4
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - id: merge-queue-tree
+        name: Compute successful merge-queue tree receipt
+        if: github.event_name == 'merge_group'
+        run: |
+          tree_hash="$(git rev-parse 'HEAD^{tree}')"
+          echo "hash=$tree_hash" >> "$GITHUB_OUTPUT"
+          printf 'tree=%s\ncommit=%s\nrun=%s/actions/runs/%s\n' \
+            "$tree_hash" "${{ github.sha }}" \
+            "${{ github.server_url }}/${{ github.repository }}" "${{ github.run_id }}" \
+            > merge-queue-validation-receipt.txt
+
+      - name: Publish successful merge-queue tree receipt
+        if: github.event_name == 'merge_group'
+        uses: actions/upload-artifact@v4
+        with:
+          name: merge-queue-validated-tree-${{ steps.merge-queue-tree.outputs.hash }}
+          path: merge-queue-validation-receipt.txt
+          retention-days: 30
+          if-no-files-found: error
 
   # Advisory lint, split out of Fast Validation so a lint pass never sits on the
   # critical path of the job that answers "do the tests pass?" (GH #142).
@@ -708,13 +787,16 @@ jobs:
   macos-check:
     name: macOS Check
     if: >-
-      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      always() && (github.event_name == 'pull_request'
+      || needs.fast-validation-main-push-dedupe.outputs.run-fast-validation == 'true')
+      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       || github.event_name == 'merge_group'
       || (github.event_name == 'pull_request'
       && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
-      || startsWith(github.ref, 'refs/tags/')))
+      || startsWith(github.ref, 'refs/tags/'))))
+    needs: fast-validation-main-push-dedupe
     # cas-59d3: key on the PULL REQUEST (falling back to the branch ref for
     # push events) and cancel superseded runs. Keying on the head SHA put every
     # push in its own group, so a rapid second push left the first run's full

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,12 @@ shared live `CARGO_TARGET_DIR`: its Cargo lock serializes the worker fleet.
 
 **Standing operator CI-load policy:** factory/* pushes run only Scoped
 Validation; protected-default PRs run only the required Fast Validation and
-macOS Check lanes. The non-required full/heavy tier (Clippy, Test Compile
-Guard, Build Benchmark, and both Panic Isolation profiles) belongs only to
+macOS Check lanes. The merge queue validates its synthetic tree once; when its
+successful tree is pushed unchanged to main, the main-push Fast Validation and
+macOS lanes reuse that receipt and name the validating run. Direct pushes,
+bypass merges, receipt lookup failures, and changed trees still run those
+lanes. The non-required full/heavy tier (Clippy, Test Compile Guard, Build
+Benchmark, and both Panic Isolation profiles) belongs only to
 supervisor-controlled main pushes, schedules, or manual dispatches—never
 factory/*, epic/*, tags, or pull requests. Keep this policy pinned by
 `scripts/test-ci-test-tiers.sh`, rather than relying on convention.

--- a/scripts/check-ci-merge-queue-validation.sh
+++ b/scripts/check-ci-merge-queue-validation.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Decide whether a main-push Fast Validation run can reuse a successful
+# merge-queue validation of the exact same Git tree. Missing or ambiguous
+# evidence deliberately keeps the full suite enabled.
+set -euo pipefail
+
+output="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+event="${GITHUB_EVENT_NAME:-}"
+ref="${GITHUB_REF:-}"
+repository="${GITHUB_REPOSITORY:-}"
+
+printf 'run-fast-validation=true\n' >>"$output"
+
+if [[ "$event" != "push" || "$ref" != "refs/heads/main" ]]; then
+    echo "Merge-queue tree dedupe applies only to main pushes; running Fast Validation for ${event:-unknown} ${ref:-unknown}."
+    exit 0
+fi
+
+tree_hash="$(git rev-parse 'HEAD^{tree}')"
+printf 'tree-hash=%s\n' "$tree_hash" >>"$output"
+marker="merge-queue-validated-tree-$tree_hash"
+
+if [[ -z "$repository" ]] || ! command -v gh >/dev/null || ! command -v jq >/dev/null; then
+    echo "::warning::Merge-queue validation lookup prerequisites unavailable; running Fast Validation."
+    exit 0
+fi
+
+if ! artifacts="$(gh api "/repos/$repository/actions/artifacts?name=$marker&per_page=100" 2>/dev/null)"; then
+    echo "::warning::Could not query merge-queue validation receipts; running Fast Validation."
+    exit 0
+fi
+
+mapfile -t run_ids < <(jq -r '.artifacts[] | select(.expired == false) | .workflow_run.id // empty' <<<"$artifacts")
+for run_id in "${run_ids[@]}"; do
+    [[ "$run_id" =~ ^[0-9]+$ ]] || continue
+    if ! run="$(gh api "/repos/$repository/actions/runs/$run_id" 2>/dev/null)"; then
+        continue
+    fi
+    if jq -e '.event == "merge_group" and .status == "completed" and .conclusion == "success"' <<<"$run" >/dev/null; then
+        run_url="$(jq -r '.html_url' <<<"$run")"
+        [[ "$run_url" == https://* ]] || continue
+        printf 'run-fast-validation=false\nvalidating-run-id=%s\nprior-run-url=%s\n' "$run_id" "$run_url" >>"$output"
+        echo "::notice title=Fast Validation deduplicated::Tree $tree_hash already passed successful merge-queue run $run_id ($run_url); skipping duplicate main-push Fast Validation and macOS work."
+        exit 0
+    fi
+done
+
+echo "No completed successful merge-queue receipt exists for tree $tree_hash; running Fast Validation."

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -199,7 +199,7 @@ require_text "$route" 'mode=self-hosted' 'runner route exposes selected self-hos
 require_text "$route" 'mode=hosted' 'runner route exposes selected hosted fallback mode'
 require_absent "$route" 'actions/checkout' 'runner route does not execute merge-queue source before label selection'
 
-require_text "$suite_build" 'needs: fast-validation-runner-route' 'required archive build waits for explicit runner routing'
+require_text "$suite_build" 'needs: [fast-validation-runner-route, fast-validation-main-push-dedupe]' 'required archive build waits for explicit runner routing and the main-push tree gate'
 require_text "$suite_build" 'fromJSON(needs.fast-validation-runner-route.outputs.runner)' 'archive build receives the fail-safe selected runner labels'
 require_text "$suite_build" "needs.fast-validation-runner-route.outputs.mode != 'self-hosted'" 'archive rejects an untrusted self-hosted route before assignment'
 require_text "$suite_build" "github.event_name == 'merge_group'" 'self-hosted archive is restricted to merge-queue events'
@@ -503,7 +503,7 @@ for job in fast-validation-runner-route fast-validation-preflight fast-validatio
 done
 require_text "$fast_admission" 'Admit protected PR to merge-queue validation' 'Fast Validation emits a PR admission receipt'
 require_text "$fast_admission" "if: github.event_name == 'pull_request'" 'Fast Validation admission is PR-only'
-require_text "$fast_admission" "if: github.event_name != 'pull_request'" 'Fast Validation only gates dependencies on the canonical tree'
+require_text "$fast_admission" "github.event_name != 'pull_request'" 'Fast Validation only gates dependencies on the canonical tree'
 require_text "$macos" "github.event_name == 'pull_request' && 'ubuntu-latest' || 'macos-26'" 'macOS PR admission stays hosted while queue validation uses macOS'
 require_text "$macos" 'Admit protected PR to merge-queue Darwin validation' 'macOS Check emits a PR admission receipt'
 require_text "$macos" "github.event_name != 'pull_request'" 'macOS compilation is deferred to the canonical tree'
@@ -537,7 +537,7 @@ for job in fast-validation-preflight fast-validation-docs clippy test-compile-gu
 done
 require_text "$suite_build" 'CARGO_TARGET_DIR:-target}/debug' 'suite packaging reads the configured Cargo target directory'
 require_text "$suite_build" "--transform='s,^cas$,target/debug/cas,'" 'suite packaging preserves the hosted runner archive layout'
-require_text "$suite_shards" 'needs: fast-validation-suite-build' 'shards wait for the shared test archive'
+require_text "$suite_shards" 'needs: [fast-validation-suite-build, fast-validation-main-push-dedupe]' 'shards wait for the shared test archive and main-push tree gate'
 require_text "$suite_shards" 'actions/download-artifact@v4' 'shards download the shared nextest archive'
 require_text "$suite_shards" 'tar -xzf fast-validation-suite-runner.tar.gz' 'shards restore the executable CLI runner payload'
 require_text "$suite_shards" 'test -x target/debug/cas' 'shards verify the restored CLI runner remains executable'
@@ -547,7 +547,7 @@ require_absent "$suite_shards" '/var/lib/cassy-actions/' 'shards do not depend o
 require_text "$suite_shards" '--workspace-remap "$GITHUB_WORKSPACE"' 'shards remap the self-hosted archive workspace to their hosted checkout'
 require_text "$suite_shards" 'INSTA_WORKSPACE_ROOT: ${{ github.workspace }}' 'shards pin insta snapshot lookup to their hosted checkout'
 require_text "$suite_shards" 'scripts/run-verified-tests.sh nextest run --archive-file fast-validation-suite.tar.zst --workspace-remap "$GITHUB_WORKSPACE" --no-fail-fast --partition count:${{ matrix.shard }}/3' 'shards execute every archived workspace nextest binary exactly once'
-require_text "$suite" 'needs: fast-validation-suite-shards' 'required full-suite context fans in every shard'
+require_text "$suite" 'needs: [fast-validation-suite-shards, fast-validation-main-push-dedupe]' 'required full-suite context fans in every shard after the main-push tree gate'
 require_text "$suite" 'test "$SHARDS" = success' 'required full-suite context rejects failed shards'
 require_text "$(<"$makefile")" '../scripts/run-verified-tests.sh nextest run --workspace --no-fail-fast' 'local make test verifies CI workspace nextest scope'
 require_text "$docs" 'scripts/run-verified-tests.sh test -p cas --doc' 'doctest coverage remains in Fast Validation with an execution receipt'
@@ -761,6 +761,7 @@ require_text "$receipt_job" "git rev-parse 'HEAD^{tree}'" 'tree receipt keys exa
 require_text "$receipt_job" 'name: pr-validated-tree-${{ steps.tree.outputs.hash }}' 'tree receipt artifact is named by tree hash'
 
 tree_guard="$repo_root/scripts/check-ci-tree-validation.sh"
+merge_queue_guard="$repo_root/scripts/check-ci-merge-queue-validation.sh"
 guard_tmp="$(mktemp -d)"
 mkdir -p "$guard_tmp/bin"
 cat >"$guard_tmp/bin/gh" <<'EOF'
@@ -771,6 +772,12 @@ case "${FAKE_GH_MODE:?}:$*" in
   hit:*actions/runs/123*) printf '%s\n' '{"event":"pull_request","status":"completed","conclusion":"success","html_url":"https://example.test/actions/runs/123"}' ;;
   wrong-event:*actions/artifacts*) printf '%s\n' '{"artifacts":[{"expired":false,"workflow_run":{"id":456}}]}' ;;
   wrong-event:*actions/runs/456*) printf '%s\n' '{"event":"push","status":"completed","conclusion":"success","html_url":"https://example.test/actions/runs/456"}' ;;
+  merge-hit:*actions/artifacts*) printf '%s\n' '{"artifacts":[{"expired":false,"workflow_run":{"id":789}}]}' ;;
+  merge-hit:*actions/runs/789*) printf '%s\n' '{"event":"merge_group","status":"completed","conclusion":"success","html_url":"https://example.test/actions/runs/789"}' ;;
+  merge-in-progress:*actions/artifacts*) printf '%s\n' '{"artifacts":[{"expired":false,"workflow_run":{"id":790}}]}' ;;
+  merge-in-progress:*actions/runs/790*) printf '%s\n' '{"event":"merge_group","status":"in_progress","conclusion":null,"html_url":"https://example.test/actions/runs/790"}' ;;
+  merge-wrong-event:*actions/artifacts*) printf '%s\n' '{"artifacts":[{"expired":false,"workflow_run":{"id":791}}]}' ;;
+  merge-wrong-event:*actions/runs/791*) printf '%s\n' '{"event":"push","status":"completed","conclusion":"success","html_url":"https://example.test/actions/runs/791"}' ;;
   miss:*actions/artifacts*) printf '%s\n' '{"artifacts":[]}' ;;
   error:*) exit 1 ;;
   *) exit 2 ;;
@@ -798,7 +805,60 @@ for mode in miss wrong-event error; do
     require_text "$output_path" 'run-heavy=true' "$mode receipt evidence fails closed to heavy work"
     require_absent "$output_path" 'run-heavy=false' "$mode receipt evidence never dedupes"
 done
+
+run_merge_queue_guard() {
+    local mode="$1"
+    local output="$guard_tmp/$mode.output"
+    : >"$output"
+    GITHUB_OUTPUT="$output" GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main \
+        GITHUB_REPOSITORY=example/repo FAKE_GH_MODE="$mode" FAKE_GH_LOG="$guard_tmp/gh.log" \
+        PATH="$guard_tmp/bin:$PATH" "$merge_queue_guard" >/dev/null
+    cat "$output"
+}
+
+merge_hit_output="$(run_merge_queue_guard merge-hit)"
+require_text "$merge_hit_output" 'run-fast-validation=false' 'matching successful merge-queue receipt skips main-push Fast Validation'
+require_text "$merge_hit_output" 'validating-run-id=789' 'matching merge-queue receipt exposes the validating run id'
+require_text "$merge_hit_output" 'prior-run-url=https://example.test/actions/runs/789' 'matching merge-queue receipt exposes the validating run URL'
+require_text "$(<"$guard_tmp/gh.log")" "merge-queue-validated-tree-$guard_tree" 'merge-queue lookup queries the exact current Git tree'
+for mode in miss merge-in-progress merge-wrong-event error; do
+    output_path="$(run_merge_queue_guard "$mode")"
+    require_text "$output_path" 'run-fast-validation=true' "$mode merge-queue evidence fails closed to Fast Validation"
+    require_absent "$output_path" 'run-fast-validation=false' "$mode merge-queue evidence never dedupes"
+done
+
+# Mutation coverage for the safety-critical event predicate: changing the
+# receipt trust from merge_group to push must make the merge-queue fixture run
+# the full suite rather than silently reusing an unrelated validation.
+mutated_guard="$guard_tmp/check-ci-merge-queue-validation-mutated.sh"
+sed 's/\.event == "merge_group"/.event == "push"/' "$merge_queue_guard" >"$mutated_guard"
+chmod +x "$mutated_guard"
+mutation_output="$guard_tmp/merge-event-mutation.output"
+: >"$mutation_output"
+GITHUB_OUTPUT="$mutation_output" GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main \
+    GITHUB_REPOSITORY=example/repo FAKE_GH_MODE=merge-hit FAKE_GH_LOG="$guard_tmp/gh.log" \
+    PATH="$guard_tmp/bin:$PATH" "$mutated_guard" >/dev/null
+require_text "$(<"$mutation_output")" 'run-fast-validation=true' 'mutating merge_group receipt trust prevents the shortcut'
+require_absent "$(<"$mutation_output")" 'run-fast-validation=false' 'mutated event predicate cannot skip the main-push suite'
 rm -rf "$guard_tmp"
+
+main_push_dedupe="$(job_block fast-validation-main-push-dedupe)"
+require_text "$main_push_dedupe" 'scripts/check-ci-merge-queue-validation.sh' 'main-push Fast Validation gate uses the merge-queue receipt guard'
+require_text "$main_push_dedupe" 'run-fast-validation: ${{ steps.tree-dedupe.outputs.run-fast-validation }}' 'main-push gate exports its fail-closed run decision'
+require_text "$main_push_dedupe" 'validating-run-id: ${{ steps.tree-dedupe.outputs.validating-run-id }}' 'main-push gate exports the validating merge-queue run id'
+require_text "$main_push_dedupe" 'prior-run-url: ${{ steps.tree-dedupe.outputs.prior-run-url }}' 'main-push gate exports the validating merge-queue run URL'
+
+for job in fast-validation-preflight fast-validation-suite-build fast-validation-suite-shards fast-validation-suite fast-validation-docs; do
+    block="$(job_block "$job")"
+    require_text "$block" 'fast-validation-main-push-dedupe' "$job waits for the main-push tree gate"
+    require_text "$block" "needs.fast-validation-main-push-dedupe.outputs.run-fast-validation == 'true'" "$job skips only a successfully receipt-matched main tree"
+done
+require_text "$macos" 'needs: fast-validation-main-push-dedupe' 'macOS Check waits for the same main-push tree gate'
+require_text "$macos" "needs.fast-validation-main-push-dedupe.outputs.run-fast-validation == 'true'" 'macOS Check skips only a successfully receipt-matched main tree'
+require_text "$fan_in" 'Report successful merge-queue validation reused by this main push' 'Fast Validation rollup gives the main-push shortcut a named receipt'
+require_text "$fan_in" 'needs.fast-validation-main-push-dedupe.outputs.validating-run-id' 'Fast Validation notice names the validating merge-queue run'
+require_text "$fan_in" 'merge-queue-validated-tree-${{ steps.merge-queue-tree.outputs.hash }}' 'successful merge-group Fast Validation publishes an exact-tree receipt'
+require_text "$fan_in" "git rev-parse 'HEAD^{tree}'" 'merge-group receipt keys exact Git contents'
 
 all_actions="$(<"$setup")$(<"$ci")$(<"$release")"
 require_text "$all_actions" 'mozilla-actions/sccache-action@v0.0.11' 'cache-v2-capable sccache action is pinned'


### PR DESCRIPTION
## Summary

- publish an exact-tree receipt after successful merge-group Fast Validation
- reuse only a completed-successful merge-group receipt on an identical main push
- preserve heavy-tier behavior and fail closed for direct, bypass, missing, wrong-event, and in-progress evidence

## Proof

`bash scripts/test-ci-test-tiers.sh` — 523 passed, 0 failed.