### PR TITLE
ci(cas-c01e): install path proof — real execution on hosted macOS ARM + clean Linux

### DIFF
--- a/.github/workflows/install-path-proof.yml
+++ b/.github/workflows/install-path-proof.yml
@@ -1,0 +1,231 @@
+name: Install path proof
+
+# This is an advisory, post-publication proof of the journey a new user takes.
+# It waits for `release.published` rather than racing the release publisher on
+# the tag push, so CAS_VERSION names assets that are already downloadable.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Published release tag to install (blank means latest)
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: install-path-proof-${{ github.event.release.tag_name || inputs.version || github.run_id }}
+  cancel-in-progress: false
+
+env:
+  INSTALLER_REPOSITORY: ${{ github.repository }}
+  INSTALLER_VERSION: ${{ inputs.version || github.event.release.tag_name }}
+
+jobs:
+  macos:
+    name: Install path proof — macOS Apple Silicon
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - name: Run the published install path
+        shell: bash
+        env:
+          PROOF_TRANSCRIPT: ${{ github.workspace }}/install-path-proof-macos.log
+        run: |
+          set -Eeuo pipefail
+
+          proof_home="$RUNNER_TEMP/cassy-install-proof-home"
+          rm -rf -- "$proof_home"
+          mkdir -p -- "$proof_home"
+          export HOME="$proof_home"
+          : >"$PROOF_TRANSCRIPT"
+          exec > >(tee -a "$PROOF_TRANSCRIPT") 2>&1
+
+          echo "Install path proof: macOS hosted runner"
+          echo "Repository: $INSTALLER_REPOSITORY"
+          echo "Requested release: ${INSTALLER_VERSION:-latest}"
+          test "$(uname -s)" = Darwin
+          test "$(uname -m)" = arm64
+          command -v xattr >/dev/null
+          original_path="$PATH"
+
+          release_version="$INSTALLER_VERSION"
+          if [[ -n "$release_version" ]]; then
+            case "$release_version" in
+              v[0-9]*) ;;
+              *) echo "Release version must be a v<semver> tag: $release_version" >&2; exit 1 ;;
+            esac
+            installer_url="https://raw.githubusercontent.com/$INSTALLER_REPOSITORY/$release_version/scripts/cas-install.sh"
+          else
+            installer_url="https://raw.githubusercontent.com/$INSTALLER_REPOSITORY/main/scripts/cas-install.sh"
+          fi
+
+          installer_env=(
+            "CAS_INSTALL_DIR=$HOME/.local/bin"
+            'CAS_WIRE_PATH=1'
+            "CAS_REPO=$INSTALLER_REPOSITORY"
+            'SHELL=/bin/zsh'
+          )
+          if [[ -n "$release_version" ]]; then
+            installer_env+=("CAS_VERSION=$release_version")
+          fi
+
+          echo "Installer: $installer_url"
+          echo 'Command shape: curl ... cas-install.sh | bash'
+          installer_output="$(
+            curl --fail --silent --show-error --location --retry 3 "$installer_url" \
+              | env "${installer_env[@]}" bash
+          )"
+          printf '%s\n' "$installer_output"
+
+          echo 'Checking the installer success contract.'
+          grep -qF 'Cassy installed successfully!' <<<"$installer_output"
+          grep -qF 'A new terminal can run `cas`.' <<<"$installer_output"
+
+          echo 'Checking a fresh zsh login shell from the pre-install PATH.'
+          fresh_login_output="$(
+            env HOME="$HOME" PATH="$original_path" SHELL=/bin/zsh \
+              /bin/zsh -lc 'set -e; command -v cas; cas --version'
+          )"
+          printf '%s\n' "$fresh_login_output"
+          test "$(printf '%s\n' "$fresh_login_output" | head -n 1)" = "$HOME/.local/bin/cas"
+          grep -qF 'cas ' <<<"$fresh_login_output"
+
+          echo 'Checking the post-install quarantine state without manual clearing.'
+          if xattr -p com.apple.quarantine "$HOME/.local/bin/cas" >/dev/null 2>&1; then
+            echo 'The installed binary still has com.apple.quarantine.' >&2
+            exit 1
+          fi
+          echo 'No com.apple.quarantine attribute remains; executing the installed binary.'
+
+          echo 'Checking bare cas and cas doctor in a fresh login shell.'
+          fresh_commands_output="$(
+            env HOME="$HOME" PATH="$original_path" SHELL=/bin/zsh \
+              /bin/zsh -lc 'set -e; cas; cas doctor'
+          )"
+          printf '%s\n' "$fresh_commands_output"
+          grep -qF 'Welcome to Cassy. Run `cas init` in a project directory to get started.' \
+            <<<"$fresh_commands_output"
+          grep -qF "Not found. Run 'cas init'" <<<"$fresh_commands_output"
+
+          echo 'PASS: macOS Apple Silicon install path, fresh shell, quarantine, bare cas, and doctor verified.'
+
+      - name: Upload macOS install proof transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-path-proof-macos-${{ github.run_id }}
+          path: ${{ github.workspace }}/install-path-proof-macos.log
+          if-no-files-found: error
+          retention-days: 90
+
+  linux:
+    name: Install path proof — clean Linux container
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ubuntu:24.04
+      options: --user root
+    env:
+      PROOF_TRANSCRIPT: ${{ github.workspace }}/install-path-proof-linux.log
+    steps:
+      - name: Install only the runtime prerequisites
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          : >"$PROOF_TRANSCRIPT"
+          exec > >(tee -a "$PROOF_TRANSCRIPT") 2>&1
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            bash ca-certificates coreutils curl grep tar
+          rm -rf -- /var/lib/apt/lists/*
+          if command -v rustc >/dev/null 2>&1; then
+            echo 'The proof container unexpectedly includes Rust.' >&2
+            exit 1
+          fi
+          echo 'Clean Linux proof container has no preinstalled rustc.'
+
+      - name: Run the published install path
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          proof_home="$RUNNER_TEMP/cassy-install-proof-home"
+          rm -rf -- "$proof_home"
+          mkdir -p -- "$proof_home"
+          export HOME="$proof_home"
+          exec > >(tee -a "$PROOF_TRANSCRIPT") 2>&1
+
+          echo "Install path proof: clean Linux container"
+          echo "Repository: $INSTALLER_REPOSITORY"
+          echo "Requested release: ${INSTALLER_VERSION:-latest}"
+          test "$(uname -s)" = Linux
+          test "$(uname -m)" = x86_64
+          original_path="$PATH"
+
+          release_version="$INSTALLER_VERSION"
+          if [[ -n "$release_version" ]]; then
+            case "$release_version" in
+              v[0-9]*) ;;
+              *) echo "Release version must be a v<semver> tag: $release_version" >&2; exit 1 ;;
+            esac
+            installer_url="https://raw.githubusercontent.com/$INSTALLER_REPOSITORY/$release_version/scripts/cas-install.sh"
+          else
+            installer_url="https://raw.githubusercontent.com/$INSTALLER_REPOSITORY/main/scripts/cas-install.sh"
+          fi
+
+          installer_env=(
+            "CAS_INSTALL_DIR=$HOME/.local/bin"
+            'CAS_WIRE_PATH=1'
+            "CAS_REPO=$INSTALLER_REPOSITORY"
+            'SHELL=/bin/bash'
+          )
+          if [[ -n "$release_version" ]]; then
+            installer_env+=("CAS_VERSION=$release_version")
+          fi
+
+          echo "Installer: $installer_url"
+          echo 'Command shape: curl ... cas-install.sh | bash'
+          installer_output="$(
+            curl --fail --silent --show-error --location --retry 3 "$installer_url" \
+              | env "${installer_env[@]}" bash
+          )"
+          printf '%s\n' "$installer_output"
+
+          echo 'Checking the installer success contract.'
+          grep -qF 'Cassy installed successfully!' <<<"$installer_output"
+          grep -qF 'A new terminal can run `cas`.' <<<"$installer_output"
+
+          echo 'Checking a fresh bash login shell from the pre-install PATH.'
+          fresh_login_output="$(
+            env HOME="$HOME" PATH="$original_path" SHELL=/bin/bash \
+              /bin/bash -lc 'set -e; command -v cas; cas --version'
+          )"
+          printf '%s\n' "$fresh_login_output"
+          test "$(printf '%s\n' "$fresh_login_output" | head -n 1)" = "$HOME/.local/bin/cas"
+          grep -qF 'cas ' <<<"$fresh_login_output"
+
+          echo 'Checking bare cas and cas doctor in a fresh login shell.'
+          fresh_commands_output="$(
+            env HOME="$HOME" PATH="$original_path" SHELL=/bin/bash \
+              /bin/bash -lc 'set -e; cas; cas doctor'
+          )"
+          printf '%s\n' "$fresh_commands_output"
+          grep -qF 'Welcome to Cassy. Run `cas init` in a project directory to get started.' \
+            <<<"$fresh_commands_output"
+          grep -qF "Not found. Run 'cas init'" <<<"$fresh_commands_output"
+
+          echo 'PASS: clean Linux install path, fresh shell, bare cas, and doctor verified.'
+
+      - name: Upload Linux install proof transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-path-proof-linux-${{ github.run_id }}
+          path: ${{ github.workspace }}/install-path-proof-linux.log
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/RELEASE_SLACK_RUBRIC.md
+++ b/docs/RELEASE_SLACK_RUBRIC.md
@@ -184,6 +184,12 @@ compatibility snapshot. Neither includes factory plumbing or ticket IDs.
   `release-published-receipt.sh --write-draft` succeeded from fresh downloads
   before any digest enters the draft (a local audit archive is not
   shipped-byte evidence)
+- [ ] The advisory `Install path proof` workflow is green for the release on
+  hosted macOS Apple Silicon and a clean Linux container; retain the run URL
+  and both transcript artifacts before claiming that installation works.
+- [ ] Hosted install proof is supplemented by the manual consumer-Mac
+  Gatekeeper checklist in [the install-proof guide](ci/install-path-proof.md);
+  its GUI/SIP limits are not silently presented as covered by CI.
 - [ ] Post 1 (user): punch (was→now) + plain-language details
 - [ ] Post 2 (dev): punch (was→now) + technical details
 - [ ] Both: zero ticket numbers, zero internal-agent narration

--- a/docs/ci/install-path-proof.md
+++ b/docs/ci/install-path-proof.md
@@ -1,0 +1,60 @@
+# Install path proof
+
+The install proof is the executable release check for the user journey behind
+the one-line installer. It is advisory: a green run is required before release
+copy claims that installation works, but it is not a required branch-protection
+check until the operator explicitly promotes it.
+
+## When it runs
+
+`.github/workflows/install-path-proof.yml` runs after every GitHub Release is
+published (`release.published`). Waiting for publication matters: a tag push can
+start before the release publisher has uploaded the two archives, while this
+event guarantees that `CAS_VERSION` points at downloadable release assets.
+
+It is also dispatchable for a historical or current release:
+
+```bash
+gh workflow run install-path-proof.yml --repo Richards-LLC/cassy -f version=v3.4.1
+```
+
+Leave `version` blank to exercise the installer’s normal latest-release lookup.
+The release event and a versioned manual run fetch `cas-install.sh` from the
+same tag being tested, then pass `CAS_VERSION` so the archive cannot silently
+come from a different release.
+
+## What the receipt proves
+
+Both jobs upload a transcript artifact, even when their assertions fail.
+
+- **macOS:** `macos-latest` must report `Darwin` and `arm64`. The real
+  published installer runs with a clean HOME, wires `.zshenv` without a tty,
+  proves `cas --version` through a fresh zsh login shell, checks that the
+  installed binary has no `com.apple.quarantine` attribute, and runs bare
+  `cas` plus `cas doctor` from another fresh login shell.
+- **Linux:** `ubuntu-latest` runs an `ubuntu:24.04` container with only bash,
+  curl, certificates, coreutils, grep, and tar installed. The job asserts that
+  `rustc` is absent, then performs the same clean-HOME install and fresh bash
+  login-shell checks.
+
+The transcript greps the plain-language contracts as well as checking exit
+codes: `Cassy installed successfully!`, `A new terminal can run \`cas\`.`, the
+fresh-machine `Welcome to Cassy. Run \`cas init\`...` hint, and the doctor
+message that says to run `cas init`.
+
+## Release checklist and honest limits
+
+Before announcing that a release is installable, retain the workflow URL and
+both uploaded transcripts in the release record. The run must be green on both
+jobs. Unit fixtures (`scripts/test-cas-install.sh`) and a successful archive
+build are useful supporting checks, but are not substitutes for this receipt.
+
+The hosted macOS job proves the scriptable quarantine surface: the binary that
+the installer leaves behind executes without a manual `xattr -d` step. Hosted
+runners do not reproduce every consumer Mac condition, including Finder's GUI
+Gatekeeper prompt, the exact SIP configuration, or a user's local security
+policy. A real-Mac manual checklist item remains: on a consumer Apple Silicon
+Mac, run the published one-liner, record whether the first launch presents a
+Gatekeeper dialog, and confirm that `cas --version`, bare `cas`, and `cas doctor`
+work in a new terminal. That manual observation supplements rather than
+replaces the two hosted transcripts.

--- a/docs/ci/release-fast-publication.md
+++ b/docs/ci/release-fast-publication.md
@@ -145,7 +145,11 @@ worth knowing before enabling it:
 3. Push the tag (`scripts/release.sh --publish-tag`). The script reports the
    same thing one last time before it pushes, so a tag is never pushed blind
    into a 15-minute path by accident.
-4. Run both receipts once the release is published.
+4. Run the published-asset receipts once the release is published, then wait
+   for the advisory `Install path proof` workflow to finish green on macOS ARM
+   and clean Linux before calling the release installable. Its transcript and
+   manual consumer-Mac limitation are documented in
+   [Install path proof](install-path-proof.md).
 
 Pushing the tag before the prebuild finishes is safe — it just costs the old
 tag-time build. Nothing breaks; the release is simply slow.


### PR DESCRIPTION
Advisory 'Install path proof' workflow: runs on release.published and via workflow_dispatch. macOS Apple Silicon hosted runner + clean ubuntu:24.04 container (no preinstalled rust) run the REAL published install path (curl ... cas-install.sh | bash) in a clean HOME, verify cas --version from a fresh login shell, quarantine state, bare cas + cas doctor, and grep the plain-language contracts. Both jobs upload transcript artifacts. Release checklist updated to demand the receipt before claiming installability; honest hosted-runner limits documented with a manual consumer-Mac Gatekeeper checklist item.

Local proof: scripts/test-cas-install.sh 10 cases PASS; bash -n, git diff --check, YAML parse clean. Live dispatch receipt to be recorded on the task after this lands on main (workflow must exist on default branch to dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)