### PR TITLE
feat(ci): publish releases from artifacts prebuilt at release-PR merge (cas-3b7c0)

### DIFF
--- a/.github/workflows/release-prebuild.yml
+++ b/.github/workflows/release-prebuild.yml
@@ -1,0 +1,329 @@
+name: Release Prebuild
+
+# Build the shipped release artifacts at release-PR MERGE instead of at tag
+# time (cas-3b7c0, the undelivered half of GH #449).
+#
+# The release tree is final the moment the version-bump PR lands on main, so
+# the two cold platform builds — measured at 12-21 minutes each and the entire
+# critical path of every historical release — no longer have to happen while an
+# operator waits on a pushed tag. Release then only publishes bytes that
+# already exist.
+#
+# SECURITY BOUNDARY (cas-6981/cas-f5638): this workflow is push-to-main only.
+# A fork cannot emit a push in Richards-LLC/cassy, so untrusted code can never
+# reach the persistent runner through it. Do not add pull_request,
+# pull_request_target, workflow_run, issue_comment, or repository_dispatch.
+#
+# CI-LOAD POLICY: the heavy tier here is gated on a *pending release tree*.
+# Ordinary main pushes pay one ~20s ubuntu gate job and stop. factory/*,
+# epic/*, tags and pull requests never trigger this workflow at all.
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+# Never cancel a prebuild: its artifacts are what a subsequent tag adopts, and
+# a cancelled prebuild silently degrades the next release to the slow path.
+concurrency:
+  group: release-prebuild-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  SCCACHE_GHA_VERSION: "cas-v2"
+  # Keep aligned with release.yml: the prebuilt bytes must be the same bytes
+  # the tag-time fallback path would have produced.
+  RELEASE_PROFILE: release-fast
+  RELEASE_DIR: release-fast
+
+# NOTE ON RUSTC_WRAPPER: unlike release.yml this workflow deliberately does not
+# declare it at workflow scope. One of its lanes can run on the persistent box,
+# whose warm target directory — not the GitHub cache — is the thing that makes
+# it fast, and a workflow-scoped wrapper cannot be cleanly retracted per job.
+# Each hosted lane opts into sccache from its own probe step instead.
+
+jobs:
+  # Cheap gate. Every main push runs this and almost every main push stops
+  # here; only the release-prep tree opens the expensive lanes below.
+  pending-release:
+    name: Detect pending release tree
+    if: github.repository == 'Richards-LLC/cassy' && github.event.repository.fork == false
+    runs-on: ubuntu-latest
+    outputs:
+      pending: ${{ steps.detect.outputs.pending }}
+      version: ${{ steps.detect.outputs.version }}
+      tag: ${{ steps.detect.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - id: detect
+        name: Detect pending release tree
+        shell: bash
+        run: ./scripts/detect-pending-release.sh | tee -a "$GITHUB_OUTPUT"
+
+      - name: Report gate decision
+        run: |
+          echo "pending=${{ steps.detect.outputs.pending }} tag=${{ steps.detect.outputs.tag }}" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+  # GitHub Actions cannot fall back after assigning an offline self-hosted
+  # runner — the job just stays queued forever. Select the label BEFORE
+  # assignment, exactly as ci.yml's merge-queue route does. The repository
+  # variable is opt-in and its absent/disabled state is the hosted fail-safe.
+  prebuild-runner-route:
+    name: Release prebuild — runner route
+    needs: pending-release
+    if: needs.pending-release.outputs.pending == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.route.outputs.runner }}
+      mode: ${{ steps.route.outputs.mode }}
+    steps:
+      - id: route
+        env:
+          SELF_HOSTED_ENABLED: ${{ vars.CASSY_RELEASE_SELF_HOSTED }}
+        run: |
+          if [[ "$SELF_HOSTED_ENABLED" == enabled ]]; then
+            echo 'runner=["self-hosted","Linux","X64","cas-ci-32core"]' >> "$GITHUB_OUTPUT"
+            echo 'mode=self-hosted' >> "$GITHUB_OUTPUT"
+          else
+            echo 'runner=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+            echo 'mode=hosted' >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Prebuild Linux x86_64
+    needs: [pending-release, prebuild-runner-route]
+    if: >-
+      needs.pending-release.outputs.pending == 'true'
+      && (needs.prebuild-runner-route.outputs.mode != 'self-hosted'
+      || (github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && github.repository == 'Richards-LLC/cassy'
+      && github.event.repository.fork == false
+      && vars.CASSY_RELEASE_SELF_HOSTED == 'enabled'))
+    runs-on: ${{ fromJSON(needs.prebuild-runner-route.outputs.runner) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ github.sha }}
+
+      - name: Verify release self-hosted trust boundary
+        if: needs.prebuild-runner-route.outputs.mode == 'self-hosted'
+        env:
+          SELF_HOSTED_ENABLED: ${{ vars.CASSY_RELEASE_SELF_HOSTED }}
+        run: ./scripts/check-release-runner-trust.sh
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Install Linux linker
+        if: needs.prebuild-runner-route.outputs.mode == 'hosted'
+        run: |
+          sudo apt-get update
+          # Keep this aligned with .cargo/config.toml's gcc + mold toolchain.
+          sudo apt-get install -y binutils file gcc mold
+          gcc --version
+          mold --version
+
+      - name: Setup sccache
+        id: setup-sccache
+        if: needs.prebuild-runner-route.outputs.mode == 'hosted'
+        continue-on-error: true
+        uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Probe sccache backend
+        if: needs.prebuild-runner-route.outputs.mode == 'hosted'
+        shell: bash
+        run: |
+          if [[ "${{ steps.setup-sccache.outcome }}" == "success" ]] && sccache --start-server; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+            echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          else
+            echo "::warning::sccache backend unavailable — building uncached"
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            echo "SCCACHE_GHA_ENABLED=false" >> "$GITHUB_ENV"
+            echo "SCCACHE_PATH=$GITHUB_WORKSPACE/scripts/sccache-unavailable.sh" >> "$GITHUB_ENV"
+          fi
+
+      # cas-065a: the box's private sccache server is an optimization behind a
+      # warm persistent target directory, never a prerequisite. Its TCP defect
+      # must not fail a release prebuild.
+      - name: Use the isolated runner cache settings
+        if: needs.prebuild-runner-route.outputs.mode == 'self-hosted'
+        run: |
+          echo 'SCCACHE_GHA_ENABLED=false' >> "$GITHUB_ENV"
+          echo 'RUSTC_WRAPPER=' >> "$GITHUB_ENV"
+
+      - name: Cache release dependencies
+        if: needs.prebuild-runner-route.outputs.mode == 'hosted'
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: release-linux-x86_64-${{ hashFiles('Cargo.lock') }}
+          cache-on-failure: true
+
+      - name: Install Zig
+        run: ./scripts/bootstrap-zig.sh
+
+      - name: Build
+        env:
+          ZIG: ${{ github.workspace }}/.context/zig/zig
+        run: |
+          # The subsequent build-input audit must inspect this build, never a
+          # stale BLAKE3 output restored from the target cache.
+          cargo clean -p blake3 --profile "$RELEASE_PROFILE" --target x86_64-unknown-linux-gnu
+          cargo build -p cas --profile "$RELEASE_PROFILE" --target x86_64-unknown-linux-gnu --locked
+
+      - name: Stage package
+        run: |
+          mkdir -p package
+          cp "${CARGO_TARGET_DIR:-target}/x86_64-unknown-linux-gnu/$RELEASE_DIR/cas" package/
+          strip package/cas
+          cp LICENSE package/
+
+      - name: Audit exact packaged Linux executable
+        run: |
+          ./scripts/check-blake3-no-avx512-build.sh "${CARGO_TARGET_DIR:-target}/x86_64-unknown-linux-gnu/$RELEASE_DIR/build"
+          ./scripts/test-check-portable-x86_64-isa.sh package/cas
+
+      - name: Package
+        run: |
+          cd package
+          tar -czvf cas-x86_64-unknown-linux-gnu.tar.gz cas LICENSE
+          mv cas-x86_64-unknown-linux-gnu.tar.gz ../
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cas-x86_64-unknown-linux-gnu
+          path: cas-x86_64-unknown-linux-gnu.tar.gz
+          retention-days: 14
+
+      - name: Report sccache stats
+        if: always()
+        run: |
+          if [[ -x ./scripts/ci-sccache-summary.sh ]]; then
+            ./scripts/ci-sccache-summary.sh "Prebuild Linux x86_64"
+          else
+            echo "::notice title=sccache stats::scripts/ci-sccache-summary.sh is absent at this checkout; skipping cache reporting."
+          fi
+
+  # There is no Mac in the fleet, so this stays on hosted macOS. Moving it off
+  # the tag's critical path is the entire reason this workflow exists: it is
+  # the slowest job in a release by a wide margin.
+  build-macos:
+    name: Prebuild macOS ARM64
+    needs: pending-release
+    if: needs.pending-release.outputs.pending == 'true'
+    # Zig 0.15.2 needs the Xcode 26.3 / macOS 26.2 SDK; macos-latest uses an
+    # incompatible newer SDK. Keep this aligned with ci.yml's macos-check.
+    runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ github.sha }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Install Zig
+        run: ./scripts/bootstrap-zig.sh
+
+      - name: Setup sccache
+        id: setup-sccache
+        continue-on-error: true
+        uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Probe sccache backend
+        shell: bash
+        run: |
+          if [[ "${{ steps.setup-sccache.outcome }}" == "success" ]] && sccache --start-server; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+            echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          else
+            echo "::warning::sccache backend unavailable — building uncached"
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            echo "SCCACHE_GHA_ENABLED=false" >> "$GITHUB_ENV"
+            echo "SCCACHE_PATH=$GITHUB_WORKSPACE/scripts/sccache-unavailable.sh" >> "$GITHUB_ENV"
+          fi
+
+      - name: Cache release dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: release-macos-aarch64-${{ hashFiles('Cargo.lock') }}
+          cache-on-failure: true
+
+      - name: Build
+        env:
+          ZIG: ${{ github.workspace }}/.context/zig/zig
+        run: cargo build -p cas --profile "$RELEASE_PROFILE" --target aarch64-apple-darwin --locked
+
+      # The codesign gate (cas-67c1) moves with the build. Whichever path
+      # produces the Darwin bytes signs and verifies them; nothing downstream
+      # can publish an unsigned or invalidly signed Mach-O.
+      - name: Package
+        run: |
+          mkdir -p package
+          cp "target/aarch64-apple-darwin/$RELEASE_DIR/cas" package/
+          strip package/cas
+          # `strip` invalidates an ad-hoc Mach-O signature. Re-sign the exact
+          # executable we publish, then fail before packaging if it is invalid.
+          codesign --sign - --force package/cas
+          codesign --verify --verbose=4 package/cas
+          cp LICENSE package/
+          cd package
+          tar -czvf cas-aarch64-apple-darwin.tar.gz cas LICENSE
+          mv cas-aarch64-apple-darwin.tar.gz ../
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cas-aarch64-apple-darwin
+          path: cas-aarch64-apple-darwin.tar.gz
+          retention-days: 14
+
+      - name: Report sccache stats
+        if: always()
+        run: |
+          if [[ -x ./scripts/ci-sccache-summary.sh ]]; then
+            ./scripts/ci-sccache-summary.sh "Prebuild macOS ARM64"
+          else
+            echo "::notice title=sccache stats::scripts/ci-sccache-summary.sh is absent at this checkout; skipping cache reporting."
+          fi
+
+  prebuild-summary:
+    name: Release prebuild summary
+    needs: [pending-release, build, build-macos]
+    if: always() && needs.pending-release.outputs.pending == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report prebuild readiness
+        run: |
+          {
+            echo "## Release prebuild for ${{ needs.pending-release.outputs.tag }}"
+            echo
+            echo "commit: \`${{ github.sha }}\`"
+            echo "linux: ${{ needs.build.result }}"
+            echo "macos: ${{ needs.build-macos.result }}"
+            echo
+            if [[ "${{ needs.build.result }}" == success && "${{ needs.build-macos.result }}" == success ]]; then
+              echo "Pushing ${{ needs.pending-release.outputs.tag }} will adopt these artifacts and publish without compiling."
+            else
+              echo "Prebuild incomplete — the tag will fall back to building release artifacts inline."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,69 @@ env:
   RELEASE_DIR: release-fast
 
 jobs:
-  verify:
-    name: Verify Release Inputs
+  # Have the release artifacts already been built? (cas-3b7c0)
+  #
+  # release-prebuild.yml builds them when the version-bump PR merges, so the
+  # tag usually only has to publish bytes that already exist. This lookup is
+  # deliberately FAIL-SAFE: any miss, partial prebuild, expired artifact or API
+  # failure reports found=false and the tag builds inline exactly as before.
+  prebuilt-lookup:
+    name: Look up prebuilt release artifacts
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      found: ${{ steps.lookup.outputs.found }}
+      run-id: ${{ steps.lookup.outputs.run-id }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - id: lookup
+        name: Find a successful prebuild for this exact commit
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/find-release-prebuild.sh | tee -a "$GITHUB_OUTPUT"
+
+  # GitHub Actions cannot fall back after assigning an offline self-hosted
+  # runner, so select the label before assignment (same contract as ci.yml's
+  # merge-queue route). Absent/disabled repository variable = hosted, which is
+  # the historical release path unchanged.
+  release-runner-route:
+    name: Release — runner route
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.route.outputs.runner }}
+      mode: ${{ steps.route.outputs.mode }}
+    steps:
+      - id: route
+        env:
+          SELF_HOSTED_ENABLED: ${{ vars.CASSY_RELEASE_SELF_HOSTED }}
+        run: |
+          if [[ "$SELF_HOSTED_ENABLED" == enabled ]]; then
+            echo 'runner=["self-hosted","Linux","X64","cas-ci-32core"]' >> "$GITHUB_OUTPUT"
+            echo 'mode=self-hosted' >> "$GITHUB_OUTPUT"
+          else
+            echo 'runner=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+            echo 'mode=hosted' >> "$GITHUB_OUTPUT"
+          fi
+
+  verify:
+    name: Verify Release Inputs
+    needs: release-runner-route
+    if: >-
+      github.event_name == 'push'
+      && (needs.release-runner-route.outputs.mode != 'self-hosted'
+      || (github.repository == 'Richards-LLC/cassy'
+      && github.event.repository.fork == false
+      && startsWith(github.ref, 'refs/tags/v')
+      && vars.CASSY_RELEASE_SELF_HOSTED == 'enabled'))
+    runs-on: ${{ fromJSON(needs.release-runner-route.outputs.runner) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -34,10 +93,17 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Verify release self-hosted trust boundary
+        if: needs.release-runner-route.outputs.mode == 'self-hosted'
+        env:
+          SELF_HOSTED_ENABLED: ${{ vars.CASSY_RELEASE_SELF_HOSTED }}
+        run: ./scripts/check-release-runner-trust.sh
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux linker
+        if: needs.release-runner-route.outputs.mode == 'hosted'
         run: |
           sudo apt-get update
           # Keep this aligned with .cargo/config.toml's gcc + mold toolchain.
@@ -45,10 +111,12 @@ jobs:
 
       - name: Setup sccache
         id: setup-sccache
+        if: needs.release-runner-route.outputs.mode == 'hosted'
         continue-on-error: true
         uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Probe sccache backend
+        if: needs.release-runner-route.outputs.mode == 'hosted'
         shell: bash
         run: |
           if [[ "${{ steps.setup-sccache.outcome }}" != "success" ]] || ! sccache --start-server; then
@@ -58,10 +126,20 @@ jobs:
             echo "SCCACHE_PATH=$GITHUB_WORKSPACE/scripts/sccache-unavailable.sh" >> "$GITHUB_ENV"
           fi
 
+      # cas-065a: on the box the warm persistent target directory is what makes
+      # this lane fast, and its private cache server has an open TCP defect. A
+      # cache must never be able to fail a release gate.
+      - name: Use the isolated runner cache settings
+        if: needs.release-runner-route.outputs.mode == 'self-hosted'
+        run: |
+          echo 'SCCACHE_GHA_ENABLED=false' >> "$GITHUB_ENV"
+          echo 'RUSTC_WRAPPER=' >> "$GITHUB_ENV"
+
       # Keep Cargo's registry and dependency artifacts warm across releases.
       # The explicit lockfile key prevents a dependency update from restoring
       # incompatible artifacts, while source changes still rebuild workspace crates.
       - name: Cache release dependencies
+        if: needs.release-runner-route.outputs.mode == 'hosted'
         uses: Swatinem/rust-cache@v2
         with:
           key: release-verify-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
@@ -87,15 +165,32 @@ jobs:
             echo "::notice title=sccache stats::scripts/ci-sccache-summary.sh is absent at this checkout; skipping cache reporting."
           fi
 
+  # FALLBACK PATH. This only runs when no prebuild exists for the tagged
+  # commit. It is the pre-cas-3b7c0 behaviour, kept intact so a release can
+  # always ship without the prebuild workflow having succeeded.
   build:
     name: Build Linux x86_64
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    needs: [prebuilt-lookup, release-runner-route]
+    if: >-
+      github.event_name == 'push'
+      && needs.prebuilt-lookup.outputs.found != 'true'
+      && (needs.release-runner-route.outputs.mode != 'self-hosted'
+      || (github.repository == 'Richards-LLC/cassy'
+      && github.event.repository.fork == false
+      && startsWith(github.ref, 'refs/tags/v')
+      && vars.CASSY_RELEASE_SELF_HOSTED == 'enabled'))
+    runs-on: ${{ fromJSON(needs.release-runner-route.outputs.runner) }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Verify release self-hosted trust boundary
+        if: needs.release-runner-route.outputs.mode == 'self-hosted'
+        env:
+          SELF_HOSTED_ENABLED: ${{ vars.CASSY_RELEASE_SELF_HOSTED }}
+        run: ./scripts/check-release-runner-trust.sh
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -103,6 +198,7 @@ jobs:
           targets: x86_64-unknown-linux-gnu
 
       - name: Install Linux linker
+        if: needs.release-runner-route.outputs.mode == 'hosted'
         run: |
           sudo apt-get update
           # Keep this aligned with .cargo/config.toml's gcc + mold toolchain.
@@ -112,10 +208,12 @@ jobs:
 
       - name: Setup sccache
         id: setup-sccache
+        if: needs.release-runner-route.outputs.mode == 'hosted'
         continue-on-error: true
         uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Probe sccache backend
+        if: needs.release-runner-route.outputs.mode == 'hosted'
         shell: bash
         run: |
           if [[ "${{ steps.setup-sccache.outcome }}" != "success" ]] || ! sccache --start-server; then
@@ -125,7 +223,14 @@ jobs:
             echo "SCCACHE_PATH=$GITHUB_WORKSPACE/scripts/sccache-unavailable.sh" >> "$GITHUB_ENV"
           fi
 
+      - name: Use the isolated runner cache settings
+        if: needs.release-runner-route.outputs.mode == 'self-hosted'
+        run: |
+          echo 'SCCACHE_GHA_ENABLED=false' >> "$GITHUB_ENV"
+          echo 'RUSTC_WRAPPER=' >> "$GITHUB_ENV"
+
       - name: Cache release dependencies
+        if: needs.release-runner-route.outputs.mode == 'hosted'
         uses: Swatinem/rust-cache@v2
         with:
           key: release-linux-x86_64-${{ hashFiles('Cargo.lock') }}
@@ -146,13 +251,13 @@ jobs:
       - name: Stage package
         run: |
           mkdir -p package
-          cp "target/x86_64-unknown-linux-gnu/$RELEASE_DIR/cas" package/
+          cp "${CARGO_TARGET_DIR:-target}/x86_64-unknown-linux-gnu/$RELEASE_DIR/cas" package/
           strip package/cas
           cp LICENSE package/
 
       - name: Audit exact packaged Linux executable
         run: |
-          ./scripts/check-blake3-no-avx512-build.sh "target/x86_64-unknown-linux-gnu/$RELEASE_DIR/build"
+          ./scripts/check-blake3-no-avx512-build.sh "${CARGO_TARGET_DIR:-target}/x86_64-unknown-linux-gnu/$RELEASE_DIR/build"
           ./scripts/test-check-portable-x86_64-isa.sh package/cas
 
       - name: Package
@@ -179,9 +284,13 @@ jobs:
             echo "::notice title=sccache stats::scripts/ci-sccache-summary.sh is absent at this checkout; skipping cache reporting."
           fi
 
+  # FALLBACK PATH. Historically the slowest job in every release (12-21 min
+  # cold). It is skipped entirely when release-prebuild.yml already produced a
+  # signed Darwin artifact for this exact commit.
   build-macos:
     name: Build macOS ARM64
-    if: github.event_name == 'push'
+    needs: prebuilt-lookup
+    if: github.event_name == 'push' && needs.prebuilt-lookup.outputs.found != 'true'
     # Zig 0.15.2 needs the Xcode 26.3 / macOS 26.2 SDK; macos-latest uses an
     # incompatible newer SDK. Keep this aligned with ci.yml's macos-check.
     runs-on: macos-26
@@ -288,18 +397,57 @@ jobs:
 
   release:
     name: Create Release
-    if: github.event_name == 'push'
-    needs: [verify, build, build-macos]
+    # Exactly one of the two supply paths must have completed: either the
+    # prebuild was adopted and both platform builds were skipped, or no
+    # prebuild existed and both platform builds succeeded here. Anything else —
+    # a failed build, a half-skipped pair, a failed lookup — publishes nothing.
+    # `always()` is only what lets this job see a *skipped* dependency at all;
+    # every real condition below is explicit and fail-closed.
+    if: >-
+      always()
+      && github.event_name == 'push'
+      && needs.verify.result == 'success'
+      && needs.prebuilt-lookup.result == 'success'
+      && ((needs.prebuilt-lookup.outputs.found == 'true'
+      && needs.build.result == 'skipped'
+      && needs.build-macos.result == 'skipped')
+      || (needs.prebuilt-lookup.outputs.found != 'true'
+      && needs.build.result == 'success'
+      && needs.build-macos.result == 'success'))
+    needs: [prebuilt-lookup, verify, build, build-macos]
+    # Deliberately hosted, never the persistent box: this is the only job that
+    # holds a `contents: write` token, and it must not execute on a machine
+    # shared with the operator's factory worktrees.
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      # Adoption is keyed on the prebuild run's head_sha, which the lookup
+      # matched to this tagged commit, so the adopted bytes are always the
+      # tagged tree's bytes.
+      - name: Adopt prebuilt release artifacts
+        if: needs.prebuilt-lookup.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREBUILD_RUN_ID: ${{ needs.prebuilt-lookup.outputs.run-id }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          gh run download "$PREBUILD_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir artifacts \
+            --name cas-x86_64-unknown-linux-gnu \
+            --name cas-aarch64-apple-darwin
+          echo "Adopted prebuilt artifacts from run $PREBUILD_RUN_ID" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Download all artifacts
+        if: needs.prebuilt-lookup.outputs.found != 'true'
         uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -309,6 +457,24 @@ jobs:
           mkdir -p release
           find artifacts -name "*.tar.gz" -exec mv {} release/ \;
           ls -la release/
+
+      # Publishing must never be a blind copy. Re-audit the exact Linux
+      # executable that is about to be published — cheap (seconds), and it
+      # closes the gap that a prebuilt artifact was audited on a different
+      # machine at a different time.
+      - name: Audit the exact assets being published
+        run: |
+          set -euo pipefail
+          test -f release/cas-x86_64-unknown-linux-gnu.tar.gz
+          test -f release/cas-aarch64-apple-darwin.tar.gz
+          rm -rf publish-audit && mkdir -p publish-audit
+          tar -xzf release/cas-x86_64-unknown-linux-gnu.tar.gz -C publish-audit
+          ./scripts/check-portable-x86_64-isa.sh publish-audit/cas
+          # Mach-O signatures cannot be verified from Linux; the signing gate
+          # runs in whichever job produced the Darwin bytes, and the published
+          # asset is inspected by the `Verify published macOS signature`
+          # dispatch. Record its digest here so that receipt names exact bytes.
+          sha256sum release/*.tar.gz | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Generate release notes
         id: notes

--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -216,6 +216,10 @@ test-ci-tiers:
 	cd .. && ./scripts/test-ci-test-tiers.sh
 	cd .. && ./scripts/test-release-publication-policy.sh
 	cd .. && ./scripts/test-release-published-receipt.sh
+	cd .. && ./scripts/test-release-latency-receipt.sh
+	cd .. && ./scripts/test-detect-pending-release.sh
+	cd .. && ./scripts/test-find-release-prebuild.sh
+	cd .. && ./scripts/test-check-release-runner-trust.sh
 	cd .. && ./scripts/test-check-release-preflight.sh
 	cd .. && ./scripts/test-check-release-host.sh
 	cd .. && ./scripts/test-cas-install.sh

--- a/docs/ci/release-fast-publication.md
+++ b/docs/ci/release-fast-publication.md
@@ -1,0 +1,164 @@
+# Fast release publication
+
+How a pushed tag becomes published, verified artifacts in single-digit minutes,
+and why the pieces are shaped the way they are.
+
+Tracked by GH #449 (fast release publication) and cas-3b7c0.
+
+## The measured problem
+
+Before this lane existed, every release compiled the shipped artifacts from
+cold at tag time. Measured tag push -> published release, from the GitHub API:
+
+| Release | Tag pushed | Published | Total | Linux build | macOS build | Create Release |
+| --- | --- | --- | --- | --- | --- | --- |
+| v3.1.0 | 2026-08-18 23:06:55Z | 23:20:13Z | 13m18s | 12m30s | 12m54s | 18s |
+| v3.0.0 | 2026-08-18 19:50:29Z | 20:05:24Z | 14m55s | 9m36s | 14m24s | 23s |
+| v3.2.0 | 2026-08-19 17:04:30Z | 17:24:33Z | 20m03s | 13m19s | 14m05s | 15s |
+| v2.72.0 | 2026-08-17 19:48:20Z | 20:14:46Z | 26m26s | 17m32s | 21m03s | 11s |
+
+Three facts decide the design:
+
+1. The critical path is **always** the two cold platform builds. Actually
+   creating the release never took more than 23 seconds.
+2. **macOS ARM64 is the long pole** at 12-21 minutes, and there is no Mac in
+   the fleet, so no amount of self-hosted Linux speedup can fix it.
+3. The builds only start **after** the tag, which serialises them behind the
+   version-bump PR's merge — even though the tree they build is final the
+   moment that PR lands.
+
+So the artifacts are built when the release PR merges, and the tag publishes
+bytes that already exist.
+
+## The architecture
+
+```
+release PR merges to main
+        |
+        v
+release-prebuild.yml
+  pending-release        cheap gate: is this a release tree?   (~20s, every main push)
+  prebuild-runner-route  pick Linux runner before assignment
+  build                  Linux x86_64  (self-hosted warm, or hosted)
+  build-macos            macOS ARM64   (hosted macos-26, signed here)
+        |
+        |  artifacts: cas-x86_64-unknown-linux-gnu, cas-aarch64-apple-darwin
+        v
+tag vX.Y.Z pushed
+        |
+        v
+release.yml
+  prebuilt-lookup        find the prebuild run for THIS commit
+  release-runner-route   pick verify/build runner before assignment
+  verify                 release-input gate (tag, versions, CHANGELOG, cargo check)
+  build / build-macos    SKIPPED when a prebuild was found; otherwise the old cold path
+  release                adopt -> re-audit -> publish  (hosted, only write-scoped job)
+```
+
+### Why the gate is where it is
+
+`scripts/detect-pending-release.sh` calls a tree pending exactly when every
+release-train crate carries the same semver, `CHANGELOG.md` has that version's
+heading, and no `v<version>` tag exists on the remote yet. The last condition
+makes it self-disarming: once the tag is pushed, later pushes at that version
+cost one ~20s ubuntu job and stop. Ordinary main pushes never open the
+expensive lanes.
+
+### Why adoption is fail-safe and publication is fail-closed
+
+`scripts/find-release-prebuild.sh` only matches a **successful** prebuild run
+whose `head_sha` is exactly the commit being published, and only when both
+artifacts are present and unexpired. Every degraded input — no run, a partial
+run, expired artifacts, an API outage — reports `found=false`, which routes the
+tag back to the pre-existing cold build path. The prebuild is an accelerator;
+it can never be the reason a release cannot ship.
+
+Publication is the opposite. `release` requires exactly one complete supply
+path: either the prebuild was adopted **and both platform builds were skipped**,
+or no prebuild existed **and both platform builds succeeded**. A failed build, a
+half-skipped pair, or a failed lookup publishes nothing.
+
+### Why the codesign gate did not move
+
+The Darwin signing gate (cas-67c1) travels with whichever job produces the
+Darwin bytes. `strip` invalidates an ad-hoc Mach-O signature, so both the
+prebuild and the fallback re-sign and then `codesign --verify` the exact
+executable they package. Nothing downstream can publish an unsigned or invalid
+binary, because nothing downstream produces Darwin bytes.
+
+Mach-O signatures cannot be verified from Linux, so the publish job records the
+published digests and the existing `Verify published macOS signature`
+`workflow_dispatch` remains the operator's on-Mac receipt.
+
+The publish job additionally re-runs the x86_64 ISA audit on the exact
+executable it is about to upload. That is seconds of work, and it closes the
+gap that a prebuilt artifact was audited on a different machine at an earlier
+time.
+
+## Self-hosted routing and the trust posture
+
+The cas-6981 posture is unchanged: only same-repository, non-fork **push**
+events can reach the persistent box, and a public fork cannot emit those.
+
+Routing is a two-key system, matching ci.yml's merge-queue route:
+
+- **Before assignment**, a `*-runner-route` job picks the label set. GitHub
+  cannot fall back after assigning an offline self-hosted runner — the job
+  simply stays queued — so the choice has to happen first. The repository
+  variable `CASSY_RELEASE_SELF_HOSTED` is opt-in, and its absent/disabled state
+  selects `ubuntu-latest`, which is the historical release path unchanged.
+- **After assignment**, `scripts/check-release-runner-trust.sh` re-asserts the
+  contract on the machine itself: push event, canonical repository, routing
+  explicitly enabled, ref in `{refs/heads/main, refs/tags/v*}`, Cargo and
+  sccache directories isolated under `/var/lib/cassy-actions/`, the runner's
+  private sccache port, and not running as root. A future edit to a workflow
+  expression therefore cannot silently hand the box untrusted input.
+
+**The publishing job is deliberately never routed to the box.** It holds the
+only `contents: write` token in the release and stays on `ubuntu-latest`.
+
+Enabling and disabling the routing is a repository-variable change:
+
+```
+gh variable set CASSY_RELEASE_SELF_HOSTED --body enabled    # opt in
+gh variable set CASSY_RELEASE_SELF_HOSTED --body disabled   # before box maintenance
+```
+
+Disable it before any maintenance on the runner. Every lane then runs hosted,
+exactly as it did before this work.
+
+## Cutting a release on the fast path
+
+1. Merge the version-bump PR to `main`. `Release Prebuild` starts on that push.
+2. Wait for its `Release prebuild summary` job. It states plainly whether a tag
+   will adopt the artifacts or fall back to building them inline.
+3. Push the tag (`scripts/release.sh --publish-tag`). The script reports the
+   same thing one last time before it pushes, so a tag is never pushed blind
+   into a 15-minute path by accident.
+4. Run both receipts once the release is published.
+
+Pushing the tag before the prebuild finishes is safe — it just costs the old
+tag-time build. Nothing breaks; the release is simply slow.
+
+## Measuring a real release
+
+Two receipts, both gates rather than reports:
+
+```
+scripts/release-published-receipt.sh vX.Y.Z    # what shipped: digests, both assets
+scripts/release-latency-receipt.sh   vX.Y.Z    # how fast: tag push -> published
+```
+
+`release-latency-receipt.sh` measures from the **first** Release workflow run
+created for the tag, so a rerun can never flatter the number, and it exits
+non-zero when the latency exceeds its budget (600s by default). A release that
+cannot produce a passing latency receipt has not demonstrated fast publication.
+
+## Contract
+
+`scripts/test-ci-test-tiers.sh` pins the properties above — trigger surface,
+the pending-release gate, audit and codesign parity between the prebuild and
+fallback paths, fail-safe lookup, fail-closed publication, both routing keys,
+and the publish job's hosted-only placement. `make -C cas-cli test-ci-tiers`
+runs it along with each new guard's own self-test, on the required Fast
+Validation lane.

--- a/docs/ci/release-fast-publication.md
+++ b/docs/ci/release-fast-publication.md
@@ -127,6 +127,16 @@ gh variable set CASSY_RELEASE_SELF_HOSTED --body disabled   # before box mainten
 Disable it before any maintenance on the runner. Every lane then runs hosted,
 exactly as it did before this work.
 
+One listener serves the `cas-ci-32core` label, so a routed release lane runs
+one job at a time and can queue behind merge-queue validation. Two consequences
+worth knowing before enabling it:
+
+- In the fallback path, `verify` and `build` are designed to run in parallel;
+  routed to the box they serialise. Warm, that is still a few minutes against
+  13-26 minutes cold, but it is not free parallelism.
+- A release cut during heavy merge-queue traffic waits for the box. The hosted
+  fail-safe is one variable away if that ever matters more than the warm cache.
+
 ## Cutting a release on the fast path
 
 1. Merge the version-bump PR to `main`. `Release Prebuild` starts on that push.

--- a/scripts/check-release-runner-trust.sh
+++ b/scripts/check-release-runner-trust.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Re-assert, at execution time on the machine itself, that a release lane which
+# landed on the persistent self-hosted runner is genuinely trusted traffic
+# (cas-6981 posture, cas-3b7c0 release routing).
+#
+# The workflow `if:` expression already gates runner ASSIGNMENT. This is the
+# second, independent control that runs after assignment, so a future edit to
+# an expression cannot silently hand the box to untrusted input. It also
+# refuses to build inside a host layout where the runner's caches are not
+# isolated from the operator's factory worktrees.
+set -euo pipefail
+
+fail() {
+    echo "error: $1" >&2
+    exit 1
+}
+
+test "${GITHUB_EVENT_NAME:?}" = push \
+    || fail "release lane on the isolated runner requires a push event; got $GITHUB_EVENT_NAME"
+test "${GITHUB_REPOSITORY:?}" = Richards-LLC/cassy \
+    || fail "release lane pinned to the canonical repository; got $GITHUB_REPOSITORY"
+test "${SELF_HOSTED_ENABLED:-}" = enabled \
+    || fail "release self-hosted routing is not explicitly enabled"
+
+# Only the two refs a release can legitimately travel on: the release-prep
+# commit on main (prebuild) and the annotated release tag (publication).
+case "${GITHUB_REF:?}" in
+    refs/heads/main | refs/tags/v*) ;;
+    *) fail "ref is outside the trusted release set: $GITHUB_REF" ;;
+esac
+
+case "${CARGO_TARGET_DIR:?}" in
+    /var/lib/cassy-actions/*) ;;
+    *) fail "CARGO_TARGET_DIR is not isolated from factory worktrees" ;;
+esac
+
+case "${SCCACHE_DIR:?}" in
+    /var/lib/cassy-actions/*) ;;
+    *) fail "SCCACHE_DIR is not isolated from the operator cache" ;;
+esac
+
+test "${SCCACHE_SERVER_PORT:?}" = 4227 \
+    || fail "SCCACHE_SERVER_PORT is not the runner's private port"
+test "$(id -u)" -ne 0 || fail "release lane must not run as root on the shared box"
+
+echo "release runner trust contract satisfied: ref=$GITHUB_REF target=$CARGO_TARGET_DIR"

--- a/scripts/detect-pending-release.sh
+++ b/scripts/detect-pending-release.sh
@@ -63,7 +63,10 @@ tag="v$version"
 # tags, and a stale local tag must never suppress a real prebuild.
 remote="${RELEASE_REMOTE:-origin}"
 if git ls-remote --tags --exit-code "$remote" "refs/tags/$tag" >/dev/null 2>&1; then
-    not_pending "$tag is already published"
+    # The disarming condition is the TAG existing, not the release object being
+    # published: once the tag is pushed its own workflow owns the artifacts, so
+    # prebuilding for that version can no longer help anything.
+    not_pending "$tag already exists on $remote"
 fi
 
 printf 'pending=true\n'

--- a/scripts/detect-pending-release.sh
+++ b/scripts/detect-pending-release.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Decide whether the checked-out tree is a *pending release* tree: the exact
+# contents a `vX.Y.Z` tag is about to be pushed at.
+#
+# This is the trigger for prebuilding release artifacts at release-PR merge
+# instead of at tag time (cas-3b7c0). The release tree is final the moment the
+# version-bump PR lands on main, so the expensive platform builds no longer
+# have to sit on the tag's critical path.
+#
+# A tree is pending exactly when:
+#   1. every release-train crate carries the same version, and
+#   2. CHANGELOG.md has a heading for that version, and
+#   3. no `v<version>` tag exists yet.
+#
+# (3) makes this self-disarming: once the tag is pushed, later main pushes at
+# the same version report pending=false and cost one cheap gate job.
+set -euo pipefail
+
+# RELEASE_TREE_ROOT exists so the self-test can point this at a fixture tree
+# instead of the checkout it lives in. CI never sets it.
+repo_root="${RELEASE_TREE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$repo_root"
+
+release_crates=(
+    "cas-cli/Cargo.toml"
+    "crates/cas-types/Cargo.toml"
+    "crates/cas-search/Cargo.toml"
+    "crates/cas-store/Cargo.toml"
+    "crates/cas-core/Cargo.toml"
+    "crates/cas-mcp/Cargo.toml"
+)
+
+crate_version() {
+    sed -n 's/^version = "\([^"]*\)"/\1/p' "$1" | head -n 1
+}
+
+not_pending() {
+    printf 'pending=false\n'
+    printf 'version=\n'
+    printf 'tag=\n'
+    printf 'reason=%s\n' "$1"
+    exit 0
+}
+
+version="$(crate_version "cas-cli/Cargo.toml")"
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    not_pending "cas-cli/Cargo.toml version is not a release semver: ${version:-<empty>}"
+fi
+
+for manifest in "${release_crates[@]}"; do
+    actual="$(crate_version "$manifest")"
+    if [[ "$actual" != "$version" ]]; then
+        not_pending "$manifest is $actual, not $version; release train is mid-bump"
+    fi
+done
+
+if ! grep -Eq "^## \[$version\]( - [0-9]{4}-[0-9]{2}-[0-9]{2})?$" CHANGELOG.md; then
+    not_pending "CHANGELOG.md has no heading for $version"
+fi
+
+tag="v$version"
+# Ask the remote, not the local ref store: a CI checkout may not have fetched
+# tags, and a stale local tag must never suppress a real prebuild.
+remote="${RELEASE_REMOTE:-origin}"
+if git ls-remote --tags --exit-code "$remote" "refs/tags/$tag" >/dev/null 2>&1; then
+    not_pending "$tag is already published"
+fi
+
+printf 'pending=true\n'
+printf 'version=%s\n' "$version"
+printf 'tag=%s\n' "$tag"
+printf 'reason=%s\n' "release train is at $version with no $tag yet"

--- a/scripts/find-release-prebuild.sh
+++ b/scripts/find-release-prebuild.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Locate prebuilt release artifacts for an exact commit (cas-3b7c0).
+#
+# Prints `found=`, `run-id=` and `reason=` for the tag-time release workflow.
+#
+# FAIL-SAFE, NOT FAIL-CLOSED. Every failure mode — no prebuild run, a partial
+# run, expired artifacts, an API outage — reports found=false, which routes the
+# release back to the pre-existing cold build path. The prebuild is an
+# accelerator; it can never be the reason a release cannot ship.
+#
+# The only accepted match is a *successful* Release Prebuild run whose
+# head_sha is exactly the commit being published, so adopted bytes always come
+# from the tagged tree.
+set -euo pipefail
+
+sha="${1:-${GITHUB_SHA:-}}"
+repo="${GITHUB_REPOSITORY:-}"
+gh_bin="${GH_BIN:-gh}"
+workflow="${RELEASE_PREBUILD_WORKFLOW:-release-prebuild.yml}"
+required_artifacts=("cas-x86_64-unknown-linux-gnu" "cas-aarch64-apple-darwin")
+
+decline() {
+    printf 'found=false\n'
+    printf 'run-id=\n'
+    printf 'reason=%s\n' "$1"
+    exit 0
+}
+
+if [[ -z "$sha" ]]; then
+    decline "no commit SHA to look up"
+fi
+if [[ -z "$repo" ]]; then
+    decline "GITHUB_REPOSITORY is unset"
+fi
+
+runs_json=""
+if ! runs_json="$("$gh_bin" api \
+    "repos/$repo/actions/workflows/$workflow/runs?head_sha=$sha&status=success&per_page=20" 2>/dev/null)"; then
+    decline "prebuild run lookup failed for $sha"
+fi
+
+mapfile -t run_ids < <(jq -r '.workflow_runs[]?.id // empty' <<<"$runs_json" 2>/dev/null || true)
+if [[ "${#run_ids[@]}" -eq 0 ]]; then
+    decline "no successful prebuild run for $sha"
+fi
+
+for run_id in "${run_ids[@]}"; do
+    artifacts_json=""
+    if ! artifacts_json="$("$gh_bin" api \
+        "repos/$repo/actions/runs/$run_id/artifacts?per_page=100" 2>/dev/null)"; then
+        continue
+    fi
+    complete=true
+    for name in "${required_artifacts[@]}"; do
+        live="$(jq -r --arg name "$name" \
+            '[.artifacts[]? | select(.name == $name and .expired == false)] | length' \
+            <<<"$artifacts_json" 2>/dev/null || echo 0)"
+        if [[ "$live" != "1" ]]; then
+            complete=false
+            break
+        fi
+    done
+    if "$complete"; then
+        printf 'found=true\n'
+        printf 'run-id=%s\n' "$run_id"
+        printf 'reason=prebuild run %s carries every release asset for %s\n' "$run_id" "$sha"
+        exit 0
+    fi
+done
+
+decline "prebuild runs for $sha have no live copy of every release asset"

--- a/scripts/release-latency-receipt.sh
+++ b/scripts/release-latency-receipt.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Measure the only release number an operator feels: tag push -> published
+# release (cas-3b7c0 / GH #449).
+#
+# The digest receipt (scripts/release-published-receipt.sh) proves *what* was
+# published. This proves *how fast*. Both are needed before a release is
+# announced as fast: a receipt that only reports digests cannot tell a
+# 3-minute prebuilt publication from a 26-minute cold one.
+#
+# Exits non-zero when the measured latency exceeds the budget, so the number is
+# a gate an operator can run rather than a figure to eyeball.
+set -euo pipefail
+
+usage() {
+    echo "Usage: scripts/release-latency-receipt.sh <vX.Y.Z> [--budget-seconds <n>]" >&2
+}
+
+if [[ "$#" -ne 1 && "$#" -ne 3 ]]; then
+    usage
+    exit 2
+fi
+
+tag="$1"
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: expected an annotated release tag like vX.Y.Z; got $tag" >&2
+    exit 2
+fi
+
+budget=600
+if [[ "$#" -eq 3 ]]; then
+    if [[ "$2" != "--budget-seconds" || ! "$3" =~ ^[0-9]+$ ]]; then
+        usage
+        exit 2
+    fi
+    budget="$3"
+fi
+
+gh_bin="${GH_BIN:-gh}"
+repo="${RELEASE_REPO:-Richards-LLC/cassy}"
+
+epoch_of() {
+    date -u -d "$1" +%s 2>/dev/null || return 1
+}
+
+published_at="$("$gh_bin" release view "$tag" --repo "$repo" --json publishedAt --jq '.publishedAt // empty')"
+if [[ -z "$published_at" ]]; then
+    echo "error: release $tag is not published yet" >&2
+    exit 1
+fi
+
+runs_json="$("$gh_bin" api "repos/$repo/actions/workflows/release.yml/runs?branch=$tag&event=push&per_page=50")"
+# The tag push itself is the clock start, so take the FIRST run created for
+# this tag. A rerun or a later attempt must never be allowed to shorten the
+# measured latency.
+tag_pushed_at="$(jq -r '[.workflow_runs[]?.created_at] | sort | first // empty' <<<"$runs_json")"
+tag_run_id="$(jq -r '[.workflow_runs[]? | {id, created_at}] | sort_by(.created_at) | first.id // empty' <<<"$runs_json")"
+if [[ -z "$tag_pushed_at" ]]; then
+    echo "error: no Release workflow run found for $tag; cannot time its publication" >&2
+    exit 1
+fi
+
+start="$(epoch_of "$tag_pushed_at")" || {
+    echo "error: could not parse tag push timestamp $tag_pushed_at" >&2
+    exit 1
+}
+end="$(epoch_of "$published_at")" || {
+    echo "error: could not parse publish timestamp $published_at" >&2
+    exit 1
+}
+latency=$((end - start))
+
+within=true
+if [[ "$latency" -lt 0 ]]; then
+    echo "error: publication ($published_at) precedes the tag push ($tag_pushed_at)" >&2
+    exit 1
+fi
+if [[ "$latency" -gt "$budget" ]]; then
+    within=false
+fi
+
+printf 'TAG=%s\n' "$tag"
+printf 'TAG_RUN_ID=%s\n' "$tag_run_id"
+printf 'TAG_PUSHED_AT=%s\n' "$tag_pushed_at"
+printf 'PUBLISHED_AT=%s\n' "$published_at"
+printf 'PUBLISH_LATENCY_SECONDS=%s\n' "$latency"
+printf 'BUDGET_SECONDS=%s\n' "$budget"
+printf 'WITHIN_BUDGET=%s\n' "$within"
+
+if ! "$within"; then
+    echo "error: $tag took ${latency}s from tag push to publication, over the ${budget}s budget" >&2
+    exit 1
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -203,6 +203,20 @@ if ! "$PUBLISH_TAG"; then
     exit 0
 fi
 
+# Tell the operator, before the tag exists, which publication path the tag will
+# take (cas-3b7c0). A missing prebuild is not an error — the tag still ships via
+# the cold build path — but it is the difference between a ~2 minute and a
+# ~15 minute publication, and that is worth knowing before pushing, not after.
+prebuild_status="$(GITHUB_REPOSITORY="${RELEASE_REPO:-Richards-LLC/cassy}" \
+    GITHUB_SHA="$(git rev-parse HEAD)" \
+    ./scripts/find-release-prebuild.sh 2>/dev/null || true)"
+if grep -q '^found=true' <<<"$prebuild_status"; then
+    echo "Prebuilt release artifacts are ready; the tag will publish without compiling."
+else
+    echo "NOTE: no prebuilt artifacts for this commit yet — the tag will build them inline (historically 13-26 min)."
+    echo "      Wait for the Release Prebuild workflow on this commit to finish if you want the fast path."
+fi
+
 echo "Pushing annotated tag $TAG to trigger the authoritative Release workflow..."
 git push origin "$TAG"
 
@@ -219,4 +233,5 @@ if "$MANUAL_PUBLISH"; then
 else
     echo "CI now owns release creation. Do not upload dist/local-audit archives or announce their digests."
     echo "After CI publishes both assets, run scripts/release-published-receipt.sh $TAG."
+    echo "Then run scripts/release-latency-receipt.sh $TAG for the tag-to-published timing receipt."
 fi

--- a/scripts/test-check-release-runner-trust.sh
+++ b/scripts/test-check-release-runner-trust.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Deterministic self-test for scripts/check-release-runner-trust.sh.
+#
+# This is the execution-time half of the self-hosted trust boundary: the
+# workflow `if:` gates runner assignment, this gates what runs after
+# assignment. A guard nobody tests is a guard that quietly stops guarding, so
+# every rejection direction is exercised here.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+guard="$script_dir/check-release-runner-trust.sh"
+
+pass=0
+fail=0
+
+run_guard() {
+    env -i PATH="$PATH" HOME="${HOME:-/tmp}" \
+        GITHUB_EVENT_NAME="${EVENT:-push}" \
+        GITHUB_REPOSITORY="${REPO:-Richards-LLC/cassy}" \
+        SELF_HOSTED_ENABLED="${ENABLED-enabled}" \
+        GITHUB_REF="${REF:-refs/tags/v3.4.0}" \
+        CARGO_TARGET_DIR="${TARGET_DIR:-/var/lib/cassy-actions/cache/cargo-target}" \
+        SCCACHE_DIR="${SCCACHE:-/var/lib/cassy-actions/cache/sccache}" \
+        SCCACHE_SERVER_PORT="${PORT:-4227}" \
+        bash "$guard" 2>&1
+}
+
+expect_accept() {
+    local label="$1"
+    if run_guard >/dev/null; then
+        printf 'ok   %s\n' "$label"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL %s (trusted input was rejected)\n' "$label"
+        fail=$((fail + 1))
+    fi
+}
+
+expect_reject() {
+    local label="$1" needle="$2" output status
+    set +e
+    output="$(run_guard)"
+    status=$?
+    set -e
+    if [[ "$status" -ne 0 ]] && grep -qF -- "$needle" <<<"$output"; then
+        printf 'ok   %s\n' "$label"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL %s (status %s, output: %s)\n' "$label" "$status" "$output"
+        fail=$((fail + 1))
+    fi
+}
+
+REF=refs/tags/v3.4.0 expect_accept 'an annotated release tag push is trusted'
+REF=refs/heads/main expect_accept 'the release-prep commit on main is trusted'
+
+REF=refs/heads/factory/some-worker \
+    expect_reject 'a factory branch cannot use the release lane' 'outside the trusted release set'
+REF=refs/pull/1/merge \
+    expect_reject 'a pull-request ref cannot use the release lane' 'outside the trusted release set'
+REF=refs/heads/gh-readonly-queue/main/x \
+    expect_reject 'a merge-queue ref cannot use the release lane' 'outside the trusted release set'
+EVENT=pull_request_target \
+    expect_reject 'a non-push event is refused' 'requires a push event'
+REPO=attacker/cassy-fork \
+    expect_reject 'a fork repository is refused' 'canonical repository'
+ENABLED= \
+    expect_reject 'routing that was never enabled is refused' 'not explicitly enabled'
+TARGET_DIR=/home/pippenz/Petrastella/cas-src/target \
+    expect_reject 'a factory worktree target directory is refused' 'not isolated from factory worktrees'
+SCCACHE=/home/pippenz/.cache/sccache \
+    expect_reject 'the operator cache directory is refused' 'not isolated from the operator cache'
+PORT=4226 \
+    expect_reject 'a foreign sccache port is refused' 'not the runner'"'"'s private port'
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+test "$fail" -eq 0

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -872,6 +872,7 @@ fi
 require_text "$ci_text" 'SCCACHE_GHA_ENABLED: "true"' 'CI enables GitHub cache-v2 backend'
 require_text "$(<"$release")" 'SCCACHE_GHA_ENABLED: "true"' 'release enables GitHub cache-v2 backend'
 release_text="$(<"$release")"
+release_verify="$(release_job_block verify)"
 release_linux="$(release_job_block build)"
 release_macos="$(release_job_block build-macos)"
 release_publish="$(release_job_block release)"
@@ -880,13 +881,13 @@ scoped_validation="$(job_block scoped-validation)"
 fast_preflight="$(job_block fast-validation-preflight)"
 require_absent "$release_linux" 'needs: verify' 'Linux release build starts in parallel with input verification'
 require_absent "$release_macos" 'needs: verify' 'macOS release build starts in parallel with input verification'
-require_text "$release_publish" 'needs: [verify, build, build-macos]' 'release publication waits for verification and both platform builds'
+require_text "$release_publish" 'needs: [prebuilt-lookup, verify, build, build-macos]' 'release publication waits for verification and both platform supply paths'
 for platform_build in "$release_linux" "$release_macos"; do
     require_text "$platform_build" '--profile "$RELEASE_PROFILE"' 'platform release build uses the thin-LTO profile'
     require_text "$platform_build" 'strip package/cas' 'platform package strips symbols before publication'
     require_text "$platform_build" '$RELEASE_DIR/cas' 'platform package selects the configured profile output'
 done
-require_text "$release_linux" 'check-blake3-no-avx512-build.sh "target/x86_64-unknown-linux-gnu/$RELEASE_DIR/build"' 'Linux release audits BLAKE3 inputs from the selected profile'
+require_text "$release_linux" 'check-blake3-no-avx512-build.sh "${CARGO_TARGET_DIR:-target}/x86_64-unknown-linux-gnu/$RELEASE_DIR/build"' 'Linux release audits BLAKE3 inputs from the selected profile'
 require_text "$release_linux" 'test-check-portable-x86_64-isa.sh package/cas' 'Linux release audits the exact stripped executable'
 require_text "$release_linux" 'name: cas-x86_64-unknown-linux-gnu' 'Linux release asset remains required'
 require_text "$release_macos" 'name: cas-aarch64-apple-darwin' 'macOS release asset remains required'
@@ -938,6 +939,131 @@ echo 'ok   partial-release retry refuses loudly and does not upload replacement 
 GITHUB_REF=refs/tags/v9.9.9 FAKE_RELEASE_EXISTS=1 FAKE_GH_LOG="$retry_tmp/creates" PATH="$retry_tmp/bin:$PATH" bash -c "$release_create_body"
 grep -qF 'release create v9.9.9' "$retry_tmp/creates"
 echo 'ok   first release run creates the release when no object exists'
+
+# ---------------------------------------------------------------------------
+# Fast release publication contract (cas-3b7c0 / GH #449).
+#
+# Measured baseline before this lane existed: tag push -> published release ran
+# 13m18s (v3.1.0), 14m55s (v3.0.0), 20m03s (v3.2.0) and 26m26s (v2.72.0). The
+# critical path was ALWAYS the two cold platform builds — `Create Release`
+# itself never took more than 23s. macOS ARM64 alone cost 12-21 minutes and
+# cannot move to the fleet, so the artifacts are built when the release-PR
+# merges and the tag only publishes them.
+#
+# Everything below pins the properties that make that safe: the prebuild is an
+# accelerator with a preserved cold fallback, publication is fail-closed on
+# exactly one complete supply path, the codesign gate travels with whichever
+# job produces Darwin bytes, and the self-hosted routing keeps the cas-6981
+# trust posture with a hosted fail-safe.
+# ---------------------------------------------------------------------------
+prebuild="$repo_root/.github/workflows/release-prebuild.yml"
+prebuild_text="$(<"$prebuild")"
+
+prebuild_job_block() {
+    local job="$1"
+    awk -v header="  ${job}:" '
+        $0 == header { inside = 1; next }
+        inside && /^  [A-Za-z0-9_-]+:$/ { exit }
+        inside { print }
+    ' "$prebuild"
+}
+
+prebuild_gate="$(prebuild_job_block pending-release)"
+prebuild_route="$(prebuild_job_block prebuild-runner-route)"
+prebuild_linux="$(prebuild_job_block build)"
+prebuild_macos="$(prebuild_job_block build-macos)"
+release_lookup="$(release_job_block prebuilt-lookup)"
+release_route="$(release_job_block release-runner-route)"
+
+# Trigger surface. A public fork must not be able to reach the persistent box
+# through the new workflow, and the standing CI-load policy keeps the heavy
+# tier off factory/*, epic/*, tags and pull requests.
+require_text "$prebuild_text" 'push:' 'release prebuild runs on canonical repository pushes'
+require_text "$prebuild_text" '      - main' 'release prebuild is limited to main'
+for forbidden_event in pull_request: pull_request_target: workflow_run: issue_comment: repository_dispatch:; do
+    require_absent "$prebuild_text" "$forbidden_event" "release prebuild rejects event before runner assignment: $forbidden_event"
+done
+require_absent "$prebuild_text" '- "factory/**"' 'release prebuild never fires on factory branches'
+require_absent "$prebuild_text" '- "epic/**"' 'release prebuild never fires on epic branches'
+require_absent "$prebuild_text" 'tags:' 'release prebuild never fires on tags'
+require_text "$prebuild_text" 'cancel-in-progress: false' 'a prebuild is never cancelled out from under the tag that will adopt it'
+
+# The gate is what keeps an ordinary main push from costing two release builds.
+require_text "$prebuild_gate" './scripts/detect-pending-release.sh' 'release prebuild gates the heavy tier on a pending release tree'
+require_text "$prebuild_linux" "needs.pending-release.outputs.pending == 'true'" 'Linux prebuild only runs for a pending release tree'
+require_text "$prebuild_macos" "needs.pending-release.outputs.pending == 'true'" 'macOS prebuild only runs for a pending release tree'
+
+# Prebuilt bytes must be indistinguishable from what the tag-time fallback
+# would have produced, including every audit and the codesign gate (cas-67c1).
+for platform_prebuild in "$prebuild_linux" "$prebuild_macos"; do
+    require_text "$platform_prebuild" '--profile "$RELEASE_PROFILE"' 'prebuilt artifact uses the shipped release profile'
+    require_text "$platform_prebuild" 'strip package/cas' 'prebuilt artifact strips symbols before packaging'
+done
+require_text "$prebuild_linux" 'check-blake3-no-avx512-build.sh' 'Linux prebuild audits BLAKE3 build inputs'
+require_text "$prebuild_linux" 'test-check-portable-x86_64-isa.sh package/cas' 'Linux prebuild audits the exact stripped executable'
+require_text "$prebuild_macos" 'codesign --sign - --force package/cas' 'macOS prebuild re-signs the binary after stripping'
+require_text "$prebuild_macos" 'codesign --verify --verbose=4 package/cas' 'macOS prebuild verifies the signature it publishes'
+require_text "$prebuild_macos" 'runs-on: macos-26' 'macOS prebuild stays on the supported hosted image'
+require_text "$prebuild_linux" 'name: cas-x86_64-unknown-linux-gnu' 'prebuilt Linux artifact uses the adopted asset name'
+require_text "$prebuild_macos" 'name: cas-aarch64-apple-darwin' 'prebuilt macOS artifact uses the adopted asset name'
+
+# Self-hosted routing: label selected before assignment, opt-in variable, and
+# an execution-time trust guard on the machine itself.
+for route in "$prebuild_route" "$release_route"; do
+    require_text "$route" 'vars.CASSY_RELEASE_SELF_HOSTED' 'release routing requires explicit self-hosted opt-in'
+    require_text "$route" 'runner=["self-hosted","Linux","X64","cas-ci-32core"]' 'release routing selects the isolated runner label set'
+    require_text "$route" 'runner=["ubuntu-latest"]' 'release routing fails safe to hosted runners'
+    require_absent "$route" 'actions/checkout' 'release routing does not execute source before label selection'
+done
+require_text "$prebuild_linux" './scripts/check-release-runner-trust.sh' 'Linux prebuild reasserts the trust boundary on the box'
+require_text "$release_verify" './scripts/check-release-runner-trust.sh' 'release verification reasserts the trust boundary on the box'
+require_text "$release_linux" './scripts/check-release-runner-trust.sh' 'fallback Linux build reasserts the trust boundary on the box'
+require_text "$(<"$repo_root/scripts/check-release-runner-trust.sh")" 'refs/heads/main | refs/tags/v*' 'trust guard admits only release-prep and release-tag refs'
+
+# The publishing job holds the only write-scoped token in the release. It must
+# never execute on the shared persistent box.
+require_text "$release_publish" 'runs-on: ubuntu-latest' 'the write-scoped publish job stays on hosted runners'
+require_absent "$release_publish" 'cas-ci-32core' 'the write-scoped publish job cannot be routed to the box'
+
+# Adoption is fail-safe on lookup and fail-closed on publication.
+require_text "$release_lookup" './scripts/find-release-prebuild.sh' 'release looks up prebuilt artifacts for the tagged commit'
+require_text "$release_lookup" 'actions: read' 'prebuilt lookup takes only read scope'
+require_text "$release_linux" "needs.prebuilt-lookup.outputs.found != 'true'" 'the cold Linux build remains the fallback when no prebuild exists'
+require_text "$release_macos" "needs.prebuilt-lookup.outputs.found != 'true'" 'the cold macOS build remains the fallback when no prebuild exists'
+require_text "$release_publish" "needs.prebuilt-lookup.outputs.found == 'true'" 'publication distinguishes the adopted path'
+require_text "$release_publish" "needs.build.result == 'skipped'" 'adoption requires the platform builds to have actually been skipped'
+require_text "$release_publish" "needs.build-macos.result == 'skipped'" 'adoption requires the macOS build to have actually been skipped'
+require_text "$release_publish" "needs.build.result == 'success'" 'the fallback path requires a successful Linux build'
+require_text "$release_publish" "needs.build-macos.result == 'success'" 'the fallback path requires a successful macOS build'
+require_text "$release_publish" "needs.verify.result == 'success'" 'no supply path can publish without the release-input gate'
+require_text "$release_publish" 'gh run download' 'publication adopts artifacts from the prebuild run'
+require_text "$release_publish" './scripts/check-portable-x86_64-isa.sh publish-audit/cas' 'publication re-audits the exact Linux executable it is about to publish'
+require_text "$release_publish" 'sha256sum release/*.tar.gz' 'publication records the digests of the exact published bytes'
+
+# The latency claim itself must be produced by a gate, not by eyeballing a run.
+latency_receipt="$repo_root/scripts/release-latency-receipt.sh"
+if [[ -x "$latency_receipt" ]]; then
+    require_text "$(<"$latency_receipt")" 'budget=600' 'the release latency receipt defaults to the ten-minute target'
+    require_text "$(<"$latency_receipt")" 'sort | first' 'latency is measured from the first run of the tag, never a rerun'
+    printf 'ok   release latency receipt is executable\n'
+    pass=$((pass + 1))
+else
+    printf 'FAIL release latency receipt must exist and be executable\n'
+    fail=$((fail + 1))
+fi
+
+for guard_script in detect-pending-release find-release-prebuild check-release-runner-trust release-latency-receipt; do
+    if [[ -x "$repo_root/scripts/test-$guard_script.sh" ]]; then
+        printf 'ok   %s has an executable self-test\n' "$guard_script"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL %s has no executable self-test\n' "$guard_script"
+        fail=$((fail + 1))
+    fi
+    require_text "$(<"$repo_root/cas-cli/Makefile")" "test-$guard_script.sh" "test-ci-tiers runs the $guard_script self-test"
+done
+
+require_text "$(<"$repo_root/docs/ci/release-fast-publication.md")" 'tag push -> published' 'fast publication architecture is documented'
 rm -rf "$retry_tmp"
 trap - EXIT
 

--- a/scripts/test-detect-pending-release.sh
+++ b/scripts/test-detect-pending-release.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Deterministic self-test for scripts/detect-pending-release.sh.
+#
+# The prebuild gate decides whether every main push pays for two full release
+# builds. Both of its failure directions are expensive: a false positive burns
+# a hosted macOS runner on an ordinary commit, and a false negative silently
+# drops the next release back to the slow tag-time path. Prove both.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+detect="$script_dir/detect-pending-release.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+expect_field() {
+    local output="$1" field="$2" expected="$3" label="$4" actual
+    actual="$(grep -m1 "^$field=" <<<"$output" | cut -d= -f2-)"
+    if [[ "$actual" == "$expected" ]]; then
+        printf 'ok   %s\n' "$label"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL %s (expected %s=%s; got %s)\n' "$label" "$field" "$expected" "$actual"
+        fail=$((fail + 1))
+    fi
+}
+
+make_tree() {
+    local root="$1" version="$2" changelog_version="$3"
+    rm -rf "$root"
+    mkdir -p "$root/cas-cli" "$root/crates"
+    for crate in cas-types cas-search cas-store cas-core cas-mcp; do
+        mkdir -p "$root/crates/$crate"
+        printf '[package]\nname = "%s"\nversion = "%s"\n' "$crate" "$version" \
+            >"$root/crates/$crate/Cargo.toml"
+    done
+    printf '[package]\nname = "cas"\nversion = "%s"\n' "$version" >"$root/cas-cli/Cargo.toml"
+    printf '# Changelog\n\n## [%s] - 2026-08-20\n\n- thing\n' "$changelog_version" \
+        >"$root/CHANGELOG.md"
+}
+
+# A bare repo stands in for `origin`, so the published-tag check is exercised
+# through the same `git ls-remote` path CI uses.
+remote="$tmp/origin.git"
+git init --quiet --bare "$remote"
+seed="$tmp/seed"
+git init --quiet "$seed"
+git -C "$seed" config user.email test@example.com
+git -C "$seed" config user.name Test
+echo seed >"$seed/README.md"
+git -C "$seed" add README.md
+git -C "$seed" commit --quiet -m seed
+git -C "$seed" tag -a v1.0.0 -m v1.0.0
+git -C "$seed" push --quiet "$remote" HEAD:refs/heads/main
+git -C "$seed" push --quiet "$remote" v1.0.0
+
+tree="$tmp/tree"
+
+# 1. Release-prep tree: versions aligned, changelog present, tag unpublished.
+make_tree "$tree" 2.0.0 2.0.0
+out="$(RELEASE_TREE_ROOT="$tree" RELEASE_REMOTE="$remote" "$detect")"
+expect_field "$out" pending true 'release-prep tree opens the prebuild lanes'
+expect_field "$out" version 2.0.0 'pending tree reports its version'
+expect_field "$out" tag v2.0.0 'pending tree reports the tag it will be published as'
+
+# 2. Already-published version: the gate must disarm itself after the tag.
+make_tree "$tree" 1.0.0 1.0.0
+out="$(RELEASE_TREE_ROOT="$tree" RELEASE_REMOTE="$remote" "$detect")"
+expect_field "$out" pending false 'a published version never re-triggers a prebuild'
+
+# 3. Ordinary main push mid-train: crate versions disagree.
+make_tree "$tree" 2.0.0 2.0.0
+printf '[package]\nname = "cas-core"\nversion = "1.9.0"\n' >"$tree/crates/cas-core/Cargo.toml"
+out="$(RELEASE_TREE_ROOT="$tree" RELEASE_REMOTE="$remote" "$detect")"
+expect_field "$out" pending false 'a half-bumped release train is not a release tree'
+
+# 4. Version bumped but CHANGELOG not written: not a release tree.
+make_tree "$tree" 2.1.0 2.0.0
+out="$(RELEASE_TREE_ROOT="$tree" RELEASE_REMOTE="$remote" "$detect")"
+expect_field "$out" pending false 'a missing CHANGELOG heading is not a release tree'
+
+# 5. Non-semver / workspace-inherited version must not open the lanes.
+make_tree "$tree" 2.2.0 2.2.0
+printf '[package]\nname = "cas"\nversion.workspace = true\n' >"$tree/cas-cli/Cargo.toml"
+out="$(RELEASE_TREE_ROOT="$tree" RELEASE_REMOTE="$remote" "$detect")"
+expect_field "$out" pending false 'an unreadable version is not a release tree'
+
+# Every path must exit 0: this gate reports a decision, it never fails a push.
+for version in 2.0.0 1.0.0; do
+    make_tree "$tree" "$version" "$version"
+    if RELEASE_TREE_ROOT="$tree" RELEASE_REMOTE="$remote" "$detect" >/dev/null; then
+        printf 'ok   gate exits 0 for version %s\n' "$version"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL gate exited non-zero for version %s\n' "$version"
+        fail=$((fail + 1))
+    fi
+done
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+test "$fail" -eq 0

--- a/scripts/test-find-release-prebuild.sh
+++ b/scripts/test-find-release-prebuild.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Deterministic self-test for scripts/find-release-prebuild.sh.
+#
+# This lookup decides whether a tag publishes prebuilt bytes or compiles from
+# scratch. It must adopt only a *complete* prebuild of the *exact* commit, and
+# it must decline — never fail — on every degraded input, because declining
+# costs minutes while failing costs the release.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+lookup="$script_dir/find-release-prebuild.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+pass=0
+fail=0
+
+expect_field() {
+    local output="$1" field="$2" expected="$3" label="$4" actual
+    actual="$(grep -m1 "^$field=" <<<"$output" | cut -d= -f2-)"
+    if [[ "$actual" == "$expected" ]]; then
+        printf 'ok   %s\n' "$label"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL %s (expected %s=%s; got %s)\n' "$label" "$field" "$expected" "$actual"
+        fail=$((fail + 1))
+    fi
+}
+
+# A fake `gh api` whose two responses are supplied as files. Anything else it
+# is asked for is an error, so an unexpected API call cannot pass silently.
+cat >"$tmp/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" != api ]]; then
+  echo "unexpected fake gh invocation: $*" >&2
+  exit 2
+fi
+case "$2" in
+  *"/actions/workflows/"*"/runs?"*)
+    if [[ -n "${FAKE_RUNS_STATUS:-}" ]]; then exit "$FAKE_RUNS_STATUS"; fi
+    cat "${FAKE_RUNS_JSON:?}"
+    ;;
+  *"/actions/runs/"*"/artifacts?"*)
+    run_id="${2#*/actions/runs/}"
+    run_id="${run_id%%/artifacts*}"
+    file="${FAKE_ARTIFACTS_DIR:?}/$run_id.json"
+    if [[ ! -f "$file" ]]; then exit 1; fi
+    cat "$file"
+    ;;
+  *)
+    echo "unexpected fake gh api path: $2" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$tmp/bin/gh"
+export GH_BIN="$tmp/bin/gh"
+export GITHUB_REPOSITORY=Richards-LLC/cassy
+mkdir -p "$tmp/artifacts"
+
+both_live='{"artifacts":[
+  {"name":"cas-x86_64-unknown-linux-gnu","expired":false},
+  {"name":"cas-aarch64-apple-darwin","expired":false}]}'
+linux_only='{"artifacts":[{"name":"cas-x86_64-unknown-linux-gnu","expired":false}]}'
+macos_expired='{"artifacts":[
+  {"name":"cas-x86_64-unknown-linux-gnu","expired":false},
+  {"name":"cas-aarch64-apple-darwin","expired":true}]}'
+
+echo '{"workflow_runs":[{"id":111}]}' >"$tmp/runs.json"
+export FAKE_RUNS_JSON="$tmp/runs.json"
+export FAKE_ARTIFACTS_DIR="$tmp/artifacts"
+
+# 1. Complete prebuild -> adopt it.
+printf '%s' "$both_live" >"$tmp/artifacts/111.json"
+out="$("$lookup" deadbeef)"
+expect_field "$out" found true 'a complete prebuild for the commit is adopted'
+expect_field "$out" run-id 111 'adoption names the prebuild run'
+
+# 2. Linux built, macOS missing -> decline (never publish half a release).
+printf '%s' "$linux_only" >"$tmp/artifacts/111.json"
+out="$("$lookup" deadbeef)"
+expect_field "$out" found false 'a partial prebuild is not adopted'
+
+# 3. Artifact aged out of retention -> decline.
+printf '%s' "$macos_expired" >"$tmp/artifacts/111.json"
+out="$("$lookup" deadbeef)"
+expect_field "$out" found false 'an expired artifact is not adopted'
+
+# 4. No prebuild run for the commit -> decline.
+echo '{"workflow_runs":[]}' >"$tmp/runs.json"
+out="$("$lookup" deadbeef)"
+expect_field "$out" found false 'a commit with no prebuild falls back to building'
+
+# 5. Newest incomplete run must not mask an older complete one.
+echo '{"workflow_runs":[{"id":222},{"id":111}]}' >"$tmp/runs.json"
+printf '%s' "$linux_only" >"$tmp/artifacts/222.json"
+printf '%s' "$both_live" >"$tmp/artifacts/111.json"
+out="$("$lookup" deadbeef)"
+expect_field "$out" found true 'a complete older prebuild is still adopted'
+expect_field "$out" run-id 111 'adoption skips the incomplete run'
+
+# 6. API outage -> decline, exit 0. The release must still be able to ship.
+out="$(FAKE_RUNS_STATUS=1 "$lookup" deadbeef)"
+expect_field "$out" found false 'an API failure declines instead of failing the release'
+
+# 7. Missing inputs decline rather than crash the workflow step.
+out="$(GITHUB_REPOSITORY= "$lookup" deadbeef)"
+expect_field "$out" found false 'an unset repository declines'
+out="$(GITHUB_SHA= "$lookup")"
+expect_field "$out" found false 'an unset commit declines'
+
+# Every path exits 0.
+for scenario in 'deadbeef'; do
+    if "$lookup" "$scenario" >/dev/null; then
+        printf 'ok   lookup exits 0 for %s\n' "$scenario"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL lookup exited non-zero for %s\n' "$scenario"
+        fail=$((fail + 1))
+    fi
+done
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+test "$fail" -eq 0

--- a/scripts/test-release-latency-receipt.sh
+++ b/scripts/test-release-latency-receipt.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Deterministic self-test for scripts/release-latency-receipt.sh.
+#
+# The latency number is the claim GH #449 is closed on, so the script that
+# produces it must be provably unable to flatter a release: it measures from
+# the FIRST run of the tag (not a rerun), and it fails when the budget is
+# exceeded rather than printing a number nobody checks.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+receipt="$script_dir/release-latency-receipt.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+pass=0
+fail=0
+
+ok() { printf 'ok   %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf 'FAIL %s\n' "$1"; fail=$((fail + 1)); }
+
+expect_field() {
+    local output="$1" field="$2" expected="$3" label="$4" actual
+    actual="$(grep -m1 "^$field=" <<<"$output" | cut -d= -f2-)"
+    if [[ "$actual" == "$expected" ]]; then ok "$label"; else
+        bad "$label (expected $field=$expected; got $actual)"
+    fi
+}
+
+cat >"$tmp/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "release view")
+    if [[ -z "${FAKE_PUBLISHED_AT:-}" ]]; then exit 1; fi
+    printf '%s\n' "$FAKE_PUBLISHED_AT"
+    ;;
+  "api repos"*)
+    cat "${FAKE_RUNS_JSON:?}"
+    ;;
+  *) echo "unexpected fake gh invocation: $*" >&2; exit 2 ;;
+esac
+EOF
+chmod +x "$tmp/bin/gh"
+export GH_BIN="$tmp/bin/gh"
+export RELEASE_REPO=Richards-LLC/cassy
+
+# Two runs for the tag: the original push and a later rerun. Measuring from
+# the rerun would understate the latency an operator actually experienced.
+cat >"$tmp/runs.json" <<'EOF'
+{"workflow_runs":[
+  {"id":999,"created_at":"2026-08-20T12:30:00Z"},
+  {"id":111,"created_at":"2026-08-20T12:00:00Z"}]}
+EOF
+export FAKE_RUNS_JSON="$tmp/runs.json"
+
+# 1. Fast publication inside the budget.
+out="$(FAKE_PUBLISHED_AT=2026-08-20T12:04:10Z "$receipt" v3.4.0)"
+expect_field "$out" PUBLISH_LATENCY_SECONDS 250 'latency is measured from the first run of the tag'
+expect_field "$out" TAG_RUN_ID 111 'receipt names the original tag run, not a rerun'
+expect_field "$out" BUDGET_SECONDS 600 'default budget is the ten-minute target'
+expect_field "$out" WITHIN_BUDGET true 'a fast release reports within budget'
+
+# 2. A slow release must fail, not merely report.
+set +e
+slow_out="$(FAKE_PUBLISHED_AT=2026-08-20T12:21:00Z "$receipt" v3.4.0 2>&1)"
+slow_status=$?
+set -e
+if [[ "$slow_status" -ne 0 ]]; then
+    ok 'an over-budget release exits non-zero'
+else
+    bad 'an over-budget release exited 0'
+fi
+grep -qF 'over the 600s budget' <<<"$slow_out" \
+    && ok 'over-budget failure names the budget' \
+    || bad 'over-budget failure does not name the budget'
+
+# 3. An explicit budget is honoured.
+out="$(FAKE_PUBLISHED_AT=2026-08-20T12:21:00Z "$receipt" v3.4.0 --budget-seconds 1800)"
+expect_field "$out" PUBLISH_LATENCY_SECONDS 1260 'explicit budget still reports the real latency'
+expect_field "$out" WITHIN_BUDGET true 'an explicit wider budget passes'
+
+# 4. An unpublished release cannot produce a latency receipt.
+set +e
+FAKE_PUBLISHED_AT= "$receipt" v3.4.0 >/dev/null 2>&1
+unpublished_status=$?
+set -e
+if [[ "$unpublished_status" -eq 1 ]]; then
+    ok 'an unpublished release fails instead of reporting a number'
+else
+    bad "an unpublished release exited $unpublished_status"
+fi
+
+# 5. Argument validation.
+for bad_args in "3.4.0" "v3.4.0 --budget-seconds"; do
+    set +e
+    # shellcheck disable=SC2086
+    FAKE_PUBLISHED_AT=2026-08-20T12:04:10Z "$receipt" $bad_args >/dev/null 2>&1
+    status=$?
+    set -e
+    if [[ "$status" -eq 2 ]]; then
+        ok "usage error for: $bad_args"
+    else
+        bad "expected usage exit 2 for: $bad_args (got $status)"
+    fi
+done
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+test "$fail" -eq 0


### PR DESCRIPTION
Fast release publication — the undelivered half of GH #449.

- New `Release Prebuild` workflow: on a main push whose tree is a pending release (all release-train crates at the same version, CHANGELOG heading present, no tag yet) it builds both platform artifacts at merge time. Ordinary main pushes pay one ~20s gate job.
- `release.yml`: fail-safe lookup for a successful prebuild of the exact tagged commit; when found, both cold builds are skipped and the tag only downloads, re-audits and publishes. Any miss → unchanged cold path. `Create Release` is fail-closed: exactly one supply path must have completed.
- Codesign gate (cas-67c1) moves with whichever job produces the Darwin bytes.
- Self-hosted Linux routing is opt-in via repo variable `CASSY_RELEASE_SELF_HOSTED=enabled`, with a runtime trust script; absent = hosted, identical to today. `contents: write` job stays hosted.
- `scripts/release-latency-receipt.sh <tag>` produces the tag→published timing receipt (non-zero over 600s). Baselines: v3.1.0 13m18s, v3.0.0 14m55s, v3.2.0 20m03s, v2.72.0 26m26s.

Closes GH #449 only once the first post-merge tag carries the measured receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)