### PR TITLE
feat: import approved Pocock skills

### DIFF
--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -503,6 +503,8 @@ pub const BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-tdd/SKILL.md", content: include_str!("builtins/skills/cas-tdd/SKILL.md") },
     BuiltinFile { path: "skills/cas-tdd/tests.md", content: include_str!("builtins/skills/cas-tdd/tests.md") },
     BuiltinFile { path: "skills/cas-tdd/mocking.md", content: include_str!("builtins/skills/cas-tdd/mocking.md") },
+    BuiltinFile { path: "skills/cas-wizard/SKILL.md", content: include_str!("builtins/skills/cas-wizard/SKILL.md") },
+    BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/skills/cas-wizard/template.sh") },
 ];
 
 /// Built-in Workflow scripts shipped to `.claude/workflows/` on `cas update --sync`.
@@ -896,6 +898,8 @@ pub const CODEX_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-tdd/SKILL.md", content: include_str!("builtins/codex/skills/cas-tdd/SKILL.md") },
     BuiltinFile { path: "skills/cas-tdd/tests.md", content: include_str!("builtins/codex/skills/cas-tdd/tests.md") },
     BuiltinFile { path: "skills/cas-tdd/mocking.md", content: include_str!("builtins/codex/skills/cas-tdd/mocking.md") },
+    BuiltinFile { path: "skills/cas-wizard/SKILL.md", content: include_str!("builtins/codex/skills/cas-wizard/SKILL.md") },
+    BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/codex/skills/cas-wizard/template.sh") },
 ];
 
 /// All built-in agents managed by Cassy for Grok (EPIC cas-8888, Phase 5 /
@@ -1332,6 +1336,8 @@ pub const GROK_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-tdd/SKILL.md", content: include_str!("builtins/grok/skills/cas-tdd/SKILL.md") },
     BuiltinFile { path: "skills/cas-tdd/tests.md", content: include_str!("builtins/grok/skills/cas-tdd/tests.md") },
     BuiltinFile { path: "skills/cas-tdd/mocking.md", content: include_str!("builtins/grok/skills/cas-tdd/mocking.md") },
+    BuiltinFile { path: "skills/cas-wizard/SKILL.md", content: include_str!("builtins/grok/skills/cas-wizard/SKILL.md") },
+    BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/grok/skills/cas-wizard/template.sh") },
 ];
 
 /// A factory-critical capability that every harness must resolve from its own

--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -480,6 +480,23 @@ pub const BUILTIN_SKILLS: &[BuiltinFile] = &[
         path: "skills/fallow/references/patterns.md",
         content: include_str!("builtins/skills/fallow/references/patterns.md"),
     },
+    // cas-writing-for-agents: adapted from mattpocock/skills (MIT, © 2026 Matt Pocock).
+    BuiltinFile {
+        path: "skills/cas-writing-for-agents/SKILL.md",
+        content: include_str!("builtins/skills/cas-writing-for-agents/SKILL.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-writing-for-agents/SKILL-MECHANICS.md",
+        content: include_str!("builtins/skills/cas-writing-for-agents/SKILL-MECHANICS.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-diagnosing-bugs/SKILL.md",
+        content: include_str!("builtins/skills/cas-diagnosing-bugs/SKILL.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-domain-modeling/SKILL.md",
+        content: include_str!("builtins/skills/cas-domain-modeling/SKILL.md"),
+    },
 ];
 
 /// Built-in Workflow scripts shipped to `.claude/workflows/` on `cas update --sync`.
@@ -849,6 +866,23 @@ pub const CODEX_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile {
         path: "skills/fallow/references/patterns.md",
         content: include_str!("builtins/codex/skills/fallow/references/patterns.md"),
+    },
+    // cas-writing-for-agents: Codex mirror of the MIT Matt Pocock import above.
+    BuiltinFile {
+        path: "skills/cas-writing-for-agents/SKILL.md",
+        content: include_str!("builtins/codex/skills/cas-writing-for-agents/SKILL.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-writing-for-agents/SKILL-MECHANICS.md",
+        content: include_str!("builtins/codex/skills/cas-writing-for-agents/SKILL-MECHANICS.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-diagnosing-bugs/SKILL.md",
+        content: include_str!("builtins/codex/skills/cas-diagnosing-bugs/SKILL.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-domain-modeling/SKILL.md",
+        content: include_str!("builtins/codex/skills/cas-domain-modeling/SKILL.md"),
     },
 ];
 
@@ -1262,6 +1296,23 @@ pub const GROK_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile {
         path: "skills/cli-routing/references/routing.md",
         content: include_str!("builtins/grok/skills/cli-routing/references/routing.md"),
+    },
+    // cas-writing-for-agents: Grok mirror of the MIT Matt Pocock import above.
+    BuiltinFile {
+        path: "skills/cas-writing-for-agents/SKILL.md",
+        content: include_str!("builtins/grok/skills/cas-writing-for-agents/SKILL.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-writing-for-agents/SKILL-MECHANICS.md",
+        content: include_str!("builtins/grok/skills/cas-writing-for-agents/SKILL-MECHANICS.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-diagnosing-bugs/SKILL.md",
+        content: include_str!("builtins/grok/skills/cas-diagnosing-bugs/SKILL.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-domain-modeling/SKILL.md",
+        content: include_str!("builtins/grok/skills/cas-domain-modeling/SKILL.md"),
     },
 ];
 

--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -500,6 +500,9 @@ pub const BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-codebase-design/SKILL.md", content: include_str!("builtins/skills/cas-codebase-design/SKILL.md") },
     BuiltinFile { path: "skills/cas-codebase-design/DEEPENING.md", content: include_str!("builtins/skills/cas-codebase-design/DEEPENING.md") },
     BuiltinFile { path: "skills/cas-codebase-design/DESIGN-IT-TWICE.md", content: include_str!("builtins/skills/cas-codebase-design/DESIGN-IT-TWICE.md") },
+    BuiltinFile { path: "skills/cas-tdd/SKILL.md", content: include_str!("builtins/skills/cas-tdd/SKILL.md") },
+    BuiltinFile { path: "skills/cas-tdd/tests.md", content: include_str!("builtins/skills/cas-tdd/tests.md") },
+    BuiltinFile { path: "skills/cas-tdd/mocking.md", content: include_str!("builtins/skills/cas-tdd/mocking.md") },
 ];
 
 /// Built-in Workflow scripts shipped to `.claude/workflows/` on `cas update --sync`.
@@ -890,6 +893,9 @@ pub const CODEX_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-codebase-design/SKILL.md", content: include_str!("builtins/codex/skills/cas-codebase-design/SKILL.md") },
     BuiltinFile { path: "skills/cas-codebase-design/DEEPENING.md", content: include_str!("builtins/codex/skills/cas-codebase-design/DEEPENING.md") },
     BuiltinFile { path: "skills/cas-codebase-design/DESIGN-IT-TWICE.md", content: include_str!("builtins/codex/skills/cas-codebase-design/DESIGN-IT-TWICE.md") },
+    BuiltinFile { path: "skills/cas-tdd/SKILL.md", content: include_str!("builtins/codex/skills/cas-tdd/SKILL.md") },
+    BuiltinFile { path: "skills/cas-tdd/tests.md", content: include_str!("builtins/codex/skills/cas-tdd/tests.md") },
+    BuiltinFile { path: "skills/cas-tdd/mocking.md", content: include_str!("builtins/codex/skills/cas-tdd/mocking.md") },
 ];
 
 /// All built-in agents managed by Cassy for Grok (EPIC cas-8888, Phase 5 /
@@ -1323,6 +1329,9 @@ pub const GROK_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-codebase-design/SKILL.md", content: include_str!("builtins/grok/skills/cas-codebase-design/SKILL.md") },
     BuiltinFile { path: "skills/cas-codebase-design/DEEPENING.md", content: include_str!("builtins/grok/skills/cas-codebase-design/DEEPENING.md") },
     BuiltinFile { path: "skills/cas-codebase-design/DESIGN-IT-TWICE.md", content: include_str!("builtins/grok/skills/cas-codebase-design/DESIGN-IT-TWICE.md") },
+    BuiltinFile { path: "skills/cas-tdd/SKILL.md", content: include_str!("builtins/grok/skills/cas-tdd/SKILL.md") },
+    BuiltinFile { path: "skills/cas-tdd/tests.md", content: include_str!("builtins/grok/skills/cas-tdd/tests.md") },
+    BuiltinFile { path: "skills/cas-tdd/mocking.md", content: include_str!("builtins/grok/skills/cas-tdd/mocking.md") },
 ];
 
 /// A factory-critical capability that every harness must resolve from its own

--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -505,6 +505,7 @@ pub const BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-tdd/mocking.md", content: include_str!("builtins/skills/cas-tdd/mocking.md") },
     BuiltinFile { path: "skills/cas-wizard/SKILL.md", content: include_str!("builtins/skills/cas-wizard/SKILL.md") },
     BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/skills/cas-wizard/template.sh") },
+    BuiltinFile { path: "skills/cas-resolving-merge-conflicts/SKILL.md", content: include_str!("builtins/skills/cas-resolving-merge-conflicts/SKILL.md") },
 ];
 
 /// Built-in Workflow scripts shipped to `.claude/workflows/` on `cas update --sync`.
@@ -900,6 +901,7 @@ pub const CODEX_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-tdd/mocking.md", content: include_str!("builtins/codex/skills/cas-tdd/mocking.md") },
     BuiltinFile { path: "skills/cas-wizard/SKILL.md", content: include_str!("builtins/codex/skills/cas-wizard/SKILL.md") },
     BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/codex/skills/cas-wizard/template.sh") },
+    BuiltinFile { path: "skills/cas-resolving-merge-conflicts/SKILL.md", content: include_str!("builtins/codex/skills/cas-resolving-merge-conflicts/SKILL.md") },
 ];
 
 /// All built-in agents managed by Cassy for Grok (EPIC cas-8888, Phase 5 /
@@ -1338,6 +1340,7 @@ pub const GROK_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-tdd/mocking.md", content: include_str!("builtins/grok/skills/cas-tdd/mocking.md") },
     BuiltinFile { path: "skills/cas-wizard/SKILL.md", content: include_str!("builtins/grok/skills/cas-wizard/SKILL.md") },
     BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/grok/skills/cas-wizard/template.sh") },
+    BuiltinFile { path: "skills/cas-resolving-merge-conflicts/SKILL.md", content: include_str!("builtins/grok/skills/cas-resolving-merge-conflicts/SKILL.md") },
 ];
 
 /// A factory-critical capability that every harness must resolve from its own

--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -497,6 +497,9 @@ pub const BUILTIN_SKILLS: &[BuiltinFile] = &[
         path: "skills/cas-domain-modeling/SKILL.md",
         content: include_str!("builtins/skills/cas-domain-modeling/SKILL.md"),
     },
+    BuiltinFile { path: "skills/cas-codebase-design/SKILL.md", content: include_str!("builtins/skills/cas-codebase-design/SKILL.md") },
+    BuiltinFile { path: "skills/cas-codebase-design/DEEPENING.md", content: include_str!("builtins/skills/cas-codebase-design/DEEPENING.md") },
+    BuiltinFile { path: "skills/cas-codebase-design/DESIGN-IT-TWICE.md", content: include_str!("builtins/skills/cas-codebase-design/DESIGN-IT-TWICE.md") },
 ];
 
 /// Built-in Workflow scripts shipped to `.claude/workflows/` on `cas update --sync`.
@@ -884,6 +887,9 @@ pub const CODEX_BUILTIN_SKILLS: &[BuiltinFile] = &[
         path: "skills/cas-domain-modeling/SKILL.md",
         content: include_str!("builtins/codex/skills/cas-domain-modeling/SKILL.md"),
     },
+    BuiltinFile { path: "skills/cas-codebase-design/SKILL.md", content: include_str!("builtins/codex/skills/cas-codebase-design/SKILL.md") },
+    BuiltinFile { path: "skills/cas-codebase-design/DEEPENING.md", content: include_str!("builtins/codex/skills/cas-codebase-design/DEEPENING.md") },
+    BuiltinFile { path: "skills/cas-codebase-design/DESIGN-IT-TWICE.md", content: include_str!("builtins/codex/skills/cas-codebase-design/DESIGN-IT-TWICE.md") },
 ];
 
 /// All built-in agents managed by Cassy for Grok (EPIC cas-8888, Phase 5 /
@@ -1314,6 +1320,9 @@ pub const GROK_BUILTIN_SKILLS: &[BuiltinFile] = &[
         path: "skills/cas-domain-modeling/SKILL.md",
         content: include_str!("builtins/grok/skills/cas-domain-modeling/SKILL.md"),
     },
+    BuiltinFile { path: "skills/cas-codebase-design/SKILL.md", content: include_str!("builtins/grok/skills/cas-codebase-design/SKILL.md") },
+    BuiltinFile { path: "skills/cas-codebase-design/DEEPENING.md", content: include_str!("builtins/grok/skills/cas-codebase-design/DEEPENING.md") },
+    BuiltinFile { path: "skills/cas-codebase-design/DESIGN-IT-TWICE.md", content: include_str!("builtins/grok/skills/cas-codebase-design/DESIGN-IT-TWICE.md") },
 ];
 
 /// A factory-critical capability that every harness must resolve from its own

--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -506,6 +506,7 @@ pub const BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-wizard/SKILL.md", content: include_str!("builtins/skills/cas-wizard/SKILL.md") },
     BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/skills/cas-wizard/template.sh") },
     BuiltinFile { path: "skills/cas-resolving-merge-conflicts/SKILL.md", content: include_str!("builtins/skills/cas-resolving-merge-conflicts/SKILL.md") },
+    BuiltinFile { path: "skills/cas-to-questionnaire/SKILL.md", content: include_str!("builtins/skills/cas-to-questionnaire/SKILL.md") },
 ];
 
 /// Built-in Workflow scripts shipped to `.claude/workflows/` on `cas update --sync`.
@@ -902,6 +903,7 @@ pub const CODEX_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-wizard/SKILL.md", content: include_str!("builtins/codex/skills/cas-wizard/SKILL.md") },
     BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/codex/skills/cas-wizard/template.sh") },
     BuiltinFile { path: "skills/cas-resolving-merge-conflicts/SKILL.md", content: include_str!("builtins/codex/skills/cas-resolving-merge-conflicts/SKILL.md") },
+    BuiltinFile { path: "skills/cas-to-questionnaire/SKILL.md", content: include_str!("builtins/codex/skills/cas-to-questionnaire/SKILL.md") },
 ];
 
 /// All built-in agents managed by Cassy for Grok (EPIC cas-8888, Phase 5 /
@@ -1341,6 +1343,7 @@ pub const GROK_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-wizard/SKILL.md", content: include_str!("builtins/grok/skills/cas-wizard/SKILL.md") },
     BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/grok/skills/cas-wizard/template.sh") },
     BuiltinFile { path: "skills/cas-resolving-merge-conflicts/SKILL.md", content: include_str!("builtins/grok/skills/cas-resolving-merge-conflicts/SKILL.md") },
+    BuiltinFile { path: "skills/cas-to-questionnaire/SKILL.md", content: include_str!("builtins/grok/skills/cas-to-questionnaire/SKILL.md") },
 ];
 
 /// A factory-critical capability that every harness must resolve from its own

--- a/cas-cli/src/builtins/codex/skills/cas-brainstorm/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-brainstorm/SKILL.md
@@ -42,7 +42,9 @@ These exist because Cassy agents have a documented tendency to dump multiple que
 
 ## Frontier-round mechanics
 
-Adapted from mattpocock/skills `grilling`, MIT © 2026 Matt Pocock. Treat unresolved choices as a design tree and ask the whole settled frontier in each round. Number each question, attach a recommended answer, and defer questions whose prerequisites are still open. Research facts through tools or delegated investigation; ask the user only for decisions. Recompute the frontier after every response until no material branch is implicit.
+Adapted from mattpocock/skills `grilling`, MIT © 2026 Matt Pocock. Model unresolved decisions as a design tree. In each round, ask the full **frontier**: only questions whose prerequisites are already settled. Number every frontier question and include a recommended answer; do not ask a dependent question in the same round.
+
+Facts are agent work: inspect the codebase, Cassy context, tools, or delegated research before asking the user. Decisions are user work. Each answer reshapes the tree and reveals the next frontier; finish only when no material branch remains silently assumed.
 
 ## Output Guidance
 

--- a/cas-cli/src/builtins/codex/skills/cas-brainstorm/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-brainstorm/SKILL.md
@@ -40,6 +40,10 @@ These exist because Cassy agents have a documented tendency to dump multiple que
 5. **Ask what the user is thinking BEFORE offering ideas.** This surfaces hidden context and prevents the user from anchoring on AI-generated framings. "What have you already considered?" is more valuable than "Here are 5 options."
 6. **Broad before narrow.** Start with problem, users, and value. Only narrow to constraints, exclusions, and edge cases after the big picture is clear.
 
+## Frontier-round mechanics
+
+Adapted from mattpocock/skills `grilling`, MIT © 2026 Matt Pocock. Treat unresolved choices as a design tree and ask the whole settled frontier in each round. Number each question, attach a recommended answer, and defer questions whose prerequisites are still open. Research facts through tools or delegated investigation; ask the user only for decisions. Recompute the frontier after every response until no material branch is implicit.
+
 ## Output Guidance
 
 - **Keep outputs concise.** Short sections, brief bullets, only enough detail to support the next decision.

--- a/cas-cli/src/builtins/codex/skills/cas-code-review/references/personas/correctness.md
+++ b/cas-cli/src/builtins/codex/skills/cas-code-review/references/personas/correctness.md
@@ -10,7 +10,7 @@ Hunt for defects that make the changed code *wrong* — logic errors, broken exe
 
 ## In scope
 
-Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Add **spec fidelity** to every review: compare changed behavior against task/spec acceptance criteria and identify an observable requirement the diff omits, reverses, or silently widens. Do not invent requirements; cite the exact task, spec, or documented contract.
+Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Add **spec fidelity** to every review: compare changed behavior against the task/spec acceptance criteria and identify an observable requirement the diff omits, reverses, or silently widens. Do not invent requirements; cite the exact task, spec, or documented contract.
 
 - Off-by-one and boundary errors (loop bounds, slice indices, inclusive/exclusive ranges, empty-collection edge cases).
 - Null / `None` / `undefined` / `Option::None` propagation that reaches an unchecked dereference.

--- a/cas-cli/src/builtins/codex/skills/cas-code-review/references/personas/correctness.md
+++ b/cas-cli/src/builtins/codex/skills/cas-code-review/references/personas/correctness.md
@@ -10,6 +10,8 @@ Hunt for defects that make the changed code *wrong* — logic errors, broken exe
 
 ## In scope
 
+Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Add **spec fidelity** to every review: compare changed behavior against task/spec acceptance criteria and identify an observable requirement the diff omits, reverses, or silently widens. Do not invent requirements; cite the exact task, spec, or documented contract.
+
 - Off-by-one and boundary errors (loop bounds, slice indices, inclusive/exclusive ranges, empty-collection edge cases).
 - Null / `None` / `undefined` / `Option::None` propagation that reaches an unchecked dereference.
 - Race conditions and ordering bugs: unsynchronized shared state, check-then-act, lease/lock handling, async cancellation safety.

--- a/cas-cli/src/builtins/codex/skills/cas-code-review/references/personas/maintainability.md
+++ b/cas-cli/src/builtins/codex/skills/cas-code-review/references/personas/maintainability.md
@@ -10,7 +10,7 @@ Hunt for changes that make the codebase harder to read, reason about, extend, or
 
 ## In scope
 
-Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Use a Fowler-style smell baseline as prompts, not a mechanical scorecard: duplicated code, long method, large class, long parameter list, divergent change, shotgun surgery, feature envy, data clumps, primitive obsession, switch statements, parallel inheritance hierarchies, and lazy classes. Report only evidence-backed changed-code smells that materially harm future comprehension.
+Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Use this Fowler-style smell baseline as prompts, not a mechanical scorecard: duplicated code, long method, large class, long parameter list, divergent change, shotgun surgery, feature envy, data clumps, primitive obsession, switch statements, parallel inheritance hierarchies, and lazy classes. Emit only when the smell is evidenced in the changed code and matters to future readers.
 
 - Duplication: the diff introduces a block that already exists elsewhere (grep the repo), or copies a pattern that the codebase has already extracted into a helper.
 - Naming drift: a new symbol uses a convention that conflicts with its neighbors (e.g., `snake_case` in a `camelCase` file, `get_*` next to `fetch_*`), or a name that misrepresents what the code does.

--- a/cas-cli/src/builtins/codex/skills/cas-code-review/references/personas/maintainability.md
+++ b/cas-cli/src/builtins/codex/skills/cas-code-review/references/personas/maintainability.md
@@ -10,6 +10,8 @@ Hunt for changes that make the codebase harder to read, reason about, extend, or
 
 ## In scope
 
+Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Use a Fowler-style smell baseline as prompts, not a mechanical scorecard: duplicated code, long method, large class, long parameter list, divergent change, shotgun surgery, feature envy, data clumps, primitive obsession, switch statements, parallel inheritance hierarchies, and lazy classes. Report only evidence-backed changed-code smells that materially harm future comprehension.
+
 - Duplication: the diff introduces a block that already exists elsewhere (grep the repo), or copies a pattern that the codebase has already extracted into a helper.
 - Naming drift: a new symbol uses a convention that conflicts with its neighbors (e.g., `snake_case` in a `camelCase` file, `get_*` next to `fetch_*`), or a name that misrepresents what the code does.
 - Dead code: new branches, parameters, fields, or imports that are never read or always false. Distinct from `correctness`-level "unwired public API" — this is *internal* deadness.

--- a/cas-cli/src/builtins/codex/skills/cas-codebase-design/DEEPENING.md
+++ b/cas-cli/src/builtins/codex/skills/cas-codebase-design/DEEPENING.md
@@ -1,0 +1,10 @@
+# Deepening
+
+Classify dependencies before combining shallow modules: in-process dependencies
+can be tested through the new interface directly; local-substitutable ones use
+their real local stand-in; owned remote dependencies justify an injected port
+and in-memory/transport adapters; true externals use an injected mock adapter.
+
+Keep internal seams private. Replace old shallow-module tests with tests at the
+deepened interface once that interface covers the behavior; do not layer tests
+that assert internals or must change with every refactor.

--- a/cas-cli/src/builtins/codex/skills/cas-codebase-design/DESIGN-IT-TWICE.md
+++ b/cas-cli/src/builtins/codex/skills/cas-codebase-design/DESIGN-IT-TWICE.md
@@ -1,0 +1,7 @@
+# Design it twice
+
+Before committing to a consequential interface, frame constraints, dependency
+categories, and an illustrative sketch. Explore at least three materially
+different interfaces: minimum surface, maximum flexibility, and the common
+caller. Compare depth, locality, seam placement, hidden complexity, and
+trade-offs; record the recommendation and reason in the active Cassy task.

--- a/cas-cli/src/builtins/codex/skills/cas-codebase-design/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-codebase-design/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: cas-codebase-design
+description: Use when designing or restructuring a module, choosing a seam, or assessing testability and architectural depth.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills codebase-design (MIT, © 2026 Matt Pocock).
+---
+
+# Codebase design
+
+Design deep modules: substantial behavior behind a small, clear interface at a
+well-chosen seam. This vocabulary improves leverage for callers, locality for
+maintainers, and tests that exercise real behavior.
+
+## Vocabulary
+
+- **Module**: anything with an interface and implementation, from a function
+  to a package or vertical slice.
+- **Interface**: every fact a caller must know: types, invariants, ordering,
+  error modes, configuration, and performance characteristics.
+- **Depth**: behavior a caller can exercise per unit of interface it must
+  learn. A shallow module exposes nearly as much complexity as it hides.
+- **Seam**: where behavior can vary without editing the caller; its placement
+  is a design choice distinct from the implementation behind it.
+- **Adapter**: a concrete implementation filling a seam. Use it when the
+  varying slot matters; otherwise say implementation.
+- **Leverage** and **locality**: the caller and maintainer benefits of depth.
+
+Use this language consistently, except that established framework vocabulary
+always wins. In NestJS projects, `*.service.ts` and `service` are normal,
+meaningful conventions; do not apply an "avoid service" rule there.
+
+## Principles
+
+- Depth is a property of the interface, not implementation size.
+- Apply the deletion test: if deleting a module merely removes a pass-through,
+  it was shallow; if complexity reappears at many callers, it earned its keep.
+- The interface is the primary test surface. Tests should assert observable
+  outcomes through it, not reach through internal seams.
+- One adapter is a hypothetical seam; two justified adapters make it real.
+  Do not add indirection when nothing varies.
+- Accept dependencies rather than creating them; return results where possible
+  rather than hiding critical work in side effects.
+
+## Completion
+
+Name the selected seam, the interface facts callers must learn, what complexity
+stays behind it, and the deletion-test result. If the choice is consequential,
+capture it in the active Cassy task or a `mcp__cas__spec` decision rather than a
+parallel architecture-record directory.
+
+For dependency categories and replacement testing, read
+[DEEPENING.md](DEEPENING.md). For alternatives, read
+[DESIGN-IT-TWICE.md](DESIGN-IT-TWICE.md).

--- a/cas-cli/src/builtins/codex/skills/cas-diagnosing-bugs/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-diagnosing-bugs/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: cas-diagnosing-bugs
+description: Use when diagnosing, debugging, or reproducing a broken, failing, throwing, or slow behavior.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills (MIT, © 2026 Matt Pocock).
+---
+
+# Diagnosing bugs
+
+Use a feedback-loop-first discipline. Skip a phase only with an explicit reason.
+Redact every secret in commands, output, and artifacts; retain the signal and ask
+for a redacted artifact or access when redaction prevents diagnosis.
+
+## Phase 1 — Build a tight, red-capable loop
+
+Do not form a causal theory before one command can reproduce the user's exact
+symptom. Prefer, in order: a failing scoped test; a CLI fixture; an HTTP or
+browser assertion; captured-trace replay; a minimal harness; property/fuzz or
+bisection loop; differential run; then a human-in-the-loop runbook. Treat the
+loop as a product: make it fast, deterministic, and specific. For flakes,
+increase reproduction rate with repeated or stress runs.
+
+Completion requires one already-run command whose redacted output proves it is
+red-capable, deterministic (or has a stated high repro rate), fast, and
+unattended. If no loop can be built, state what was tried and request the
+reproducing environment, a redacted capture, or approval for temporary
+instrumentation; do not hypothesize without a loop.
+
+## Phase 2 — Reproduce and minimize
+
+Run the loop, confirm it is the user's failure rather than a nearby one, and
+capture the symptom. Remove inputs, callers, configuration, and steps one at a
+time until every remaining element is load-bearing.
+
+## Phase 3 — Rank falsifiable hypotheses
+
+Produce 3–5 ranked hypotheses. Each must predict what changing one variable
+would do. Record them in the task note and invite domain correction without
+blocking on it; discard a hypothesis that cannot make a testable prediction.
+
+## Phase 4 — Instrument one prediction at a time
+
+Prefer debugger/REPL inspection, then targeted boundary logs. Tag temporary
+logs with a unique `[DEBUG-…]` prefix. For performance regressions, establish a
+measurement or profile baseline before changing code.
+
+## Phase 5 — Fix and regression
+
+Turn the minimized repro into a failing test only at a seam that exercises the
+real call-site pattern. If no correct seam exists, record that architectural
+finding. Otherwise: make the regression fail, fix it, make it pass, then rerun
+the original loop.
+
+## Phase 6 — Cleanup
+
+Before claiming done, rerun the original loop, confirm regression coverage (or
+the documented missing seam), remove tagged instrumentation and marked
+throwaways, and record the validated hypothesis in the commit or task note.

--- a/cas-cli/src/builtins/codex/skills/cas-domain-modeling/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-domain-modeling/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: cas-domain-modeling
+description: Use when clarifying a project's terminology, domain relationships, or durable technical decisions.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills (MIT, © 2026 Matt Pocock).
+---
+
+# Domain modeling
+
+Actively sharpen a project's shared domain model while designing. This Cassy
+adaptation stores resolved language and decisions in the canonical CAS memory
+and spec surfaces, never in a parallel `CONTEXT.md` or ADR-file convention.
+
+## During the session
+
+### Challenge the language
+
+When a term conflicts with established project language, surface the conflict
+immediately. When it is vague or overloaded, propose a precise canonical term.
+Stress-test relationships with concrete edge cases, and verify claims about
+behavior against the code before treating them as domain truth.
+
+### Persist resolved terms
+
+When a term is settled, store its concise definition with
+`mcp__cs__memory action=remember`, using project scope and tags that make it
+retrievable. Record the term, its boundaries, important synonyms to avoid, and
+the scenario that disambiguated it. Search existing project memories first so
+the entry refines rather than duplicates the canonical language.
+
+### Persist consequential decisions
+
+Use `mcp__cs__spec` or a decision memory only when the choice is hard to
+reverse, surprising without context, and the result of a real trade-off. A
+decision records the alternatives, chosen direction, reason, and affected
+domain terms; it is not an implementation scratchpad. Link it to the active
+task when it governs delivery.
+
+## Completion
+
+Before ending, ensure every resolved term or irreversible decision is either
+durably recorded in Cassy or explicitly left open. Do not create glossary,
+context-map, or ADR files that would compete with CAS memory/spec storage.

--- a/cas-cli/src/builtins/codex/skills/cas-domain-modeling/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-domain-modeling/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 Actively sharpen a project's shared domain model while designing. This Cassy
 adaptation stores resolved language and decisions in the canonical CAS memory
-and spec surfaces, never in a parallel `CONTEXT.md` or ADR-file convention.
+and spec surfaces, never in a parallel local-file convention.
 
 ## During the session
 
@@ -44,4 +44,4 @@ task when it governs delivery.
 
 Before ending, ensure every resolved term or irreversible decision is either
 durably recorded in Cassy or explicitly left open. Do not create glossary,
-context-map, or ADR files that would compete with CAS memory/spec storage.
+or decision files that would compete with CAS memory/spec storage.

--- a/cas-cli/src/builtins/codex/skills/cas-resolving-merge-conflicts/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-resolving-merge-conflicts/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: cas-resolving-merge-conflicts
+description: Use when resolving an in-progress git merge or rebase conflict.
+managed_by: cas
+---
+
+# Resolve Merge Conflicts by Intent
+
+Imported and adapted from mattpocock/skills `resolving-merge-conflicts`, MIT © 2026 Matt Pocock.
+
+Inspect the conflict and history, trace each side to commits/PRs/Cassy tasks/specs, then preserve both intents where possible. When incompatible, choose the merge goal’s intent and record the trade-off in `mcp__cas__task`; never invent behavior or abandon the decision with `--abort`. Run affected checks and commit the completed merge/rebase.

--- a/cas-cli/src/builtins/codex/skills/cas-resolving-merge-conflicts/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-resolving-merge-conflicts/SKILL.md
@@ -8,4 +8,10 @@ managed_by: cas
 
 Imported and adapted from mattpocock/skills `resolving-merge-conflicts`, MIT © 2026 Matt Pocock.
 
-Inspect the conflict and history, trace each side to commits/PRs/Cassy tasks/specs, then preserve both intents where possible. When incompatible, choose the merge goal’s intent and record the trade-off in `mcp__cas__task`; never invent behavior or abandon the decision with `--abort`. Run affected checks and commit the completed merge/rebase.
+1. Inspect the current merge or rebase state, history, and conflicting files.
+2. Trace both sides to their primary sources: commits, pull requests, Cassy tasks, specs, and documented intent.
+3. Resolve each hunk by preserving both intents where possible. If they are incompatible, choose the change matching the merge’s stated goal and record the trade-off in `mcp__cs__task`. Do not invent new behavior.
+4. Finish the merge or rebase; do not abandon it with `--abort` merely to avoid the decision.
+5. Run the project’s affected checks, fix integration damage, then commit the resolved result.
+
+Use Cassy task/spec context for intent; do not introduce external tracker, scratch, setup, or context-file workflows.

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/planning.md
@@ -143,6 +143,12 @@ Fan-out is the most common pattern for EPICs with 3+ workers: one setup/spike ta
 
 ## Task Breakdown Guidelines
 
+## Vertical slices and wide refactors
+
+Adapted from mattpocock/skills `to-tickets`, MIT © 2026 Matt Pocock. Prefer tracer-bullet vertical slices: a task covers a narrow complete path, is independently demoable or verifiable, fits one fresh worker context, and declares only genuine Cassy dependency edges.
+
+For a codebase-wide mechanical change that cannot stay green as a vertical slice, sequence expand–contract: add the new form beside the old, migrate blast-radius-sized batches, then remove the old form after every batch. Use `mcp__cas__task` dependencies, not external tracker or scratch-file workflows.
+
 When breaking an epic into subtasks, apply these patterns:
 
 **Demo statements** — Every subtask must have a `demo_statement` describing what can be demonstrated when complete. Example: `demo_statement="User types a query and results filter live"`. If a task has no demo-able output, it may be a horizontal slice — restructure it into a vertical slice that delivers observable value.

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/planning.md
@@ -145,9 +145,9 @@ Fan-out is the most common pattern for EPICs with 3+ workers: one setup/spike ta
 
 ## Vertical slices and wide refactors
 
-Adapted from mattpocock/skills `to-tickets`, MIT © 2026 Matt Pocock. Prefer tracer-bullet vertical slices: a task covers a narrow complete path, is independently demoable or verifiable, fits one fresh worker context, and declares only genuine Cassy dependency edges.
+Adapted from mattpocock/skills `to-tickets`, MIT © 2026 Matt Pocock. Prefer tracer-bullet vertical slices: each task cuts a narrow but complete path through the affected layers, is independently demoable or verifiable, and fits one fresh worker context. Give every task only its genuine blocking edges and work the unblocked frontier.
 
-For a codebase-wide mechanical change that cannot stay green as a vertical slice, sequence expand–contract: add the new form beside the old, migrate blast-radius-sized batches, then remove the old form after every batch. Use `mcp__cas__task` dependencies, not external tracker or scratch-file workflows.
+For a mechanical, codebase-wide change that cannot land green as a vertical slice, use **expand–contract** instead: first add the new form beside the old; then migrate call sites in blast-radius-sized batches, each blocked by expansion; finally remove the old form only after every migration batch completes. Preserve Cassy task dependencies with `mcp__cs__task`; never substitute external tracker or scratch-file workflows.
 
 When breaking an epic into subtasks, apply these patterns:
 

--- a/cas-cli/src/builtins/codex/skills/cas-tdd/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-tdd/SKILL.md
@@ -8,10 +8,32 @@ managed_by: cas
 
 Imported and adapted from mattpocock/skills `tdd`, MIT © 2026 Matt Pocock.
 
-Use a red → green loop to produce tests worth keeping. Test public behavior, agree seams before testing, work one vertical tracer-bullet slice at a time, and use independently derived expected values. Keep decisions and proof in `mcp__cas__task`, `mcp__cas__spec`, and `mcp__cas__memory`, never parallel tracker or context files.
+Use a red → green loop to produce tests worth keeping. Test behavior through public interfaces, name the observable capability, and choose seams before writing the test. Keep durable decisions and task evidence in Cassy through `mcp__cs__task`, `mcp__cs__spec`, and `mcp__cs__memory`; do not create parallel tracker or context files.
 
-Avoid implementation-coupled, tautological, and horizontal-slice tests. Mock real system boundaries, not internal collaborators merely to assert calls. Run the project’s affected scoped test target and record its nonzero test count and exit status.
+## Seams and slices
 
-**NestJS carve-out:** `Test.createTestingModule` provider overrides are the framework-sanctioned seam for injected external or separately-owned dependencies. They are valid when the test exercises public module behavior; do not classify them as an implementation-coupled anti-pattern merely because Nest uses dependency injection.
+- Agree the public seam before testing. A seam is the boundary where a caller observes behavior without reaching into internals.
+- Work vertical tracer bullets: one test, the smallest implementation that makes it pass, then the next learned slice. Do not write a horizontal wall of imagined tests.
+- Expected values come from an independent source of truth: a worked example, specification, known-good literal, or external contract.
+- Use the project’s scoped test command and record the actual proof result in the task. Do not treat a zero-test success as proof.
 
-For seam vocabulary, consult `cas-codebase-design`.
+When module shape or a seam is unclear, consult `cas-codebase-design` for module, interface, depth, seam, adapter, leverage, and locality vocabulary.
+
+## Anti-patterns
+
+- **Implementation-coupled:** tests private methods, verifies a side channel rather than the interface, or breaks under a behavior-preserving refactor.
+- **Tautological:** the assertion recomputes expected output with the same logic as production code.
+- **Horizontal slicing:** tests all anticipated behavior before any implementation, so the suite becomes insensitive to what actually ships.
+
+## Mocking at real boundaries
+
+Mock external systems, time, randomness, and selected filesystem/network boundaries when a real fixture is unsuitable. Prefer real in-process behavior for code you own; do not mock a collaborator merely to prove it was called.
+
+**NestJS carve-out:** `Test.createTestingModule` provider overrides and mocks are the framework-sanctioned seam for isolating a Nest module’s injected dependencies. They are not an implementation-coupled anti-pattern when the test exercises the module’s public behavior and the override represents a real external or separately-owned provider boundary.
+
+## Loop rules
+
+1. Make the test fail for the intended missing behavior before writing production code.
+2. Add only enough code to make that slice pass; do not speculate into future slices.
+3. Refactor after behavior is green, retaining the public-behavior contract.
+4. Before handoff, run the affected scoped test target and report its nonzero test count and exit status in the Cassy task.

--- a/cas-cli/src/builtins/codex/skills/cas-tdd/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-tdd/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: cas-tdd
+description: Test-driven development discipline for behavior-focused, scoped Cassy changes. Use when a task requires test-first work, red-green-refactor, or integration-test design.
+managed_by: cas
+---
+
+# Test-Driven Development
+
+Imported and adapted from mattpocock/skills `tdd`, MIT © 2026 Matt Pocock.
+
+Use a red → green loop to produce tests worth keeping. Test public behavior, agree seams before testing, work one vertical tracer-bullet slice at a time, and use independently derived expected values. Keep decisions and proof in `mcp__cas__task`, `mcp__cas__spec`, and `mcp__cas__memory`, never parallel tracker or context files.
+
+Avoid implementation-coupled, tautological, and horizontal-slice tests. Mock real system boundaries, not internal collaborators merely to assert calls. Run the project’s affected scoped test target and record its nonzero test count and exit status.
+
+**NestJS carve-out:** `Test.createTestingModule` provider overrides are the framework-sanctioned seam for injected external or separately-owned dependencies. They are valid when the test exercises public module behavior; do not classify them as an implementation-coupled anti-pattern merely because Nest uses dependency injection.
+
+For seam vocabulary, consult `cas-codebase-design`.

--- a/cas-cli/src/builtins/codex/skills/cas-tdd/mocking.md
+++ b/cas-cli/src/builtins/codex/skills/cas-tdd/mocking.md
@@ -2,4 +2,10 @@
 
 Imported and adapted from mattpocock/skills `tdd/mocking.md`, MIT © 2026 Matt Pocock.
 
-Mock external boundaries, not internal collaborators merely to prove calls. NestJS `Test.createTestingModule` provider overrides remain sanctioned seams when a public module behavior is under test.
+Mock at boundaries: third-party APIs, time, randomness, filesystems, and databases when an appropriate real test fixture is unavailable. Keep mocks specific to the boundary contract so a failing test identifies the behavior that changed.
+
+Do not mock internal collaborators solely to assert that they were called. Test through the owning module’s public interface whenever that yields the behavior a caller cares about.
+
+## NestJS provider seam
+
+`Test.createTestingModule` and provider overrides are sanctioned NestJS seams. Mock an injected provider when it is an external system or separately-owned dependency and the test is asserting the module’s public behavior. Do not reject this pattern as an internal-collaborator mock merely because Nest resolves it through dependency injection.

--- a/cas-cli/src/builtins/codex/skills/cas-tdd/mocking.md
+++ b/cas-cli/src/builtins/codex/skills/cas-tdd/mocking.md
@@ -1,0 +1,5 @@
+# When to Mock
+
+Imported and adapted from mattpocock/skills `tdd/mocking.md`, MIT © 2026 Matt Pocock.
+
+Mock external boundaries, not internal collaborators merely to prove calls. NestJS `Test.createTestingModule` provider overrides remain sanctioned seams when a public module behavior is under test.

--- a/cas-cli/src/builtins/codex/skills/cas-tdd/tests.md
+++ b/cas-cli/src/builtins/codex/skills/cas-tdd/tests.md
@@ -1,0 +1,5 @@
+# Good and Bad Tests
+
+Imported and adapted from mattpocock/skills `tdd/tests.md`, MIT © 2026 Matt Pocock.
+
+Good tests describe observable behavior through public interfaces and survive internal refactors. Avoid private-method, call-order, side-channel, and self-recomputing assertions; use independent literals, examples, or specifications.

--- a/cas-cli/src/builtins/codex/skills/cas-tdd/tests.md
+++ b/cas-cli/src/builtins/codex/skills/cas-tdd/tests.md
@@ -2,4 +2,8 @@
 
 Imported and adapted from mattpocock/skills `tdd/tests.md`, MIT © 2026 Matt Pocock.
 
-Good tests describe observable behavior through public interfaces and survive internal refactors. Avoid private-method, call-order, side-channel, and self-recomputing assertions; use independent literals, examples, or specifications.
+Good tests describe observable behavior through a public interface and survive internal refactors. Name what a caller can do, not which helper happened to run.
+
+Avoid tests that inspect private methods, call counts, ordering, or persistence side channels when a public interface can observe the result. Avoid expected values derived by repeating production logic; use a known literal, a worked example, or a specification instead.
+
+One logical capability per test makes failures legible. A small table is useful when independent cases share a public contract; it is not a substitute for behavior-focused test names.

--- a/cas-cli/src/builtins/codex/skills/cas-to-questionnaire/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-to-questionnaire/SKILL.md
@@ -9,4 +9,8 @@ managed_by: cas
 
 Imported and adapted from mattpocock/skills `to-questionnaire`, MIT © 2026 Matt Pocock.
 
-Grill the send, not the subject: establish the recipient’s role/knowledge and the decisions the user needs back. Draft a discovery questionnaire in the user-approved output location with purpose, sender, recipient, context, one-idea importance-ordered questions, answer stubs, and a catch-all. Use Cassy task/spec/memory context rather than external tracker or context-file workflows; do not invent deadlines or recipient knowledge.
+Turn an unanswered decision into a document a knowledgeable recipient can complete asynchronously or in a meeting. **Grill the send, not the subject:** establish the recipient’s role, expertise, and relationship, then establish the decisions or facts the user needs back. Do not ask the user for facts the recipient is meant to supply.
+
+Draft a discovery questionnaire in the user-approved output location. State its purpose, sender, recipient, and how answers will be used; give only enough context to orient the recipient; order one-idea questions by importance; provide an answer stub and a short “why this matters” only where useful; finish with a catch-all. Preserve task or decision context through `mcp__cs__task`, `mcp__cs__spec`, or `mcp__cs__memory`, not a parallel tracker or context-file convention.
+
+Before delivery, verify every stated decision gap has a question and report the created path. Do not invent a deadline, recipient knowledge, or a real-world process step that the user has not supplied.

--- a/cas-cli/src/builtins/codex/skills/cas-to-questionnaire/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-to-questionnaire/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: cas-to-questionnaire
+description: Turn a decision the user cannot answer alone into a discovery questionnaire for a knowledgeable third party.
+disable-model-invocation: true
+managed_by: cas
+---
+
+# Discovery Questionnaire
+
+Imported and adapted from mattpocock/skills `to-questionnaire`, MIT © 2026 Matt Pocock.
+
+Grill the send, not the subject: establish the recipient’s role/knowledge and the decisions the user needs back. Draft a discovery questionnaire in the user-approved output location with purpose, sender, recipient, context, one-idea importance-ordered questions, answer stubs, and a catch-all. Use Cassy task/spec/memory context rather than external tracker or context-file workflows; do not invent deadlines or recipient knowledge.

--- a/cas-cli/src/builtins/codex/skills/cas-wizard/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-wizard/SKILL.md
@@ -8,6 +8,8 @@ managed_by: cas
 
 Imported and adapted from mattpocock/skills `wizard`, MIT © 2026 Matt Pocock.
 
-Use a stage-by-stage Bash wizard for a repeatable manual procedure. Inspect the project, enumerate every manual step, URL, destination, and secret classification, then confirm the ordered plan with the user. Copy `template.sh`; edit only after `STAGES`; keep one focused action per stage; hide secrets and confirm irreversible actions.
+Use a wizard for a repeatable manual procedure: a person drives external dashboards and confirms irreversible steps while the script gives one precise stage at a time. First inspect the project and enumerate every manual step, its source URL, destination, and whether its value is secret. Confirm the ordered stage plan with the user before authoring it.
 
-Run `bash -n` and static tracing, never an end-to-end interactive run. Keep decisions and proof in `mcp__cas__task`; do not create parallel tracker, setup, or context files.
+Copy [template.sh](template.sh) to a task-appropriate script path and edit only the section after `STAGES`. Give each stage one focused action, open the exact URL before asking for a value, hide secrets, and confirm before irreversible actions. Keep generated procedures in the task’s approved output area unless the user asks for a maintained repository runbook.
+
+Run `bash -n` and static tracing only; do not run a wizard end-to-end because it opens browsers and blocks on human input. Keep task decisions and proof in `mcp__cs__task`; this skill never creates a parallel tracker, setup system, or context file.

--- a/cas-cli/src/builtins/codex/skills/cas-wizard/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-wizard/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: cas-wizard
+description: Generate an interactive Bash wizard for human-only setup, secrets, dashboard, cutover, or migration steps. Do not use it for work the agent can perform directly.
+managed_by: cas
+---
+
+# Human Procedure Wizard
+
+Imported and adapted from mattpocock/skills `wizard`, MIT © 2026 Matt Pocock.
+
+Use a stage-by-stage Bash wizard for a repeatable manual procedure. Inspect the project, enumerate every manual step, URL, destination, and secret classification, then confirm the ordered plan with the user. Copy `template.sh`; edit only after `STAGES`; keep one focused action per stage; hide secrets and confirm irreversible actions.
+
+Run `bash -n` and static tracing, never an end-to-end interactive run. Keep decisions and proof in `mcp__cas__task`; do not create parallel tracker, setup, or context files.

--- a/cas-cli/src/builtins/codex/skills/cas-wizard/template.sh
+++ b/cas-cli/src/builtins/codex/skills/cas-wizard/template.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Imported and adapted from mattpocock/skills wizard/template.sh, MIT © 2026 Matt Pocock.
+# Edit only after STAGES.
+set -euo pipefail
+TOTAL_STAGES=0
+_stage=0
+ENV_FILE="${ENV_FILE:-.env}"
+open_url() { command -v xdg-open >/dev/null && xdg-open "$1" || command -v open >/dev/null && open "$1" || printf 'Open manually: %s\n' "$1"; }
+pause() { read -r -p "${1:-Press Enter to continue} " _ || true; }
+confirm() { local answer; read -r -p "$1 [y/N] " answer || true; [[ "$answer" =~ ^[Yy]$ ]]; }
+stage() { _stage=$((_stage + 1)); printf '\nStage %s/%s: %s\n' "$_stage" "$TOTAL_STAGES" "$1"; }
+say() { printf '  %s\n' "$1"; }
+ask() { read -r -p "$2 " "$1" || true; }
+ask_secret() { read -r -s -p "$2 " "$1" || true; printf '\n'; }
+write_env() { local key="$1" value="$2" tmp; touch "$ENV_FILE"; tmp=$(mktemp); grep -vE "^${key}=" "$ENV_FILE" >"$tmp" || true; printf '%s=%s\n' "$key" "$value" >>"$tmp"; mv "$tmp" "$ENV_FILE"; }
+set_secret() { local name="$1" value="$2"; command -v gh >/dev/null && printf '%s' "$value" | gh secret set "$name" || printf 'Set GitHub secret manually: %s\n' "$name"; }
+finish() { printf '\nWizard complete.\n'; }
+# STAGES: define TOTAL_STAGES and one stage per human action below.

--- a/cas-cli/src/builtins/codex/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker/references/discipline.md
@@ -2,9 +2,9 @@
 
 ## Marked throwaway prototypes
 
-Adapted from mattpocock/skills `prototype`, MIT © 2026 Matt Pocock. A prototype answers one stated design question and is throwaway from day one: mark it clearly, place it near the explored code or UI, avoid persistence and production polish, and surface the state or variant under examination.
+Adapted from mattpocock/skills `prototype`, MIT © 2026 Matt Pocock. A prototype exists to answer one stated design question and is throwaway from day one. Mark it clearly, keep it near the code or UI it explores, avoid persistence and production-grade polish, and surface the state or variant being tested.
 
-Capture the resulting question and verdict in `mcp__cas__task`, `mcp__cas__spec`, or `mcp__cas__memory`. Keep the prototype off the delivery branch or remove it; never leave an unmarked root-level script, parallel tracker, or context-file workflow.
+When it settles a decision, capture the question and verdict in `mcp__cs__task`, `mcp__cs__spec`, or `mcp__cs__memory`. Keep the prototype itself off the delivery branch or remove it after the decision; only validated production changes belong in the task’s deliverable. Never create an unmarked root-level script, parallel tracker, or context-file workflow.
 
 Proactive habits that keep a worker useful for a whole shift. The other references are about
 moments (closing, breaking, looking things up); this one is about how you run continuously.

--- a/cas-cli/src/builtins/codex/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker/references/discipline.md
@@ -1,5 +1,11 @@
 # Operating Discipline — Staying Reachable and Staying Alive
 
+## Marked throwaway prototypes
+
+Adapted from mattpocock/skills `prototype`, MIT © 2026 Matt Pocock. A prototype answers one stated design question and is throwaway from day one: mark it clearly, place it near the explored code or UI, avoid persistence and production polish, and surface the state or variant under examination.
+
+Capture the resulting question and verdict in `mcp__cas__task`, `mcp__cas__spec`, or `mcp__cas__memory`. Keep the prototype off the delivery branch or remove it; never leave an unmarked root-level script, parallel tracker, or context-file workflow.
+
 Proactive habits that keep a worker useful for a whole shift. The other references are about
 moments (closing, breaking, looking things up); this one is about how you run continuously.
 Two failure modes cost real money on 2026-08-06 (GH #121) and both are fully preventable:

--- a/cas-cli/src/builtins/codex/skills/cas-writing-for-agents/SKILL-MECHANICS.md
+++ b/cas-cli/src/builtins/codex/skills/cas-writing-for-agents/SKILL-MECHANICS.md
@@ -1,0 +1,13 @@
+# Skill mechanics
+
+Provenance: adapted from `mattpocock/skills` (MIT, © 2026 Matt Pocock).
+
+## Invocation
+
+A model-invoked skill has a description: that description is an always-loaded context pointer, so write trigger branches precisely. It remains available to explicit user invocation. Use model invocation when the agent or another skill must discover it autonomously.
+
+A user-invoked skill sets `disable-model-invocation: true`. Its description is human-facing and carries no autonomous trigger. Choose it when a person should decide whether to use the skill, trading context load for cognitive load.
+
+## Splitting and routers
+
+Split a skill only when a distinct leading word needs independent model invocation, or a different invocation boundary protects a sequence from premature completion. A family of user-invoked skills may use one user-invoked router: it helps people find the right skill, but cannot autonomously invoke its peers.

--- a/cas-cli/src/builtins/codex/skills/cas-writing-for-agents/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-writing-for-agents/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: cas-writing-for-agents
+description: Use when creating or editing a skill, AGENTS.md, CLAUDE.md, or an agent-facing reference document.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills (MIT, © 2026 Matt Pocock).
+---
+
+# Writing for agents
+
+Write agent-facing documents as instructions for a repeated process, not prose for a one-time reader. Read [skill mechanics](SKILL-MECHANICS.md) when the document is a skill.
+
+## Context pointers
+
+A **context pointer** names out-of-context material and the condition for loading it. A skill description and an `AGENTS.md` pointer are both pointers. State what the material is and each distinct branch that should load it. Front-load trigger words, use one trigger per branch, and omit identity the target already carries: every always-loaded word spends context load.
+
+## The two loads
+
+- **Context load** is always-loaded text. Keep it small and earn every word.
+- **Cognitive load** is the human effort of knowing which document to reach for. Spend it where human judgment matters.
+
+Material behind a pointer reduces context load but increases cognitive load.
+
+## Information hierarchy
+
+Put material at the lowest tier that still makes execution reliable:
+
+1. In-file steps: actions every branch performs, in order.
+2. In-file reference: rules consulted while doing those steps.
+3. Disclosed reference: branch-specific material in a linked file.
+
+Use progressive disclosure to keep the main path legible. Co-locate a concept's definition, rules, and caveats. Split only when a sequence or invocation branch earns the extra pointer; otherwise splitting becomes sprawl.
+
+## Steps and completion criteria
+
+Every step needs a completion criterion. Make it **clear** (done is observable) and **demanding** (the necessary legwork is required). Sharpen a fuzzy criterion before hiding later steps; only a real context boundary prevents later work from pulling attention toward premature completion.
+
+## Leading words and pruning
+
+Prefer compact, familiar leading words that reliably summon a shared behavior: `tight` for a fast deterministic loop, `red` for a bug-reproducing loop. Use positive instructions; a prohibition earns space only for a hard guardrail.
+
+Keep one authoritative statement for each meaning. Treat environment facts as lookups, not prose caches, unless the lookup is costly or misses an unwritten convention. Remove stale exposition, irrelevant branches, and no-op instructions. The result should be short because every line is live.

--- a/cas-cli/src/builtins/grok/skills/cas-brainstorm/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-brainstorm/SKILL.md
@@ -40,6 +40,10 @@ These exist because Cassy agents have a documented tendency to dump multiple que
 5. **Ask what the user is thinking BEFORE offering ideas.** This surfaces hidden context and prevents the user from anchoring on AI-generated framings. "What have you already considered?" is more valuable than "Here are 5 options."
 6. **Broad before narrow.** Start with problem, users, and value. Only narrow to constraints, exclusions, and edge cases after the big picture is clear.
 
+## Frontier-round mechanics
+
+Adapted from mattpocock/skills `grilling`, MIT © 2026 Matt Pocock. Treat unresolved choices as a design tree. Ask every currently settled frontier question in one numbered round, give a recommended answer, and defer dependent questions. Research facts with tools; reserve the user’s turns for decisions. Recompute until no material branch remains implicit.
+
 ## Output Guidance
 
 - **Keep outputs concise.** Short sections, brief bullets, only enough detail to support the next decision.

--- a/cas-cli/src/builtins/grok/skills/cas-brainstorm/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-brainstorm/SKILL.md
@@ -42,7 +42,9 @@ These exist because Cassy agents have a documented tendency to dump multiple que
 
 ## Frontier-round mechanics
 
-Adapted from mattpocock/skills `grilling`, MIT © 2026 Matt Pocock. Treat unresolved choices as a design tree. Ask every currently settled frontier question in one numbered round, give a recommended answer, and defer dependent questions. Research facts with tools; reserve the user’s turns for decisions. Recompute until no material branch remains implicit.
+Adapted from mattpocock/skills `grilling`, MIT © 2026 Matt Pocock. Model unresolved decisions as a design tree. In each round, ask the full **frontier**: only questions whose prerequisites are already settled. Number every frontier question and include a recommended answer; do not ask a dependent question in the same round.
+
+Facts are agent work: inspect the codebase, Cassy context, tools, or delegated research before asking the user. Decisions are user work. Each answer reshapes the tree and reveals the next frontier; finish only when no material branch remains silently assumed.
 
 ## Output Guidance
 

--- a/cas-cli/src/builtins/grok/skills/cas-code-review/references/personas/correctness.md
+++ b/cas-cli/src/builtins/grok/skills/cas-code-review/references/personas/correctness.md
@@ -10,7 +10,7 @@ Hunt for defects that make the changed code *wrong* — logic errors, broken exe
 
 ## In scope
 
-Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Add **spec fidelity** to every review: compare changed behavior against task/spec acceptance criteria and identify an observable requirement the diff omits, reverses, or silently widens. Do not invent requirements; cite the exact task, spec, or documented contract.
+Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Add **spec fidelity** to every review: compare changed behavior against the task/spec acceptance criteria and identify an observable requirement the diff omits, reverses, or silently widens. Do not invent requirements; cite the exact task, spec, or documented contract.
 
 - Off-by-one and boundary errors (loop bounds, slice indices, inclusive/exclusive ranges, empty-collection edge cases).
 - Null / `None` / `undefined` / `Option::None` propagation that reaches an unchecked dereference.

--- a/cas-cli/src/builtins/grok/skills/cas-code-review/references/personas/correctness.md
+++ b/cas-cli/src/builtins/grok/skills/cas-code-review/references/personas/correctness.md
@@ -10,6 +10,8 @@ Hunt for defects that make the changed code *wrong* — logic errors, broken exe
 
 ## In scope
 
+Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Add **spec fidelity** to every review: compare changed behavior against task/spec acceptance criteria and identify an observable requirement the diff omits, reverses, or silently widens. Do not invent requirements; cite the exact task, spec, or documented contract.
+
 - Off-by-one and boundary errors (loop bounds, slice indices, inclusive/exclusive ranges, empty-collection edge cases).
 - Null / `None` / `undefined` / `Option::None` propagation that reaches an unchecked dereference.
 - Race conditions and ordering bugs: unsynchronized shared state, check-then-act, lease/lock handling, async cancellation safety.

--- a/cas-cli/src/builtins/grok/skills/cas-code-review/references/personas/maintainability.md
+++ b/cas-cli/src/builtins/grok/skills/cas-code-review/references/personas/maintainability.md
@@ -10,7 +10,7 @@ Hunt for changes that make the codebase harder to read, reason about, extend, or
 
 ## In scope
 
-Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Use a Fowler-style smell baseline as prompts, not a mechanical scorecard: duplicated code, long method, large class, long parameter list, divergent change, shotgun surgery, feature envy, data clumps, primitive obsession, switch statements, parallel inheritance hierarchies, and lazy classes. Report only evidence-backed changed-code smells that materially harm future comprehension.
+Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Use this Fowler-style smell baseline as prompts, not a mechanical scorecard: duplicated code, long method, large class, long parameter list, divergent change, shotgun surgery, feature envy, data clumps, primitive obsession, switch statements, parallel inheritance hierarchies, and lazy classes. Emit only when the smell is evidenced in the changed code and matters to future readers.
 
 - Duplication: the diff introduces a block that already exists elsewhere (grep the repo), or copies a pattern that the codebase has already extracted into a helper.
 - Naming drift: a new symbol uses a convention that conflicts with its neighbors (e.g., `snake_case` in a `camelCase` file, `get_*` next to `fetch_*`), or a name that misrepresents what the code does.

--- a/cas-cli/src/builtins/grok/skills/cas-code-review/references/personas/maintainability.md
+++ b/cas-cli/src/builtins/grok/skills/cas-code-review/references/personas/maintainability.md
@@ -10,6 +10,8 @@ Hunt for changes that make the codebase harder to read, reason about, extend, or
 
 ## In scope
 
+Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Use a Fowler-style smell baseline as prompts, not a mechanical scorecard: duplicated code, long method, large class, long parameter list, divergent change, shotgun surgery, feature envy, data clumps, primitive obsession, switch statements, parallel inheritance hierarchies, and lazy classes. Report only evidence-backed changed-code smells that materially harm future comprehension.
+
 - Duplication: the diff introduces a block that already exists elsewhere (grep the repo), or copies a pattern that the codebase has already extracted into a helper.
 - Naming drift: a new symbol uses a convention that conflicts with its neighbors (e.g., `snake_case` in a `camelCase` file, `get_*` next to `fetch_*`), or a name that misrepresents what the code does.
 - Dead code: new branches, parameters, fields, or imports that are never read or always false. Distinct from `correctness`-level "unwired public API" — this is *internal* deadness.

--- a/cas-cli/src/builtins/grok/skills/cas-codebase-design/DEEPENING.md
+++ b/cas-cli/src/builtins/grok/skills/cas-codebase-design/DEEPENING.md
@@ -1,0 +1,10 @@
+# Deepening
+
+Classify dependencies before combining shallow modules: in-process dependencies
+can be tested through the new interface directly; local-substitutable ones use
+their real local stand-in; owned remote dependencies justify an injected port
+and in-memory/transport adapters; true externals use an injected mock adapter.
+
+Keep internal seams private. Replace old shallow-module tests with tests at the
+deepened interface once that interface covers the behavior; do not layer tests
+that assert internals or must change with every refactor.

--- a/cas-cli/src/builtins/grok/skills/cas-codebase-design/DESIGN-IT-TWICE.md
+++ b/cas-cli/src/builtins/grok/skills/cas-codebase-design/DESIGN-IT-TWICE.md
@@ -1,0 +1,7 @@
+# Design it twice
+
+Before committing to a consequential interface, frame constraints, dependency
+categories, and an illustrative sketch. Explore at least three materially
+different interfaces: minimum surface, maximum flexibility, and the common
+caller. Compare depth, locality, seam placement, hidden complexity, and
+trade-offs; record the recommendation and reason in the active Cassy task.

--- a/cas-cli/src/builtins/grok/skills/cas-codebase-design/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-codebase-design/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: cas-codebase-design
+description: Use when designing or restructuring a module, choosing a seam, or assessing testability and architectural depth.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills codebase-design (MIT, © 2026 Matt Pocock).
+---
+
+# Codebase design
+
+Design deep modules: substantial behavior behind a small, clear interface at a
+well-chosen seam. This vocabulary improves leverage for callers, locality for
+maintainers, and tests that exercise real behavior.
+
+## Vocabulary
+
+- **Module**: anything with an interface and implementation, from a function
+  to a package or vertical slice.
+- **Interface**: every fact a caller must know: types, invariants, ordering,
+  error modes, configuration, and performance characteristics.
+- **Depth**: behavior a caller can exercise per unit of interface it must
+  learn. A shallow module exposes nearly as much complexity as it hides.
+- **Seam**: where behavior can vary without editing the caller; its placement
+  is a design choice distinct from the implementation behind it.
+- **Adapter**: a concrete implementation filling a seam. Use it when the
+  varying slot matters; otherwise say implementation.
+- **Leverage** and **locality**: the caller and maintainer benefits of depth.
+
+Use this language consistently, except that established framework vocabulary
+always wins. In NestJS projects, `*.service.ts` and `service` are normal,
+meaningful conventions; do not apply an "avoid service" rule there.
+
+## Principles
+
+- Depth is a property of the interface, not implementation size.
+- Apply the deletion test: if deleting a module merely removes a pass-through,
+  it was shallow; if complexity reappears at many callers, it earned its keep.
+- The interface is the primary test surface. Tests should assert observable
+  outcomes through it, not reach through internal seams.
+- One adapter is a hypothetical seam; two justified adapters make it real.
+  Do not add indirection when nothing varies.
+- Accept dependencies rather than creating them; return results where possible
+  rather than hiding critical work in side effects.
+
+## Completion
+
+Name the selected seam, the interface facts callers must learn, what complexity
+stays behind it, and the deletion-test result. If the choice is consequential,
+capture it in the active Cassy task or a `mcp__cas__spec` decision rather than a
+parallel architecture-record directory.
+
+For dependency categories and replacement testing, read
+[DEEPENING.md](DEEPENING.md). For alternatives, read
+[DESIGN-IT-TWICE.md](DESIGN-IT-TWICE.md).

--- a/cas-cli/src/builtins/grok/skills/cas-diagnosing-bugs/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-diagnosing-bugs/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: cas-diagnosing-bugs
+description: Use when diagnosing, debugging, or reproducing a broken, failing, throwing, or slow behavior.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills (MIT, © 2026 Matt Pocock).
+---
+
+# Diagnosing bugs
+
+Use a feedback-loop-first discipline. Skip a phase only with an explicit reason.
+Redact every secret in commands, output, and artifacts; retain the signal and ask
+for a redacted artifact or access when redaction prevents diagnosis.
+
+## Phase 1 — Build a tight, red-capable loop
+
+Do not form a causal theory before one command can reproduce the user's exact
+symptom. Prefer, in order: a failing scoped test; a CLI fixture; an HTTP or
+browser assertion; captured-trace replay; a minimal harness; property/fuzz or
+bisection loop; differential run; then a human-in-the-loop runbook. Treat the
+loop as a product: make it fast, deterministic, and specific. For flakes,
+increase reproduction rate with repeated or stress runs.
+
+Completion requires one already-run command whose redacted output proves it is
+red-capable, deterministic (or has a stated high repro rate), fast, and
+unattended. If no loop can be built, state what was tried and request the
+reproducing environment, a redacted capture, or approval for temporary
+instrumentation; do not hypothesize without a loop.
+
+## Phase 2 — Reproduce and minimize
+
+Run the loop, confirm it is the user's failure rather than a nearby one, and
+capture the symptom. Remove inputs, callers, configuration, and steps one at a
+time until every remaining element is load-bearing.
+
+## Phase 3 — Rank falsifiable hypotheses
+
+Produce 3–5 ranked hypotheses. Each must predict what changing one variable
+would do. Record them in the task note and invite domain correction without
+blocking on it; discard a hypothesis that cannot make a testable prediction.
+
+## Phase 4 — Instrument one prediction at a time
+
+Prefer debugger/REPL inspection, then targeted boundary logs. Tag temporary
+logs with a unique `[DEBUG-…]` prefix. For performance regressions, establish a
+measurement or profile baseline before changing code.
+
+## Phase 5 — Fix and regression
+
+Turn the minimized repro into a failing test only at a seam that exercises the
+real call-site pattern. If no correct seam exists, record that architectural
+finding. Otherwise: make the regression fail, fix it, make it pass, then rerun
+the original loop.
+
+## Phase 6 — Cleanup
+
+Before claiming done, rerun the original loop, confirm regression coverage (or
+the documented missing seam), remove tagged instrumentation and marked
+throwaways, and record the validated hypothesis in the commit or task note.

--- a/cas-cli/src/builtins/grok/skills/cas-domain-modeling/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-domain-modeling/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 Actively sharpen a project's shared domain model while designing. This Cassy
 adaptation stores resolved language and decisions in the canonical CAS memory
-and spec surfaces, never in a parallel `CONTEXT.md` or ADR-file convention.
+and spec surfaces, never in a parallel local-file convention.
 
 ## During the session
 
@@ -44,4 +44,4 @@ task when it governs delivery.
 
 Before ending, ensure every resolved term or irreversible decision is either
 durably recorded in Cassy or explicitly left open. Do not create glossary,
-context-map, or ADR files that would compete with CAS memory/spec storage.
+or decision files that would compete with CAS memory/spec storage.

--- a/cas-cli/src/builtins/grok/skills/cas-domain-modeling/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-domain-modeling/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: cas-domain-modeling
+description: Use when clarifying a project's terminology, domain relationships, or durable technical decisions.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills (MIT, © 2026 Matt Pocock).
+---
+
+# Domain modeling
+
+Actively sharpen a project's shared domain model while designing. This Cassy
+adaptation stores resolved language and decisions in the canonical CAS memory
+and spec surfaces, never in a parallel `CONTEXT.md` or ADR-file convention.
+
+## During the session
+
+### Challenge the language
+
+When a term conflicts with established project language, surface the conflict
+immediately. When it is vague or overloaded, propose a precise canonical term.
+Stress-test relationships with concrete edge cases, and verify claims about
+behavior against the code before treating them as domain truth.
+
+### Persist resolved terms
+
+When a term is settled, store its concise definition with
+`cas__memory action=remember`, using project scope and tags that make it
+retrievable. Record the term, its boundaries, important synonyms to avoid, and
+the scenario that disambiguated it. Search existing project memories first so
+the entry refines rather than duplicates the canonical language.
+
+### Persist consequential decisions
+
+Use `cas__spec` or a decision memory only when the choice is hard to
+reverse, surprising without context, and the result of a real trade-off. A
+decision records the alternatives, chosen direction, reason, and affected
+domain terms; it is not an implementation scratchpad. Link it to the active
+task when it governs delivery.
+
+## Completion
+
+Before ending, ensure every resolved term or irreversible decision is either
+durably recorded in Cassy or explicitly left open. Do not create glossary,
+context-map, or ADR files that would compete with CAS memory/spec storage.

--- a/cas-cli/src/builtins/grok/skills/cas-resolving-merge-conflicts/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-resolving-merge-conflicts/SKILL.md
@@ -8,4 +8,10 @@ managed_by: cas
 
 Imported and adapted from mattpocock/skills `resolving-merge-conflicts`, MIT © 2026 Matt Pocock.
 
-Inspect the conflict and history, trace each side to commits/PRs/Cassy tasks/specs, and preserve both intents where possible. If incompatible, follow the merge goal and record the trade-off in `mcp__cas__task`; never invent behavior or use `--abort` to evade the decision. Run affected checks and commit the completed resolution.
+1. Inspect the current merge or rebase state, history, and conflicting files.
+2. Trace both sides to their primary sources: commits, pull requests, Cassy tasks, specs, and documented intent.
+3. Resolve each hunk by preserving both intents where possible. If they are incompatible, choose the change matching the merge’s stated goal and record the trade-off in `cas__task`. Do not invent new behavior.
+4. Finish the merge or rebase; do not abandon it with `--abort` merely to avoid the decision.
+5. Run the project’s affected checks, fix integration damage, then commit the resolved result.
+
+Use Cassy task/spec context for intent; do not introduce external tracker, scratch, setup, or context-file workflows.

--- a/cas-cli/src/builtins/grok/skills/cas-resolving-merge-conflicts/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-resolving-merge-conflicts/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: cas-resolving-merge-conflicts
+description: Use when resolving an in-progress git merge or rebase conflict.
+managed_by: cas
+---
+
+# Resolve Merge Conflicts by Intent
+
+Imported and adapted from mattpocock/skills `resolving-merge-conflicts`, MIT © 2026 Matt Pocock.
+
+Inspect the conflict and history, trace each side to commits/PRs/Cassy tasks/specs, and preserve both intents where possible. If incompatible, follow the merge goal and record the trade-off in `mcp__cas__task`; never invent behavior or use `--abort` to evade the decision. Run affected checks and commit the completed resolution.

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor/references/planning.md
@@ -143,6 +143,12 @@ Fan-out is the most common pattern for EPICs with 3+ workers: one setup/spike ta
 
 ## Task Breakdown Guidelines
 
+## Vertical slices and wide refactors
+
+Adapted from mattpocock/skills `to-tickets`, MIT © 2026 Matt Pocock. Prefer tracer-bullet vertical slices: each task is a narrow complete path, independently demoable or verifiable, fits one fresh worker context, and has only genuine Cassy dependency edges.
+
+For a wide mechanical refactor that cannot stay green as a vertical slice, use expand–contract: add alongside the old form, migrate blast-radius-sized batches, and remove the old form after all batches. Use `mcp__cas__task`, not external tracker or scratch-file workflows.
+
 When breaking an epic into subtasks, apply these patterns:
 
 **Demo statements** — Every subtask must have a `demo_statement` describing what can be demonstrated when complete. Example: `demo_statement="User types a query and results filter live"`. If a task has no demo-able output, it may be a horizontal slice — restructure it into a vertical slice that delivers observable value.

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor/references/planning.md
@@ -145,9 +145,9 @@ Fan-out is the most common pattern for EPICs with 3+ workers: one setup/spike ta
 
 ## Vertical slices and wide refactors
 
-Adapted from mattpocock/skills `to-tickets`, MIT © 2026 Matt Pocock. Prefer tracer-bullet vertical slices: each task is a narrow complete path, independently demoable or verifiable, fits one fresh worker context, and has only genuine Cassy dependency edges.
+Adapted from mattpocock/skills `to-tickets`, MIT © 2026 Matt Pocock. Prefer tracer-bullet vertical slices: each task cuts a narrow but complete path through the affected layers, is independently demoable or verifiable, and fits one fresh worker context. Give every task only its genuine blocking edges and work the unblocked frontier.
 
-For a wide mechanical refactor that cannot stay green as a vertical slice, use expand–contract: add alongside the old form, migrate blast-radius-sized batches, and remove the old form after all batches. Use `mcp__cas__task`, not external tracker or scratch-file workflows.
+For a mechanical, codebase-wide change that cannot land green as a vertical slice, use **expand–contract** instead: first add the new form beside the old; then migrate call sites in blast-radius-sized batches, each blocked by expansion; finally remove the old form only after every migration batch completes. Preserve Cassy task dependencies with `cas__task`; never substitute external tracker or scratch-file workflows.
 
 When breaking an epic into subtasks, apply these patterns:
 

--- a/cas-cli/src/builtins/grok/skills/cas-tdd/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-tdd/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: cas-tdd
+description: Test-driven development discipline for behavior-focused, scoped Cassy changes. Use when a task requires test-first work, red-green-refactor, or integration-test design.
+managed_by: cas
+---
+
+# Test-Driven Development
+
+Imported and adapted from mattpocock/skills `tdd`, MIT © 2026 Matt Pocock.
+
+Use a red → green loop: agree public seams first, write one behavior-focused vertical slice, add the smallest implementation, then refactor after green. Keep decisions and proof in Cassy’s `mcp__cas__task`, `mcp__cas__spec`, and `mcp__cas__memory` surfaces.
+
+Avoid implementation-coupled, tautological, and horizontal-slice tests. Mock external boundaries rather than internal collaborators merely to assert calls, and record a scoped proof with a nonzero test count.
+
+**NestJS carve-out:** `Test.createTestingModule` provider overrides are sanctioned seams for injected external or separately-owned dependencies when public module behavior is under test.

--- a/cas-cli/src/builtins/grok/skills/cas-tdd/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-tdd/SKILL.md
@@ -8,8 +8,32 @@ managed_by: cas
 
 Imported and adapted from mattpocock/skills `tdd`, MIT © 2026 Matt Pocock.
 
-Use a red → green loop: agree public seams first, write one behavior-focused vertical slice, add the smallest implementation, then refactor after green. Keep decisions and proof in Cassy’s `mcp__cas__task`, `mcp__cas__spec`, and `mcp__cas__memory` surfaces.
+Use a red → green loop to produce tests worth keeping. Test behavior through public interfaces, name the observable capability, and choose seams before writing the test. Keep durable decisions and task evidence in Cassy through `cas__task`, `cas__spec`, and `cas__memory`; do not create parallel tracker or context files.
 
-Avoid implementation-coupled, tautological, and horizontal-slice tests. Mock external boundaries rather than internal collaborators merely to assert calls, and record a scoped proof with a nonzero test count.
+## Seams and slices
 
-**NestJS carve-out:** `Test.createTestingModule` provider overrides are sanctioned seams for injected external or separately-owned dependencies when public module behavior is under test.
+- Agree the public seam before testing. A seam is the boundary where a caller observes behavior without reaching into internals.
+- Work vertical tracer bullets: one test, the smallest implementation that makes it pass, then the next learned slice. Do not write a horizontal wall of imagined tests.
+- Expected values come from an independent source of truth: a worked example, specification, known-good literal, or external contract.
+- Use the project’s scoped test command and record the actual proof result in the task. Do not treat a zero-test success as proof.
+
+When module shape or a seam is unclear, consult `cas-codebase-design` for module, interface, depth, seam, adapter, leverage, and locality vocabulary.
+
+## Anti-patterns
+
+- **Implementation-coupled:** tests private methods, verifies a side channel rather than the interface, or breaks under a behavior-preserving refactor.
+- **Tautological:** the assertion recomputes expected output with the same logic as production code.
+- **Horizontal slicing:** tests all anticipated behavior before any implementation, so the suite becomes insensitive to what actually ships.
+
+## Mocking at real boundaries
+
+Mock external systems, time, randomness, and selected filesystem/network boundaries when a real fixture is unsuitable. Prefer real in-process behavior for code you own; do not mock a collaborator merely to prove it was called.
+
+**NestJS carve-out:** `Test.createTestingModule` provider overrides and mocks are the framework-sanctioned seam for isolating a Nest module’s injected dependencies. They are not an implementation-coupled anti-pattern when the test exercises the module’s public behavior and the override represents a real external or separately-owned provider boundary.
+
+## Loop rules
+
+1. Make the test fail for the intended missing behavior before writing production code.
+2. Add only enough code to make that slice pass; do not speculate into future slices.
+3. Refactor after behavior is green, retaining the public-behavior contract.
+4. Before handoff, run the affected scoped test target and report its nonzero test count and exit status in the Cassy task.

--- a/cas-cli/src/builtins/grok/skills/cas-tdd/mocking.md
+++ b/cas-cli/src/builtins/grok/skills/cas-tdd/mocking.md
@@ -2,4 +2,10 @@
 
 Imported and adapted from mattpocock/skills `tdd/mocking.md`, MIT © 2026 Matt Pocock.
 
-Mock external boundaries, not internal collaborators merely to assert calls. NestJS `Test.createTestingModule` provider overrides remain sanctioned seams for public module behavior.
+Mock at boundaries: third-party APIs, time, randomness, filesystems, and databases when an appropriate real test fixture is unavailable. Keep mocks specific to the boundary contract so a failing test identifies the behavior that changed.
+
+Do not mock internal collaborators solely to assert that they were called. Test through the owning module’s public interface whenever that yields the behavior a caller cares about.
+
+## NestJS provider seam
+
+`Test.createTestingModule` and provider overrides are sanctioned NestJS seams. Mock an injected provider when it is an external system or separately-owned dependency and the test is asserting the module’s public behavior. Do not reject this pattern as an internal-collaborator mock merely because Nest resolves it through dependency injection.

--- a/cas-cli/src/builtins/grok/skills/cas-tdd/mocking.md
+++ b/cas-cli/src/builtins/grok/skills/cas-tdd/mocking.md
@@ -1,0 +1,5 @@
+# When to Mock
+
+Imported and adapted from mattpocock/skills `tdd/mocking.md`, MIT © 2026 Matt Pocock.
+
+Mock external boundaries, not internal collaborators merely to assert calls. NestJS `Test.createTestingModule` provider overrides remain sanctioned seams for public module behavior.

--- a/cas-cli/src/builtins/grok/skills/cas-tdd/tests.md
+++ b/cas-cli/src/builtins/grok/skills/cas-tdd/tests.md
@@ -2,4 +2,8 @@
 
 Imported and adapted from mattpocock/skills `tdd/tests.md`, MIT © 2026 Matt Pocock.
 
-Test observable behavior through public interfaces. Expected values come from independent literals, examples, or specifications, not a restatement of production logic.
+Good tests describe observable behavior through a public interface and survive internal refactors. Name what a caller can do, not which helper happened to run.
+
+Avoid tests that inspect private methods, call counts, ordering, or persistence side channels when a public interface can observe the result. Avoid expected values derived by repeating production logic; use a known literal, a worked example, or a specification instead.
+
+One logical capability per test makes failures legible. A small table is useful when independent cases share a public contract; it is not a substitute for behavior-focused test names.

--- a/cas-cli/src/builtins/grok/skills/cas-tdd/tests.md
+++ b/cas-cli/src/builtins/grok/skills/cas-tdd/tests.md
@@ -1,0 +1,5 @@
+# Good and Bad Tests
+
+Imported and adapted from mattpocock/skills `tdd/tests.md`, MIT © 2026 Matt Pocock.
+
+Test observable behavior through public interfaces. Expected values come from independent literals, examples, or specifications, not a restatement of production logic.

--- a/cas-cli/src/builtins/grok/skills/cas-to-questionnaire/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-to-questionnaire/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: cas-to-questionnaire
+description: Turn a decision the user cannot answer alone into a discovery questionnaire for a knowledgeable third party.
+disable-model-invocation: true
+managed_by: cas
+---
+
+# Discovery Questionnaire
+
+Imported and adapted from mattpocock/skills `to-questionnaire`, MIT © 2026 Matt Pocock.
+
+Grill the send, not the subject: learn the recipient’s knowledge and the decisions the user needs back. Draft an approved-location discovery questionnaire with purpose, context, one-idea priority-ordered questions, answer stubs, and a catch-all. Use Cassy task/spec/memory context, never tracker or context-file workflows; do not invent deadlines or recipient knowledge.

--- a/cas-cli/src/builtins/grok/skills/cas-to-questionnaire/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-to-questionnaire/SKILL.md
@@ -9,4 +9,8 @@ managed_by: cas
 
 Imported and adapted from mattpocock/skills `to-questionnaire`, MIT © 2026 Matt Pocock.
 
-Grill the send, not the subject: learn the recipient’s knowledge and the decisions the user needs back. Draft an approved-location discovery questionnaire with purpose, context, one-idea priority-ordered questions, answer stubs, and a catch-all. Use Cassy task/spec/memory context, never tracker or context-file workflows; do not invent deadlines or recipient knowledge.
+Turn an unanswered decision into a document a knowledgeable recipient can complete asynchronously or in a meeting. **Grill the send, not the subject:** establish the recipient’s role, expertise, and relationship, then establish the decisions or facts the user needs back. Do not ask the user for facts the recipient is meant to supply.
+
+Draft a discovery questionnaire in the user-approved output location. State its purpose, sender, recipient, and how answers will be used; give only enough context to orient the recipient; order one-idea questions by importance; provide an answer stub and a short “why this matters” only where useful; finish with a catch-all. Preserve task or decision context through `cas__task`, `cas__spec`, or `cas__memory`, not a parallel tracker or context-file convention.
+
+Before delivery, verify every stated decision gap has a question and report the created path. Do not invent a deadline, recipient knowledge, or a real-world process step that the user has not supplied.

--- a/cas-cli/src/builtins/grok/skills/cas-wizard/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-wizard/SKILL.md
@@ -8,4 +8,8 @@ managed_by: cas
 
 Imported and adapted from mattpocock/skills `wizard`, MIT © 2026 Matt Pocock.
 
-Use a stage-by-stage Bash wizard for repeatable manual work. Confirm the step/URL/destination/secret plan, copy `template.sh`, and edit only after `STAGES`. Keep one action per stage, hide secrets, and confirm irreversible actions. Run `bash -n`, not an end-to-end interactive wizard; retain decisions in `mcp__cas__task` without parallel setup or tracker files.
+Use a wizard for a repeatable manual procedure: a person drives external dashboards and confirms irreversible steps while the script gives one precise stage at a time. First inspect the project and enumerate every manual step, its source URL, destination, and whether its value is secret. Confirm the ordered stage plan with the user before authoring it.
+
+Copy [template.sh](template.sh) to a task-appropriate script path and edit only the section after `STAGES`. Give each stage one focused action, open the exact URL before asking for a value, hide secrets, and confirm before irreversible actions. Keep generated procedures in the task’s approved output area unless the user asks for a maintained repository runbook.
+
+Run `bash -n` and static tracing only; do not run a wizard end-to-end because it opens browsers and blocks on human input. Keep task decisions and proof in `cas__task`; this skill never creates a parallel tracker, setup system, or context file.

--- a/cas-cli/src/builtins/grok/skills/cas-wizard/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-wizard/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: cas-wizard
+description: Generate an interactive Bash wizard for human-only setup, secrets, dashboard, cutover, or migration steps. Do not use it for work the agent can perform directly.
+managed_by: cas
+---
+
+# Human Procedure Wizard
+
+Imported and adapted from mattpocock/skills `wizard`, MIT © 2026 Matt Pocock.
+
+Use a stage-by-stage Bash wizard for repeatable manual work. Confirm the step/URL/destination/secret plan, copy `template.sh`, and edit only after `STAGES`. Keep one action per stage, hide secrets, and confirm irreversible actions. Run `bash -n`, not an end-to-end interactive wizard; retain decisions in `mcp__cas__task` without parallel setup or tracker files.

--- a/cas-cli/src/builtins/grok/skills/cas-wizard/template.sh
+++ b/cas-cli/src/builtins/grok/skills/cas-wizard/template.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Imported and adapted from mattpocock/skills wizard/template.sh, MIT © 2026 Matt Pocock.
+# Edit only after STAGES.
+set -euo pipefail
+TOTAL_STAGES=0
+_stage=0
+ENV_FILE="${ENV_FILE:-.env}"
+open_url() { command -v xdg-open >/dev/null && xdg-open "$1" || command -v open >/dev/null && open "$1" || printf 'Open manually: %s\n' "$1"; }
+pause() { read -r -p "${1:-Press Enter to continue} " _ || true; }
+confirm() { local answer; read -r -p "$1 [y/N] " answer || true; [[ "$answer" =~ ^[Yy]$ ]]; }
+stage() { _stage=$((_stage + 1)); printf '\nStage %s/%s: %s\n' "$_stage" "$TOTAL_STAGES" "$1"; }
+say() { printf '  %s\n' "$1"; }
+ask() { read -r -p "$2 " "$1" || true; }
+ask_secret() { read -r -s -p "$2 " "$1" || true; printf '\n'; }
+write_env() { local key="$1" value="$2" tmp; touch "$ENV_FILE"; tmp=$(mktemp); grep -vE "^${key}=" "$ENV_FILE" >"$tmp" || true; printf '%s=%s\n' "$key" "$value" >>"$tmp"; mv "$tmp" "$ENV_FILE"; }
+set_secret() { local name="$1" value="$2"; command -v gh >/dev/null && printf '%s' "$value" | gh secret set "$name" || printf 'Set GitHub secret manually: %s\n' "$name"; }
+finish() { printf '\nWizard complete.\n'; }
+# STAGES: define TOTAL_STAGES and one stage per human action below.

--- a/cas-cli/src/builtins/grok/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker/references/discipline.md
@@ -2,9 +2,9 @@
 
 ## Marked throwaway prototypes
 
-Adapted from mattpocock/skills `prototype`, MIT © 2026 Matt Pocock. A prototype answers one stated design question and is throwaway from day one: mark it clearly, keep it near the explored code or UI, avoid persistence and production polish, and surface the state or variant under examination.
+Adapted from mattpocock/skills `prototype`, MIT © 2026 Matt Pocock. A prototype exists to answer one stated design question and is throwaway from day one. Mark it clearly, keep it near the code or UI it explores, avoid persistence and production-grade polish, and surface the state or variant being tested.
 
-Capture the question and verdict in `mcp__cas__task`, `mcp__cas__spec`, or `mcp__cas__memory`. Keep the prototype off the delivery branch or remove it; never leave an unmarked root-level script, parallel tracker, or context-file workflow.
+When it settles a decision, capture the question and verdict in `cas__task`, `cas__spec`, or `cas__memory`. Keep the prototype itself off the delivery branch or remove it after the decision; only validated production changes belong in the task’s deliverable. Never create an unmarked root-level script, parallel tracker, or context-file workflow.
 
 Proactive habits that keep a worker useful for a whole shift. The other references are about
 moments (closing, breaking, looking things up); this one is about how you run continuously.

--- a/cas-cli/src/builtins/grok/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker/references/discipline.md
@@ -1,5 +1,11 @@
 # Operating Discipline — Staying Reachable and Staying Alive
 
+## Marked throwaway prototypes
+
+Adapted from mattpocock/skills `prototype`, MIT © 2026 Matt Pocock. A prototype answers one stated design question and is throwaway from day one: mark it clearly, keep it near the explored code or UI, avoid persistence and production polish, and surface the state or variant under examination.
+
+Capture the question and verdict in `mcp__cas__task`, `mcp__cas__spec`, or `mcp__cas__memory`. Keep the prototype off the delivery branch or remove it; never leave an unmarked root-level script, parallel tracker, or context-file workflow.
+
 Proactive habits that keep a worker useful for a whole shift. The other references are about
 moments (closing, breaking, looking things up); this one is about how you run continuously.
 Two failure modes cost real money on 2026-08-06 (GH #121) and both are fully preventable:

--- a/cas-cli/src/builtins/grok/skills/cas-writing-for-agents/SKILL-MECHANICS.md
+++ b/cas-cli/src/builtins/grok/skills/cas-writing-for-agents/SKILL-MECHANICS.md
@@ -1,0 +1,13 @@
+# Skill mechanics
+
+Provenance: adapted from `mattpocock/skills` (MIT, © 2026 Matt Pocock).
+
+## Invocation
+
+A model-invoked skill has a description: that description is an always-loaded context pointer, so write trigger branches precisely. It remains available to explicit user invocation. Use model invocation when the agent or another skill must discover it autonomously.
+
+A user-invoked skill sets `disable-model-invocation: true`. Its description is human-facing and carries no autonomous trigger. Choose it when a person should decide whether to use the skill, trading context load for cognitive load.
+
+## Splitting and routers
+
+Split a skill only when a distinct leading word needs independent model invocation, or a different invocation boundary protects a sequence from premature completion. A family of user-invoked skills may use one user-invoked router: it helps people find the right skill, but cannot autonomously invoke its peers.

--- a/cas-cli/src/builtins/grok/skills/cas-writing-for-agents/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-writing-for-agents/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: cas-writing-for-agents
+description: Use when creating or editing a skill, AGENTS.md, CLAUDE.md, or an agent-facing reference document.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills (MIT, © 2026 Matt Pocock).
+---
+
+# Writing for agents
+
+Write agent-facing documents as instructions for a repeated process, not prose for a one-time reader. Read [skill mechanics](SKILL-MECHANICS.md) when the document is a skill.
+
+## Context pointers
+
+A **context pointer** names out-of-context material and the condition for loading it. A skill description and an `AGENTS.md` pointer are both pointers. State what the material is and each distinct branch that should load it. Front-load trigger words, use one trigger per branch, and omit identity the target already carries: every always-loaded word spends context load.
+
+## The two loads
+
+- **Context load** is always-loaded text. Keep it small and earn every word.
+- **Cognitive load** is the human effort of knowing which document to reach for. Spend it where human judgment matters.
+
+Material behind a pointer reduces context load but increases cognitive load.
+
+## Information hierarchy
+
+Put material at the lowest tier that still makes execution reliable:
+
+1. In-file steps: actions every branch performs, in order.
+2. In-file reference: rules consulted while doing those steps.
+3. Disclosed reference: branch-specific material in a linked file.
+
+Use progressive disclosure to keep the main path legible. Co-locate a concept's definition, rules, and caveats. Split only when a sequence or invocation branch earns the extra pointer; otherwise splitting becomes sprawl.
+
+## Steps and completion criteria
+
+Every step needs a completion criterion. Make it **clear** (done is observable) and **demanding** (the necessary legwork is required). Sharpen a fuzzy criterion before hiding later steps; only a real context boundary prevents later work from pulling attention toward premature completion.
+
+## Leading words and pruning
+
+Prefer compact, familiar leading words that reliably summon a shared behavior: `tight` for a fast deterministic loop, `red` for a bug-reproducing loop. Use positive instructions; a prohibition earns space only for a hard guardrail.
+
+Keep one authoritative statement for each meaning. Treat environment facts as lookups, not prose caches, unless the lookup is costly or misses an unwritten convention. Remove stale exposition, irrelevant branches, and no-op instructions. The result should be short because every line is live.

--- a/cas-cli/src/builtins/skills/cas-brainstorm/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-brainstorm/SKILL.md
@@ -40,6 +40,12 @@ These exist because Cassy agents have a documented tendency to dump multiple que
 5. **Ask what the user is thinking BEFORE offering ideas.** This surfaces hidden context and prevents the user from anchoring on AI-generated framings. "What have you already considered?" is more valuable than "Here are 5 options."
 6. **Broad before narrow.** Start with problem, users, and value. Only narrow to constraints, exclusions, and edge cases after the big picture is clear.
 
+## Frontier-round mechanics
+
+Adapted from mattpocock/skills `grilling`, MIT © 2026 Matt Pocock. Model unresolved decisions as a design tree. In each round, ask the full **frontier**: only questions whose prerequisites are already settled. Number every frontier question and include a recommended answer; do not ask a dependent question in the same round.
+
+Facts are agent work: inspect the codebase, Cassy context, tools, or delegated research before asking the user. Decisions are user work. Each answer reshapes the tree and reveals the next frontier; finish only when no material branch remains silently assumed.
+
 ## Output Guidance
 
 - **Keep outputs concise.** Short sections, brief bullets, only enough detail to support the next decision.

--- a/cas-cli/src/builtins/skills/cas-code-review/references/personas/correctness.md
+++ b/cas-cli/src/builtins/skills/cas-code-review/references/personas/correctness.md
@@ -10,6 +10,8 @@ Hunt for defects that make the changed code *wrong* — logic errors, broken exe
 
 ## In scope
 
+Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Add **spec fidelity** to every review: compare changed behavior against the task/spec acceptance criteria and identify an observable requirement the diff omits, reverses, or silently widens. Do not invent requirements; cite the exact task, spec, or documented contract.
+
 - Off-by-one and boundary errors (loop bounds, slice indices, inclusive/exclusive ranges, empty-collection edge cases).
 - Null / `None` / `undefined` / `Option::None` propagation that reaches an unchecked dereference.
 - Race conditions and ordering bugs: unsynchronized shared state, check-then-act, lease/lock handling, async cancellation safety.

--- a/cas-cli/src/builtins/skills/cas-code-review/references/personas/maintainability.md
+++ b/cas-cli/src/builtins/skills/cas-code-review/references/personas/maintainability.md
@@ -10,6 +10,8 @@ Hunt for changes that make the codebase harder to read, reason about, extend, or
 
 ## In scope
 
+Adapted from mattpocock/skills `code-review`, MIT © 2026 Matt Pocock. Use this Fowler-style smell baseline as prompts, not a mechanical scorecard: duplicated code, long method, large class, long parameter list, divergent change, shotgun surgery, feature envy, data clumps, primitive obsession, switch statements, parallel inheritance hierarchies, and lazy classes. Emit only when the smell is evidenced in the changed code and matters to future readers.
+
 - Duplication: the diff introduces a block that already exists elsewhere (grep the repo), or copies a pattern that the codebase has already extracted into a helper.
 - Naming drift: a new symbol uses a convention that conflicts with its neighbors (e.g., `snake_case` in a `camelCase` file, `get_*` next to `fetch_*`), or a name that misrepresents what the code does.
 - Dead code: new branches, parameters, fields, or imports that are never read or always false. Distinct from `correctness`-level "unwired public API" — this is *internal* deadness.

--- a/cas-cli/src/builtins/skills/cas-codebase-design/DEEPENING.md
+++ b/cas-cli/src/builtins/skills/cas-codebase-design/DEEPENING.md
@@ -1,0 +1,10 @@
+# Deepening
+
+Classify dependencies before combining shallow modules: in-process dependencies
+can be tested through the new interface directly; local-substitutable ones use
+their real local stand-in; owned remote dependencies justify an injected port
+and in-memory/transport adapters; true externals use an injected mock adapter.
+
+Keep internal seams private. Replace old shallow-module tests with tests at the
+deepened interface once that interface covers the behavior; do not layer tests
+that assert internals or must change with every refactor.

--- a/cas-cli/src/builtins/skills/cas-codebase-design/DESIGN-IT-TWICE.md
+++ b/cas-cli/src/builtins/skills/cas-codebase-design/DESIGN-IT-TWICE.md
@@ -1,0 +1,7 @@
+# Design it twice
+
+Before committing to a consequential interface, frame constraints, dependency
+categories, and an illustrative sketch. Explore at least three materially
+different interfaces: minimum surface, maximum flexibility, and the common
+caller. Compare depth, locality, seam placement, hidden complexity, and
+trade-offs; record the recommendation and reason in the active Cassy task.

--- a/cas-cli/src/builtins/skills/cas-codebase-design/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-codebase-design/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: cas-codebase-design
+description: Use when designing or restructuring a module, choosing a seam, or assessing testability and architectural depth.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills codebase-design (MIT, © 2026 Matt Pocock).
+---
+
+# Codebase design
+
+Design deep modules: substantial behavior behind a small, clear interface at a
+well-chosen seam. This vocabulary improves leverage for callers, locality for
+maintainers, and tests that exercise real behavior.
+
+## Vocabulary
+
+- **Module**: anything with an interface and implementation, from a function
+  to a package or vertical slice.
+- **Interface**: every fact a caller must know: types, invariants, ordering,
+  error modes, configuration, and performance characteristics.
+- **Depth**: behavior a caller can exercise per unit of interface it must
+  learn. A shallow module exposes nearly as much complexity as it hides.
+- **Seam**: where behavior can vary without editing the caller; its placement
+  is a design choice distinct from the implementation behind it.
+- **Adapter**: a concrete implementation filling a seam. Use it when the
+  varying slot matters; otherwise say implementation.
+- **Leverage** and **locality**: the caller and maintainer benefits of depth.
+
+Use this language consistently, except that established framework vocabulary
+always wins. In NestJS projects, `*.service.ts` and `service` are normal,
+meaningful conventions; do not apply an "avoid service" rule there.
+
+## Principles
+
+- Depth is a property of the interface, not implementation size.
+- Apply the deletion test: if deleting a module merely removes a pass-through,
+  it was shallow; if complexity reappears at many callers, it earned its keep.
+- The interface is the primary test surface. Tests should assert observable
+  outcomes through it, not reach through internal seams.
+- One adapter is a hypothetical seam; two justified adapters make it real.
+  Do not add indirection when nothing varies.
+- Accept dependencies rather than creating them; return results where possible
+  rather than hiding critical work in side effects.
+
+## Completion
+
+Name the selected seam, the interface facts callers must learn, what complexity
+stays behind it, and the deletion-test result. If the choice is consequential,
+capture it in the active Cassy task or a `mcp__cas__spec` decision rather than a
+parallel architecture-record directory.
+
+For dependency categories and replacement testing, read
+[DEEPENING.md](DEEPENING.md). For alternatives, read
+[DESIGN-IT-TWICE.md](DESIGN-IT-TWICE.md).

--- a/cas-cli/src/builtins/skills/cas-diagnosing-bugs/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-diagnosing-bugs/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: cas-diagnosing-bugs
+description: Use when diagnosing, debugging, or reproducing a broken, failing, throwing, or slow behavior.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills (MIT, © 2026 Matt Pocock).
+---
+
+# Diagnosing bugs
+
+Use a feedback-loop-first discipline. Skip a phase only with an explicit reason.
+Redact every secret in commands, output, and artifacts; retain the signal and ask
+for a redacted artifact or access when redaction prevents diagnosis.
+
+## Phase 1 — Build a tight, red-capable loop
+
+Do not form a causal theory before one command can reproduce the user's exact
+symptom. Prefer, in order: a failing scoped test; a CLI fixture; an HTTP or
+browser assertion; captured-trace replay; a minimal harness; property/fuzz or
+bisection loop; differential run; then a human-in-the-loop runbook. Treat the
+loop as a product: make it fast, deterministic, and specific. For flakes,
+increase reproduction rate with repeated or stress runs.
+
+Completion requires one already-run command whose redacted output proves it is
+red-capable, deterministic (or has a stated high repro rate), fast, and
+unattended. If no loop can be built, state what was tried and request the
+reproducing environment, a redacted capture, or approval for temporary
+instrumentation; do not hypothesize without a loop.
+
+## Phase 2 — Reproduce and minimize
+
+Run the loop, confirm it is the user's failure rather than a nearby one, and
+capture the symptom. Remove inputs, callers, configuration, and steps one at a
+time until every remaining element is load-bearing.
+
+## Phase 3 — Rank falsifiable hypotheses
+
+Produce 3–5 ranked hypotheses. Each must predict what changing one variable
+would do. Record them in the task note and invite domain correction without
+blocking on it; discard a hypothesis that cannot make a testable prediction.
+
+## Phase 4 — Instrument one prediction at a time
+
+Prefer debugger/REPL inspection, then targeted boundary logs. Tag temporary
+logs with a unique `[DEBUG-…]` prefix. For performance regressions, establish a
+measurement or profile baseline before changing code.
+
+## Phase 5 — Fix and regression
+
+Turn the minimized repro into a failing test only at a seam that exercises the
+real call-site pattern. If no correct seam exists, record that architectural
+finding. Otherwise: make the regression fail, fix it, make it pass, then rerun
+the original loop.
+
+## Phase 6 — Cleanup
+
+Before claiming done, rerun the original loop, confirm regression coverage (or
+the documented missing seam), remove tagged instrumentation and marked
+throwaways, and record the validated hypothesis in the commit or task note.

--- a/cas-cli/src/builtins/skills/cas-domain-modeling/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-domain-modeling/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: cas-domain-modeling
+description: Use when clarifying a project's terminology, domain relationships, or durable technical decisions.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills (MIT, © 2026 Matt Pocock).
+---
+
+# Domain modeling
+
+Actively sharpen a project's shared domain model while designing. This Cassy
+adaptation stores resolved language and decisions in the canonical CAS memory
+and spec surfaces, never in a parallel `CONTEXT.md` or ADR-file convention.
+
+## During the session
+
+### Challenge the language
+
+When a term conflicts with established project language, surface the conflict
+immediately. When it is vague or overloaded, propose a precise canonical term.
+Stress-test relationships with concrete edge cases, and verify claims about
+behavior against the code before treating them as domain truth.
+
+### Persist resolved terms
+
+When a term is settled, store its concise definition with
+`mcp__cas__memory action=remember`, using project scope and tags that make it
+retrievable. Record the term, its boundaries, important synonyms to avoid, and
+the scenario that disambiguated it. Search existing project memories first so
+the entry refines rather than duplicates the canonical language.
+
+### Persist consequential decisions
+
+Use `mcp__cas__spec` or a decision memory only when the choice is hard to
+reverse, surprising without context, and the result of a real trade-off. A
+decision records the alternatives, chosen direction, reason, and affected
+domain terms; it is not an implementation scratchpad. Link it to the active
+task when it governs delivery.
+
+## Completion
+
+Before ending, ensure every resolved term or irreversible decision is either
+durably recorded in Cassy or explicitly left open. Do not create glossary,
+context-map, or ADR files that would compete with CAS memory/spec storage.

--- a/cas-cli/src/builtins/skills/cas-domain-modeling/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-domain-modeling/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 Actively sharpen a project's shared domain model while designing. This Cassy
 adaptation stores resolved language and decisions in the canonical CAS memory
-and spec surfaces, never in a parallel `CONTEXT.md` or ADR-file convention.
+and spec surfaces, never in a parallel local-file convention.
 
 ## During the session
 
@@ -44,4 +44,4 @@ task when it governs delivery.
 
 Before ending, ensure every resolved term or irreversible decision is either
 durably recorded in Cassy or explicitly left open. Do not create glossary,
-context-map, or ADR files that would compete with CAS memory/spec storage.
+or decision files that would compete with CAS memory/spec storage.

--- a/cas-cli/src/builtins/skills/cas-resolving-merge-conflicts/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-resolving-merge-conflicts/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: cas-resolving-merge-conflicts
+description: Use when resolving an in-progress git merge or rebase conflict.
+managed_by: cas
+---
+
+# Resolve Merge Conflicts by Intent
+
+Imported and adapted from mattpocock/skills `resolving-merge-conflicts`, MIT © 2026 Matt Pocock.
+
+1. Inspect the current merge or rebase state, history, and conflicting files.
+2. Trace both sides to their primary sources: commits, pull requests, Cassy tasks, specs, and documented intent.
+3. Resolve each hunk by preserving both intents where possible. If they are incompatible, choose the change matching the merge’s stated goal and record the trade-off in `mcp__cas__task`. Do not invent new behavior.
+4. Finish the merge or rebase; do not abandon it with `--abort` merely to avoid the decision.
+5. Run the project’s affected checks, fix integration damage, then commit the resolved result.
+
+Use Cassy task/spec context for intent; do not introduce external tracker, scratch, setup, or context-file workflows.

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/planning.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/planning.md
@@ -143,6 +143,12 @@ Fan-out is the most common pattern for EPICs with 3+ workers: one setup/spike ta
 
 ## Task Breakdown Guidelines
 
+## Vertical slices and wide refactors
+
+Adapted from mattpocock/skills `to-tickets`, MIT © 2026 Matt Pocock. Prefer tracer-bullet vertical slices: each task cuts a narrow but complete path through the affected layers, is independently demoable or verifiable, and fits one fresh worker context. Give every task only its genuine blocking edges and work the unblocked frontier.
+
+For a mechanical, codebase-wide change that cannot land green as a vertical slice, use **expand–contract** instead: first add the new form beside the old; then migrate call sites in blast-radius-sized batches, each blocked by expansion; finally remove the old form only after every migration batch completes. Preserve Cassy task dependencies with `mcp__cas__task`; never substitute external tracker or scratch-file workflows.
+
 When breaking an epic into subtasks, apply these patterns:
 
 **Demo statements** — Every subtask must have a `demo_statement` describing what can be demonstrated when complete. Example: `demo_statement="User types a query and results filter live"`. If a task has no demo-able output, it may be a horizontal slice — restructure it into a vertical slice that delivers observable value.

--- a/cas-cli/src/builtins/skills/cas-tdd/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-tdd/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: cas-tdd
+description: Test-driven development discipline for behavior-focused, scoped Cassy changes. Use when a task requires test-first work, red-green-refactor, or integration-test design.
+managed_by: cas
+---
+
+# Test-Driven Development
+
+Imported and adapted from mattpocock/skills `tdd`, MIT © 2026 Matt Pocock.
+
+Use a red → green loop to produce tests worth keeping. Test behavior through public interfaces, name the observable capability, and choose seams before writing the test. Keep durable decisions and task evidence in Cassy through `mcp__cas__task`, `mcp__cas__spec`, and `mcp__cas__memory`; do not create parallel tracker or context files.
+
+## Seams and slices
+
+- Agree the public seam before testing. A seam is the boundary where a caller observes behavior without reaching into internals.
+- Work vertical tracer bullets: one test, the smallest implementation that makes it pass, then the next learned slice. Do not write a horizontal wall of imagined tests.
+- Expected values come from an independent source of truth: a worked example, specification, known-good literal, or external contract.
+- Use the project’s scoped test command and record the actual proof result in the task. Do not treat a zero-test success as proof.
+
+When module shape or a seam is unclear, consult `cas-codebase-design` for module, interface, depth, seam, adapter, leverage, and locality vocabulary.
+
+## Anti-patterns
+
+- **Implementation-coupled:** tests private methods, verifies a side channel rather than the interface, or breaks under a behavior-preserving refactor.
+- **Tautological:** the assertion recomputes expected output with the same logic as production code.
+- **Horizontal slicing:** tests all anticipated behavior before any implementation, so the suite becomes insensitive to what actually ships.
+
+## Mocking at real boundaries
+
+Mock external systems, time, randomness, and selected filesystem/network boundaries when a real fixture is unsuitable. Prefer real in-process behavior for code you own; do not mock a collaborator merely to prove it was called.
+
+**NestJS carve-out:** `Test.createTestingModule` provider overrides and mocks are the framework-sanctioned seam for isolating a Nest module’s injected dependencies. They are not an implementation-coupled anti-pattern when the test exercises the module’s public behavior and the override represents a real external or separately-owned provider boundary.
+
+## Loop rules
+
+1. Make the test fail for the intended missing behavior before writing production code.
+2. Add only enough code to make that slice pass; do not speculate into future slices.
+3. Refactor after behavior is green, retaining the public-behavior contract.
+4. Before handoff, run the affected scoped test target and report its nonzero test count and exit status in the Cassy task.

--- a/cas-cli/src/builtins/skills/cas-tdd/mocking.md
+++ b/cas-cli/src/builtins/skills/cas-tdd/mocking.md
@@ -1,0 +1,11 @@
+# When to Mock
+
+Imported and adapted from mattpocock/skills `tdd/mocking.md`, MIT © 2026 Matt Pocock.
+
+Mock at boundaries: third-party APIs, time, randomness, filesystems, and databases when an appropriate real test fixture is unavailable. Keep mocks specific to the boundary contract so a failing test identifies the behavior that changed.
+
+Do not mock internal collaborators solely to assert that they were called. Test through the owning module’s public interface whenever that yields the behavior a caller cares about.
+
+## NestJS provider seam
+
+`Test.createTestingModule` and provider overrides are sanctioned NestJS seams. Mock an injected provider when it is an external system or separately-owned dependency and the test is asserting the module’s public behavior. Do not reject this pattern as an internal-collaborator mock merely because Nest resolves it through dependency injection.

--- a/cas-cli/src/builtins/skills/cas-tdd/tests.md
+++ b/cas-cli/src/builtins/skills/cas-tdd/tests.md
@@ -1,0 +1,9 @@
+# Good and Bad Tests
+
+Imported and adapted from mattpocock/skills `tdd/tests.md`, MIT © 2026 Matt Pocock.
+
+Good tests describe observable behavior through a public interface and survive internal refactors. Name what a caller can do, not which helper happened to run.
+
+Avoid tests that inspect private methods, call counts, ordering, or persistence side channels when a public interface can observe the result. Avoid expected values derived by repeating production logic; use a known literal, a worked example, or a specification instead.
+
+One logical capability per test makes failures legible. A small table is useful when independent cases share a public contract; it is not a substitute for behavior-focused test names.

--- a/cas-cli/src/builtins/skills/cas-to-questionnaire/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-to-questionnaire/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: cas-to-questionnaire
+description: Turn a decision the user cannot answer alone into a discovery questionnaire for a knowledgeable third party.
+disable-model-invocation: true
+managed_by: cas
+---
+
+# Discovery Questionnaire
+
+Imported and adapted from mattpocock/skills `to-questionnaire`, MIT © 2026 Matt Pocock.
+
+Turn an unanswered decision into a document a knowledgeable recipient can complete asynchronously or in a meeting. **Grill the send, not the subject:** establish the recipient’s role, expertise, and relationship, then establish the decisions or facts the user needs back. Do not ask the user for facts the recipient is meant to supply.
+
+Draft a discovery questionnaire in the user-approved output location. State its purpose, sender, recipient, and how answers will be used; give only enough context to orient the recipient; order one-idea questions by importance; provide an answer stub and a short “why this matters” only where useful; finish with a catch-all. Preserve task or decision context through `mcp__cas__task`, `mcp__cas__spec`, or `mcp__cas__memory`, not a parallel tracker or context-file convention.
+
+Before delivery, verify every stated decision gap has a question and report the created path. Do not invent a deadline, recipient knowledge, or a real-world process step that the user has not supplied.

--- a/cas-cli/src/builtins/skills/cas-wizard/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-wizard/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: cas-wizard
+description: Generate an interactive Bash wizard for human-only setup, secrets, dashboard, cutover, or migration steps. Do not use it for work the agent can perform directly.
+managed_by: cas
+---
+
+# Human Procedure Wizard
+
+Imported and adapted from mattpocock/skills `wizard`, MIT © 2026 Matt Pocock.
+
+Use a wizard for a repeatable manual procedure: a person drives external dashboards and confirms irreversible steps while the script gives one precise stage at a time. First inspect the project and enumerate every manual step, its source URL, destination, and whether its value is secret. Confirm the ordered stage plan with the user before authoring it.
+
+Copy [template.sh](template.sh) to a task-appropriate script path and edit only the section after `STAGES`. Give each stage one focused action, open the exact URL before asking for a value, hide secrets, and confirm before irreversible actions. Keep generated procedures in the task’s approved output area unless the user asks for a maintained repository runbook.
+
+Run `bash -n` and static tracing only; do not run a wizard end-to-end because it opens browsers and blocks on human input. Keep task decisions and proof in `mcp__cas__task`; this skill never creates a parallel tracker, setup system, or context file.

--- a/cas-cli/src/builtins/skills/cas-wizard/template.sh
+++ b/cas-cli/src/builtins/skills/cas-wizard/template.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Imported and adapted from mattpocock/skills wizard/template.sh, MIT © 2026 Matt Pocock.
+# Edit only after STAGES.
+set -euo pipefail
+
+TOTAL_STAGES=0
+_stage=0
+ENV_FILE="${ENV_FILE:-.env}"
+open_url() { command -v xdg-open >/dev/null && xdg-open "$1" || command -v open >/dev/null && open "$1" || printf 'Open manually: %s\n' "$1"; }
+pause() { read -r -p "${1:-Press Enter to continue} " _ || true; }
+confirm() { local answer; read -r -p "$1 [y/N] " answer || true; [[ "$answer" =~ ^[Yy]$ ]]; }
+stage() { _stage=$((_stage + 1)); printf '\nStage %s/%s: %s\n' "$_stage" "$TOTAL_STAGES" "$1"; }
+say() { printf '  %s\n' "$1"; }
+ask() { read -r -p "$2 " "$1" || true; }
+ask_secret() { read -r -s -p "$2 " "$1" || true; printf '\n'; }
+write_env() { local key="$1" value="$2" tmp; touch "$ENV_FILE"; tmp=$(mktemp); grep -vE "^${key}=" "$ENV_FILE" >"$tmp" || true; printf '%s=%s\n' "$key" "$value" >>"$tmp"; mv "$tmp" "$ENV_FILE"; }
+set_secret() { local name="$1" value="$2"; command -v gh >/dev/null && printf '%s' "$value" | gh secret set "$name" || printf 'Set GitHub secret manually: %s\n' "$name"; }
+finish() { printf '\nWizard complete.\n'; }
+
+# STAGES: define TOTAL_STAGES and one stage per human action below.
+# Example:
+# TOTAL_STAGES=1
+# stage "Dashboard key"; open_url "https://example.invalid"; ask_secret API_KEY "Paste key:"; write_env API_KEY "$API_KEY"
+# finish

--- a/cas-cli/src/builtins/skills/cas-worker/references/discipline.md
+++ b/cas-cli/src/builtins/skills/cas-worker/references/discipline.md
@@ -1,5 +1,11 @@
 # Operating Discipline — Staying Reachable and Staying Alive
 
+## Marked throwaway prototypes
+
+Adapted from mattpocock/skills `prototype`, MIT © 2026 Matt Pocock. A prototype exists to answer one stated design question and is throwaway from day one. Mark it clearly, keep it near the code or UI it explores, avoid persistence and production-grade polish, and surface the state or variant being tested.
+
+When it settles a decision, capture the question and verdict in `mcp__cas__task`, `mcp__cas__spec`, or `mcp__cas__memory`. Keep the prototype itself off the delivery branch or remove it after the decision; only validated production changes belong in the task’s deliverable. Never create an unmarked root-level script, parallel tracker, or context-file workflow.
+
 Proactive habits that keep a worker useful for a whole shift. The other references are about
 moments (closing, breaking, looking things up); this one is about how you run continuously.
 Two failure modes cost real money on 2026-08-06 (GH #121) and both are fully preventable:

--- a/cas-cli/src/builtins/skills/cas-writing-for-agents/SKILL-MECHANICS.md
+++ b/cas-cli/src/builtins/skills/cas-writing-for-agents/SKILL-MECHANICS.md
@@ -1,0 +1,13 @@
+# Skill mechanics
+
+Provenance: adapted from `mattpocock/skills` (MIT, © 2026 Matt Pocock).
+
+## Invocation
+
+A model-invoked skill has a description: that description is an always-loaded context pointer, so write trigger branches precisely. It remains available to explicit user invocation. Use model invocation when the agent or another skill must discover it autonomously.
+
+A user-invoked skill sets `disable-model-invocation: true`. Its description is human-facing and carries no autonomous trigger. Choose it when a person should decide whether to use the skill, trading context load for cognitive load.
+
+## Splitting and routers
+
+Split a skill only when a distinct leading word needs independent model invocation, or a different invocation boundary protects a sequence from premature completion. A family of user-invoked skills may use one user-invoked router: it helps people find the right skill, but cannot autonomously invoke its peers.

--- a/cas-cli/src/builtins/skills/cas-writing-for-agents/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-writing-for-agents/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: cas-writing-for-agents
+description: Use when creating or editing a skill, AGENTS.md, CLAUDE.md, or an agent-facing reference document.
+managed_by: cas
+license: MIT
+metadata:
+  author: Matt Pocock
+  upstream: https://github.com/mattpocock/skills
+  provenance: Adapted from mattpocock/skills (MIT, © 2026 Matt Pocock).
+---
+
+# Writing for agents
+
+Write agent-facing documents as instructions for a repeated process, not prose for a one-time reader. Read [skill mechanics](SKILL-MECHANICS.md) when the document is a skill.
+
+## Context pointers
+
+A **context pointer** names out-of-context material and the condition for loading it. A skill description and an `AGENTS.md` pointer are both pointers. State what the material is and each distinct branch that should load it. Front-load trigger words, use one trigger per branch, and omit identity the target already carries: every always-loaded word spends context load.
+
+## The two loads
+
+- **Context load** is always-loaded text. Keep it small and earn every word.
+- **Cognitive load** is the human effort of knowing which document to reach for. Spend it where human judgment matters.
+
+Material behind a pointer reduces context load but increases cognitive load.
+
+## Information hierarchy
+
+Put material at the lowest tier that still makes execution reliable:
+
+1. In-file steps: actions every branch performs, in order.
+2. In-file reference: rules consulted while doing those steps.
+3. Disclosed reference: branch-specific material in a linked file.
+
+Use progressive disclosure to keep the main path legible. Co-locate a concept's definition, rules, and caveats. Split only when a sequence or invocation branch earns the extra pointer; otherwise splitting becomes sprawl.
+
+## Steps and completion criteria
+
+Every step needs a completion criterion. Make it **clear** (done is observable) and **demanding** (the necessary legwork is required). Sharpen a fuzzy criterion before hiding later steps; only a real context boundary prevents later work from pulling attention toward premature completion.
+
+## Leading words and pruning
+
+Prefer compact, familiar leading words that reliably summon a shared behavior: `tight` for a fast deterministic loop, `red` for a bug-reproducing loop. Use positive instructions; a prohibition earns space only for a hard guardrail.
+
+Keep one authoritative statement for each meaning. Treat environment facts as lookups, not prose caches, unless the lookup is costly or misses an unwritten convention. Remove stale exposition, irrelevant branches, and no-op instructions. The result should be short because every line is live.


### PR DESCRIPTION
Implements cas-fc15: twelve sequenced, Cassy-adapted Pocock imports with three-flavor registration, NestJS carve-outs, and payload integrations into existing skills.