### PR TITLE
fix(ci): warm merge-queue validation lanes on the trusted runner (cas-6dec)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,9 @@ jobs:
   # Full Fast Validation runs exactly once on GitHub's canonical merge-queue
   # tree. The required rollup below emits a cheap hosted PR admission context,
   # then this job family validates the tree that will actually land. This avoids
-  # compiling the PR head and its merge tree back-to-back without widening the
-  # self-hosted route beyond merge_group.
+  # compiling the PR head and its merge tree back-to-back. When the explicitly
+  # trusted merge-queue runner is enabled, its persistent target and sccache
+  # make all three compiling Linux lanes warm across synthetic queue refs.
   fast-validation-preflight:
     name: Fast Validation — preflight (no test suite)
     if: >-
@@ -270,8 +271,13 @@ jobs:
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/'))))
-    needs: fast-validation-main-push-dedupe
-    runs-on: ubuntu-latest
+      && (needs.fast-validation-runner-route.outputs.mode != 'self-hosted'
+      || (github.event_name == 'merge_group'
+      && github.repository == 'Richards-LLC/cassy'
+      && github.event.repository.fork == false
+      && vars.CASSY_MERGE_QUEUE_SELF_HOSTED == 'enabled'))
+    needs: [fast-validation-runner-route, fast-validation-main-push-dedupe]
+    runs-on: ${{ fromJSON(needs.fast-validation-runner-route.outputs.runner) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -284,6 +290,20 @@ jobs:
         with:
           base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
 
+      - name: Verify merge-queue self-hosted trust boundary
+        if: needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        env:
+          SELF_HOSTED_ENABLED: ${{ vars.CASSY_MERGE_QUEUE_SELF_HOSTED }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_EVENT_NAME" = merge_group
+          test "$GITHUB_REPOSITORY" = Richards-LLC/cassy
+          test "$SELF_HOSTED_ENABLED" = enabled
+          case "$GITHUB_REF" in
+            refs/heads/gh-readonly-queue/*) ;;
+            *) echo "self-hosted route received a non-queue ref: $GITHUB_REF" >&2; exit 1 ;;
+          esac
+
       - name: Test portable installer fixtures
         run: ./scripts/test-cas-install.sh
 
@@ -291,10 +311,39 @@ jobs:
         if: steps.classify-diff.outputs.rust-unaffected == 'true'
         run: echo "Rust work skipped for ${{ steps.classify-diff.outputs.class }} diff."
 
-      - if: steps.classify-diff.outputs.rust-unaffected != 'true'
+      - if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'hosted'
         uses: ./.github/actions/setup-rust-linux
         with:
           cache-key: fast-validation
+
+      - name: Set up the isolated merge-queue runner
+        if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Zig on the isolated merge-queue runner
+        if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        run: ./scripts/bootstrap-zig.sh
+
+      - name: Verify private self-hosted sccache
+        if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          test "${SCCACHE_SERVER_PORT:?}" = 4227
+          case "${SCCACHE_DIR:?}" in
+            /var/lib/cassy-actions/*) ;;
+            *) echo "SCCACHE_DIR is not isolated from the runner cache" >&2; exit 1 ;;
+          esac
+          sccache rustc -vV
+          sccache --show-stats
 
       - name: Build and test Commander web assets
         if: steps.classify-diff.outputs.web-check-needed == 'true'
@@ -594,8 +643,13 @@ jobs:
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || startsWith(github.ref, 'refs/tags/'))))
-    needs: fast-validation-main-push-dedupe
-    runs-on: ubuntu-latest
+      && (needs.fast-validation-runner-route.outputs.mode != 'self-hosted'
+      || (github.event_name == 'merge_group'
+      && github.repository == 'Richards-LLC/cassy'
+      && github.event.repository.fork == false
+      && vars.CASSY_MERGE_QUEUE_SELF_HOSTED == 'enabled'))
+    needs: [fast-validation-runner-route, fast-validation-main-push-dedupe]
+    runs-on: ${{ fromJSON(needs.fast-validation-runner-route.outputs.runner) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -608,14 +662,57 @@ jobs:
         with:
           base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
 
+      - name: Verify merge-queue self-hosted trust boundary
+        if: needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        env:
+          SELF_HOSTED_ENABLED: ${{ vars.CASSY_MERGE_QUEUE_SELF_HOSTED }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_EVENT_NAME" = merge_group
+          test "$GITHUB_REPOSITORY" = Richards-LLC/cassy
+          test "$SELF_HOSTED_ENABLED" = enabled
+          case "$GITHUB_REF" in
+            refs/heads/gh-readonly-queue/*) ;;
+            *) echo "self-hosted route received a non-queue ref: $GITHUB_REF" >&2; exit 1 ;;
+          esac
+
       - name: Report Rust short-circuit
         if: steps.classify-diff.outputs.rust-unaffected == 'true'
         run: echo "Doctests skipped for ${{ steps.classify-diff.outputs.class }} diff."
 
-      - if: steps.classify-diff.outputs.rust-unaffected != 'true'
+      - if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'hosted'
         uses: ./.github/actions/setup-rust-linux
         with:
           cache-key: fast-validation-docs
+
+      - name: Set up the isolated merge-queue runner
+        if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Zig on the isolated merge-queue runner
+        if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        run: ./scripts/bootstrap-zig.sh
+
+      - name: Verify private self-hosted sccache
+        if: >-
+          steps.classify-diff.outputs.rust-unaffected != 'true'
+          && needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          test "${SCCACHE_SERVER_PORT:?}" = 4227
+          case "${SCCACHE_DIR:?}" in
+            /var/lib/cassy-actions/*) ;;
+            *) echo "SCCACHE_DIR is not isolated from the runner cache" >&2; exit 1 ;;
+          esac
+          sccache rustc -vV
+          sccache --show-stats
 
       # nextest does not run doctests; keep this separate so it never waits
       # behind the partitioned suite.

--- a/docs/ci/self-hosted-runner-pilot.md
+++ b/docs/ci/self-hosted-runner-pilot.md
@@ -2,9 +2,10 @@
 
 The push-triggered pilot is an advisory duplicate of the required hosted Fast
 Validation archive producer. Separately, the CI workflow may route the required
-archive producer for a `merge_group` tree to the same 32-core `soundwave` host.
+archive producer, preflight, and doctest lanes for a `merge_group` tree to the
+same 32-core `soundwave` host.
 The route is explicit and fail-safe: unless repository variable
-`CASSY_MERGE_QUEUE_SELF_HOSTED` is exactly `enabled`, the required archive runs
+`CASSY_MERGE_QUEUE_SELF_HOSTED` is exactly `enabled`, those required lanes run
 on GitHub-hosted Ubuntu. Pull-request work always remains hosted. The first
 real measurement kept the three exhaustive partitions in the same local job for
 evaluation; shard 1 stalled in three subprocess-spawning integration tests for
@@ -68,9 +69,9 @@ changing runner routing or retiring the merge-queue acceleration.
 The pilot job is not present in `docs/branch-protection/main-ruleset.json`. The
 ruleset still requires only the `Fast Validation` rollup and `macOS Check`.
 For ordinary PRs, and whenever the self-hosted control variable is absent or
-disabled, every Fast Validation component runs hosted. A merge-queue archive
-may use the trusted box only after the runner is confirmed online; its shards
-remain hosted and parallel.
+disabled, every Fast Validation component runs hosted. A merge-queue archive,
+preflight, and doctest lane may use the trusted box only after the runner is
+confirmed online; the exhaustive shards remain hosted and parallel.
 
 GitHub cannot reassign a job after it has been scheduled on an offline
 self-hosted label. The safe maintenance/offline-fallback sequence is therefore

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -209,6 +209,20 @@ require_text "$suite_build" "needs.fast-validation-runner-route.outputs.mode == 
 require_text "$suite_build" "needs.fast-validation-runner-route.outputs.mode == 'self-hosted'" 'self-hosted setup is limited to selected merge-queue validation'
 require_text "$suite_build" 'Verify merge-queue self-hosted trust boundary' 'self-hosted archive verifies queue-only trust at execution'
 require_text "$suite_build" 'refs/heads/gh-readonly-queue/*' 'self-hosted archive rejects non-queue refs'
+for job in fast-validation-preflight fast-validation-docs; do
+    block="$(job_block "$job")"
+    require_text "$block" 'needs: [fast-validation-runner-route, fast-validation-main-push-dedupe]' "$job waits for explicit runner routing and the main-push tree gate"
+    require_text "$block" 'fromJSON(needs.fast-validation-runner-route.outputs.runner)' "$job receives the fail-safe selected runner labels"
+    require_text "$block" "needs.fast-validation-runner-route.outputs.mode != 'self-hosted'" "$job rejects an untrusted self-hosted route before assignment"
+    require_text "$block" "github.event_name == 'merge_group'" "$job limits self-hosted execution to merge-queue events"
+    require_text "$block" "github.repository == 'Richards-LLC/cassy'" "$job pins self-hosted execution to the canonical repository"
+    require_text "$block" "vars.CASSY_MERGE_QUEUE_SELF_HOSTED == 'enabled'" "$job repeats explicit self-hosted readiness opt-in"
+    require_text "$block" "needs.fast-validation-runner-route.outputs.mode == 'hosted'" "$job retains hosted setup as the fail-safe"
+    require_text "$block" "needs.fast-validation-runner-route.outputs.mode == 'self-hosted'" "$job limits isolated runner setup to selected merge-queue validation"
+    require_text "$block" 'Verify merge-queue self-hosted trust boundary' "$job verifies queue-only trust at execution"
+    require_text "$block" 'refs/heads/gh-readonly-queue/*' "$job rejects non-queue refs on the isolated runner"
+    require_text "$block" 'Verify private self-hosted sccache' "$job confirms the persistent compiler cache remains isolated"
+done
 probe_step="$(named_step_block "$suite_build" 'Verify private self-hosted sccache')"
 disable_step="$(named_step_block "$suite_build" 'Disable sccache for the self-hosted suite archive')"
 archive_step="$(named_step_block "$suite_build" 'Build full suite archive')"
@@ -1077,7 +1091,7 @@ require_text "$(<"$setup")" 'sccache backend unavailable — building uncached' 
 require_text "$(<"$setup")" 'echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"' 'sccache outage clears compiler wrapper'
 require_text "$(<"$setup")" 'echo "SCCACHE_GHA_ENABLED=false" >> "$GITHUB_ENV"' 'sccache outage disables its backend'
 require_count "$all_actions" 'mozilla-actions/sccache-action@v0.0.11' '5' 'every sccache setup is accounted for'
-require_count "$all_actions" 'continue-on-error: true' '6' 'every sccache setup action and the self-hosted probe fail open'
+require_count "$all_actions" 'continue-on-error: true' '8' 'every sccache setup action and the self-hosted probes fail open'
 require_count "$all_actions" 'sccache --start-server' '5' 'every sccache setup probes backend availability'
 require_count "$all_actions" 'sccache backend unavailable — building uncached' '5' 'every sccache outage logs its uncached fallback'
 require_count "$all_actions" 'SCCACHE_PATH=$GITHUB_WORKSPACE/scripts/sccache-unavailable.sh' '5' 'every sccache fallback makes the action post hook harmless'


### PR DESCRIPTION
Merge-queue runs have been cold (11–14 min) since main-push validation was deduped: queue runs execute on temporary `gh-readonly-queue/*` refs and can only save rust-cache there; `gh cache list --ref refs/heads/main` holds no fast-validation entries, so hosted preflight/doctests log "No cache found" on every queue run (#575: preflight 13m27s, doctests 8m04s, sccache 0.79% / 5.56% hits).

Fix: route `fast-validation-preflight` and `fast-validation-docs` through the existing merge-queue runner selector (persistent target + private sccache on the box), same trust boundary as the suite-build lane (merge_group only, canonical repo, non-fork, `CASSY_MERGE_QUEUE_SELF_HOSTED=enabled`, queue-ref check at execution). Hosted setup/cache remains the fail-safe for every other event and when the variable is absent. `scripts/test-ci-test-tiers.sh` pins both routes; docs updated.

Receipt required after merge: two consecutive queue runs <6 min with cache-hit summaries (this PR's own queue run is measurement #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)