### PR TITLE
feat(install): leave a working `cas` in a fresh shell, and say so honestly (cas-c741)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- **Installing Cassy now leaves a working `cas` in a new terminal.** The installer detects whether its install directory is on PATH in your *login* shell, offers to add a marker-guarded guard to the right startup file (`.zshenv` on zsh, so the non-interactive shells MCP clients spawn also see it; `.bashrc` or `.profile` on bash), never edits the same file twice, and prints the exact line to add if you decline or there is no terminal to ask on. It then checks the result by running `cas --version` in a fresh login shell and only reports success when that actually works.
+- **A brand-new machine gets one friendly line.** Typing `cas` before anything is configured now names the next command instead of printing a factory preflight's list of everything missing.
+
 ## [3.4.1] - 2026-08-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ curl -fsSL https://raw.githubusercontent.com/Richards-LLC/cassy/main/scripts/cas
 
 Installs the latest release binary to `~/.local/bin/cas`. Override with `CAS_INSTALL_DIR`, `CAS_VERSION`, or `CAS_REPO`.
 
+Pipe it to `bash`, not `sh` — a piped script has no shebang, and the installer
+is written for bash.
+
+If the install directory is not already on your PATH, the installer offers to
+add a marker-guarded guard to your **login** shell's startup file (`.zshenv` for
+zsh, `.bashrc` or `.profile` for bash), and re-running it never adds the block
+twice. It then verifies by running `cas --version` in a fresh login shell and
+reports success only when that works. Decline with `CAS_WIRE_PATH=0` (it prints
+the exact line instead), accept without a prompt with `CAS_WIRE_PATH=1`; an
+unattended run with no terminal available never edits a startup file.
+
 ### macOS (Apple Silicon)
 
 ```bash

--- a/cas-cli/docs/CONTRIBUTING.md
+++ b/cas-cli/docs/CONTRIBUTING.md
@@ -34,7 +34,12 @@ subagent invoking `cas` via absolute path) can promote a stale copy and
 silently reintroduce fixed bugs.
 
 - `scripts/cas-install.sh` installs to `~/.local/bin/cas` and warns about any
-  other `cas` binaries it finds on PATH.
+  other `cas` binaries it finds on PATH. It also offers to wire that directory
+  onto PATH in the **login** shell's startup file (zsh `.zshenv`, bash
+  `.bashrc`/`.profile`), guarded by `# >>> cassy path >>>` markers so a re-run
+  is a no-op, and verifies the result with `cas --version` in a fresh login
+  shell before claiming the install succeeded. `CAS_WIRE_PATH=1|0` overrides the
+  prompt; the rc-edit seam is covered by `scripts/test-cas-install.sh`.
 - On startup, `cas` itself scans PATH and emits a single-line stderr warning
   when duplicates with diverging mtimes are present. Silence it with
   `CAS_SUPPRESS_DUPLICATE_WARNING=1`, or force it on in non-TTY contexts with

--- a/cas-cli/src/cli/first_run.rs
+++ b/cas-cli/src/cli/first_run.rs
@@ -1,0 +1,92 @@
+//! What a brand-new machine sees when someone types `cas`.
+//!
+//! Bare `cas` launches factory mode, which on a machine that has never been
+//! configured fails a preflight and prints a list of everything that is wrong.
+//! That is the correct output for a developer debugging a broken setup and the
+//! wrong output for a person who just ran the install one-liner. This module
+//! owns the one friendly line they get instead.
+//!
+//! # Why the command name is a constant
+//!
+//! The front door is expected to become `cas setup` (cas-b635). That command
+//! does not exist yet, and pointing someone at a command that does not exist is
+//! worse than pointing them at a plainer one that works. So the name lives in
+//! exactly one place: cas-b635 changes [`FRONT_DOOR_COMMAND`] and nothing else,
+//! and the test below refuses to let either version ship if the named command
+//! is not a real subcommand.
+
+use std::path::Path;
+
+/// The single command a brand-new machine is told to run.
+///
+/// Change this to `"setup"` when `cas setup` exists (cas-b635). The test
+/// `front_door_command_is_a_real_subcommand` fails the build if the name here
+/// is not an actual clap subcommand, so the pointer can never become a
+/// dead end.
+pub const FRONT_DOOR_COMMAND: &str = "init";
+
+/// A machine nobody has set up yet: no host-level `~/.cas/` and no project to
+/// stand in for it.
+///
+/// Deliberately conservative. If either exists, this is a configured machine
+/// having a bad day — a broken project, a missing dependency — and the detailed
+/// preflight output is what that person needs.
+pub fn machine_is_unconfigured(host_cas_dir: &Path, project_cas_root: Option<&Path>) -> bool {
+    project_cas_root.is_none() && !host_cas_dir.exists()
+}
+
+/// The one line. Not a banner, not a checklist: someone who just installed a
+/// binary needs the next command and nothing else.
+pub fn front_door_hint() -> String {
+    format!("Welcome to Cassy. Run `cas {FRONT_DOOR_COMMAND}` in a project directory to get started.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    /// The whole point of the constant. A first-run pointer that names a
+    /// command the binary does not have strands exactly the person it is meant
+    /// to help, and nothing else in the codebase would catch it.
+    #[test]
+    fn front_door_command_is_a_real_subcommand() {
+        let command = crate::cli::Cli::command();
+        let names: Vec<_> = command.get_subcommands().map(|c| c.get_name()).collect();
+        assert!(
+            names.contains(&FRONT_DOOR_COMMAND),
+            "first-run hint points at `cas {FRONT_DOOR_COMMAND}`, which is not a subcommand. \
+             Available: {names:?}"
+        );
+    }
+
+    #[test]
+    fn hint_names_the_front_door_command_once_and_fits_one_line() {
+        let hint = front_door_hint();
+        assert!(hint.contains(&format!("cas {FRONT_DOOR_COMMAND}")));
+        assert!(!hint.contains('\n'), "first-run hint must be one line: {hint}");
+    }
+
+    #[test]
+    fn a_host_cas_dir_means_the_machine_is_configured() {
+        let temp = tempfile::tempdir().unwrap();
+        let host_cas = temp.path().join(".cas");
+        std::fs::create_dir_all(&host_cas).unwrap();
+        assert!(!machine_is_unconfigured(&host_cas, None));
+    }
+
+    #[test]
+    fn a_project_root_means_the_machine_is_configured() {
+        let temp = tempfile::tempdir().unwrap();
+        let absent_host_cas = temp.path().join("nope/.cas");
+        let project = temp.path().join("project/.cas");
+        assert!(!machine_is_unconfigured(&absent_host_cas, Some(&project)));
+    }
+
+    #[test]
+    fn no_host_dir_and_no_project_is_a_fresh_machine() {
+        let temp = tempfile::tempdir().unwrap();
+        let absent_host_cas = temp.path().join("nope/.cas");
+        assert!(machine_is_unconfigured(&absent_host_cas, None));
+    }
+}

--- a/cas-cli/src/cli/mod.rs
+++ b/cas-cli/src/cli/mod.rs
@@ -41,6 +41,8 @@ mod doctor;
 // cli::factory::wedged's transcript-mtime liveness primitives.
 pub(crate) mod factory;
 mod factory_tooling;
+// cas-c741: the one friendly line a brand-new machine gets from bare `cas`.
+pub mod first_run;
 // cas-fc6fa: read-only cross-project contamination scan used by `cas doctor`.
 pub mod foreign_rows;
 // cas-9e81: pub(crate) so factory_ops can reuse `config_gen`'s canonical
@@ -613,6 +615,16 @@ fn run_command(cli: &Cli, cas_root: Option<&Path>) -> anyhow::Result<()> {
     let command = match &cli.command {
         Some(cmd) => cmd,
         None => {
+            // cas-c741: someone who just ran the install one-liner and typed
+            // `cas` gets one line naming the next command, not the factory
+            // preflight's list of everything a fresh machine is missing.
+            if first_run::machine_is_unconfigured(
+                &crate::store::known_repos::host_cas_dir(),
+                cas_root,
+            ) {
+                println!("{}", first_run::front_door_hint());
+                return Ok(());
+            }
             let default_args = FactoryArgs::default();
             return factory::execute(&default_args, cli, cas_root);
         }

--- a/docs/onboarding/macbook-from-zero.md
+++ b/docs/onboarding/macbook-from-zero.md
@@ -24,11 +24,31 @@ if [[ "$(uname -m)" != "arm64" ]]; then
 fi
 
 curl -fsSL https://raw.githubusercontent.com/Richards-LLC/cassy/main/scripts/cas-install.sh | bash
+```
 
-# Persist the Cassy binary path for terminal and non-interactive MCP shells.
-grep -qxF 'export PATH="$HOME/.local/bin:$PATH"' ~/.zshenv 2>/dev/null \
-  || echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshenv
-export PATH="$HOME/.local/bin:$PATH"
+Run it with `bash`, not `sh`. A piped script has no shebang, so `| sh` would
+run it under a shell it is not written for.
+
+If `~/.local/bin` is not already on your PATH, the installer offers to add a
+marker-guarded guard to `~/.zshenv` and tells you what it did. Say yes. It then
+verifies the result by running `cas --version` in a fresh login shell, and only
+reports success if that works — so trust what it prints.
+
+Two things worth knowing about that file choice. `.zshenv`, not `.zshrc`,
+because zsh reads `.zshrc` only for *interactive* shells: a PATH exported there
+is invisible to the non-interactive shell a tool like Claude Code uses to spawn
+`cas serve`, which is exactly how MCP ends up reporting a missing binary on a
+machine where `cas` works fine in the terminal. And the guard is idempotent
+twice over — the installer will not add it a second time, and the block itself
+will not re-prepend if the file is sourced again.
+
+To skip the prompt entirely, set `CAS_WIRE_PATH=1` to accept or `CAS_WIRE_PATH=0`
+to decline; declining prints the exact line to add yourself. An unattended run
+with no terminal to ask on never edits a startup file.
+
+Then open a new terminal (or `source ~/.zshenv`) and confirm:
+
+```bash
 cas --version
 ```
 

--- a/scripts/cas-install.sh
+++ b/scripts/cas-install.sh
@@ -8,6 +8,25 @@
 #   CAS_INSTALL_DIR   Override install directory (default: ~/.local/bin — the canonical location)
 #   CAS_VERSION       Install a specific version (default: latest)
 #   CAS_REPO          Override GitHub repo (default: Richards-LLC/cassy)
+#   CAS_WIRE_PATH     1 = wire PATH into the login shell's rc file without asking,
+#                     0 = never edit an rc file (just print the line to add).
+#                     Unset = ask on the terminal when one is available.
+
+# --- POSIX-safe preamble: this installer requires bash -------------------------
+# A piped script has no shebang: `curl ... | sh` runs THIS FILE under /bin/sh
+# whatever the first line says. That matters because the body below uses bash
+# syntax, and under a strict POSIX shell some of it does not fail — it
+# MISPARSES. `command -v curl &>/dev/null` under dash is read as
+# `command -v curl &` plus `>/dev/null`, which backgrounds the probe and prints
+# to stdout instead of testing anything. Detect the wrong interpreter here, in
+# syntax every shell agrees on, and say exactly what to run instead. Re-exec is
+# not an option: when the script arrives on stdin there is no file to re-exec.
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "x The Cassy installer needs bash, but it is running under a different shell." >&2
+  echo "  Re-run it with bash:" >&2
+  echo "    curl -fsSL https://raw.githubusercontent.com/Richards-LLC/cassy/main/scripts/cas-install.sh | bash" >&2
+  exit 1
+fi
 
 set -euo pipefail
 
@@ -20,6 +39,9 @@ INSTALL_DIR="${CAS_INSTALL_DIR:-}"
 VERSION="${CAS_VERSION:-}"
 BINARY_NAME="cas"
 GITHUB_API="https://api.github.com"
+# Captured before anything can extend it, so the fresh-login-shell check below
+# measures what a NEW terminal sees rather than what this process arranged.
+ORIGINAL_PATH="$PATH"
 
 # ---------------------------------------------------------------------------
 # Colors (disable if not a terminal)
@@ -112,15 +134,9 @@ ensure_install_dir() {
     fi
   fi
 
-  # Check if install dir is in PATH
-  case ":$PATH:" in
-    *":$INSTALL_DIR:"*) ;;
-    *)
-      warn "$INSTALL_DIR is not in your PATH"
-      warn "Add this to your shell profile:"
-      warn "  export PATH=\"$INSTALL_DIR:\$PATH\""
-      ;;
-  esac
+  # PATH is handled after the binary exists — see wire_path(). Warning about it
+  # here, before there is anything to run, produced advice the user had to
+  # remember through a download; now it is an offer to fix it.
 
   # Flag other cas binaries on PATH that will silently shadow (or be shadowed
   # by) the one we're about to install. Scan PATH directly rather than relying
@@ -244,29 +260,224 @@ download_and_install() {
 }
 
 # ---------------------------------------------------------------------------
+# PATH wiring
+#
+# Installing a binary the user's shell cannot find is not an install. The
+# offer below is the difference between "cas: command not found" on a fresh
+# Mac and a working tool.
+# ---------------------------------------------------------------------------
+
+MARKER_BEGIN='# >>> cassy path >>>'
+MARKER_END='# <<< cassy path <<<'
+
+# The LOGIN shell, which is not the shell running this script. `curl | bash`
+# runs the installer under bash even on a Mac whose login shell is zsh, so
+# reading $0 or $BASH would confidently wire the wrong file.
+detect_login_shell() {
+  local shell_path="${SHELL:-}"
+  if [ -z "$shell_path" ] && command -v getent >/dev/null 2>&1; then
+    shell_path="$(getent passwd "$(id -un)" 2>/dev/null | awk -F: '{print $7}')"
+  fi
+  LOGIN_SHELL="$shell_path"
+  LOGIN_SHELL_NAME="$(basename -- "${shell_path:-unknown}")"
+}
+
+# Which file the guard belongs in.
+#
+# zsh -> .zshenv, deliberately, and NOT .zshrc: zsh reads .zshrc only for
+# interactive shells, so a PATH exported there is invisible to the
+# non-interactive shells that MCP clients use to spawn `cas serve`. That exact
+# failure is documented in docs/onboarding/macbook-from-zero.md.
+#
+# bash -> .bashrc when it exists (every mainstream Linux distro sources it from
+# the login path), otherwise .profile.
+#
+# Anything else -> no guess. Wiring an unknown shell's startup file is how an
+# installer corrupts someone's environment; print the line instead.
+resolve_rc_file() {
+  RC_FILE=""
+  case "$LOGIN_SHELL_NAME" in
+    zsh)
+      RC_FILE="${ZDOTDIR:-$HOME}/.zshenv"
+      ;;
+    bash)
+      if [ -f "$HOME/.bashrc" ]; then
+        RC_FILE="$HOME/.bashrc"
+      else
+        RC_FILE="$HOME/.profile"
+      fi
+      ;;
+    *)
+      RC_FILE=""
+      ;;
+  esac
+}
+
+manual_path_line() {
+  printf 'export PATH="%s:$PATH"\n' "$INSTALL_DIR"
+}
+
+print_manual_instructions() {
+  warn "Add this line to your shell startup file, then open a new terminal:"
+  echo "    $(manual_path_line)"
+}
+
+rc_already_wired() {
+  [ -n "$RC_FILE" ] && [ -f "$RC_FILE" ] && grep -qF "$MARKER_BEGIN" "$RC_FILE"
+}
+
+# The block is idempotent twice over: the markers stop this installer from
+# appending it again, and the `case` inside stops the block itself from
+# re-prepending if the file is sourced more than once in a session.
+append_path_guard() {
+  local dir="$1" file="$2"
+  [ -e "$file" ] || : >"$file"
+  {
+    printf '\n%s\n' "$MARKER_BEGIN"
+    printf '%s\n' '# Added by the Cassy installer (scripts/cas-install.sh).'
+    printf '%s\n' '# Keeps the Cassy install directory on PATH for every shell, including the'
+    printf '%s\n' '# non-interactive ones MCP clients use to spawn `cas serve`.'
+    printf '%s\n' 'case ":$PATH:" in'
+    printf '  *":%s:"*) ;;\n' "$dir"
+    printf '  *) export PATH="%s:$PATH" ;;\n' "$dir"
+    printf '%s\n' 'esac'
+    printf '%s\n' "$MARKER_END"
+  } >>"$file"
+}
+
+# Ask on the controlling terminal, never on stdin: under `curl | bash` stdin IS
+# the script, and reading from it would consume the installer's own body.
+prompt_yes_no() {
+  local question="$1" answer=""
+  # `[ -r /dev/tty ]` is not the test you want: the device node exists and is
+  # readable by mode even when this process has no controlling terminal, and
+  # the open then fails with ENXIO mid-install. Try the open itself.
+  if ! { : >/dev/tty; } 2>/dev/null; then
+    return 2
+  fi
+  printf '%b %s [Y/n] ' "${YELLOW}?${RESET}" "$question" >/dev/tty 2>/dev/null || return 2
+  read -r answer </dev/tty 2>/dev/null || return 2
+  case "$answer" in
+    ""|y|Y|yes|YES|Yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+wire_path() {
+  PATH_WIRED_FILE=""
+
+  case ":$PATH:" in
+    *":$INSTALL_DIR:"*)
+      # Already visible to this shell. Say nothing: the fresh-login-shell check
+      # in verify_install() is the claim that actually matters.
+      return 0
+      ;;
+  esac
+
+  detect_login_shell
+  resolve_rc_file
+
+  echo ""
+  warn "$INSTALL_DIR is not on your PATH, so \`cas\` will not be found yet."
+
+  if [ -z "$RC_FILE" ]; then
+    warn "Your login shell (${LOGIN_SHELL_NAME}) is not one this installer edits automatically."
+    print_manual_instructions
+    return 0
+  fi
+
+  if rc_already_wired; then
+    info "$RC_FILE already has the Cassy PATH guard — leaving it alone."
+    PATH_WIRED_FILE="$RC_FILE"
+    return 0
+  fi
+
+  local decision=""
+  case "${CAS_WIRE_PATH:-}" in
+    1) decision=yes ;;
+    0) decision=no ;;
+    *)
+      if prompt_yes_no "Add it to $RC_FILE?"; then
+        decision=yes
+      else
+        # Exit status 2 means there was no terminal to ask on. An unattended
+        # install must not silently edit a startup file nobody consented to.
+        decision=no
+      fi
+      ;;
+  esac
+
+  if [ "$decision" = yes ]; then
+    append_path_guard "$INSTALL_DIR" "$RC_FILE"
+    info "Added the Cassy PATH guard to $RC_FILE"
+    PATH_WIRED_FILE="$RC_FILE"
+  else
+    print_manual_instructions
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Verification
 # ---------------------------------------------------------------------------
+
+# The honest question is not "did a file land on disk" but "can a new terminal
+# run it". Ask a fresh LOGIN shell, which re-reads the startup files, so a
+# successful answer proves the wiring above actually worked.
+fresh_login_shell_sees_cas() {
+  [ -n "${LOGIN_SHELL:-}" ] || return 1
+  [ -x "$LOGIN_SHELL" ] || return 1
+  case "$LOGIN_SHELL_NAME" in
+    zsh|bash|sh|dash|ksh) ;;
+    *) return 1 ;;
+  esac
+  # Start the child from the PATH this process had BEFORE any wiring. If it
+  # inherited a PATH the installer had already extended, this check would pass
+  # by construction and prove nothing about a new terminal — the one thing it
+  # exists to prove.
+  #
+  # A startup file can also be slow or interactive; a verification step must
+  # never be the thing that hangs an install.
+  if command -v timeout >/dev/null 2>&1; then
+    env PATH="$ORIGINAL_PATH" timeout 15 "$LOGIN_SHELL" -lc 'command -v cas >/dev/null 2>&1' >/dev/null 2>&1
+  else
+    env PATH="$ORIGINAL_PATH" "$LOGIN_SHELL" -lc 'command -v cas >/dev/null 2>&1' >/dev/null 2>&1
+  fi
+}
 
 verify_install() {
   local installed_version
 
-  if ! command -v "$BINARY_NAME" &>/dev/null; then
-    # Try the explicit path
-    if [ -x "${INSTALL_DIR}/${BINARY_NAME}" ]; then
-      installed_version="$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>/dev/null || echo "unknown")"
-    else
-      error "Installation failed — ${BINARY_NAME} not found."
-      exit 1
-    fi
-  else
-    installed_version="$("$BINARY_NAME" --version 2>/dev/null || echo "unknown")"
+  if [ ! -x "${INSTALL_DIR}/${BINARY_NAME}" ]; then
+    error "Installation failed — ${BINARY_NAME} not found at ${INSTALL_DIR}/${BINARY_NAME}."
+    exit 1
   fi
+  installed_version="$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>/dev/null || echo "unknown")"
+
+  detect_login_shell
 
   echo ""
-  bold "Cassy installed successfully!"
-  echo ""
-  info "Version:  $installed_version"
-  info "Location: ${INSTALL_DIR}/${BINARY_NAME}"
+  if fresh_login_shell_sees_cas; then
+    bold "Cassy installed successfully!"
+    echo ""
+    info "Version:  $installed_version"
+    info "Location: ${INSTALL_DIR}/${BINARY_NAME}"
+    info "A new terminal can run \`cas\`."
+  else
+    # Deliberately not "installed successfully". The binary is there, but the
+    # thing the user is about to try — typing `cas` in a new window — does not
+    # work yet, and saying otherwise is how someone ends up stranded.
+    bold "Cassy is installed, but a new terminal cannot run \`cas\` yet."
+    echo ""
+    info "Version:  $installed_version"
+    info "Location: ${INSTALL_DIR}/${BINARY_NAME}"
+    if [ -n "${PATH_WIRED_FILE:-}" ]; then
+      warn "$PATH_WIRED_FILE was updated — open a new terminal (or run: source $PATH_WIRED_FILE)."
+    else
+      print_manual_instructions
+    fi
+    warn "Until then, run it by full path: ${INSTALL_DIR}/${BINARY_NAME}"
+  fi
+
   echo ""
   bold "Next steps:"
   echo "  1. Initialize a project:  cd your-project && cas init"
@@ -296,6 +507,7 @@ main() {
   echo ""
 
   download_and_install
+  wire_path
   verify_install
 }
 

--- a/scripts/test-cas-install.sh
+++ b/scripts/test-cas-install.sh
@@ -74,4 +74,150 @@ test "$intel_status" -ne 0
 grep -qF 'macOS Apple Silicon binary only; Intel Macs must build from source' <<<"$intel_output"
 echo 'ok   macOS Intel names the source-build path instead of selecting a missing asset'
 
-echo 'PASS: portable installer macOS behavior verified.'
+# ---------------------------------------------------------------------------
+# PATH wiring seam (cas-c741)
+#
+# Installing a binary the user's shell cannot find is not an install. These
+# cases drive the rc-edit seam directly: which file, exactly once, only with
+# consent, and an honest verdict afterwards.
+#
+# The fake login shells live OUTSIDE the installer's PATH and are named by
+# absolute path through $SHELL, because the whole point is that the login shell
+# is not the shell running the installer.
+# ---------------------------------------------------------------------------
+
+mkdir -p "$tmpdir/shells"
+cat >"$tmpdir/shells/zsh" <<'EOF'
+#!/usr/bin/env bash
+# Enough of zsh to exercise the seam: a login shell reads .zshenv.
+[ -f "$HOME/.zshenv" ] && . "$HOME/.zshenv"
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    -lc) shift; eval "$1"; exit $? ;;
+    *) shift ;;
+  esac
+done
+EOF
+cat >"$tmpdir/shells/bash" <<'EOF'
+#!/usr/bin/env bash
+# A bash login shell path that reaches .bashrc (as distro .profile files do),
+# falling back to .profile when there is no .bashrc.
+if [ -f "$HOME/.bashrc" ]; then . "$HOME/.bashrc"
+elif [ -f "$HOME/.profile" ]; then . "$HOME/.profile"
+fi
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    -lc) shift; eval "$1"; exit $? ;;
+    *) shift ;;
+  esac
+done
+EOF
+cat >"$tmpdir/shells/fish" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$tmpdir/shells/zsh" "$tmpdir/shells/bash" "$tmpdir/shells/fish"
+
+wire_run() {
+  # A fresh HOME per scenario keeps rc state from leaking between cases.
+  local home="$1" shell="$2"
+  shift 2
+  mkdir -p "$home"
+  env -i \
+    PATH="$tmpdir/bin:/usr/bin:/bin" \
+    HOME="$home" \
+    SHELL="$shell" \
+    FIXTURE_OS=Darwin \
+    FIXTURE_ARCH=arm64 \
+    FIXTURE_ARCHIVE="$tmpdir/release.tar.gz" \
+    FIXTURE_CURL_LOG="$tmpdir/curl.log" \
+    FIXTURE_XATTR_LOG="$tmpdir/xattr.log" \
+    CAS_INSTALL_DIR="$home/.local/bin" \
+    CAS_REPO=fixture/cassy \
+    "$@" \
+    "$installer" 2>&1
+}
+
+count_markers() {
+  grep -cF '# >>> cassy path >>>' "$1" 2>/dev/null || true
+}
+
+# 1. zsh writes .zshenv — NOT .zshrc, because .zshrc is interactive-only and an
+#    MCP client spawning `cas serve` would never see it.
+zsh_home="$tmpdir/home-zsh"
+zsh_output="$(wire_run "$zsh_home" "$tmpdir/shells/zsh" CAS_WIRE_PATH=1)"
+test -f "$zsh_home/.zshenv"
+test ! -f "$zsh_home/.zshrc"
+grep -qF "$zsh_home/.local/bin" "$zsh_home/.zshenv"
+test "$(count_markers "$zsh_home/.zshenv")" -eq 1
+grep -qF 'Cassy installed successfully!' <<<"$zsh_output"
+echo 'ok   zsh login shell is wired through .zshenv and verifies in a fresh login shell'
+
+# 2. Re-running must not append a second block.
+zsh_second="$(wire_run "$zsh_home" "$tmpdir/shells/zsh" CAS_WIRE_PATH=1)"
+test "$(count_markers "$zsh_home/.zshenv")" -eq 1
+grep -qF 'already has the Cassy PATH guard' <<<"$zsh_second"
+echo 'ok   a second install leaves exactly one guard block and says so'
+
+# 3. bash prefers an existing .bashrc over .profile.
+bashrc_home="$tmpdir/home-bashrc"
+mkdir -p "$bashrc_home"
+: >"$bashrc_home/.bashrc"
+wire_run "$bashrc_home" "$tmpdir/shells/bash" CAS_WIRE_PATH=1 >/dev/null
+test "$(count_markers "$bashrc_home/.bashrc")" -eq 1
+test ! -f "$bashrc_home/.profile"
+echo 'ok   bash with a .bashrc is wired there, not in .profile'
+
+# 4. bash with no .bashrc falls back to .profile.
+profile_home="$tmpdir/home-profile"
+wire_run "$profile_home" "$tmpdir/shells/bash" CAS_WIRE_PATH=1 >/dev/null
+test "$(count_markers "$profile_home/.profile")" -eq 1
+test ! -f "$profile_home/.bashrc"
+echo 'ok   bash without a .bashrc falls back to .profile'
+
+# 5. Declining edits nothing and prints the exact line — and the installer must
+#    NOT claim success, because a new terminal still cannot run `cas`.
+declined_home="$tmpdir/home-declined"
+declined_output="$(wire_run "$declined_home" "$tmpdir/shells/zsh" CAS_WIRE_PATH=0)"
+test ! -f "$declined_home/.zshenv"
+grep -qF "export PATH=\"$declined_home/.local/bin:\$PATH\"" <<<"$declined_output"
+grep -qF 'a new terminal cannot run `cas` yet' <<<"$declined_output"
+grep -qvF 'installed successfully' <<<"$declined_output"
+echo 'ok   declining touches no file, prints the exact line, and does not claim success'
+
+# 6. An unknown login shell is never guessed at.
+fish_home="$tmpdir/home-fish"
+fish_output="$(wire_run "$fish_home" "$tmpdir/shells/fish" CAS_WIRE_PATH=1)"
+test -z "$(find "$fish_home" -maxdepth 1 -name '.*' -type f 2>/dev/null)"
+grep -qF 'not one this installer edits automatically' <<<"$fish_output"
+grep -qF "export PATH=\"$fish_home/.local/bin:\$PATH\"" <<<"$fish_output"
+echo 'ok   an unfamiliar login shell gets instructions instead of an edited startup file'
+
+# 7. No override and no terminal to ask on. An unattended `curl | bash` in CI or
+#    a provisioning script must never silently edit someone's startup file, and
+#    it must not spray tty errors either: /dev/tty exists and is readable by
+#    mode here, but opening it fails with ENXIO.
+unattended_home="$tmpdir/home-unattended"
+unattended_output="$(wire_run "$unattended_home" "$tmpdir/shells/zsh" </dev/null)"
+test ! -f "$unattended_home/.zshenv"
+grep -qF "export PATH=\"$unattended_home/.local/bin:\$PATH\"" <<<"$unattended_output"
+grep -qvF '/dev/tty' <<<"$unattended_output"
+echo 'ok   an unattended install edits nothing, prints the line, and reports no tty errors'
+
+# 8. `curl | sh` ignores the shebang. Under a POSIX shell the body below the
+#    preamble does not fail cleanly — it misparses — so the preamble must catch
+#    it and name the working command.
+if command -v dash >/dev/null 2>&1; then
+  set +e
+  sh_output="$(dash "$installer" 2>&1)"
+  sh_status=$?
+  set -e
+  test "$sh_status" -eq 1
+  grep -qF 'needs bash' <<<"$sh_output"
+  grep -qF '| bash' <<<"$sh_output"
+  echo 'ok   running the installer under a non-bash shell fails loudly with the right command'
+else
+  echo 'ok   (not observable here) dash is unavailable to exercise the non-bash invocation'
+fi
+
+echo 'PASS: portable installer macOS behavior and PATH wiring verified.'


### PR DESCRIPTION
Installer PATH wiring + honest verification + first-run pointer.

- `scripts/cas-install.sh`: detects the LOGIN shell from `$SHELL` (not the shell running the piped script); zsh → `~/.zshenv` (non-interactive MCP spawns see it), bash → `.bashrc` else `.profile`, other shells → print the exact line. Marker-guarded block (`# >>> cassy path >>>`), itself a `case ":$PATH:"` guard — idempotent twice over. Consent on `/dev/tty` (open-tested, not `-r`), `CAS_WIRE_PATH=1|0` override, unattended = no edit + exact line. Post-install check runs `$SHELL -lc 'command -v cas'` from the pre-wiring PATH and only claims success when a fresh login shell can run `cas`. Bash preamble rejects `| sh` with the correct command.
- Bare `cas` on an unconfigured machine (no `~/.cas`, no project) prints one line pointing at the front-door command, held in `first_run::FRONT_DOOR_COMMAND` (`init` today; cas-b635 flips to `setup`), with a test asserting it is a real clap subcommand.
- 8 new installer seam cases (fake login shells outside PATH) + 2 existing macOS cases; 5 Rust tests.
- CHANGELOG [Unreleased] entry only; docs (macbook-from-zero, README, CONTRIBUTING) match the installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)