### PR TITLE
docs(release): record the v3.4.1 fast-publication release receipt (cas-9a81)

### DIFF
--- a/docs/release-notes/2026-08-20-v3.4.1-slack.md
+++ b/docs/release-notes/2026-08-20-v3.4.1-slack.md
@@ -1,0 +1,72 @@
+# Slack draft — Cassy v3.4.1 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Receipt-verified from published assets; posting.
+
+Release published 2026-08-20T20:33:36Z from tag `v3.4.1` (annotated `a5f3c345`,
+peeling to `fbf2588b`). Tag-triggered run 32414489374 skipped both platform
+builds and adopted the artifacts from prebuild run 32413007504.
+`scripts/release-latency-receipt.sh v3.4.1` exits 0:
+`PUBLISH_LATENCY_SECONDS=166 BUDGET_SECONDS=600 WITHIN_BUDGET=true`.
+Install receipt: the published Linux archive extracts to a binary reporting
+`cas 3.4.1 (fbf2588 2026-08-20)`.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Cassy v3.4.1 publishes minutes after a change is approved instead of a quarter of an hour later: this release went from tagged to downloadable in 2 minutes 46 seconds.
+
+**Reply (Was → Now):**
+- Was: after a change was approved, the release sat through a full cold rebuild of both platforms before anyone could install it — about a quarter of an hour of waiting, and longer if a machine was busy. Now: the archives are already built by the time the release is cut, so publishing just hands them over. Measured on this release: 2 minutes 46 seconds from cut to downloadable, against 15 minutes 33 seconds for the previous one.
+- Was: nothing about that wait was visible, so "is it out yet?" was answered by refreshing a page. Now: every release records its own publish time, and a release that drifts past ten minutes is flagged automatically rather than quietly tolerated.
+- Was: the 3.4.0 notes described a Mac install step and a skills count that did not match what shipped. Now: both entries are corrected in place — the installer prints the PATH line for you rather than editing a startup file, and eight new skills arrived with four more folded into existing ones.
+- Install: use `cas update` for an existing installation, or download the
+  v3.4.1 archive for Linux x86_64 (SHA-256 `a0226e3266ac6799edce70f40b9a869eab54b9b2e8a04384ecf7619b186c93aa`) or macOS ARM64
+  (SHA-256 `e3333bb8863cb3e3555e95f1032ea4b0f1c2853ff949c0dff7855bf1da3087ac`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v3.4.1 moves the platform builds off the tag's critical path: artifacts are prebuilt when the version-bump PR merges, and the tag adopts them. Measured 166s tag→published, down from 933s.
+
+**Reply (Was → Now):**
+- Was: pushing the tag started two cold cross-platform builds, so tag→published was 15m33s and the macOS lane alone owned most of it. Now: the release tree is final the moment the bump PR lands, so a prebuild fires there and the tag-triggered run skips both platform builds and adopts the uploaded artifacts. On this release both `Build Linux x86_64` and `Build macOS ARM64` reported skipped, and `Verify Release Inputs` — now the only compiling job left on the critical path — finished in 40 seconds.
+- Was: the trigger would have had to be guessed from branch names. Now: a tree is a pending release exactly when every release-train crate carries one version, the changelog has that heading, and no such tag exists yet — so the gate self-disarms after the tag and later pushes at the same version cost one cheap job. It armed 3 seconds after the merge here.
+- Was: a slow release was only ever noticed by someone watching. Now: the publish latency is a checked receipt with a 600-second budget, and a tag with no usable prebuild still builds at tag time, so the cold path remains a working fallback rather than a failure mode.
+- Also in this release: the 3.4.0 changelog entries for the macOS installer and the skill imports are corrected in place — `cas-install.sh` prints the `export PATH=...` line and edits no shell startup file, and eight new skill directories landed with four further imports folded into existing builtins.
+- Validation and artifact: the bump landed on main through the merge queue; the prebuild ran Linux x86_64 on the self-hosted runner in 3m30s and macOS ARM64 hosted in 14m19s, both off the tag's path. Digests verified by fresh downloads of the published assets, and the published Linux binary reports `cas 3.4.1`. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `a0226e3266ac6799edce70f40b9a869eab54b9b2e8a04384ecf7619b186c93aa`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `e3333bb8863cb3e3555e95f1032ea4b0f1c2853ff949c0dff7855bf1da3087ac`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-20 20:34 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787258095505899 |
+| User reply (Was → Now) | 2026-08-20 20:35 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787258104890849?thread_ts=1787258095.505899&cid=C0B44GUKDK2 |
+| Dev top-level | 2026-08-20 20:35 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787258108194679 |
+| Dev reply (Was → Now) | 2026-08-20 20:35 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787258119423269 |
+
+## Hub promotion
+
+N/A with evidence. `git rev-parse origin/main:hub-web/dist` is
+`f93c7d80861d80bea9b165e8371c6d0c3feef05c` — identical to the tree at the last
+promotion (CAS v3.0.0, source commit `0fe75360`) — and
+`git log 0fe75360..origin/main -- hub-web/dist` returns zero commits. The
+hosted origin already serves those exact bytes.
+
+## Release latency receipt
+
+```
+TAG=v3.4.1
+TAG_RUN_ID=32414489374
+TAG_PUSHED_AT=2026-08-20T20:30:50Z
+PUBLISHED_AT=2026-08-20T20:33:36Z
+PUBLISH_LATENCY_SECONDS=166
+BUDGET_SECONDS=600
+WITHIN_BUDGET=true
+```


### PR DESCRIPTION
Docs-only: docs/release-notes/2026-08-20-v3.4.1-slack.md — the posted #cas-internal user/dev threads, hub N/A evidence, and the latency receipt.

v3.4.1 was the first release on the prebuilt path: tag→published **166s** (20:30:50Z → 20:33:36Z) vs 933s for v3.4.0; both platform builds skipped at tag time, prebuilt artifacts adopted, Verify 40s on the self-hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)