### PR TITLE
docs(release): record v3.4.0 runtime-release Slack draft and posting receipt (cas-f77c)

### DIFF
--- a/docs/release-notes/2026-08-20-v3.4.0-slack.md
+++ b/docs/release-notes/2026-08-20-v3.4.0-slack.md
@@ -1,0 +1,56 @@
+# Slack draft — Cassy v3.4.0 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Receipt-verified from published assets; posting.
+
+Release published 2026-08-20T19:37:21Z from tag `v3.4.0` (annotated `31e17b57`,
+peeling to `62fd2944`). Both assets uploaded by workflow run 32408252290;
+digests below come from `release-published-receipt.sh --write-draft` fresh
+downloads. Install receipt: the published Linux archive extracts to a binary
+reporting `cas 3.4.0 (62fd294 2026-08-20)`.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Cassy v3.4.0 is out: Macs install with the same one-liner everyone else uses, one command brings every project on the machine fully up to date, a shelf of new expert skills ships in the box, and when Cassy pulls something from memory it now tells you why.
+
+**Reply (Was → Now):**
+- Was: installing on an Apple Silicon Mac meant fighting Gatekeeper by hand, and an Intel Mac failed in a confusing way with no explanation. Now: the standard install script handles Apple Silicon end to end — it clears the quarantine flag for you — and an Intel Mac gets a plain-language stop that says why. If the install directory is not on your PATH it tells you the exact line to add.
+- Was: bringing a machine current meant repeating the same steps project by project, and two update runs at once could corrupt a shared build. Now: `cas update --all-projects` walks every project you have and does the whole job — migrations, skills, team membership, cloud sync — with a receipt per project, and concurrent runs wait their turn instead of colliding.
+- Was: you had to write or import expert workflows yourself. Now: eight new built-in skills — writing for agents, diagnosing bugs, domain modeling, codebase design, TDD, resolving merge conflicts, and two more — are available in every harness on day one, with four more imported workflows folded into skills you already use.
+- Was: recalled context appeared with no explanation, and useful memories could stay silent. Now: a strong match surfaces even in casual conversation, what Cassy is working on informs what it recalls, and every recall — or deliberate silence — comes with a short note saying where it came from.
+- Was: finishing Viktor setup meant hand-placing a key file. Now: `cas viktor key` takes the pasted operator key, checks it, and stores it locked down on that machine only.
+- Was: work that got dropped mid-flight went quiet and you found out late. Now: a dropped or stalled delivery announces itself immediately instead of leaving the task waiting.
+- Was: a cloud sync could quietly reopen something you had already closed. Now: closed stays closed unless there is a real, attributed reopen on record.
+- Install: use `cas update` for an existing installation, or download the
+  v3.4.0 archive for Linux x86_64 (SHA-256 `2948be0197cddcccb91b3f32636b63cc00e2f2032d38e5958e83deb493ed9e10`) or macOS ARM64
+  (SHA-256 `aca4b6ba3e91780b22492e7d8ec9d91ec440bc722eb05a179f40d971336c7b5d`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v3.4.0 takes a change from merge to main in under five minutes, ships signed Darwin binaries with a verification gate before packaging, and makes recall auditable: every injection or suppression carries a source-attributed decision trace.
+
+**Reply (Was → Now):**
+- Was: a merge to main took the better part of an hour, with admission checks re-running the suite per PR and stale queue runs left to time out. Now: PR admission collapses to seconds, the merge queue validates the full suite exactly once on self-hosted hardware with runtime-path-portable test archives, and behavior-tested watchdogs cancel stale runs — a measured 4m58 merge-to-main.
+- Was: release binaries were stripped after signing, so the ad-hoc Mach-O signature was invalid by the time it shipped. Now: the exact packaged executable is re-signed after `strip` and verified before packaging, with a dispatch-only job to inspect any published archive's signature.
+- Was: recall drew its trigger terms from conversation text alone and silently applied a precision gate that suppressed strong matches. Now: trigger terms also come from tool results and MCP queries (bounded and redacted), a strong-signal floor overrides the conversational gate, and each decision emits an attributed trace.
+- Was: cloud pull was last-writer-wins over terminal task state, and closing a large epic could hang past its own timeout with an ambiguous result. Now: terminal transitions require an attributed reopen and unattributed remote reopens park once in the conflict journal; epic close commits first and returns a compact receipt in about a second, and a timeout message states whether the write landed.
+- Was: CI could skip Rust validation for markdown that is compiled into the binary. Now: everything under `cas-cli/src/` is rust-affecting, enforced by a mutation-proof guard.
+- Also in this release: `cas update --all-projects` with per-project receipts and continuable failures; an atomic, holder-visible lock in the `cas-update` helper; Darwin/aarch64 support in `cas-install.sh` including `xattr` quarantine clearing and an Intel-Mac gate; `cas viktor key` with 0600 machine-only storage; twelve MIT-provenanced Pocock imports landing as `cas-` builtins across all three harnesses (eight new skills, four merged into existing ones) with harness-correct tool aliases; durable episode-keyed relays for ejections and delivery stalls.
+- Validation and artifact: release PR landed on main through the merge queue with the required Fast Validation and macOS Check lanes green; digests below verified by fresh downloads of the published assets. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `2948be0197cddcccb91b3f32636b63cc00e2f2032d38e5958e83deb493ed9e10`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `aca4b6ba3e91780b22492e7d8ec9d91ec440bc722eb05a179f40d971336c7b5d`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-20 19:43 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787255000263539 |
+| User reply (Was → Now) | 2026-08-20 19:43 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787255012741799?thread_ts=1787255000.263539&cid=C0B44GUKDK2 |
+| Dev top-level | 2026-08-20 19:43 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787255016696299 |
+| Dev reply (Was → Now) | 2026-08-20 19:43 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787255030086409?thread_ts=1787255016.696299&cid=C0B44GUKDK2 |


### PR DESCRIPTION
Docs-only: adds docs/release-notes/2026-08-20-v3.4.0-slack.md — the posted #cas-internal user/dev threads for v3.4.0 with the POSTED receipt table (permalinks, asset digests from the published-asset receipt).

Release itself is already shipped: tag v3.4.0 on 62fd2944, published 19:37:21Z (tag-push→published 15m33s, baseline for the fast-publication work in #573).

🤖 Generated with [Claude Code](https://claude.com/claude-code)