### PR TITLE
docs(release): track posted announcement receipts

### DIFF
--- a/docs/release-notes/2026-08-18-v3.0.0-slack.md
+++ b/docs/release-notes/2026-08-18-v3.0.0-slack.md
@@ -1,0 +1,51 @@
+# Slack draft — Cassy v3.0.0 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** POSTED 2026-08-18 (all four messages; permalinks below).
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — CAS is now Cassy: same tool, new name everywhere you can see it, with a new boot splash to match.
+
+**Reply (Was → Now):**
+- Was: the terminal, Commander, pairing email, and docs all said CAS with a plain block logo at startup. Now: every visible surface says Cassy (new splash, rebranded Commander at hub.petrastella.io, redesigned pairing email); everything you type is unchanged.
+- Install: use `cas update` for an existing installation, or download the
+  vX.Y.Z archive for Linux x86_64 (SHA-256 `19c206e11514f7ef843c191f6b938e4ea9e820f90625489816316f41d1ce7901`) or macOS ARM64
+  (SHA-256 `f280316a048ce7676cc79605dde1ed0e96822ade31feea053326c98b07fff0ea`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v3.0.0: the Cassy rebrand is prose-only by construction — machine-facing names are test-pinned to cas — plus account-aware Codex spawn selection.
+
+**Reply (Was → Now):**
+- Was: CAS was both product name and protocol vocabulary with no enforced boundary; codex spawns with an explicit account dir silently fell back to Claude when ~/.codex was logged out. Now: user-facing strings say Cassy while mcp__cas__*/CAS_* env/.cas paths/cli verbs/envelopes/skill spellings stay cas (word-diff scans + re-pinned suites); the spawn probe/preflight inspect the account home actually used and name it in launch output.
+- Validation and artifact: Full Fast Validation suite green on the release merge (3/3 shards, doctests, test-compile guard, macOS check). The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `19c206e11514f7ef843c191f6b938e4ea9e820f90625489816316f41d1ce7901`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `f280316a048ce7676cc79605dde1ed0e96822ade31feea053326c98b07fff0ea`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-18 20:06:56Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787083616366829 |
+| User reply (Was → Now) | 2026-08-18 20:07:06Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787083626391609 |
+| Dev top-level | 2026-08-18 20:07:11Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787083631292699 |
+| Dev reply (Was → Now) | 2026-08-18 20:07:23Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787083643871389 |

--- a/docs/release-notes/2026-08-19-v3.2.0-slack.md
+++ b/docs/release-notes/2026-08-19-v3.2.0-slack.md
@@ -1,0 +1,53 @@
+# Slack draft — Cassy v3.2.0 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Cassy stopped taking anyone's word for it: unfinished work can't be marked done, silent test skips can't read as passing, and a worker that quietly dies now gets noticed instead of ignored.
+
+**Reply (Was → Now):**
+- Was: Work could slip through the cracks — a task could close before its code actually landed, a test command could report success without running anything, a helper on a second account could be declared dead while it was still working, and Viktor went silent after a restart. Now: Every close is checked against what actually shipped, every test run must prove it ran real tests, helpers on any account are tracked correctly, Viktor tells you loudly when he's unreachable and can now start conversations with Cassy himself — and merges to the main line go through an automatic queue that re-checks everything before it lands.
+- Install: use `cas update` for an existing installation, or download the
+  v3.2.0 archive for Linux x86_64 (SHA-256 `b98fbdef1c2fde5e085d8f6609fc2f9565b3eb5446fe3925d0dba37e4ecbf5cd`) or macOS ARM64
+  (SHA-256 `a8bff0b4ece72e9d8632c41a29310a8d0227fa7347a1e58a3ce013406c132089`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — Main is now merge-queue-gated with a minimal required set, the test path is wrapped in zero-execution-proof receipts, and a self-hosted 32-core lane is wired (queue-refs-only, fail-safe hosted fallback) to cut required-check latency.
+
+**Reply (Was → Now):**
+- Was: Close gates trusted lease-window attribution and full-context patch checks (false accepts/rejects both possible); cargo/nextest exit codes could green a zero-test run; sleep-state suspends left the box unreachable; branch creation could write unresolved refspecs into .git; Codex workers under named CODEX_HOMEs were reaped on stale heartbeats; Viktor state died with the daemon. Now: Delivery-proof gates use commit-identity attribution plus multiset containment for superset conflict resolutions; a receipt wrapper fails any harness-silent or zero-passed run across CI/Make/hooks/release scripts; the merge queue (single-entry ALLGREEN) revalidates merged trees with a 30-min check budget; branch creation resolves and post-verifies SHAs; worker liveness is dual-signal (heartbeat OR live identifiable process); Viktor watches are durable across restarts, absent upstreams alert loudly, and Viktor-originated threads route to a live session as inbox notifications; suite archive is 549MB stripped with second-scale shard downloads.
+- Validation and artifact: Every change landed through PR-gated required checks (Fast Validation rollup + macOS) with scoped nextest proofs and tier-contract mutation tests (382 assertions). The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `b98fbdef1c2fde5e085d8f6609fc2f9565b3eb5446fe3925d0dba37e4ecbf5cd`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `a8bff0b4ece72e9d8632c41a29310a8d0227fa7347a1e58a3ce013406c132089`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-19T17:25:45Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787160345998389 |
+| User reply (Was → Now) | 2026-08-19T17:26:01Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787160361109929 |
+| Dev top-level | 2026-08-19T17:26:10Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787160370833799 |
+| Dev reply (Was → Now) | 2026-08-19T17:26:28Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787160388508029 |

--- a/docs/release-notes/2026-08-19-v3.3.0-slack.md
+++ b/docs/release-notes/2026-08-19-v3.3.0-slack.md
@@ -1,0 +1,61 @@
+# Slack draft — Cassy v3.3.0 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Cloud sync is back for every longtime project — teams whose sync had silently stopped working now reconnect on their own, no setup commands needed.
+
+**Reply (Was → Now):**
+- Was: On many established projects, syncing with the team cloud failed on every attempt with a confusing error that blamed the server, and the documented fix command quietly did nothing — one project was cut off for two days. Now: Syncing just works again: Cassy now accepts the server's answer about which team project a checkout belongs to, remembers it, and completes the same sync it's in — and if you ever set a project id by hand, that choice is now respected exactly as typed.
+- Install: use `cas update` for an existing installation, or download the
+  v3.3.0 archive for Linux x86_64 (SHA-256 `e318de0fe833610bca7ce14a3f6a1fea367613237945620ebafdba91a0b6e189`) or macOS ARM64
+  (SHA-256 `23f7d3edd73a00fae2726c3cc2399c0dbc2b519456b2a7d5f7fc301988cb3c33`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — Team registration now adopts the server-resolved canonical_id from the push response and pins it mid-run; an explicit `[project] canonical_id` pin is authoritative again (PR #532).
+
+**Reply (Was → Now):**
+- Was: `ensure()` discarded the registration response body, re-looked-up the *sent* canonical id, and aborted the whole sync as a "server-side defect" whenever the server resolved the push onto an existing legacy bare-slug bucket via git-remote match; the legacy-slug reconcile also rewrote explicit pins back to remote form, so `cas cloud project set` was a silent no-op — deadlocking every pre-contract project (bucket slug == repo name) on any unpinned checkout. Now: `register()` returns the response's resolved canonical_id; `ensure()` verifies that id against `/projects` and returns `AdoptedExisting`; the caller pins it (`set_canonical_id_in_config_toml` + cache invalidation) so the same run's team push and pull hit the real bucket; the reconcile is gone and `should_adopt_canonical_id` never overrides an existing pin; divergence failures name the resolved id instead of blaming the server. Covered test-first, including an end-to-end wiremock sync asserting the registration POST uses the sent id and the same run's queued push + pull use the adopted id.
+- Validation and artifact: team_registration_test 11/11, cloud config suite 95/95 (independently re-run at review), plus live verification on two previously-failing projects — registration adopted and pinned the legacy bucket id and sync completed on the first run. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `e318de0fe833610bca7ce14a3f6a1fea367613237945620ebafdba91a0b6e189`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `23f7d3edd73a00fae2726c3cc2399c0dbc2b519456b2a7d5f7fc301988cb3c33`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-08-19 20:16:10 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787170570239589 |
+| User reply (Was → Now) | 2026-08-19 20:16:21 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787170581006049 |
+| Dev top-level | 2026-08-19 20:16:32 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787170592281179 |
+| Dev reply (Was → Now) | 2026-08-19 20:16:47 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787170607186239 |
+
+Publication note: assets published manually under explicit operator authorization
+(Daniel, 2026-08-19 "PUBLISH IT") from run 32293253311's green build artifacts
+(commit e9631b37, both platform jobs success) after the tag-push publisher was
+delayed twice: a hosted-runner apt hang (attempt 1) and a lightweight-tag
+preflight failure (attempt 2; tag recreated annotated). Redundant rerun
+32297319060 cancelled after publication. Receipt digests above are from
+`release-published-receipt.sh v3.3.0` against the published assets.

--- a/docs/release-notes/2026-08-20-burn-down-v21-slack.md
+++ b/docs/release-notes/2026-08-20-burn-down-v21-slack.md
@@ -1,0 +1,37 @@
+# 2026-08-20 — Burn-down v21 afternoon wave — Slack draft
+
+Channel: `#cas-internal` (`C0B44GUKDK2`)
+Covers main merges: PR #551, #552, #554–#565.
+
+## User thread
+
+**Top-level**
+
+> **Live on production — User**
+> Cassy's memory now speaks up when it knows something relevant, Viktor works with one pasted key, Macs install with one command — and eleven long-standing annoyances are gone in one afternoon.
+
+**Reply**
+
+> **Was:** Cassy could hold the exact answer you were rediscovering and stay silent about it; getting Viktor working needed hand-provisioning; Macs had to build from source; a helper whose work fell out of the merge line waited forever without telling anyone; the dashboard listed long-dead projects as live; and closing a big project could time out with no way to tell if it actually closed.
+> **Now:** stored knowledge surfaces on its own when your work matches it — and every silence is now explainable, not a mystery; `cas viktor key` plus a key from the operator is the whole Viktor setup; Macs on Apple Silicon install with the standard one-liner; dropped work announces itself immediately; the dashboard shows only genuinely live projects; and big closes come back in about a second with a clear receipt.
+
+## Dev thread
+
+**Top-level**
+
+> **Live on production — Dev**
+> Eleven issues closed in one wave: ambient recall reads tool traffic with per-turn decision traces, terminal task states are audit-trailed against LWW resurrection, merge-queue ejections push durable relays, and the fork-PR approval gate seals the self-hosted runner.
+
+**Reply**
+
+> **Was:** ambient recall's trigger read only prompt text and Write/Edit paths, silently starving on sessions whose signals lived in tool results (#553); cloud pull's LWW reconcile could flip Closed epics back to Open with no actor trail (#516); a PR ejected from the merge queue left its task in awaiting_merge forever; the docs-only CI short-circuit skipped the Rust tier for markdown compiled into the binary; installs rejected macOS; concurrent cas-updates reset the shared build worktree mid-build; worktree GC stranded 1900+ symlinks producing false-green jest runs; bare-/tmp writes were advisory-only; epic close rendered a 200KB narrative synchronously and timed out ambiguously at 55s.
+> **Now:** recall ingests bounded, redacted tool-traffic terms with source-attributed decision traces and a strong-signal injection floor (#560, #562); terminal status changes require an attributed reopen and unattributed remote reopens park in the conflict journal exactly once (#556); queue ejections push episode-keyed durable relays to supervisor and worker (#561); everything under cas-cli/src/ is rust-affecting with a mutation-proof guard (#563); cas-install.sh handles Apple Silicon with Gatekeeper quarantine clearing and the from-zero doc gets a binary fast path plus the documented team-membership flow (#564); cas-update takes an atomic holder-visible lock (#554); GC refuses removal when external symlinks resolve into the worktree (#555); a configured scratch root is PreToolUse-enforced with bare-/tmp denial preserved (#557); epic close is commit-then-respond with a compact receipt and timeout messages state whether the write landed (#565); Viktor is one `cas viktor key` away (#552, #559); org fork-PR approval covers all external contributors (#551); Commander panes derive epic liveness from task status (#558).
+
+## POSTED
+
+- UTC: 2026-08-20T16:55Z (all four messages)
+- Channel: `#cas-internal` (`C0B44GUKDK2`)
+- User top-level: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787244881332049 (`ts 1787244881.332049`)
+- User reply: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787244887911929
+- Dev top-level: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787244893101729 (`ts 1787244893.101729`)
+- Dev reply: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787244902264639

--- a/docs/release-notes/2026-08-20-installer-path-and-warm-queue-slack.md
+++ b/docs/release-notes/2026-08-20-installer-path-and-warm-queue-slack.md
@@ -1,0 +1,49 @@
+# 2026-08-20 — Installer PATH wiring + warm merge-queue lanes — Slack draft
+
+Channel: `#cas-internal` (`C0B44GUKDK2`)
+Covers main merges: PR #576, #577, #578.
+
+## User thread
+
+**Top-level**
+
+> **Live on production — User**
+> Installing Cassy now leaves you with a `cas` command that actually works in a brand-new terminal — and the installer tells the truth about whether it did.
+
+**Reply**
+
+> **Was → Now**
+> - *Was:* the one-line installer dropped `cas` into `~/.local/bin` and printed a generic "add this to your PATH" hint. On a fresh Mac (zsh) a new terminal still couldn't find `cas`, and anything launching Cassy without an interactive shell (for example an editor starting the MCP server) missed it entirely. The script said "installed successfully" regardless.
+>   *Now:* the installer figures out your real login shell and offers to wire the PATH line into the right file once, idempotently (zsh → `~/.zshenv` so non-interactive launches see it too; bash → `.bashrc` or `.profile`). Say no and it prints the exact line to paste. It then opens a fresh login shell and only reports success when `cas --version` really runs there — otherwise it says plainly that a new terminal can't run `cas` yet and shows the remedy.
+> - *Was:* a brand-new machine running bare `cas` with nothing set up dropped you into internal preflight output.
+>   *Now:* it prints one friendly line pointing at the command to get started (arrives with the next release build).
+> - *Was:* the v3.4.0 notes claimed the `.zshenv` wiring already existed.
+>   *Now:* it does — this is the change that makes that sentence true, and the notes were corrected in the meantime.
+
+## Dev thread
+
+**Top-level**
+
+> **Live on production — Dev**
+> `cas-install.sh` detects the login shell from `$SHELL`, wires a marker-guarded PATH block into `.zshenv`/`.bashrc`/`.profile` with tty consent or `CAS_WIRE_PATH=1|0`, and verifies in a fresh login shell from the pre-wiring PATH; merge-queue preflight and doctests now run on the trusted runner's persistent target dir (queue run 7m07s, down from 11–14 min cold).
+
+**Reply**
+
+> **Was → Now**
+> - *Was:* `scripts/cas-install.sh` only warned "`$INSTALL_DIR` is not in your PATH" and never touched an rc file; the success banner was unconditional. (PR #577)
+>   *Now:* `detect_login_shell`/`resolve_rc_file`/`append_path_guard`/`wire_path`: zsh → `${ZDOTDIR:-$HOME}/.zshenv` (interactive-only `.zshrc` misses MCP spawns), bash → `.bashrc` if present else `.profile`, other shells → print the line. The block is idempotent twice over — `# >>> cassy path >>>` markers stop a second append and the block itself is a `case ":$PATH:"` test. Consent opens `/dev/tty` (a real open, not `[ -r ]` — that was ENXIO-spraying under no controlling terminal); no tty + no override = no edit + exact line. `verify_install` runs `$SHELL -lc 'command -v cas'` under `env PATH="$ORIGINAL_PATH"` with `timeout 15`, so the check can't be self-confirmed by the installer's own exported PATH. Bash preamble rejects `| sh`. 8 new seam cases in `scripts/test-cas-install.sh` (fake login shells outside PATH) + 2 macOS cases; `cas-cli/src/cli/first_run.rs` adds `FRONT_DOOR_COMMAND` (`init` today) with a test asserting it resolves to a real clap subcommand. Docs: README, macbook-from-zero, CONTRIBUTING.
+> - *Was:* merge-queue runs executed on temporary `gh-readonly-queue/*` refs with no rust-cache on `refs/heads/main`, so hosted preflight (13m27s) and doctests (8m04s) started cold every time; sccache hit rates 0.79% / 5.56%. (PR #576)
+>   *Now:* `fast-validation-preflight` and `fast-validation-docs` route through the merge-queue runner selector onto the trusted box (persistent `CARGO_TARGET_DIR`, private sccache) under the same trust boundary as suite-build: `merge_group` only, canonical non-fork repo, `CASSY_MERGE_QUEUE_SELF_HOSTED=enabled`, queue-ref check at execution; hosted remains the fail-safe. `scripts/test-ci-test-tiers.sh` pins both routes; `docs/ci/self-hosted-runner-pilot.md` updated. First measured queue run: 7m07s (suite-build 1m28 → doctests 2m12 → preflight 2m26, serialized on the single runner slot — the remaining gap to <6 min).
+> - *Was:* the v3.4.1 fast-publication receipt lived only in the run logs. (PR #578)
+>   *Now:* `docs/release-notes/2026-08-20-v3.4.1-slack.md` records the posted announcement, the 166 s tag→publish latency receipt, and the hub-promotion N/A evidence.
+
+## POSTED
+
+Posted 2026-08-20 ~21:33 UTC to `#cas-internal` (`C0B44GUKDK2`):
+
+| Message | Permalink |
+|---|---|
+| User top-level | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787260790156429 |
+| User reply | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787260796916959?thread_ts=1787260790.156429&cid=C0B44GUKDK2 |
+| Dev top-level | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787260798321729 |
+| Dev reply | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787260809269979?thread_ts=1787260798.321729&cid=C0B44GUKDK2 |

--- a/docs/release-notes/2026-08-20-merge-queue-reliability-slack.md
+++ b/docs/release-notes/2026-08-20-merge-queue-reliability-slack.md
@@ -1,0 +1,37 @@
+# 2026-08-20 — Merge-queue reliability — Slack draft
+
+Channel: `#cas-internal` (`C0B44GUKDK2`)
+Covers main merges: PR #538, #539, #540, #541.
+
+## User thread
+
+**Top-level**
+
+> **Live on production — User**
+> Code changes now sail through the automatic merge queue and land on main in about ten minutes — no more merges stuck for hours or dying on infrastructure hiccups.
+
+**Reply**
+
+> **Was:** merging a change could stall for hours — the fast build machine kept rejecting its work at the last step, and stuck jobs quietly hogged the pipeline until someone noticed and cleared them by hand. Two release publications once sat unnoticed for almost two weeks.
+> **Now:** the queue validates and merges changes end-to-end on its own — the fast build machine's results are accepted every time, and two watchdogs automatically clear anything stuck or outdated within minutes instead of waiting for a human.
+
+## Dev thread
+
+**Top-level**
+
+> **Live on production — Dev**
+> The self-hosted merge-queue lane is green end-to-end: archive builds on the private runner now execute cleanly on hosted shard runners, and stale/superseded CI runs cancel themselves.
+
+**Reply**
+
+> **Was:** merge_group runs failed on a chain of cross-machine defects — a poisoned compiler-probe cache killed `cargo metadata`, the shared `CARGO_TARGET_DIR` broke CLI packaging, and producer paths baked into test binaries (nextest workspace, insta snapshot roots, `CARGO_BIN_EXE_*`/`CARGO_MANIFEST_DIR`) broke every hosted shard. Orphaned queue runs and superseded heavy-tier validations squatted on capacity for hours to days with no auto-cancel.
+> **Now:** the archive lane is fully portable — compiler wrapper cleared for queue builds, target-dir-aware packaging, `--workspace-remap`, `INSTA_WORKSPACE_ROOT`, and gated producer-path shims (#538); a flaky PTY test race is fixed (#539); the runner group policy, committed systemd provisioning (`SCCACHE_IDLE_TIMEOUT=0`, `CARGO_CACHE_RUSTC_INFO=0`), and a 5-minute merge-queue watchdog are durable (#540); heavy-tier lanes carry per-ref concurrency cancellation and a second watchdog reclaims non-queue runs stuck in queued (#541). Receipts: queue claim 8s, archive build 88s, PR open→merged 11m50s.
+
+## POSTED
+
+- UTC: 2026-08-20T12:27Z (all four messages)
+- Channel: `#cas-internal` (`C0B44GUKDK2`)
+- User top-level: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787228842949429 (`ts 1787228842.949429`)
+- User reply: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787228847501989
+- Dev top-level: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787228851364689 (`ts 1787228851.364689`)
+- Dev reply: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787228858940029

--- a/docs/release-notes/2026-08-20-second-runner-slot-slack.md
+++ b/docs/release-notes/2026-08-20-second-runner-slot-slack.md
@@ -1,0 +1,45 @@
+# 2026-08-20 — Second trusted runner slot for the merge queue — Slack draft
+
+Channel: `#cas-internal` (`C0B44GUKDK2`)
+Covers main merges: PR #580, #581, #582.
+
+## User thread
+
+**Top-level**
+
+> **Live on production — User**
+> The merge queue's Linux checks no longer wait in a single-file line: a second build slot runs them side by side, and the honest numbers say the remaining wait is the Mac check, not Linux.
+
+**Reply**
+
+> **Was → Now**
+> - *Was:* the private Linux build box had one listener, so the three compile-heavy merge-queue jobs ran one after another (about six minutes of pure queueing on the box).
+>   *Now:* two independent listeners on the same box, each with its own build cache, so two of those jobs start together and the third waits for at most one. In the second measured run every Linux build job was finished 3 minutes 15 seconds after the run started.
+> - *Was:* the plan said "under six minutes end to end" without evidence either way.
+>   *Now:* measured and written down: whole-queue times were 7m54 and 7m39 for the two runs, and in both the last thing to finish was the hosted Mac check (7m37 / 7m22). The six-minute target is not met yet, and the docs say so plainly — the next lever is the Mac lane, not more Linux capacity.
+
+## Dev thread
+
+**Top-level**
+
+> **Live on production — Dev**
+> `soundwave-cas-ci-2` is registered as a second org-level listener with its own Cargo target, sccache dir and port; every trusted self-hosted lane now fail-closes on an exact slot tuple, and two consecutive queue receipts (7m54, 7m39) pin hosted macOS as the critical path.
+
+**Reply**
+
+> **Was → Now**
+> - *Was:* one `cassy-actions-runner.service` listener; the merge-queue trust steps checked `CARGO_TARGET_DIR`/`SCCACHE_DIR` prefixes and `SCCACHE_SERVER_PORT=4227` independently, so a mixed configuration could have shared a Cargo lock or cache server unnoticed. (PR #580)
+>   *Now:* `scripts/install-cassy-actions-runner.sh` takes `RUNNER_SLOT=1|2` (explicit per-slot name, checkout, target, sccache dir, unit and wrapper; anything else rejected); `ops/systemd/cassy-actions-runner-2.service` mirrors slot 1's hardening (non-root, `NoNewPrivileges`, `ProtectSystem=strict`, empty capability set, `nice 10`, `CARGO_BUILD_JOBS=12`, `TasksMax=2048`) on `cargo-target-2` / `sccache-2` / port 4228. New `scripts/check-cassy-actions-runner-isolation.sh` accepts only the two exact target/cache/port tuples plus non-root; the merge-queue suite-build/preflight/doctests trust steps, the self-hosted pilot workflow and `check-release-runner-trust.sh` all delegate to it (fail-closed), while the fail-open sccache probe no longer owns the decision. `scripts/test-ci-test-tiers.sh` (632) and `test-check-release-runner-trust.sh` (13, incl. mixed-tuple rejection) pin it.
+> - *Was:* no receipts for a two-listener queue. (PR #581, #582)
+>   *Now:* `docs/ci/self-hosted-runner-pilot.md` records both consecutive runs with per-job runner names: #580 — archive 1m38 (slot 1) ∥ preflight 3m36 (slot 2, cold), doctests 1m21 (slot 1), Linux Fast Validation 4m02, macOS 7m37, total 7m54; #581 — archive 3m00 (slot 2) ∥ doctests 1m22 (slot 1), preflight 1m31 (slot 1), all self-hosted jobs done at +3m15, hosted shards stretched the Linux rollup to 6m12, macOS 7m22, total 7m39. Option B (hosted cache-warm on main push) was evaluated against the #568 numbers and rejected as cache-dependent and blind to macOS variance. Target not met; floor and critical path recorded honestly.
+
+## POSTED
+
+Posted 2026-08-20 ~22:02 UTC to `#cas-internal` (`C0B44GUKDK2`):
+
+| Message | Permalink |
+|---|---|
+| User top-level | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787263330320019 |
+| User reply | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787263336213909?thread_ts=1787263330.320019&cid=C0B44GUKDK2 |
+| Dev top-level | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787263337241789 |
+| Dev reply | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787263347561769?thread_ts=1787263337.241789&cid=C0B44GUKDK2 |

--- a/docs/release-notes/2026-08-20-sub-5-minute-merges-slack.md
+++ b/docs/release-notes/2026-08-20-sub-5-minute-merges-slack.md
@@ -1,0 +1,37 @@
+# 2026-08-20 — Sub-5-minute merges — Slack draft
+
+Channel: `#cas-internal` (`C0B44GUKDK2`)
+Covers main merges: PR #542, #543, #544, #545, #547, #548, #550.
+
+## User thread
+
+**Top-level**
+
+> **Live on production — User**
+> A code change now goes from "submitted" to "live on main" in under five minutes — measured today at 4 minutes 58 seconds, down from over twenty.
+
+**Reply**
+
+> **Was:** getting a change onto main took over twenty minutes on a good day — every submission re-ran heavy duplicate checks before it could even enter the merge line, and a stuck helper could silently stall the whole team.
+> **Now:** submission checks pass in seconds, the merge line does the full validation once on fast machines, and a real change measured 4m58 from opened to merged. Stopped or stuck helpers now always raise their hand automatically instead of going quiet.
+
+## Dev thread
+
+**Top-level**
+
+> **Live on production — Dev**
+> Open→merged for a rust-touched PR measured 4m58 (queue-created→merged 4m27): PR admissions collapsed to 3–4s, archive builds run 51s on the self-hosted box, and archived test binaries are now fully runtime-path-portable with the consumer shim deleted.
+
+**Reply**
+
+> **Was:** PR admission cost a duplicate ~6m macOS compile before queue entry (#544 baseline: 5m58 queue-only, 58s over target); archived test binaries baked producer paths (`CARGO_BIN_EXE_*`, `CARGO_MANIFEST_DIR`, insta roots, `assert_cmd::cargo_bin`) that broke hosted shards, papered over by consumer symlinks; worker stoppage classes (silent delivery stalls, usage-limited harnesses with live heartbeats) never reached a durable supervisor alert; watchdog scripts were text-asserted only and defaulted to production; sccache died with EAGAIN under parallel load (cgroup TasksMax=512).
+> **Now:** required macOS/Fast Validation on PR heads are short admission receipts with full coverage retained on every merge-group tree (#544); every archive consumer resolves paths at runtime via a workspace-walking resolver and the CI shim is deleted, proven by a producer-target-renamed cross-directory run plus a green queue run (#550); worker stoppage relays are durable, ACK-bridged, persistence-confirmed, and episode-stable (#542, #547); both watchdogs share one threshold authority with a fake-gh behavioral suite, explicit-repo guard, dry-run, and job-scoped measurement (#545); tier-contract assertions are step-scoped with mutation coverage (#543); the runner unit reserves 2,048 cgroup task slots, fixing the measured sccache spawn failure (#548).
+
+## POSTED
+
+- UTC: 2026-08-20T14:18Z (all four messages)
+- Channel: `#cas-internal` (`C0B44GUKDK2`)
+- User top-level: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787235491398239 (`ts 1787235491.398239`)
+- User reply: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787235497538219
+- Dev top-level: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787235501956039 (`ts 1787235501.956039`)
+- Dev reply: https://petra-stella.slack.com/archives/C0B44GUKDK2/p1787235510085589


### PR DESCRIPTION
## Outcome

Adds the eight already-posted release-note drafts to the searchable repository record, byte-identical to their staged artifacts.

- eight additive-only Markdown files
- exactly one POSTED receipt block per file
- no Slack messages sent by this PR

Task: cas-cf57