### PR TITLE
feat(ci): add second trusted runner slot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,7 @@ jobs:
             refs/heads/gh-readonly-queue/*) ;;
             *) echo "self-hosted route received a non-queue ref: $GITHUB_REF" >&2; exit 1 ;;
           esac
+          ./scripts/check-cassy-actions-runner-isolation.sh
 
       - name: Test portable installer fixtures
         run: ./scripts/test-cas-install.sh
@@ -337,11 +338,6 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          test "${SCCACHE_SERVER_PORT:?}" = 4227
-          case "${SCCACHE_DIR:?}" in
-            /var/lib/cassy-actions/*) ;;
-            *) echo "SCCACHE_DIR is not isolated from the runner cache" >&2; exit 1 ;;
-          esac
           sccache rustc -vV
           sccache --show-stats
 
@@ -431,6 +427,7 @@ jobs:
             refs/heads/gh-readonly-queue/*) ;;
             *) echo "self-hosted route received a non-queue ref: $GITHUB_REF" >&2; exit 1 ;;
           esac
+          ./scripts/check-cassy-actions-runner-isolation.sh
 
       - name: Report Rust short-circuit
         if: steps.classify-diff.outputs.rust-unaffected == 'true'
@@ -468,11 +465,6 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          test "${SCCACHE_SERVER_PORT:?}" = 4227
-          case "${SCCACHE_DIR:?}" in
-            /var/lib/cassy-actions/*) ;;
-            *) echo "SCCACHE_DIR is not isolated from the runner cache" >&2; exit 1 ;;
-          esac
           sccache rustc -vV
           sccache --show-stats
 
@@ -675,6 +667,7 @@ jobs:
             refs/heads/gh-readonly-queue/*) ;;
             *) echo "self-hosted route received a non-queue ref: $GITHUB_REF" >&2; exit 1 ;;
           esac
+          ./scripts/check-cassy-actions-runner-isolation.sh
 
       - name: Report Rust short-circuit
         if: steps.classify-diff.outputs.rust-unaffected == 'true'
@@ -706,11 +699,6 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          test "${SCCACHE_SERVER_PORT:?}" = 4227
-          case "${SCCACHE_DIR:?}" in
-            /var/lib/cassy-actions/*) ;;
-            *) echo "SCCACHE_DIR is not isolated from the runner cache" >&2; exit 1 ;;
-          esac
           sccache rustc -vV
           sccache --show-stats
 

--- a/.github/workflows/self-hosted-fast-validation.yml
+++ b/.github/workflows/self-hosted-fast-validation.yml
@@ -69,16 +69,7 @@ jobs:
             refs/heads/main|refs/heads/epic/*|refs/heads/factory/*) ;;
             *) echo "ref is outside the trusted same-repository branch set: $GITHUB_REF" >&2; exit 1 ;;
           esac
-          case "${CARGO_TARGET_DIR:?}" in
-            /var/lib/cassy-actions/*) ;;
-            *) echo "CARGO_TARGET_DIR is not isolated from factory worktrees" >&2; exit 1 ;;
-          esac
-          test "${SCCACHE_SERVER_PORT:?}" = 4227
-          case "${SCCACHE_DIR:?}" in
-            /var/lib/cassy-actions/*) ;;
-            *) echo "SCCACHE_DIR is not isolated from the operator cache" >&2; exit 1 ;;
-          esac
-          test "$(id -u)" -ne 0
+          ./scripts/check-cassy-actions-runner-isolation.sh
           test "$(nproc)" -ge 16
           command -v cargo rustup sccache mold gcc >/dev/null
 

--- a/docs/ci/self-hosted-runner-pilot.md
+++ b/docs/ci/self-hosted-runner-pilot.md
@@ -21,6 +21,28 @@ not reach the pilot's two-minute target. This is an honest partial result;
 the private sccache service remains outside the workflow and is not a hidden
 prerequisite for the measurement.
 
+## Merge-queue latency follow-up
+
+The first routing change exposed a single-listener queue rather than a slow
+individual lane. GitHub may assign the archive, preflight, and doctest jobs in
+any order, but one `soundwave-cas-ci` listener can execute only one at a time.
+
+| Queue run | Total | Archive | Preflight | Doctests | Limiting observation |
+| --- | ---: | ---: | ---: | ---: | --- |
+| [PR #568](https://github.com/Richards-LLC/cassy/actions/runs/32399555279) | 5m32s | 1m20s, `soundwave-cas-ci` | 3m28s, hosted | 2m36s, hosted | Hosted comparison; Linux lanes ran in parallel. |
+| [PR #576](https://github.com/Richards-LLC/cassy/actions/runs/32413795966) | 7m07s | 1m28s | 2m26s | 2m12s | All three `soundwave-cas-ci` jobs serialized for 6m08s. |
+| [PR #577](https://github.com/Richards-LLC/cassy/actions/runs/32414486769) | 6m03s | 1m30s | 1m20s | 1m09s | Linux rollup finished in 4m57s; macOS finished at 6m02s. |
+| [PR #578](https://github.com/Richards-LLC/cassy/actions/runs/32415089032) | 11m19s | 1m25s | 1m18s | 0m51s | Archive was assigned third, delaying hosted shards; macOS independently took 11m04s. |
+
+The hosted-cache option has one demonstrated sub-six-minute run (#568), but it
+depends on two hosted compiler caches staying warm and adds main-push compiler
+work after the exact tree was already validated. It also does nothing for the
+observed macOS variance. The selected option is a second trusted listener with
+the same labels. That directly bounds the Linux serialization: two of the
+three compiling jobs start together, and the third waits for at most one warm
+job instead of two. macOS remains an independent floor and is reported rather
+than hidden in the acceptance receipts.
+
 ## Trust boundary
 
 `Richards-LLC/cassy` is public. GitHub warns that persistent self-hosted runners
@@ -82,18 +104,26 @@ the workflow can repair after assignment; treat the variable as a readiness
 lease and disable it before any maintenance. This preserves a concrete hosted
 fallback instead of wedging planned queue work.
 
-The listener runs as the non-login `cassy-actions` system account under
-`cassy-actions-runner.service`. Its checkout, Cargo target directory, Rust
-toolchain, and sccache live under `/var/lib/cassy-actions`, never under `.cas`
-or the factory worktrees. The unit has no privileges or Docker access, applies
-systemd filesystem/device/kernel hardening, uses `nice=10` and best-effort
-`ionice=7`, caps Cargo at 12 jobs, and reserves 2,048 cgroup task slots. This
+Two listeners run as the non-login `cassy-actions` system account under
+`cassy-actions-runner.service` and `cassy-actions-runner-2.service`. Their
+checkouts, Cargo target directories, Rust toolchain, and sccache live under
+`/var/lib/cassy-actions`, never under `.cas` or the factory worktrees. The
+listeners share the read-only toolchain but not mutable build state:
+
+| Slot | Runner | Checkout | Cargo target | sccache | Port |
+| --- | --- | --- | --- | --- | ---: |
+| 1 | `soundwave-cas-ci` | `runner` | `cache/cargo-target` | `cache/sccache` | 4227 |
+| 2 | `soundwave-cas-ci-2` | `runner-2` | `cache/cargo-target-2` | `cache/sccache-2` | 4228 |
+
+Both units have no privileges or Docker access and apply
+systemd filesystem/device/kernel hardening, use `nice=10` and best-effort
+`ionice=7`, cap Cargo at 12 jobs, and reserve 2,048 cgroup task slots. This
 does not raise compilation concurrency: it prevents sccache plus 12 parallel
 rustc/linker process trees from exhausting the distro's 512-task service
-default and returning `EAGAIN` while spawning a compiler. One listener and one
-workflow concurrency group enforce host job concurrency 1. The runner uses dedicated sccache port
-4227; the default port belongs to the operator's cache server and must not be
-shared across Unix users. The systemd launch wrapper starts sccache before the
+default and returning `EAGAIN` while spawning a compiler. The two 12-way caps
+leave eight of the host's 32 logical CPUs outside Cargo's job budget. Dedicated
+sccache ports 4227 and 4228 prevent either slot from finding the operator's
+default-port cache or the other listener's server. The systemd launch wrapper starts sccache before the
 GitHub listener, outside Runner.Worker's per-step process tracking; starting it
 inside one workflow step causes the runner to reap it before Cargo's next step.
 The launch wrapper then uses GitHub's `bin/runsvc.sh`, which translates systemd
@@ -139,15 +169,18 @@ gh api orgs/Richards-LLC/actions/runner-groups/GROUP_ID \\
   --jq '{restricted_to_workflows, selected_workflows}'
 ```
 
-Generate a short-lived organization registration token, then run from a trusted
-checkout:
+Generate a short-lived organization registration token for each registration,
+then run from a trusted checkout. `RUNNER_SLOT` defaults to `1`; provisioning
+slot 2 is explicit so rerunning the installer cannot silently change the
+existing listener:
 
 ```bash
-RUNNER_TOKEN=... SCCACHE_SOURCE="$(command -v sccache)" \
-  sudo --preserve-env=RUNNER_TOKEN,SCCACHE_SOURCE scripts/install-cassy-actions-runner.sh
+RUNNER_TOKEN=... RUNNER_SLOT=2 SCCACHE_SOURCE="$(command -v sccache)" \
+  sudo --preserve-env=RUNNER_TOKEN,RUNNER_SLOT,SCCACHE_SOURCE \
+    scripts/install-cassy-actions-runner.sh
 ```
 
-Verify the runner reports `online` before enabling the job:
+Verify both runner names report `online` before enabling the job:
 
 ```bash
 gh api orgs/Richards-LLC/actions/runners
@@ -167,6 +200,7 @@ merge-queue routing and advisory assignment first, then stop the listener:
 gh variable set CASSY_SELF_HOSTED_PILOT --repo Richards-LLC/cassy --body disabled
 gh variable set CASSY_MERGE_QUEUE_SELF_HOSTED --repo Richards-LLC/cassy --body disabled
 sudo systemctl stop cassy-actions-runner.service
+sudo systemctl stop cassy-actions-runner-2.service
 ```
 
 Audit without exposing tokens:
@@ -175,7 +209,7 @@ Audit without exposing tokens:
 gh api orgs/Richards-LLC/actions/runner-groups
 gh api orgs/Richards-LLC/actions/runner-groups/GROUP_ID/repositories
 gh api orgs/Richards-LLC/actions/runner-groups/GROUP_ID/runners
-systemctl show cassy-actions-runner.service \
+systemctl show cassy-actions-runner.service cassy-actions-runner-2.service \
   -p User -p Group -p Nice -p CPUWeight -p IOWeight -p TasksCurrent -p TasksMax \
   -p ReadWritePaths
 ```

--- a/ops/systemd/cassy-actions-runner-2.service
+++ b/ops/systemd/cassy-actions-runner-2.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=Cassy trusted-branch GitHub Actions runner (slot 2)
+Documentation=https://github.com/Richards-LLC/cassy/blob/main/docs/ci/self-hosted-runner-pilot.md
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=cassy-actions
+Group=cassy-actions
+WorkingDirectory=/var/lib/cassy-actions/runner-2
+ExecStart=/usr/bin/ionice -c 2 -n 7 /var/lib/cassy-actions/run-service-2.sh
+Restart=always
+RestartSec=10s
+TimeoutStopSec=2min
+KillMode=mixed
+
+# Two 12-way jobs leave eight logical CPUs for the worker fleet. Each slot has
+# its own Cargo target and sccache server, so concurrent jobs never share a
+# Cargo lock or compiler-cache process.
+Nice=10
+CPUWeight=25
+IOWeight=25
+TasksMax=2048
+Environment=HOME=/var/lib/cassy-actions
+Environment=CARGO_HOME=/var/lib/cassy-actions/.cargo
+Environment=RUSTUP_HOME=/var/lib/cassy-actions/.rustup
+Environment=CARGO_TARGET_DIR=/var/lib/cassy-actions/cache/cargo-target-2
+Environment=SCCACHE_DIR=/var/lib/cassy-actions/cache/sccache-2
+Environment=SCCACHE_SERVER_PORT=4228
+Environment=SCCACHE_CACHE_SIZE=50G
+Environment=SCCACHE_IDLE_TIMEOUT=0
+Environment=CARGO_CACHE_RUSTC_INFO=0
+Environment=CARGO_BUILD_JOBS=12
+Environment=RUSTC_WRAPPER=sccache
+Environment=PATH=/var/lib/cassy-actions/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+UMask=0027
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictRealtime=true
+LockPersonality=true
+CapabilityBoundingSet=
+AmbientCapabilities=
+ReadWritePaths=/var/lib/cassy-actions
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/run-cassy-actions-runner-2.sh
+++ b/ops/systemd/run-cassy-actions-runner-2.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Slot 2 owns a distinct sccache server and GitHub listener. Keep both outside
+# Runner.Worker's per-step process tracking so they survive between jobs.
+set -euo pipefail
+
+sccache --start-server
+sccache --show-stats >/dev/null
+exec /var/lib/cassy-actions/runner-2/bin/runsvc.sh

--- a/scripts/check-cassy-actions-runner-isolation.sh
+++ b/scripts/check-cassy-actions-runner-isolation.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Verify that a trusted self-hosted lane received one complete, isolated slot
+# tuple. Accepting the target, cache, and port independently could combine
+# slot 1 and slot 2 and silently reintroduce a shared Cargo lock or cache
+# server.
+set -euo pipefail
+
+fail() {
+    echo "error: $1" >&2
+    exit 1
+}
+
+case "${CARGO_TARGET_DIR:?}:${SCCACHE_DIR:?}:${SCCACHE_SERVER_PORT:?}" in
+    /var/lib/cassy-actions/cache/cargo-target:/var/lib/cassy-actions/cache/sccache:4227)
+        slot=1
+        ;;
+    /var/lib/cassy-actions/cache/cargo-target-2:/var/lib/cassy-actions/cache/sccache-2:4228)
+        slot=2
+        ;;
+    *)
+        fail "runner target/cache/port is not an approved isolated slot tuple"
+        ;;
+esac
+
+test "$(id -u)" -ne 0 || fail "trusted lane must not run as root"
+echo "runner isolation contract satisfied: slot=$slot target=$CARGO_TARGET_DIR"

--- a/scripts/check-release-runner-trust.sh
+++ b/scripts/check-release-runner-trust.sh
@@ -29,18 +29,6 @@ case "${GITHUB_REF:?}" in
     *) fail "ref is outside the trusted release set: $GITHUB_REF" ;;
 esac
 
-case "${CARGO_TARGET_DIR:?}" in
-    /var/lib/cassy-actions/*) ;;
-    *) fail "CARGO_TARGET_DIR is not isolated from factory worktrees" ;;
-esac
-
-case "${SCCACHE_DIR:?}" in
-    /var/lib/cassy-actions/*) ;;
-    *) fail "SCCACHE_DIR is not isolated from the operator cache" ;;
-esac
-
-test "${SCCACHE_SERVER_PORT:?}" = 4227 \
-    || fail "SCCACHE_SERVER_PORT is not the runner's private port"
-test "$(id -u)" -ne 0 || fail "release lane must not run as root on the shared box"
+"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-cassy-actions-runner-isolation.sh"
 
 echo "release runner trust contract satisfied: ref=$GITHUB_REF target=$CARGO_TARGET_DIR"

--- a/scripts/install-cassy-actions-runner.sh
+++ b/scripts/install-cassy-actions-runner.sh
@@ -1,20 +1,46 @@
 #!/usr/bin/env bash
 # Install the pinned GitHub runner and register it in the pre-created,
 # selected-repository/selected-workflow group. Run from a trusted checkout:
-#   SCCACHE_SOURCE="$(command -v sccache)" \
-#     sudo --preserve-env=RUNNER_TOKEN,SCCACHE_SOURCE scripts/install-cassy-actions-runner.sh
+#   RUNNER_SLOT=2 SCCACHE_SOURCE="$(command -v sccache)" \
+#     sudo --preserve-env=RUNNER_TOKEN,RUNNER_SLOT,SCCACHE_SOURCE \
+#       scripts/install-cassy-actions-runner.sh
 set -euo pipefail
 
 runner_user=cassy-actions
 runner_root=/var/lib/cassy-actions
-runner_dir="$runner_root/runner"
+runner_slot="${RUNNER_SLOT:-1}"
 runner_version=2.336.0
 runner_archive="actions-runner-linux-x64-${runner_version}.tar.gz"
 runner_url="https://github.com/actions/runner/releases/download/v${runner_version}/${runner_archive}"
 runner_sha256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d
 runner_group=cassy-public-trusted
-unit_source="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/ops/systemd/cassy-actions-runner.service"
-wrapper_source="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/ops/systemd/run-cassy-actions-runner.sh"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+case "$runner_slot" in
+    1)
+        runner_name=soundwave-cas-ci
+        runner_dir="$runner_root/runner"
+        cargo_target_dir="$runner_root/cache/cargo-target"
+        sccache_dir="$runner_root/cache/sccache"
+        service_name=cassy-actions-runner.service
+        wrapper_source="$repo_root/ops/systemd/run-cassy-actions-runner.sh"
+        wrapper_dest="$runner_root/run-service.sh"
+        ;;
+    2)
+        runner_name=soundwave-cas-ci-2
+        runner_dir="$runner_root/runner-2"
+        cargo_target_dir="$runner_root/cache/cargo-target-2"
+        sccache_dir="$runner_root/cache/sccache-2"
+        service_name=cassy-actions-runner-2.service
+        wrapper_source="$repo_root/ops/systemd/run-cassy-actions-runner-2.sh"
+        wrapper_dest="$runner_root/run-service-2.sh"
+        ;;
+    *)
+        echo "RUNNER_SLOT must be 1 or 2; got $runner_slot" >&2
+        exit 1
+        ;;
+esac
+unit_source="$repo_root/ops/systemd/$service_name"
 
 if [[ "$(id -u)" -ne 0 ]]; then
     echo "run as root (sudo --preserve-env=RUNNER_TOKEN $0)" >&2
@@ -33,8 +59,8 @@ if ! id "$runner_user" >/dev/null 2>&1; then
     useradd --system --create-home --home-dir "$runner_root" --shell /usr/sbin/nologin "$runner_user"
 fi
 install -d -o "$runner_user" -g "$runner_user" -m 0750 \
-    "$runner_dir" "$runner_root/cache" "$runner_root/cache/cargo-target" \
-    "$runner_root/cache/sccache" "$runner_root/.cargo" \
+    "$runner_dir" "$runner_root/cache" "$cargo_target_dir" \
+    "$sccache_dir" "$runner_root/.cargo" \
     "$runner_root/.cargo/bin" "$runner_root/.rustup"
 chown -R "$runner_user:$runner_user" \
     "$runner_root/cache" "$runner_root/.cargo" "$runner_root/.rustup"
@@ -78,15 +104,15 @@ fi
         ./config.sh --unattended --replace \
         --url https://github.com/Richards-LLC \
         --token "$RUNNER_TOKEN" \
-        --name soundwave-cas-ci \
+        --name "$runner_name" \
         --runnergroup "$runner_group" \
         --labels cas-ci-32core,trusted-branches \
         --work _work
 )
 
 install -o "$runner_user" -g "$runner_user" -m 0755 \
-    "$wrapper_source" "$runner_root/run-service.sh"
-install -o root -g root -m 0644 "$unit_source" /etc/systemd/system/cassy-actions-runner.service
+    "$wrapper_source" "$wrapper_dest"
+install -o root -g root -m 0644 "$unit_source" "/etc/systemd/system/$service_name"
 systemctl daemon-reload
-systemctl enable --now cassy-actions-runner.service
-systemctl --no-pager --full status cassy-actions-runner.service
+systemctl enable --now "$service_name"
+systemctl --no-pager --full status "$service_name"

--- a/scripts/test-check-release-runner-trust.sh
+++ b/scripts/test-check-release-runner-trust.sh
@@ -53,6 +53,9 @@ expect_reject() {
 
 REF=refs/tags/v3.4.0 expect_accept 'an annotated release tag push is trusted'
 REF=refs/heads/main expect_accept 'the release-prep commit on main is trusted'
+TARGET_DIR=/var/lib/cassy-actions/cache/cargo-target-2 \
+    SCCACHE=/var/lib/cassy-actions/cache/sccache-2 PORT=4228 \
+    expect_accept 'the second isolated runner slot is trusted'
 
 REF=refs/heads/factory/some-worker \
     expect_reject 'a factory branch cannot use the release lane' 'outside the trusted release set'
@@ -67,11 +70,14 @@ REPO=attacker/cassy-fork \
 ENABLED= \
     expect_reject 'routing that was never enabled is refused' 'not explicitly enabled'
 TARGET_DIR=/home/pippenz/Petrastella/cas-src/target \
-    expect_reject 'a factory worktree target directory is refused' 'not isolated from factory worktrees'
+    expect_reject 'a factory worktree target directory is refused' 'not an approved isolated slot tuple'
 SCCACHE=/home/pippenz/.cache/sccache \
-    expect_reject 'the operator cache directory is refused' 'not isolated from the operator cache'
+    expect_reject 'the operator cache directory is refused' 'not an approved isolated slot tuple'
 PORT=4226 \
-    expect_reject 'a foreign sccache port is refused' 'not the runner'"'"'s private port'
+    expect_reject 'a foreign sccache port is refused' 'not an approved isolated slot tuple'
+TARGET_DIR=/var/lib/cassy-actions/cache/cargo-target \
+    SCCACHE=/var/lib/cassy-actions/cache/sccache-2 PORT=4228 \
+    expect_reject 'a mixed slot tuple is refused' 'not an approved isolated slot tuple'
 
 printf '\n%s passed, %s failed\n' "$pass" "$fail"
 test "$fail" -eq 0

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -16,6 +16,11 @@ migration_guard="$repo_root/scripts/check-release-migration-snapshots.sh"
 watchdog="$repo_root/.github/workflows/merge-queue-watchdog.yml"
 watchdog_script="$repo_root/scripts/cancel-stale-merge-group-runs.sh"
 runner_unit="$repo_root/ops/systemd/cassy-actions-runner.service"
+runner_unit_2="$repo_root/ops/systemd/cassy-actions-runner-2.service"
+runner_wrapper_2="$repo_root/ops/systemd/run-cassy-actions-runner-2.sh"
+runner_installer="$repo_root/scripts/install-cassy-actions-runner.sh"
+runner_isolation="$repo_root/scripts/check-cassy-actions-runner-isolation.sh"
+release_runner_trust="$repo_root/scripts/check-release-runner-trust.sh"
 stale_queue_watchdog="$repo_root/.github/workflows/stale-queued-run-watchdog.yml"
 stale_queue_script="$repo_root/scripts/cancel-stale-non-merge-group-queued-runs.sh"
 watchdog_policy="$repo_root/scripts/watchdog-policy.sh"
@@ -141,9 +146,7 @@ require_text "$self_hosted_text" 'permissions:' 'self-hosted workflow declares e
 require_text "$self_hosted_text" 'contents: read' 'self-hosted workflow token is read-only'
 require_text "$self_hosted_text" 'CARGO_BUILD_JOBS: "12"' 'self-hosted compile leaves CPU capacity for the worker fleet'
 require_text "$self_hosted_text" 'RUSTC_WRAPPER: ""' 'pilot archive timing is not coupled to sccache availability'
-require_text "$self_hosted_text" 'CARGO_TARGET_DIR is not isolated from factory worktrees' 'self-hosted job fails if host isolation is lost'
-require_text "$self_hosted_text" 'test "${SCCACHE_SERVER_PORT:?}" = 4227' 'self-hosted job pins its isolated sccache server'
-require_text "$self_hosted_text" 'SCCACHE_DIR is not isolated from the operator cache' 'self-hosted job rejects the operator sccache directory'
+require_text "$self_hosted_text" './scripts/check-cassy-actions-runner-isolation.sh' 'self-hosted job verifies an approved target/cache/port tuple'
 require_absent "$self_hosted_text" 'sccache --start-server' 'workflow steps cannot start a cache server that Runner.Worker will reap'
 require_absent "$self_hosted_text" 'sccache --zero-stats' 'pilot workflow does not depend on a cache server for its first receipt'
 require_text "$self_hosted_text" 'cargo nextest archive --workspace --archive-file fast-validation-suite.tar.zst' 'self-hosted pilot measures the same suite archive'
@@ -161,10 +164,54 @@ require_text "$pilot_doc" 'approval_policy=all_external_contributors' 'pilot pin
 require_text "$pilot_doc" 'Ephemeral/JIT runners remain future' 'pilot records the deferred runner-isolation alternative'
 
 runner_unit_text="$(<"$runner_unit")"
+runner_unit_2_text="$(<"$runner_unit_2")"
 require_text "$runner_unit_text" 'Environment=CARGO_CACHE_RUSTC_INFO=0' 'runner does not persist failed sccache rustc probes across jobs'
 require_text "$runner_unit_text" 'Environment=SCCACHE_IDLE_TIMEOUT=0' 'runner keeps its private sccache server alive between merge-queue jobs'
 require_text "$runner_unit_text" 'TasksMax=2048' 'runner reserves enough cgroup task slots for parallel sccache compiler spawns'
+require_text "$runner_unit_2_text" 'WorkingDirectory=/var/lib/cassy-actions/runner-2' 'slot 2 has an independent runner checkout'
+require_text "$runner_unit_2_text" 'Environment=CARGO_TARGET_DIR=/var/lib/cassy-actions/cache/cargo-target-2' 'slot 2 has an independent Cargo target'
+require_text "$runner_unit_2_text" 'Environment=SCCACHE_DIR=/var/lib/cassy-actions/cache/sccache-2' 'slot 2 has an independent sccache directory'
+require_text "$runner_unit_2_text" 'Environment=SCCACHE_SERVER_PORT=4228' 'slot 2 has an independent sccache server port'
+require_text "$runner_unit_2_text" '/var/lib/cassy-actions/run-service-2.sh' 'slot 2 unit starts its dedicated wrapper'
+require_text "$(<"$runner_wrapper_2")" '/var/lib/cassy-actions/runner-2/bin/runsvc.sh' 'slot 2 wrapper starts its independent listener'
+require_text "$(<"$runner_installer")" 'RUNNER_SLOT must be 1 or 2' 'runner installer rejects unbounded slot identifiers'
+require_text "$(<"$runner_installer")" 'runner_name=soundwave-cas-ci-2' 'runner installer registers a distinct slot-2 name'
+require_text "$(<"$runner_installer")" 'service_name=cassy-actions-runner-2.service' 'runner installer enables the slot-2 unit'
+require_text "$(<"$release_runner_trust")" 'check-cassy-actions-runner-isolation.sh' 'release trust guard accepts only approved slot tuples'
 require_text "$pilot_doc" '2,048 cgroup task slots' 'pilot documents the parallel sccache task-slot budget'
+
+if [[ -x "$runner_isolation" ]]; then
+    if CARGO_TARGET_DIR=/var/lib/cassy-actions/cache/cargo-target \
+        SCCACHE_DIR=/var/lib/cassy-actions/cache/sccache \
+        SCCACHE_SERVER_PORT=4227 "$runner_isolation" >/dev/null; then
+        printf 'ok   runner isolation accepts slot 1 tuple\n'
+        pass=$((pass + 1))
+    else
+        printf 'FAIL runner isolation must accept slot 1 tuple\n'
+        fail=$((fail + 1))
+    fi
+    if CARGO_TARGET_DIR=/var/lib/cassy-actions/cache/cargo-target-2 \
+        SCCACHE_DIR=/var/lib/cassy-actions/cache/sccache-2 \
+        SCCACHE_SERVER_PORT=4228 "$runner_isolation" >/dev/null; then
+        printf 'ok   runner isolation accepts slot 2 tuple\n'
+        pass=$((pass + 1))
+    else
+        printf 'FAIL runner isolation must accept slot 2 tuple\n'
+        fail=$((fail + 1))
+    fi
+    if CARGO_TARGET_DIR=/var/lib/cassy-actions/cache/cargo-target \
+        SCCACHE_DIR=/var/lib/cassy-actions/cache/sccache-2 \
+        SCCACHE_SERVER_PORT=4228 "$runner_isolation" >/dev/null 2>&1; then
+        printf 'FAIL runner isolation must reject a mixed slot tuple\n'
+        fail=$((fail + 1))
+    else
+        printf 'ok   runner isolation rejects a mixed slot tuple\n'
+        pass=$((pass + 1))
+    fi
+else
+    printf 'FAIL runner isolation script must be executable\n'
+    fail=$((fail + 1))
+fi
 
 if [[ -x "$watchdog_script" ]]; then
     watchdog_text="$(<"$watchdog")"
@@ -209,6 +256,8 @@ require_text "$suite_build" "needs.fast-validation-runner-route.outputs.mode == 
 require_text "$suite_build" "needs.fast-validation-runner-route.outputs.mode == 'self-hosted'" 'self-hosted setup is limited to selected merge-queue validation'
 require_text "$suite_build" 'Verify merge-queue self-hosted trust boundary' 'self-hosted archive verifies queue-only trust at execution'
 require_text "$suite_build" 'refs/heads/gh-readonly-queue/*' 'self-hosted archive rejects non-queue refs'
+suite_trust_step="$(named_step_block "$suite_build" 'Verify merge-queue self-hosted trust boundary')"
+require_text "$suite_trust_step" './scripts/check-cassy-actions-runner-isolation.sh' 'self-hosted archive fail-closed trust step pins an approved slot tuple'
 for job in fast-validation-preflight fast-validation-docs; do
     block="$(job_block "$job")"
     require_text "$block" 'needs: [fast-validation-runner-route, fast-validation-main-push-dedupe]' "$job waits for explicit runner routing and the main-push tree gate"
@@ -221,13 +270,15 @@ for job in fast-validation-preflight fast-validation-docs; do
     require_text "$block" "needs.fast-validation-runner-route.outputs.mode == 'self-hosted'" "$job limits isolated runner setup to selected merge-queue validation"
     require_text "$block" 'Verify merge-queue self-hosted trust boundary' "$job verifies queue-only trust at execution"
     require_text "$block" 'refs/heads/gh-readonly-queue/*' "$job rejects non-queue refs on the isolated runner"
+    trust_step="$(named_step_block "$block" 'Verify merge-queue self-hosted trust boundary')"
+    require_text "$trust_step" './scripts/check-cassy-actions-runner-isolation.sh' "$job fail-closed trust step pins an approved slot tuple"
     require_text "$block" 'Verify private self-hosted sccache' "$job confirms the persistent compiler cache remains isolated"
 done
 probe_step="$(named_step_block "$suite_build" 'Verify private self-hosted sccache')"
 disable_step="$(named_step_block "$suite_build" 'Disable sccache for the self-hosted suite archive')"
 archive_step="$(named_step_block "$suite_build" 'Build full suite archive')"
 require_text "$probe_step" 'continue-on-error: true' 'self-hosted cache probe itself cannot fail the merge queue'
-require_text "$probe_step" 'test "${SCCACHE_SERVER_PORT:?}" = 4227' 'self-hosted cache probe pins the private cache port'
+require_absent "$probe_step" './scripts/check-cassy-actions-runner-isolation.sh' 'fail-open cache probe does not own the slot trust decision'
 require_text "$probe_step" 'cas-065a' 'self-hosted cache probe cites the tracked server defect'
 require_text "$disable_step" "steps.classify-diff.outputs.rust-unaffected != 'true'" 'wrapper disable step requires Rust work'
 require_text "$disable_step" "needs.fast-validation-runner-route.outputs.mode == 'self-hosted'" 'wrapper disable step is self-hosted only'


### PR DESCRIPTION
## Summary
- provision `soundwave-cas-ci-2` with independent checkout, Cargo target, sccache directory, port, wrapper, and systemd unit
- enforce exact slot tuples in merge-queue, pilot, and release trust gates
- document option comparison and measured PR #568/#576/#577/#578 baselines

## Validation
- `bash scripts/test-ci-test-tiers.sh` (632 passed)
- `bash scripts/test-check-release-runner-trust.sh` (13 passed)
- `bash -n ...`, `git diff --check`, and `systemd-analyze verify ...`

Task: cas-329e