### PR TITLE
GitHub issue burn-down v22: delivery reliability, gate honesty, hook containment, Slack transport (GH #571, #579, #584, #586-#590)

### DIFF
--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -3158,6 +3158,10 @@ This is the body content."#;
                 "cas-2327",
                 "reverse states",
                 "release-notes impact",
+                "Release-note transport handoff",
+                "do not spend a turn searching for one",
+                "supervisor-owned posting",
+                "returned receipt",
             ] {
                 assert!(content.contains(required), "{label} surface checklist missing {required:?}");
             }
@@ -3833,6 +3837,10 @@ This is the body content."#;
                 "Staging",
                 "## POSTED",
                 "UTC timestamp",
+                "Step 1a — preflight and worker ownership",
+                "supervisor-owned",
+                "designed handoff",
+                "timestamps/permalinks",
             ] {
                 assert!(
                     skill.content.contains(required),

--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -3138,6 +3138,9 @@ This is the body content."#;
 
     /// cas-641f: workers must walk the repository's cross-surface blast
     /// radius before close, rather than proving only the path they changed.
+    /// Release-note transport ownership is detailed in the on-demand
+    /// release-notes skill; keeping it out of the protected worker core
+    /// preserves the SessionStart hard-limit margin.
     #[test]
     fn test_worker_skills_require_cas_src_surface_checklist() {
         for (label, content) in [
@@ -3158,10 +3161,6 @@ This is the body content."#;
                 "cas-2327",
                 "reverse states",
                 "release-notes impact",
-                "Release-note transport handoff",
-                "do not spend a turn searching for one",
-                "supervisor-owned posting",
-                "returned receipt",
             ] {
                 assert!(content.contains(required), "{label} surface checklist missing {required:?}");
             }

--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -28,6 +28,22 @@ You execute tasks assigned by the Supervisor. You may be working in an isolated 
    - **MERGE REQUIRED:** run the [close-gate freshness handshake](cas-worker/references/close-gate.md), including `inbox_poll` for unread supervisor messages, before any corrective commit; if a merge is still needed, send the current factory-branch tip SHA. Never bypass with `status=closed`.
    - **task-scoped verification:** forward the exact guidance once and trust the DB.
 
+## Release-note transport handoff
+
+When the project has a release-notes rubric and your assigned work reaches a
+staging or main merge:
+
+- Check whether this worker session exposes a sanctioned Slack transport. If it
+  does not, do not spend a turn searching for one.
+- Save the exact release-note draft and hand the supervisor its path, target
+  channel, deploy target, and request for returned timestamps/permalinks.
+- Treat supervisor-owned posting as the designed path for workers without
+  Slack, not as a failed fallback. Do not claim `POSTED` or invent receipts.
+- Add the returned receipt to the saved draft before closing the release task.
+
+If no approved transport passes preflight, leave the draft saved and report the
+duty blocked with the measured error.
+
 ## Task Types
 
 - **Spike** — record its decision with `note_type=decision`; its criteria are question-based.

--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -28,22 +28,6 @@ You execute tasks assigned by the Supervisor. You may be working in an isolated 
    - **MERGE REQUIRED:** run the [close-gate freshness handshake](cas-worker/references/close-gate.md), including `inbox_poll` for unread supervisor messages, before any corrective commit; if a merge is still needed, send the current factory-branch tip SHA. Never bypass with `status=closed`.
    - **task-scoped verification:** forward the exact guidance once and trust the DB.
 
-## Release-note transport handoff
-
-When the project has a release-notes rubric and your assigned work reaches a
-staging or main merge:
-
-- Check whether this worker session exposes a sanctioned Slack transport. If it
-  does not, do not spend a turn searching for one.
-- Save the exact release-note draft and hand the supervisor its path, target
-  channel, deploy target, and request for returned timestamps/permalinks.
-- Treat supervisor-owned posting as the designed path for workers without
-  Slack, not as a failed fallback. Do not claim `POSTED` or invent receipts.
-- Add the returned receipt to the saved draft before closing the release task.
-
-If no approved transport passes preflight, leave the draft saved and report the
-duty blocked with the measured error.
-
 ## Task Types
 
 - **Spike** — record its decision with `note_type=decision`; its criteria are question-based.

--- a/cas-cli/src/builtins/codex/skills/cli-routing/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cli-routing/SKILL.md
@@ -36,9 +36,9 @@ Every merge to `main` or `staging` needs the existing
 project-local. For the actual Slack transport, follow
 [`docs/SLACK_POSTING_RUNBOOK.md`](../../../../../docs/SLACK_POSTING_RUNBOOK.md):
 write exact bodies to a separator-delimited file, read the channel to dedupe,
-then post and retain returned timestamps as receipts. That flow uses this
-skill's Codex-first router; Claude Slack MCP is allowed only on the eligible
-current profile.
+then post and retain returned timestamps as receipts. For cas-src, use the
+approved Claude Slack MCP route after its account/server preflight; use the
+Codex Slack plugin only when the current session's resource probe is positive.
 
 ## Do not trigger
 

--- a/cas-cli/src/builtins/codex/skills/cli-routing/references/routing.md
+++ b/cas-cli/src/builtins/codex/skills/cli-routing/references/routing.md
@@ -93,8 +93,10 @@ for content. The operational sequence is:
 1. Write the exact user and dev bodies to a file with `=== MESSAGE N ===`
    separators; keep the headers out of the sent text.
 2. Read the target channel first to deduplicate a previous or partial attempt.
-3. Use the Codex `codex_apps` Slack plugin through the Codex-first route; use
-   Claude Slack MCP only if the already-gated current profile authorizes it.
+3. Use the approved Claude Slack MCP route after the account/server preflight.
+   Use the Codex `codex_apps` Slack plugin only when the current session's
+   resource probe is positive; default Codex workers must use the supervisor
+   handoff in the project runbook when it is absent.
 4. Post the two top-level messages and required replies in rubric order, then
    record the returned message timestamps as receipts.
 

--- a/cas-cli/src/builtins/codex/skills/release-notes/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/release-notes/SKILL.md
@@ -15,6 +15,20 @@ Check for `docs/release-notes/RUBRIC.md`.
 - **Missing:** copy the canonical template from this skill's `references/RUBRIC-template.md` to `docs/release-notes/RUBRIC.md`, then fill the placeholders: the project's Slack **channel name + channel ID**, and the branch → deploy-target mapping (which branch means `Staging`, which means `Live on production`). Leave the rules verbatim — they are the framework-level contract, not per-project taste.
 - **Present:** read it. A project-local rubric may add rules (extra threads, a diary workflow, a different channel); it must never relax the hard rules below.
 
+## Step 1a — preflight and worker ownership
+
+Run the transport preflight in `docs/SLACK_POSTING_RUNBOOK.md` before attempting
+to post. For cas-src, the canonical route is the supervisor-owned
+`claude.ai Slack` MCP on the approved `pippenz@gmail.com` profile. A connected
+server listing is not a posting receipt; the read-only preflight must succeed.
+
+Default Codex workers do not have a Slack transport. When the worker reaches
+this duty, it saves the exact draft and hands the supervisor the draft path,
+target channel, deploy target, and receipt request. The supervisor posts through
+the canonical route and returns timestamps/permalinks for the worker to record.
+This is a designed handoff, not a failed fallback. If preflight fails, stop
+after saving the draft and report the measured error; do not claim `POSTED`.
+
 ## Step 2 — gather the merge
 
 ```bash

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -28,6 +28,22 @@ You execute tasks assigned by the Supervisor. You may be working in an isolated 
    - **MERGE REQUIRED:** run the [close-gate freshness handshake](cas-worker/references/close-gate.md), including `inbox_poll` for unread supervisor messages, before any corrective commit; if a merge is still needed, send the current factory-branch tip SHA. Never bypass with `status=closed`.
    - **task-scoped verification:** forward the exact guidance once and trust the DB.
 
+## Release-note transport handoff
+
+When the project has a release-notes rubric and your assigned work reaches a
+staging or main merge:
+
+- Check whether this worker session exposes a sanctioned Slack transport. If it
+  does not, do not spend a turn searching for one.
+- Save the exact release-note draft and hand the supervisor its path, target
+  channel, deploy target, and request for returned timestamps/permalinks.
+- Treat supervisor-owned posting as the designed path for workers without
+  Slack, not as a failed fallback. Do not claim `POSTED` or invent receipts.
+- Add the returned receipt to the saved draft before closing the release task.
+
+If no approved transport passes preflight, leave the draft saved and report the
+duty blocked with the measured error.
+
 ## Task Types
 
 - **Spike** — record its decision with `note_type=decision`; its criteria are question-based.

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -28,22 +28,6 @@ You execute tasks assigned by the Supervisor. You may be working in an isolated 
    - **MERGE REQUIRED:** run the [close-gate freshness handshake](cas-worker/references/close-gate.md), including `inbox_poll` for unread supervisor messages, before any corrective commit; if a merge is still needed, send the current factory-branch tip SHA. Never bypass with `status=closed`.
    - **task-scoped verification:** forward the exact guidance once and trust the DB.
 
-## Release-note transport handoff
-
-When the project has a release-notes rubric and your assigned work reaches a
-staging or main merge:
-
-- Check whether this worker session exposes a sanctioned Slack transport. If it
-  does not, do not spend a turn searching for one.
-- Save the exact release-note draft and hand the supervisor its path, target
-  channel, deploy target, and request for returned timestamps/permalinks.
-- Treat supervisor-owned posting as the designed path for workers without
-  Slack, not as a failed fallback. Do not claim `POSTED` or invent receipts.
-- Add the returned receipt to the saved draft before closing the release task.
-
-If no approved transport passes preflight, leave the draft saved and report the
-duty blocked with the measured error.
-
 ## Task Types
 
 - **Spike** — record its decision with `note_type=decision`; its criteria are question-based.

--- a/cas-cli/src/builtins/grok/skills/cli-routing/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cli-routing/SKILL.md
@@ -36,9 +36,9 @@ Every merge to `main` or `staging` needs the existing
 project-local. For the actual Slack transport, follow
 [`docs/SLACK_POSTING_RUNBOOK.md`](../../../../../docs/SLACK_POSTING_RUNBOOK.md):
 write exact bodies to a separator-delimited file, read the channel to dedupe,
-then post and retain returned timestamps as receipts. That flow uses this
-skill's Codex-first router; Claude Slack MCP is allowed only on the eligible
-current profile.
+then post and retain returned timestamps as receipts. For cas-src, use the
+approved Claude Slack MCP route after its account/server preflight; use the
+Codex Slack plugin only when the current session's resource probe is positive.
 
 ## Do not trigger
 

--- a/cas-cli/src/builtins/grok/skills/cli-routing/references/routing.md
+++ b/cas-cli/src/builtins/grok/skills/cli-routing/references/routing.md
@@ -93,8 +93,10 @@ for content. The operational sequence is:
 1. Write the exact user and dev bodies to a file with `=== MESSAGE N ===`
    separators; keep the headers out of the sent text.
 2. Read the target channel first to deduplicate a previous or partial attempt.
-3. Use the Codex `codex_apps` Slack plugin through the Codex-first route; use
-   Claude Slack MCP only if the already-gated current profile authorizes it.
+3. Use the approved Claude Slack MCP route after the account/server preflight.
+   Use the Codex `codex_apps` Slack plugin only when the current session's
+   resource probe is positive; default Codex workers must use the supervisor
+   handoff in the project runbook when it is absent.
 4. Post the two top-level messages and required replies in rubric order, then
    record the returned message timestamps as receipts.
 

--- a/cas-cli/src/builtins/grok/skills/release-notes/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/release-notes/SKILL.md
@@ -15,6 +15,20 @@ Check for `docs/release-notes/RUBRIC.md`.
 - **Missing:** copy the canonical template from this skill's `references/RUBRIC-template.md` to `docs/release-notes/RUBRIC.md`, then fill the placeholders: the project's Slack **channel name + channel ID**, and the branch → deploy-target mapping (which branch means `Staging`, which means `Live on production`). Leave the rules verbatim — they are the framework-level contract, not per-project taste.
 - **Present:** read it. A project-local rubric may add rules (extra threads, a diary workflow, a different channel); it must never relax the hard rules below.
 
+## Step 1a — preflight and worker ownership
+
+Run the transport preflight in `docs/SLACK_POSTING_RUNBOOK.md` before attempting
+to post. For cas-src, the canonical route is the supervisor-owned
+`claude.ai Slack` MCP on the approved `pippenz@gmail.com` profile. A connected
+server listing is not a posting receipt; the read-only preflight must succeed.
+
+Default Codex workers do not have a Slack transport. When the worker reaches
+this duty, it saves the exact draft and hands the supervisor the draft path,
+target channel, deploy target, and receipt request. The supervisor posts through
+the canonical route and returns timestamps/permalinks for the worker to record.
+This is a designed handoff, not a failed fallback. If preflight fails, stop
+after saving the draft and report the measured error; do not claim `POSTED`.
+
 ## Step 2 — gather the merge
 
 ```bash

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -28,6 +28,22 @@ You execute tasks assigned by the Supervisor. You may be working in an isolated 
    - **MERGE REQUIRED:** run the [close-gate freshness handshake](cas-worker/references/close-gate.md), including `inbox_poll` for unread supervisor messages, before any corrective commit; if a merge is still needed, send the current factory-branch tip SHA. Never bypass with `status=closed`.
    - **task-scoped verification:** forward the exact guidance once and trust the DB.
 
+## Release-note transport handoff
+
+When the project has a release-notes rubric and your assigned work reaches a
+staging or main merge:
+
+- Check whether this worker session exposes a sanctioned Slack transport. If it
+  does not, do not spend a turn searching for one.
+- Save the exact release-note draft and hand the supervisor its path, target
+  channel, deploy target, and request for returned timestamps/permalinks.
+- Treat supervisor-owned posting as the designed path for workers without
+  Slack, not as a failed fallback. Do not claim `POSTED` or invent receipts.
+- Add the returned receipt to the saved draft before closing the release task.
+
+If no approved transport passes preflight, leave the draft saved and report the
+duty blocked with the measured error.
+
 ## Task Types
 
 - **Spike** — record its decision with `note_type=decision`; its criteria are question-based.

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -28,22 +28,6 @@ You execute tasks assigned by the Supervisor. You may be working in an isolated 
    - **MERGE REQUIRED:** run the [close-gate freshness handshake](cas-worker/references/close-gate.md), including `inbox_poll` for unread supervisor messages, before any corrective commit; if a merge is still needed, send the current factory-branch tip SHA. Never bypass with `status=closed`.
    - **task-scoped verification:** forward the exact guidance once and trust the DB.
 
-## Release-note transport handoff
-
-When the project has a release-notes rubric and your assigned work reaches a
-staging or main merge:
-
-- Check whether this worker session exposes a sanctioned Slack transport. If it
-  does not, do not spend a turn searching for one.
-- Save the exact release-note draft and hand the supervisor its path, target
-  channel, deploy target, and request for returned timestamps/permalinks.
-- Treat supervisor-owned posting as the designed path for workers without
-  Slack, not as a failed fallback. Do not claim `POSTED` or invent receipts.
-- Add the returned receipt to the saved draft before closing the release task.
-
-If no approved transport passes preflight, leave the draft saved and report the
-duty blocked with the measured error.
-
 ## Task Types
 
 - **Spike** — record its decision with `note_type=decision`; its criteria are question-based.

--- a/cas-cli/src/builtins/skills/cli-routing/SKILL.md
+++ b/cas-cli/src/builtins/skills/cli-routing/SKILL.md
@@ -36,9 +36,9 @@ Every merge to `main` or `staging` needs the existing
 project-local. For the actual Slack transport, follow
 [`docs/SLACK_POSTING_RUNBOOK.md`](../../../../../docs/SLACK_POSTING_RUNBOOK.md):
 write exact bodies to a separator-delimited file, read the channel to dedupe,
-then post and retain returned timestamps as receipts. That flow uses this
-skill's Codex-first router; Claude Slack MCP is allowed only on the eligible
-current profile.
+then post and retain returned timestamps as receipts. For cas-src, use the
+approved Claude Slack MCP route after its account/server preflight; use the
+Codex Slack plugin only when the current session's resource probe is positive.
 
 ## Do not trigger
 

--- a/cas-cli/src/builtins/skills/cli-routing/references/routing.md
+++ b/cas-cli/src/builtins/skills/cli-routing/references/routing.md
@@ -93,8 +93,10 @@ for content. The operational sequence is:
 1. Write the exact user and dev bodies to a file with `=== MESSAGE N ===`
    separators; keep the headers out of the sent text.
 2. Read the target channel first to deduplicate a previous or partial attempt.
-3. Use the Codex `codex_apps` Slack plugin through the Codex-first route; use
-   Claude Slack MCP only if the already-gated current profile authorizes it.
+3. Use the approved Claude Slack MCP route after the account/server preflight.
+   Use the Codex `codex_apps` Slack plugin only when the current session's
+   resource probe is positive; default Codex workers must use the supervisor
+   handoff in the project runbook when it is absent.
 4. Post the two top-level messages and required replies in rubric order, then
    record the returned message timestamps as receipts.
 

--- a/cas-cli/src/builtins/skills/release-notes/SKILL.md
+++ b/cas-cli/src/builtins/skills/release-notes/SKILL.md
@@ -15,6 +15,20 @@ Check for `docs/release-notes/RUBRIC.md`.
 - **Missing:** copy the canonical template from this skill's `references/RUBRIC-template.md` to `docs/release-notes/RUBRIC.md`, then fill the placeholders: the project's Slack **channel name + channel ID**, and the branch → deploy-target mapping (which branch means `Staging`, which means `Live on production`). Leave the rules verbatim — they are the framework-level contract, not per-project taste.
 - **Present:** read it. A project-local rubric may add rules (extra threads, a diary workflow, a different channel); it must never relax the hard rules below.
 
+## Step 1a — preflight and worker ownership
+
+Run the transport preflight in `docs/SLACK_POSTING_RUNBOOK.md` before attempting
+to post. For cas-src, the canonical route is the supervisor-owned
+`claude.ai Slack` MCP on the approved `pippenz@gmail.com` profile. A connected
+server listing is not a posting receipt; the read-only preflight must succeed.
+
+Default Codex workers do not have a Slack transport. When the worker reaches
+this duty, it saves the exact draft and hands the supervisor the draft path,
+target channel, deploy target, and receipt request. The supervisor posts through
+the canonical route and returns timestamps/permalinks for the worker to record.
+This is a designed handoff, not a failed fallback. If preflight fails, stop
+after saving the draft and report the measured error; do not claim `POSTED`.
+
 ## Step 2 — gather the merge
 
 ```bash

--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -2050,6 +2050,8 @@ mod workspace_contract_tests {
         let first_path = first_root.path().to_string_lossy().to_string();
         let second_path = second_root.path().to_string_lossy().to_string();
         let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_AGENT_ROLE", Some("worker")),
+            ("CAS_FACTORY_MODE", Some("1")),
             ("CAS_SESSION_ID", Some("refresh-session")),
             ("CAS_CLONE_PATH", Some(first_path.as_str())),
         ]);

--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -296,21 +296,36 @@ pub fn handle_pre_tool_use(
     // A scratchpad may itself be under /tmp, but it is explicitly ephemeral
     // and is rejected later if cited as close evidence.
     if is_factory_agent {
-        let config = stores.config();
-        let factory = config.factory();
-        let scratch_root = config
-            .staging
-            .as_ref()
-            .and_then(|staging| staging.scratch_root.as_deref());
-        if let Some(path) = factory_unsanctioned_write_path(
+        // `input.cwd` is the tool's current directory, not the worker's
+        // registered checkout. Claude can report a nested cwd (and it may
+        // change during a long session), so resolve the durable binding from
+        // the current agent row on every hook invocation. The environment is
+        // the bootstrap fallback until SessionStart has registered the row.
+        let registered_worktree = registered_factory_worktree_root(&mut stores, input);
+        let (artifacts_root, scratch_root) = {
+            let config = stores.config();
+            let factory = config.factory();
+            (
+                factory.artifacts_root.clone(),
+                config
+                    .staging
+                    .as_ref()
+                    .and_then(|staging| staging.scratch_root.clone()),
+            )
+        };
+        if let Some(violation) = factory_write_violation(
             input,
-            &factory.artifacts_root,
-            scratch_root,
+            &artifacts_root,
+            scratch_root.as_deref(),
             crate::harness_policy::is_supervisor(input),
+            registered_worktree.as_deref(),
         ) {
+            let path = &violation.resolved_path;
+            log_factory_workspace_rejection(cas_root, input, &violation);
             let artifacts =
-                crate::config::resolved_factory_artifacts_root(factory.artifacts_root.as_deref());
+                crate::config::resolved_factory_artifacts_root(artifacts_root.as_deref());
             let scratch = scratch_root
+                .as_deref()
                 .map(|root| format!(" or `{root}/...` for ephemeral scratch output"))
                 .unwrap_or_default();
             return Ok(HookOutput::with_pre_tool_permission(
@@ -1474,6 +1489,30 @@ fn factory_unsanctioned_write_path(
     configured_scratch_root: Option<&str>,
     is_supervisor: bool,
 ) -> Option<std::path::PathBuf> {
+    factory_write_violation(
+        input,
+        configured_artifacts_root,
+        configured_scratch_root,
+        is_supervisor,
+        None,
+    )
+    .map(|violation| violation.resolved_path)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FactoryWriteViolation {
+    evaluated_path: String,
+    resolved_path: std::path::PathBuf,
+    matched_rule: &'static str,
+}
+
+fn factory_write_violation(
+    input: &HookInput,
+    configured_artifacts_root: &Option<String>,
+    configured_scratch_root: Option<&str>,
+    is_supervisor: bool,
+    registered_worktree_root: Option<&std::path::Path>,
+) -> Option<FactoryWriteViolation> {
     let tool = input.tool_name.as_deref()?;
     let tool_input = input.tool_input.as_ref()?;
     let raw_paths = match tool {
@@ -1491,13 +1530,19 @@ fn factory_unsanctioned_write_path(
     };
 
     raw_paths.into_iter().find_map(|raw_path| {
-        unsanctioned_factory_path(
+        unsanctioned_factory_path_with_worktree(
             input,
             configured_artifacts_root,
             configured_scratch_root,
             is_supervisor,
             &raw_path,
+            registered_worktree_root,
         )
+        .map(|resolved_path| FactoryWriteViolation {
+            evaluated_path: raw_path,
+            resolved_path,
+            matched_rule: "none",
+        })
     })
 }
 
@@ -1508,21 +1553,45 @@ fn unsanctioned_factory_path(
     is_supervisor: bool,
     raw_path: &str,
 ) -> Option<std::path::PathBuf> {
+    unsanctioned_factory_path_with_worktree(
+        input,
+        configured_artifacts_root,
+        configured_scratch_root,
+        is_supervisor,
+        raw_path,
+        None,
+    )
+}
+
+fn unsanctioned_factory_path_with_worktree(
+    input: &HookInput,
+    configured_artifacts_root: &Option<String>,
+    configured_scratch_root: Option<&str>,
+    is_supervisor: bool,
+    raw_path: &str,
+    registered_worktree_root: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
     let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
-    let mut sanctioned = vec![lexically_normalize_path(std::path::PathBuf::from(
-        &input.cwd,
-    ))];
-    sanctioned.push(lexically_normalize_path(
-        crate::config::resolved_factory_artifacts_root(configured_artifacts_root.as_deref()),
+    let env_worktree_root = std::env::var_os("CAS_CLONE_PATH")
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from);
+    let worktree_root = registered_worktree_root
+        .map(std::path::Path::to_path_buf)
+        .or(env_worktree_root);
+    // Once a durable clone binding exists, cwd is only a tool location and
+    // must not widen the contract. Keep cwd as the standalone-worker fallback
+    // for sessions that have no registered or environment-provided root.
+    let mut sanctioned = vec![worktree_root
+        .unwrap_or_else(|| std::path::PathBuf::from(&input.cwd))];
+    sanctioned.push(crate::config::resolved_factory_artifacts_root(
+        configured_artifacts_root.as_deref(),
     ));
     if let Some(scratch_root) = configured_scratch_root.filter(|root| !root.trim().is_empty()) {
-        sanctioned.push(lexically_normalize_path(std::path::PathBuf::from(
-            scratch_root,
-        )));
+        sanctioned.push(std::path::PathBuf::from(scratch_root));
     }
     for key in ["CAS_SCRATCHPAD", "CAS_SCRATCHPAD_PATH", "CLAUDE_SCRATCHPAD"] {
         if let Some(value) = std::env::var_os(key) {
-            sanctioned.push(lexically_normalize_path(std::path::PathBuf::from(value)));
+            sanctioned.push(std::path::PathBuf::from(value));
         }
     }
 
@@ -1538,15 +1607,100 @@ fn unsanctioned_factory_path(
     } else {
         lexically_normalize_path(std::path::PathBuf::from(&input.cwd).join(raw_path))
     };
-    let is_explicitly_sanctioned = sanctioned.iter().any(|root| path.starts_with(root));
-    if is_non_creation_stream_device(&path)
-        || is_harness_session_scratchpad(&path, &input.session_id)
-        || (is_supervisor && is_harness_file_memory_path(&path, home.as_deref()))
+    // A path whose symlink chain cannot be resolved is not safely attributable
+    // to any sanctioned root. Fail closed rather than letting `None` mean
+    // "allowed"; the narrow stream-device exception is handled first.
+    if is_non_creation_stream_device(&path) {
+        return None;
+    }
+    let Some(resolved_path) = canonicalize_for_containment(&path) else {
+        return Some(path);
+    };
+    let is_explicitly_sanctioned = sanctioned.iter().any(|root| {
+        canonicalize_for_containment(&lexically_normalize_path(root.clone()))
+            .is_some_and(|root| resolved_path.starts_with(root))
+    });
+    if is_harness_session_scratchpad(&resolved_path, &input.session_id)
+        || (is_supervisor && is_harness_file_memory_path(&resolved_path, home.as_deref()))
         || is_explicitly_sanctioned
     {
         return None;
     }
-    Some(path)
+    Some(resolved_path)
+}
+
+/// Resolve the worker's registered checkout for each hook call.
+///
+/// SessionStart persists `CAS_CLONE_PATH` in the current agent's metadata.
+/// Reading that row here makes a mid-session registration refresh visible to
+/// PreToolUse immediately. The environment remains the bootstrap fallback for
+/// the short interval before the first registration succeeds.
+fn registered_factory_worktree_root(
+    stores: &mut ToolHookStores<'_>,
+    input: &HookInput,
+) -> Option<std::path::PathBuf> {
+    let agent_id = current_agent_id(input);
+    stores
+        .agents()
+        .and_then(|store| store.get(&agent_id).ok())
+        .and_then(|agent| agent.metadata.get("clone_path").cloned())
+        .filter(|path| !path.trim().is_empty())
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("CAS_CLONE_PATH")
+                .filter(|value| !value.is_empty())
+                .map(std::path::PathBuf::from)
+        })
+}
+
+/// Canonicalize a path for containment checks even when its final components
+/// do not exist yet. The nearest existing ancestor carries symlink semantics;
+/// the missing suffix is then appended. Dangling symlinks fail closed because
+/// they are reported by `symlink_metadata` but cannot be canonicalized.
+fn canonicalize_for_containment(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let normalized = lexically_normalize_path(path.to_path_buf());
+    let mut existing = normalized.clone();
+    let mut missing = Vec::new();
+    while !existing.exists() {
+        if std::fs::symlink_metadata(&existing).is_ok() {
+            break;
+        }
+        let name = existing.file_name()?.to_os_string();
+        missing.push(name);
+        existing.pop();
+    }
+
+    let mut canonical = existing.canonicalize().ok()?;
+    for component in missing.into_iter().rev() {
+        canonical.push(component);
+    }
+    Some(canonical)
+}
+
+fn log_factory_workspace_rejection(
+    cas_root: &Path,
+    input: &HookInput,
+    violation: &FactoryWriteViolation,
+) {
+    let tool = input.tool_name.as_deref().unwrap_or("unknown");
+    let payload_bytes = input
+        .tool_input
+        .as_ref()
+        .and_then(|value| serde_json::to_vec(value).ok())
+        .map(|payload| payload.len().to_string())
+        .unwrap_or_else(|| "0".to_string());
+    let resolved_path = violation.resolved_path.display().to_string();
+    let _ = crate::hooks::handlers::session_hygiene::append_factory_session_event(
+        cas_root,
+        "workspace_contract_rejection",
+        &[
+            ("tool", tool),
+            ("evaluated_path", violation.evaluated_path.as_str()),
+            ("resolved_path", resolved_path.as_str()),
+            ("matched_rule", violation.matched_rule),
+            ("payload_bytes", payload_bytes.as_str()),
+        ],
+    );
 }
 
 /// Normalize `.` and `..` without requiring the target to exist. Write
@@ -1555,12 +1709,20 @@ fn unsanctioned_factory_path(
 fn lexically_normalize_path(path: std::path::PathBuf) -> std::path::PathBuf {
     use std::path::Component;
 
+    let rooted = matches!(
+        path.components().next(),
+        Some(Component::RootDir | Component::Prefix(_))
+    );
     let mut normalized = std::path::PathBuf::new();
     for component in path.components() {
         match component {
             Component::CurDir => {}
             Component::ParentDir => {
-                normalized.pop();
+                if normalized.file_name().is_some() {
+                    normalized.pop();
+                } else if !rooted {
+                    normalized.push(component.as_os_str());
+                }
             }
             Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
                 normalized.push(component.as_os_str());
@@ -1737,6 +1899,7 @@ mod workspace_contract_tests {
     #[test]
     fn relative_worktree_writes_remain_sanctioned_and_bare_tmp_is_denied() {
         let cwd = tempfile::tempdir().expect("worktree");
+        let _env = TestEnvGuard::with_optional_vars(&[("CAS_CLONE_PATH", None)]);
         let input = bash_input("true", cwd.path());
 
         assert_eq!(
@@ -1757,6 +1920,319 @@ mod workspace_contract_tests {
             Some(std::env::temp_dir().join("cas-3bd6-tool-temp.log")),
             "bare system temp must remain outside the workspace contract"
         );
+    }
+
+    #[test]
+    fn registered_worktree_allows_sibling_subtrees_when_cwd_is_nested() {
+        let cwd = tempfile::tempdir().expect("worktree");
+        let frontend = cwd.path().join("apps/frontend");
+        let backend = cwd.path().join("apps/backend");
+        std::fs::create_dir_all(&frontend).expect("frontend");
+        std::fs::create_dir_all(&backend).expect("backend");
+        let clone_path = cwd.path().to_string_lossy().to_string();
+        let _env = TestEnvGuard::with_optional_vars(&[(
+            "CAS_CLONE_PATH",
+            Some(clone_path.as_str()),
+        )]);
+        let input = bash_input("true", &backend);
+
+        assert_eq!(
+            unsanctioned_factory_path(
+                &input,
+                &None,
+                None,
+                false,
+                &frontend.join("new-component.ts").to_string_lossy(),
+            ),
+            None,
+            "the registered worktree root must permit every nested subtree"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_registered_worktree_root_is_canonicalized() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().expect("parent");
+        let real_root = parent.path().join("real-worktree");
+        let linked_root = parent.path().join("linked-worktree");
+        std::fs::create_dir_all(real_root.join("apps/frontend")).expect("real root");
+        std::fs::create_dir_all(real_root.join("apps/backend")).expect("real subtrees");
+        symlink(&real_root, &linked_root).expect("worktree symlink");
+        let clone_path = linked_root.to_string_lossy().to_string();
+        let _env = TestEnvGuard::with_optional_vars(&[(
+            "CAS_CLONE_PATH",
+            Some(clone_path.as_str()),
+        )]);
+        let input = bash_input("true", &linked_root.join("apps/backend"));
+
+        assert_eq!(
+            unsanctioned_factory_path(
+                &input,
+                &None,
+                None,
+                false,
+                &linked_root
+                    .join("apps/frontend/new-component.ts")
+                    .to_string_lossy(),
+            ),
+            None,
+            "symlinked registered roots must compare by their canonical target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_worktree_subtree_that_escapes_is_denied() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().expect("parent");
+        let worktree = parent.path().join("worktree");
+        let outside = parent.path().join("outside");
+        std::fs::create_dir_all(&worktree).expect("worktree");
+        std::fs::create_dir_all(&outside).expect("outside");
+        symlink(&outside, worktree.join("link-out")).expect("escape symlink");
+        let clone_path = worktree.to_string_lossy().to_string();
+        let _env = TestEnvGuard::with_optional_vars(&[(
+            "CAS_CLONE_PATH",
+            Some(clone_path.as_str()),
+        )]);
+        let input = bash_input("true", worktree.as_path());
+        let target = worktree.join("link-out/escape.txt");
+
+        assert_eq!(
+            unsanctioned_factory_path(
+                &input,
+                &None,
+                None,
+                false,
+                &target.to_string_lossy(),
+            ),
+            Some(outside.join("escape.txt")),
+            "canonical containment must reject a symlinked subtree outside the worktree"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_write_is_denied() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().expect("parent");
+        let worktree = parent.path().join("worktree");
+        std::fs::create_dir_all(&worktree).expect("worktree");
+        symlink(
+            worktree.join("missing-target"),
+            worktree.join("dangling"),
+        )
+        .expect("dangling symlink");
+        let clone_path = worktree.to_string_lossy().to_string();
+        let _env = TestEnvGuard::with_optional_vars(&[(
+            "CAS_CLONE_PATH",
+            Some(clone_path.as_str()),
+        )]);
+        let input = bash_input("true", worktree.as_path());
+        let target = worktree.join("dangling/escape.txt");
+
+        assert_eq!(
+            unsanctioned_factory_path(&input, &None, None, false, &target.to_string_lossy()),
+            Some(target),
+            "unresolvable symlink targets must fail closed"
+        );
+    }
+
+    #[test]
+    fn refreshed_registered_worktree_is_used_mid_session() {
+        let cas_root = tempfile::tempdir().expect("cas root");
+        let first_root = tempfile::tempdir().expect("first worktree");
+        let second_root = tempfile::tempdir().expect("refreshed worktree");
+        let first_path = first_root.path().to_string_lossy().to_string();
+        let second_path = second_root.path().to_string_lossy().to_string();
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_SESSION_ID", Some("refresh-session")),
+            ("CAS_CLONE_PATH", Some(first_path.as_str())),
+        ]);
+
+        let agent_store = open_agent_store(cas_root.path()).expect("agent store");
+        let mut agent = Agent::new("refresh-session".to_string(), "refresh-worker".to_string());
+        agent.role = AgentRole::Worker;
+        agent
+            .metadata
+            .insert("clone_path".to_string(), first_path.clone());
+        agent_store.register(&agent).expect("register worker");
+
+        let input = bash_input("true", &second_root.path().join("apps/backend"));
+        assert_eq!(
+            registered_factory_worktree_root(
+                &mut ToolHookStores::new(cas_root.path()),
+                &input,
+            )
+            .as_deref(),
+            Some(first_root.path()),
+            "the initial durable registration should be authoritative"
+        );
+
+        agent
+            .metadata
+            .insert("clone_path".to_string(), second_path.clone());
+        agent_store.update(&agent).expect("refresh worker");
+        let mut stores = ToolHookStores::new(cas_root.path());
+        let refreshed = registered_factory_worktree_root(&mut stores, &input)
+            .expect("refreshed registered root");
+        assert_eq!(refreshed, second_root.path());
+        assert_eq!(
+            unsanctioned_factory_path_with_worktree(
+                &input,
+                &None,
+                None,
+                false,
+                &second_root
+                    .path()
+                    .join("apps/frontend/new-component.ts")
+                    .to_string_lossy(),
+                Some(&refreshed),
+            ),
+            None,
+            "PreToolUse must see a refreshed worktree binding without a new process"
+        );
+    }
+
+    #[test]
+    fn pre_tool_uses_registered_worktree_for_nested_cwd() {
+        let cas_root = tempfile::tempdir().expect("cas root");
+        let worktree = tempfile::tempdir().expect("worktree");
+        let frontend = worktree.path().join("apps/frontend");
+        let backend = worktree.path().join("apps/backend");
+        std::fs::create_dir_all(&frontend).expect("frontend");
+        std::fs::create_dir_all(&backend).expect("backend");
+        let clone_path = worktree.path().to_string_lossy().to_string();
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_AGENT_ROLE", Some("worker")),
+            ("CAS_FACTORY_MODE", Some("1")),
+            ("CAS_SESSION_ID", Some("registered-session")),
+            ("CAS_CLONE_PATH", None),
+        ]);
+
+        let agent_store = open_agent_store(cas_root.path()).expect("agent store");
+        let mut agent = Agent::new(
+            "registered-session".to_string(),
+            "registered-worker".to_string(),
+        );
+        agent.role = AgentRole::Worker;
+        agent
+            .metadata
+            .insert("clone_path".to_string(), clone_path);
+        agent_store.register(&agent).expect("register worker");
+
+        let input = HookInput {
+            session_id: "native-session-id".to_string(),
+            cwd: backend.to_string_lossy().to_string(),
+            hook_event_name: "PreToolUse".to_string(),
+            tool_name: Some("Write".to_string()),
+            tool_input: Some(serde_json::json!({
+                "file_path": frontend.join("new-component.ts")
+            })),
+            agent_role: Some("worker".to_string()),
+            ..HookInput::default()
+        };
+
+        let output = handle_pre_tool_use(&input, Some(cas_root.path())).expect("handler ok");
+        let value = serde_json::to_value(output).expect("hook output JSON");
+        assert_eq!(
+            value["hookSpecificOutput"]["permissionDecision"],
+            "allow",
+            "a registered worktree sibling must not be rejected: {value}"
+        );
+    }
+
+    #[test]
+    fn outside_worktree_with_similar_prefix_stays_denied() {
+        let parent = tempfile::tempdir().expect("parent");
+        let worktree = parent.path().join("worktree");
+        let sibling = parent.path().join("worktree-sibling");
+        std::fs::create_dir_all(&worktree).expect("worktree");
+        std::fs::create_dir_all(&sibling).expect("sibling");
+        let clone_path = worktree.to_string_lossy().to_string();
+        let _env = TestEnvGuard::with_optional_vars(&[(
+            "CAS_CLONE_PATH",
+            Some(clone_path.as_str()),
+        )]);
+        let input = bash_input("true", worktree.as_path());
+        let target = sibling.join("not-allowed.txt");
+
+        assert_eq!(
+            unsanctioned_factory_path(
+                &input,
+                &None,
+                None,
+                false,
+                &target.to_string_lossy(),
+            ),
+            Some(target),
+            "a sibling path sharing the root's string prefix must remain outside"
+        );
+    }
+
+    #[test]
+    fn cwd_outside_registered_worktree_stays_denied() {
+        let worktree = tempfile::tempdir().expect("worktree");
+        let outside = tempfile::tempdir().expect("outside");
+        let clone_path = worktree.path().to_string_lossy().to_string();
+        let _env = TestEnvGuard::with_optional_vars(&[(
+            "CAS_CLONE_PATH",
+            Some(clone_path.as_str()),
+        )]);
+        let input = bash_input("true", outside.path());
+        let target = outside.path().join("not-allowed.txt");
+
+        assert_eq!(
+            unsanctioned_factory_path(&input, &None, None, false, &target.to_string_lossy()),
+            Some(target),
+            "an out-of-worktree cwd must not become a sanctioned write root"
+        );
+    }
+
+    #[test]
+    fn workspace_rejection_log_contains_path_rule_and_payload_size() {
+        let cas_root = tempfile::tempdir().expect("cas root");
+        let outside = tempfile::tempdir().expect("outside");
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_FACTORY_SESSION", Some("workspace-contract-test")),
+            ("CAS_AGENT_NAME", Some("test-worker")),
+            ("CAS_AGENT_ROLE", Some("worker")),
+        ]);
+        let input = HookInput {
+            session_id: "test-session".to_string(),
+            cwd: outside.path().to_string_lossy().to_string(),
+            tool_name: Some("Write".to_string()),
+            tool_input: Some(serde_json::json!({
+                "file_path": "/not-sanctioned/escape.txt",
+                "content": "payload"
+            })),
+            ..HookInput::default()
+        };
+        let violation = FactoryWriteViolation {
+            evaluated_path: "/not-sanctioned/escape.txt".to_string(),
+            resolved_path: std::path::PathBuf::from("/not-sanctioned/escape.txt"),
+            matched_rule: "none",
+        };
+
+        log_factory_workspace_rejection(cas_root.path(), &input, &violation);
+        let log_path = cas_root
+            .path()
+            .join(format!("logs/factory-session-{}.log", chrono::Utc::now().format("%Y-%m-%d")));
+        let line = std::fs::read_to_string(log_path).expect("workspace rejection log");
+        let record: serde_json::Value = serde_json::from_str(line.trim()).expect("JSON event");
+        let expected_payload_bytes = serde_json::to_vec(input.tool_input.as_ref().unwrap())
+            .unwrap()
+            .len()
+            .to_string();
+        assert_eq!(record["event"], "workspace_contract_rejection");
+        assert_eq!(record["evaluated_path"], "/not-sanctioned/escape.txt");
+        assert_eq!(record["resolved_path"], "/not-sanctioned/escape.txt");
+        assert_eq!(record["matched_rule"], "none");
+        assert_eq!(record["payload_bytes"], expected_payload_bytes);
     }
 }
 

--- a/cas-cli/src/hooks/handlers/handlers_tests/factory_auto_approve.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/factory_auto_approve.rs
@@ -506,14 +506,21 @@ fn factory_agent_unknown_tool_without_cas_root_is_not_auto_approved() {
 // concurrent tests across sibling modules don't race on CAS_AGENT_ROLE.
 // ----------------------------------------------------------------------------
 
-struct RoleGuard(Option<String>);
+struct RoleGuard {
+    role: Option<String>,
+    clone_path: Option<std::ffi::OsString>,
+}
 
 impl Drop for RoleGuard {
     fn drop(&mut self) {
         unsafe {
-            match &self.0 {
+            match &self.role {
                 Some(v) => std::env::set_var("CAS_AGENT_ROLE", v),
                 None => std::env::remove_var("CAS_AGENT_ROLE"),
+            }
+            match &self.clone_path {
+                Some(v) => std::env::set_var("CAS_CLONE_PATH", v),
+                None => std::env::remove_var("CAS_CLONE_PATH"),
             }
         }
     }
@@ -521,11 +528,13 @@ impl Drop for RoleGuard {
 
 fn set_role_env(role: Option<&str>) -> RoleGuard {
     let prev = std::env::var("CAS_AGENT_ROLE").ok();
+    let clone_path = std::env::var_os("CAS_CLONE_PATH");
     unsafe {
         match role {
             Some(v) => std::env::set_var("CAS_AGENT_ROLE", v),
             None => std::env::remove_var("CAS_AGENT_ROLE"),
         }
+        std::env::remove_var("CAS_CLONE_PATH");
     }
-    RoleGuard(prev)
+    RoleGuard { role: prev, clone_path }
 }

--- a/cas-cli/src/hybrid_search/search_index_query.rs
+++ b/cas-cli/src/hybrid_search/search_index_query.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use chrono::Utc;
-use tantivy::{IndexReader, ReloadPolicy};
-use tantivy::collector::TopDocs;
+use tantivy::collector::{Count, TopDocs};
 use tantivy::query::{BooleanQuery, Occur, Query, QueryParser, TermQuery};
 use tantivy::schema::{IndexRecordOption, Value};
+use tantivy::{IndexReader, ReloadPolicy};
 
 use cas_core::dedup::{SearchHit, SearchIndexTrait};
 use cas_core::error::CoreError;
@@ -94,6 +94,19 @@ impl SearchIndex {
 }
 
 impl SearchIndex {
+    /// Count committed documents for one logical search document type.
+    ///
+    /// The unified index can also contain code, history, artifact, and
+    /// knowledge documents, so doctor must compare store-backed types
+    /// individually instead of comparing the total Tantivy document count.
+    pub fn count_documents(&self, doc_type: DocType) -> Result<u64, MemError> {
+        let reader = self.reader()?;
+        reader.reload()?;
+        let term = tantivy::Term::from_field_text(self.doc_type_field, doc_type.as_str());
+        let query = TermQuery::new(term, IndexRecordOption::Basic);
+        Ok(reader.searcher().search(&query, &Count)? as u64)
+    }
+
     /// Resolve a filter key (from [`parse_filter_query`]) to its Tantivy field.
     /// Returns `None` for unrecognized keys — caller should treat them as
     /// raw keyword text.

--- a/cas-cli/src/mcp/tools/core/system.rs
+++ b/cas-cli/src/mcp/tools/core/system.rs
@@ -1,5 +1,59 @@
 use crate::mcp::tools::core::imports::*;
 
+#[derive(Debug, Default)]
+struct StoreBackedIndexCounts {
+    entries: usize,
+    tasks: usize,
+    rules: usize,
+    skills: usize,
+    latest_store_update: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Filesystem timestamps can be coarser than the store clock on some
+/// platforms, so tolerate a small amount of clock/filesystem skew while still
+/// catching edits that remain unindexed for an operator-visible interval.
+const INDEX_FRESHNESS_TOLERANCE_SECS: i64 = 2;
+
+fn index_last_modified(index_dir: &std::path::Path) -> Option<chrono::DateTime<chrono::Utc>> {
+    std::fs::metadata(index_dir.join("meta.json"))
+        .ok()?
+        .modified()
+        .ok()
+        .map(chrono::DateTime::<chrono::Utc>::from)
+}
+
+impl StoreBackedIndexCounts {
+    fn total(&self) -> usize {
+        self.entries + self.tasks + self.rules + self.skills
+    }
+
+    fn observe(&mut self, timestamp: chrono::DateTime<chrono::Utc>) {
+        self.latest_store_update = Some(
+            self.latest_store_update
+                .map_or(timestamp, |current| current.max(timestamp)),
+        );
+    }
+}
+
+fn format_index_counts(
+    indexed: &StoreBackedIndexCounts,
+    expected: &StoreBackedIndexCounts,
+) -> String {
+    format!(
+        "{} of {} store-backed documents (entries {}/{}, tasks {}/{}, rules {}/{}, skills {}/{})",
+        indexed.total(),
+        expected.total(),
+        indexed.entries,
+        expected.entries,
+        indexed.tasks,
+        expected.tasks,
+        indexed.rules,
+        expected.rules,
+        indexed.skills,
+        expected.skills,
+    )
+}
+
 impl CasCore {
     // ========================================================================
     // System Tools (5)
@@ -303,11 +357,21 @@ impl CasCore {
     pub async fn cas_doctor(&self) -> Result<CallToolResult, McpError> {
         let mut checks = Vec::new();
         let mut issues = Vec::new();
+        let mut expected_index = StoreBackedIndexCounts::default();
 
         // Check store
         match self.open_store() {
             Ok(store) => match store.list() {
-                Ok(entries) => checks.push(format!("Store: OK ({} entries)", entries.len())),
+                Ok(entries) => {
+                    expected_index.entries = entries.len();
+                    if let Ok(recent) = store.recent(1)
+                        && let Some(entry) = recent.first()
+                        && let Ok(updated) = store.recent_timestamp(entry)
+                    {
+                        expected_index.observe(updated);
+                    }
+                    checks.push(format!("Store: OK ({} entries)", entries.len()));
+                }
                 Err(e) => issues.push(format!("Store list failed: {e}")),
             },
             Err(e) => issues.push(format!("Store open failed: {e}")),
@@ -316,7 +380,13 @@ impl CasCore {
         // Check task store
         match self.open_task_store() {
             Ok(store) => match store.list(None) {
-                Ok(tasks) => checks.push(format!("Task Store: OK ({} tasks)", tasks.len())),
+                Ok(tasks) => {
+                    expected_index.tasks = tasks.len();
+                    for task in &tasks {
+                        expected_index.observe(task.updated_at);
+                    }
+                    checks.push(format!("Task Store: OK ({} tasks)", tasks.len()));
+                }
                 Err(e) => issues.push(format!("Task store list failed: {e}")),
             },
             Err(e) => issues.push(format!("Task store open failed: {e}")),
@@ -325,7 +395,13 @@ impl CasCore {
         // Check rule store
         match self.open_rule_store() {
             Ok(store) => match store.list() {
-                Ok(rules) => checks.push(format!("Rule Store: OK ({} rules)", rules.len())),
+                Ok(rules) => {
+                    expected_index.rules = rules.len();
+                    for rule in &rules {
+                        expected_index.observe(rule.created);
+                    }
+                    checks.push(format!("Rule Store: OK ({} rules)", rules.len()));
+                }
                 Err(e) => issues.push(format!("Rule store list failed: {e}")),
             },
             Err(e) => issues.push(format!("Rule store open failed: {e}")),
@@ -334,7 +410,13 @@ impl CasCore {
         // Check skill store
         match self.open_skill_store() {
             Ok(store) => match store.list(None) {
-                Ok(skills) => checks.push(format!("Skill Store: OK ({} skills)", skills.len())),
+                Ok(skills) => {
+                    expected_index.skills = skills.len();
+                    for skill in &skills {
+                        expected_index.observe(skill.updated_at);
+                    }
+                    checks.push(format!("Skill Store: OK ({} skills)", skills.len()));
+                }
                 Err(e) => issues.push(format!("Skill store list failed: {e}")),
             },
             Err(e) => issues.push(format!("Skill store open failed: {e}")),
@@ -342,7 +424,48 @@ impl CasCore {
 
         // Check search index
         match self.open_search_index() {
-            Ok(_) => checks.push("Search Index: OK".to_string()),
+            Ok(search) => {
+                let mut indexed = StoreBackedIndexCounts::default();
+                let count_result = (|| -> Result<(), String> {
+                    indexed.entries = search
+                        .count_documents(DocType::Entry)
+                        .map_err(|e| e.to_string())? as usize;
+                    indexed.tasks = search
+                        .count_documents(DocType::Task)
+                        .map_err(|e| e.to_string())? as usize;
+                    indexed.rules = search
+                        .count_documents(DocType::Rule)
+                        .map_err(|e| e.to_string())? as usize;
+                    indexed.skills = search
+                        .count_documents(DocType::Skill)
+                        .map_err(|e| e.to_string())? as usize;
+                    Ok(())
+                })();
+
+                match count_result {
+                    Ok(())
+                        if indexed.total() != expected_index.total()
+                            || index_last_modified(&self.cas_root.join("index/tantivy"))
+                                .zip(expected_index.latest_store_update.as_ref())
+                                .is_some_and(|(indexed_at, store_update)| {
+                                    store_update.signed_duration_since(indexed_at).num_seconds()
+                                        > INDEX_FRESHNESS_TOLERANCE_SECS
+                                }) =>
+                    {
+                        issues.push(format!(
+                            "Search Index: STALE — run reindex bm25=true ({})",
+                            format_index_counts(&indexed, &expected_index)
+                        ));
+                    }
+                    Ok(()) => checks.push(format!(
+                        "Search Index: OK ({})",
+                        format_index_counts(&indexed, &expected_index)
+                    )),
+                    Err(error) => issues.push(format!(
+                        "Search Index: unable to verify freshness — run reindex bm25=true ({error})"
+                    )),
+                }
+            }
             Err(e) => issues.push(format!("Search index failed: {e}")),
         }
 

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -1210,6 +1210,23 @@ impl CasCore {
             }
         };
 
+        // cas-2b667 / GH #588: the receipt path must not project an
+        // unmerged current source tip into PendingSupervisorReview. The
+        // receipt's commit/target fields are a snapshot supplied by the
+        // worker; re-fetch and inspect the live branch immediately before
+        // creating the immutable delivery boundary so a straggler commit
+        // cannot hide behind an earlier receipt or parked anchor.
+        if let Err(message) = validate_current_factory_branch_tip_ancestry(
+            &context.repo_root,
+            &input.source_branch,
+            &input.target_branch,
+        ) {
+            return Ok(Self::tool_error(format!(
+                "DELIVERY RECEIPT REJECTED: task {} cannot enter pending_supervisor_review until the current source tip is merged.\n\n{message}",
+                task.id
+            )));
+        }
+
         // A receipt creates a fresh proof boundary. A legacy or earlier-cycle
         // verdict must never authorize this immutable commit by accident.
         // Exact retries return the existing transaction (which may already
@@ -3942,6 +3959,28 @@ impl CasCore {
                     )));
                 }
                 LightweightLintOutcome::Pass => {
+                    // cas-2b667 / GH #588: this is the final decision point
+                    // before the task becomes PendingSupervisorReview. The
+                    // earlier merge gate may have used a parked task anchor
+                    // (which is correct for final-close/content accounting),
+                    // but that cached anchor cannot authorize this queue hop
+                    // while the current factory branch has a straggler tip.
+                    if is_factory_worker
+                        && let Some(assignee) = task.assignee.as_deref()
+                    {
+                        let factory_branch = format!("factory/{assignee}");
+                        if let Err(message) = validate_current_factory_branch_tip_ancestry(
+                            &close_project_root,
+                            &factory_branch,
+                            &resolved_parent_branch,
+                        ) {
+                            return Ok(Self::tool_error(format!(
+                                "⚠️ MERGE REQUIRED\n\nTask {} cannot enter pending_supervisor_review until its current factory branch tip is merged.\n\n{message}",
+                                req.id
+                            )));
+                        }
+                    }
+
                     // Transition to PendingSupervisorReview.
                     let mut task_to_pend = task.clone();
                     let now = chrono::Utc::now();
@@ -6544,6 +6583,54 @@ fn delivery_content_anchor_at_close<'a>(
     } else {
         recorded_anchor
     }
+}
+
+/// Re-fetch the integration target and verify the *live* factory branch tip
+/// before a close path enters `PendingSupervisorReview`.
+///
+/// The ordinary merge gate may intentionally use a parked anchor for an
+/// `AwaitingMerge` task: that anchor keeps a recycled worker lane's later,
+/// unrelated commits from re-stranding an already-delivered task. That
+/// historical proof is not sufficient for the supervisor-review queue,
+/// however. Queueing review advertises the current branch as ready, so the
+/// current branch tip must itself be reachable from the current target.
+///
+/// `fetch_parent_branch_best_effort` refreshes `origin/<parent_branch>` before
+/// the target ref is selected. When that remote-tracking ref exists it is the
+/// authoritative target view; local-only repositories retain their local
+/// target behavior. Missing or unresolvable Git state fails closed because a
+/// review-pending transition must never be based on a cached anchor alone.
+pub(crate) fn validate_current_factory_branch_tip_ancestry(
+    repo_path: &std::path::Path,
+    factory_branch: &str,
+    parent_branch: &str,
+) -> Result<String, String> {
+    if !is_safe_git_refname(factory_branch) || !is_safe_git_refname(parent_branch) {
+        return Err(format!(
+            "current close-tip ancestry check rejected unsafe ref name(s): factory branch {factory_branch:?}, target branch {parent_branch:?}."
+        ));
+    }
+
+    let fetch_attempted = fetch_parent_branch_best_effort(repo_path, parent_branch);
+    let branch_tip = resolve_branch_sha(repo_path, factory_branch).ok_or_else(|| {
+        format!(
+            "current factory branch tip {factory_branch} could not be resolved after the target fetch (fetch_attempted={fetch_attempted})."
+        )
+    })?;
+    let target_ref = preferred_diff_target_ref(repo_path, parent_branch);
+    let target_tip = resolve_branch_sha(repo_path, &target_ref).ok_or_else(|| {
+        format!(
+            "current integration target {target_ref} could not be resolved after the target fetch (fetch_attempted={fetch_attempted})."
+        )
+    })?;
+
+    if !git_commit_is_ancestor(repo_path, &branch_tip, &target_ref) {
+        return Err(format!(
+            "current factory branch tip {factory_branch}@{branch_tip} is not an ancestor of the current integration target {target_ref}@{target_tip} after a target fetch (fetch_attempted={fetch_attempted}). Merge the current factory branch tip into {parent_branch} before retrying close."
+        ));
+    }
+
+    Ok(branch_tip)
 }
 
 /// Backwards-compatible shim: evaluate the gate with no delivery-scoping
@@ -18494,6 +18581,135 @@ mod merge_state_gate_tests {
              regardless of task B's later unmerged work on the same branch, \
              got {out:?}"
         );
+    }
+
+    /// cas-2b667 / GH #588: a parked anchor can be fully merged while the
+    /// worker pushes a straggler before the review decision is persisted. The
+    /// ordinary gate intentionally proceeds on the historical anchor, but a
+    /// review-pending transition must reject the current branch tip.
+    #[test]
+    fn review_queue_revalidation_rejects_partial_merge_with_straggler_tip_cas_2b667() {
+        let dir = init_factory_repo("worker");
+        let p = dir.path();
+
+        // The first close captured A+B as the task's parked delivery anchor.
+        for (name, contents) in [("a.rs", "// A\n"), ("b.rs", "// B\n")] {
+            std::fs::write(p.join(name), contents).unwrap();
+            git(p, &["add", name]);
+            git(p, &["commit", "-q", "-m", &format!("feat: task {name}")]);
+        }
+        let parked_anchor = rev_parse(p, "factory/worker");
+
+        // The supervisor merges A+B, then the worker pushes C before the
+        // close decision reaches the supervisor-review queue.
+        git(p, &["checkout", "-q", "main"]);
+        git(
+            p,
+            &[
+                "merge",
+                "-q",
+                "--no-ff",
+                "factory/worker",
+                "-m",
+                "merge task A+B",
+            ],
+        );
+        git(p, &["checkout", "-q", "factory/worker"]);
+        std::fs::write(p.join("c.rs"), "// straggler C\n").unwrap();
+        git(p, &["add", "c.rs"]);
+        git(p, &["commit", "-q", "-m", "feat: straggler C"]);
+        let current_tip = rev_parse(p, "factory/worker");
+
+        assert!(
+            git_commit_is_ancestor(p, &parked_anchor, "main"),
+            "precondition: the parked A+B anchor must be merged"
+        );
+        assert!(
+            !git_commit_is_ancestor(p, &current_tip, "main"),
+            "precondition: straggler C must not be merged"
+        );
+
+        let mut task = worker_task("worker");
+        task.status = TaskStatus::AwaitingMerge;
+        task.deliverables.factory_branch_anchor = Some(parked_anchor);
+        let req = base_req(&task.id);
+        assert!(
+            matches!(
+                run_factory_branch_merge_gate(&task, &req, "main", p),
+                MergeStateGateOutcome::Proceed
+            ),
+            "precondition: the historical-anchor gate reproduces the GH #588 false Proceed"
+        );
+
+        let rejection = validate_current_factory_branch_tip_ancestry(
+            p,
+            "factory/worker",
+            "main",
+        )
+        .expect_err("review queue must reject the unmerged current tip");
+        assert!(rejection.contains(&current_tip), "{rejection}");
+        assert!(rejection.contains("not an ancestor of"), "{rejection}");
+        assert!(rejection.contains("main"), "{rejection}");
+    }
+
+    /// The decision-time check must use the freshly fetched remote target,
+    /// not a stale local target ref. The live source tip is still rejected
+    /// when the remote target contains only the partially merged A+B.
+    #[test]
+    fn review_queue_revalidation_refreshes_remote_target_before_ancestry_check_cas_2b667() {
+        let bare = tempfile::tempdir().unwrap();
+        git_command(bare.path(), &["init", "-q", "--bare"])
+            .status()
+            .expect("init bare origin");
+        let dir = init_factory_repo("worker");
+        let p = dir.path();
+        git(p, &["remote", "add", "origin", bare.path().to_str().unwrap()]);
+        git(p, &["push", "-q", "origin", "main"]);
+
+        for (name, contents) in [("a.rs", "// A\n"), ("b.rs", "// B\n")] {
+            std::fs::write(p.join(name), contents).unwrap();
+            git(p, &["add", name]);
+            git(p, &["commit", "-q", "-m", &format!("feat: task {name}")]);
+        }
+        let parked_anchor = rev_parse(p, "factory/worker");
+        git(p, &["checkout", "-q", "main"]);
+        git(
+            p,
+            &[
+                "merge",
+                "-q",
+                "--no-ff",
+                "factory/worker",
+                "-m",
+                "merge task A+B",
+            ],
+        );
+        git(p, &["push", "-q", "origin", "main"]);
+        let old_local_main = rev_parse(p, "main~1");
+        git(p, &["checkout", "-q", "factory/worker"]);
+        git(p, &["branch", "-f", "main", &old_local_main]);
+        std::fs::write(p.join("c.rs"), "// straggler C\n").unwrap();
+        git(p, &["add", "c.rs"]);
+        git(p, &["commit", "-q", "-m", "feat: straggler C"]);
+        let current_tip = rev_parse(p, "factory/worker");
+
+        assert!(
+            !git_commit_is_ancestor(p, &parked_anchor, "main"),
+            "precondition: local target ref must be stale"
+        );
+        assert!(
+            git_commit_is_ancestor(p, &parked_anchor, "origin/main"),
+            "precondition: remote target contains the partial merge"
+        );
+
+        let rejection = validate_current_factory_branch_tip_ancestry(
+            p,
+            "factory/worker",
+            "main",
+        )
+        .expect_err("the current straggler tip must not pass against origin/main");
+        assert!(rejection.contains(&current_tip), "{rejection}");
+        assert!(rejection.contains("origin/main"), "{rejection}");
     }
 
     /// cas-fe81: sequential batch merges may edit adjacent context in one

--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -25,8 +25,15 @@ pub(crate) const INBOX_REDELIVERY_MARKER: &str = "[redelivery]";
 /// A plain sender prefix cannot distinguish a late spawn task brief from a
 /// fresh supervisor reply. The queue already knows the facts a worker needs;
 /// keep them visible at the final render boundary instead of asking an agent
-/// to reconstruct them from prose and timing.
-pub(crate) fn queued_message_provenance(message: &cas_store::QueuedPrompt) -> String {
+/// to reconstruct them from prose and timing. Five minutes is an operational
+/// freshness marker, not the 24-hour terminal quarantine TTL: a message can be
+/// valid but still worth calling out as late to the recipient.
+pub(crate) const MESSAGE_PROVENANCE_STALE_AFTER_SECS: i64 = 5 * 60;
+
+pub(crate) fn queued_message_provenance_at(
+    message: &cas_store::QueuedPrompt,
+    observed_at: chrono::DateTime<chrono::Utc>,
+) -> String {
     let origin = if message.source.eq_ignore_ascii_case("supervisor") {
         "supervisor-authored"
     } else if message.source.eq_ignore_ascii_case("viktor") {
@@ -50,18 +57,26 @@ pub(crate) fn queued_message_provenance(message: &cas_store::QueuedPrompt) -> St
     } else {
         "first-delivery"
     };
+    let age_secs = (observed_at - message.created_at).num_seconds().max(0);
+    let stale = age_secs >= MESSAGE_PROVENANCE_STALE_AFTER_SECS;
     format!(
-        "CAS provenance: notification_id={} origin={} queued_at={} delivery={}",
+        "CAS provenance: notification_id={} origin={} queued_at={} age_secs={} stale={} delivery={}",
         message.id,
         origin,
         message.created_at.to_rfc3339(),
+        age_secs,
+        stale,
         delivery,
     )
 }
 
+pub(crate) fn queued_message_provenance(message: &cas_store::QueuedPrompt) -> String {
+    queued_message_provenance_at(message, chrono::Utc::now())
+}
+
 #[cfg(test)]
 mod viktor_provenance_tests {
-    use super::queued_message_provenance;
+    use super::queued_message_provenance_at;
     use cas_store::{NotificationPriority, QueuedPrompt};
 
     #[test]
@@ -82,10 +97,36 @@ mod viktor_provenance_tests {
             urgent: false,
         };
 
+        let observed_at = chrono::DateTime::parse_from_rfc3339("2026-08-18T20:06:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
         assert_eq!(
-            queued_message_provenance(&row),
-            "CAS provenance: notification_id=73 origin=viktor queued_at=2026-08-18T20:00:00+00:00 delivery=first-delivery"
+            queued_message_provenance_at(&row, observed_at),
+            "CAS provenance: notification_id=73 origin=viktor queued_at=2026-08-18T20:00:00+00:00 age_secs=360 stale=true delivery=first-delivery"
         );
+    }
+
+    #[test]
+    fn provenance_marks_only_rows_past_the_operational_freshness_window() {
+        let row = QueuedPrompt {
+            id: 74,
+            source: "director".to_string(),
+            target: "worker-1".to_string(),
+            prompt: "assignment".to_string(),
+            created_at: chrono::DateTime::parse_from_rfc3339("2026-08-18T20:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            processed_at: None,
+            factory_session: Some("factory-1".to_string()),
+            summary: Some("Assigned task: cas-test".to_string()),
+            priority: NotificationPriority::Normal,
+            acked_at: None,
+            urgent: false,
+        };
+        let observed_at = row.created_at + chrono::Duration::seconds(299);
+        let provenance = queued_message_provenance_at(&row, observed_at);
+        assert!(provenance.contains("age_secs=299"));
+        assert!(provenance.contains("stale=false"));
     }
 }
 
@@ -1559,6 +1600,48 @@ impl CasService {
                 withheld.push((
                     message.id,
                     format!("assignment for {task_id}, already done: {status}"),
+                ));
+                continue;
+            }
+            // GH #589: a registration-time spawn brief that arrives after the
+            // addressed worker has already moved its task beyond Open is stale
+            // even when the daemon never stamped transport delivery. Do not
+            // render old `task start` boilerplate from a direct inbox poll.
+            let started_spawn_assignment = if message.source.eq_ignore_ascii_case("director")
+                && message
+                    .summary
+                    .as_deref()
+                    .is_some_and(|summary| summary.starts_with("Assigned task:"))
+            {
+                solicited_task.as_deref().and_then(|task_id| {
+                    task_store.as_ref().and_then(|store| {
+                        store.get(task_id).ok().and_then(|task| {
+                            crate::prompt_revalidation::assignment_targets_started_task(
+                                &message.prompt,
+                                task.status,
+                                task.assignee.as_deref(),
+                                &recipient,
+                            )
+                            .map(|task_id| (task_id, task.status))
+                        })
+                    })
+                })
+            } else {
+                None
+            };
+            if let Some((task_id, status)) = started_spawn_assignment {
+                tracing::info!(
+                    target: "cas::coordination",
+                    stage = "inbox_withheld_started_assignment",
+                    prompt_id = message.id,
+                    recipient = %recipient,
+                    task_id = %task_id,
+                    status = %status,
+                    "cas-589: withheld a delayed spawn assignment after the addressed worker started the task"
+                );
+                withheld.push((
+                    message.id,
+                    format!("spawn assignment for {task_id}, already started: {status}"),
                 ));
                 continue;
             }

--- a/cas-cli/src/mcp/tools/service/agent_search_system/system.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/system.rs
@@ -1,5 +1,150 @@
 use crate::mcp::tools::service::imports::*;
 
+use std::path::Path;
+use std::process::{Command, Output};
+
+const ISSUE_REPO_SETUP: &str =
+    "issues.repo is not configured; set it with `cas config set issues.repo owner/name`";
+
+#[derive(Debug, PartialEq, Eq)]
+struct BugFilingOutcome {
+    url: String,
+    degradation: Option<String>,
+}
+
+trait BugFilingTransport {
+    fn ensure_agent_reported_label(&self, repo: &str) -> Result<(), String>;
+
+    fn create_issue(
+        &self,
+        repo: &str,
+        title: &str,
+        body: &str,
+        labels: &[&str],
+    ) -> Result<String, String>;
+}
+
+struct GhBugFilingTransport;
+
+impl BugFilingTransport for GhBugFilingTransport {
+    fn ensure_agent_reported_label(&self, repo: &str) -> Result<(), String> {
+        let output = Command::new("gh")
+            .args([
+                "label",
+                "create",
+                "agent-reported",
+                "--repo",
+                repo,
+                "--color",
+                "B60205",
+                "--description",
+                "Reported by an automated Cassy agent",
+                "--force",
+            ])
+            .output()
+            .map_err(|error| format!("Failed to run gh CLI while preparing label: {error}"))?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(command_failure_detail(&output))
+        }
+    }
+
+    fn create_issue(
+        &self,
+        repo: &str,
+        title: &str,
+        body: &str,
+        labels: &[&str],
+    ) -> Result<String, String> {
+        let mut command = Command::new("gh");
+        command.args([
+            "issue", "create", "--repo", repo, "--title", title, "--body", body,
+        ]);
+        for label in labels {
+            command.args(["--label", label]);
+        }
+
+        let output = command.output().map_err(|error| {
+            format!("Failed to run gh CLI: {error}. Is gh installed and authenticated?")
+        })?;
+
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            Err(command_failure_detail(&output))
+        }
+    }
+}
+
+fn command_failure_detail(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        stderr
+    } else {
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("exit status {}", output.status)
+        }
+    }
+}
+
+fn resolve_issue_repo(cas_root: &Path) -> Result<String, String> {
+    let config = crate::config::Config::load(cas_root)
+        .map_err(|error| format!("Failed to load config: {error}"))?;
+    let Some(repo) = config.issues.and_then(|issues| issues.repo) else {
+        return Err(ISSUE_REPO_SETUP.to_string());
+    };
+
+    let repo = repo.trim();
+    if repo.is_empty() {
+        return Err(ISSUE_REPO_SETUP.to_string());
+    }
+    if crate::gh_graphql::split_repo(repo).is_err() {
+        return Err(
+            "issues.repo must be configured as `owner/name`; set it with `cas config set issues.repo owner/name`"
+                .to_string(),
+        );
+    }
+
+    Ok(repo.to_string())
+}
+
+fn file_bug_report<T: BugFilingTransport>(
+    transport: &T,
+    repo: &str,
+    title: &str,
+    body: &str,
+) -> Result<BugFilingOutcome, String> {
+    let label_error = transport.ensure_agent_reported_label(repo).err();
+    let labels: &[&str] = if label_error.is_none() {
+        &["bug", "agent-reported"]
+    } else {
+        &[]
+    };
+
+    let url = transport.create_issue(repo, title, body, labels).map_err(|error| {
+        if let Some(label_error) = label_error.as_deref() {
+            format!(
+                "Failed to create issue: {error}; agent-reported label setup failed ({label_error})"
+            )
+        } else {
+            format!("Failed to create issue: {error}")
+        }
+    })?;
+
+    let degradation = label_error.map(|error| {
+        format!(
+            "Warning: could not prepare the agent-reported label ({error}); issue was filed labeless."
+        )
+    });
+
+    Ok(BugFilingOutcome { url, degradation })
+}
+
 #[cfg(feature = "mcp-proxy")]
 fn parse_proxy_health_cache(json: &str) -> serde_json::Result<serde_json::Value> {
     serde_json::from_str::<cmcp_core::ProxyHealthSnapshot>(json)
@@ -209,40 +354,20 @@ impl CasService {
             arch = arch,
         );
 
-        let output = std::process::Command::new("gh")
-            .args([
-                "issue",
-                "create",
-                "--repo",
-                "Richards-LLC/cassy",
-                "--title",
-                &title,
-                "--body",
-                &body,
-                "--label",
-                "bug,agent-reported",
-            ])
-            .output()
-            .map_err(|error| {
-                Self::error(
-                    ErrorCode::INTERNAL_ERROR,
-                    format!("Failed to run gh CLI: {error}. Is gh installed and authenticated?"),
-                )
-            })?;
+        let repo = resolve_issue_repo(&self.inner.cas_root)
+            .map_err(|message| Self::error(ErrorCode::INVALID_PARAMS, message))?;
+        let outcome = file_bug_report(&GhBugFilingTransport, &repo, &title, &body)
+            .map_err(|message| Self::error(ErrorCode::INTERNAL_ERROR, message))?;
+        let degradation = outcome
+            .degradation
+            .map(|message| format!("\n\n{message}"))
+            .unwrap_or_default();
 
-        if output.status.success() {
-            let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            Ok(Self::success(format!(
-                "Bug report created: {url}\n\nNote: Home directory paths were auto-anonymized. \
-                Please verify the issue doesn't contain sensitive project data."
-            )))
-        } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            Err(Self::error(
-                ErrorCode::INTERNAL_ERROR,
-                format!("Failed to create issue: {stderr}"),
-            ))
-        }
+        Ok(Self::success(format!(
+            "Bug report created: {}\n\nNote: Home directory paths were auto-anonymized. \
+            Please verify the issue doesn't contain sensitive project data.{}",
+            outcome.url, degradation
+        )))
     }
 
     // ========================================================================
@@ -532,10 +657,106 @@ impl CasService {
     }
 }
 
-#[cfg(all(test, feature = "mcp-proxy"))]
+#[cfg(test)]
 mod tests {
+    use super::{BugFilingTransport, file_bug_report, resolve_issue_repo};
+
+    #[derive(Debug)]
+    struct FakeTransport {
+        label_result: Result<(), String>,
+        issue_url: String,
+        labels_seen: std::cell::RefCell<Vec<String>>,
+    }
+
+    impl BugFilingTransport for FakeTransport {
+        fn ensure_agent_reported_label(&self, _repo: &str) -> Result<(), String> {
+            self.label_result.clone()
+        }
+
+        fn create_issue(
+            &self,
+            _repo: &str,
+            _title: &str,
+            _body: &str,
+            labels: &[&str],
+        ) -> Result<String, String> {
+            self.labels_seen
+                .borrow_mut()
+                .extend(labels.iter().map(|label| (*label).to_string()));
+            Ok(self.issue_url.clone())
+        }
+    }
+
+    #[test]
+    fn missing_agent_label_files_labeless_and_reports_degradation() {
+        let transport = FakeTransport {
+            label_result: Err("permission denied".to_string()),
+            issue_url: "https://github.com/example/cassy/issues/1".to_string(),
+            labels_seen: std::cell::RefCell::new(Vec::new()),
+        };
+
+        let outcome = file_bug_report(&transport, "example/cassy", "title", "body")
+            .expect("issue creation should continue without the cosmetic label");
+
+        assert_eq!(outcome.url, "https://github.com/example/cassy/issues/1");
+        assert!(
+            outcome
+                .degradation
+                .as_deref()
+                .is_some_and(|message| message.contains("filed labeless"))
+        );
+        assert!(transport.labels_seen.borrow().is_empty());
+    }
+
+    #[test]
+    fn available_agent_label_is_applied_with_the_bug_label() {
+        let transport = FakeTransport {
+            label_result: Ok(()),
+            issue_url: "https://github.com/example/cassy/issues/2".to_string(),
+            labels_seen: std::cell::RefCell::new(Vec::new()),
+        };
+
+        let outcome = file_bug_report(&transport, "example/cassy", "title", "body")
+            .expect("issue creation should succeed");
+
+        assert_eq!(outcome.url, "https://github.com/example/cassy/issues/2");
+        assert!(outcome.degradation.is_none());
+        assert_eq!(
+            &*transport.labels_seen.borrow(),
+            &["bug".to_string(), "agent-reported".to_string()]
+        );
+    }
+
+    #[test]
+    fn unset_issue_repo_refuses_without_an_implicit_target() {
+        let temp = tempfile::tempdir().expect("temporary config directory");
+        let error = resolve_issue_repo(temp.path()).expect_err("unset repo must refuse");
+
+        assert!(error.contains("issues.repo"));
+        assert!(error.contains("cas config set issues.repo owner/name"));
+    }
+
+    #[test]
+    fn configured_issue_repo_is_the_only_filing_target() {
+        let temp = tempfile::tempdir().expect("temporary config directory");
+        let mut config = crate::config::Config::default();
+        config
+            .set("issues.repo", "example/project")
+            .expect("repo setting should be valid");
+        config
+            .save(temp.path())
+            .expect("project config should be saved");
+
+        assert_eq!(
+            resolve_issue_repo(temp.path()).expect("configured repo should resolve"),
+            "example/project"
+        );
+    }
+
+    #[cfg(feature = "mcp-proxy")]
     use super::parse_proxy_health_cache;
 
+    #[cfg(feature = "mcp-proxy")]
     #[test]
     fn forged_cached_health_is_sanitized_before_system_json() {
         let raw_name = "https://user:token@example.invalid/private";

--- a/cas-cli/src/prompt_revalidation.rs
+++ b/cas-cli/src/prompt_revalidation.rs
@@ -53,6 +53,30 @@ pub(crate) fn assignment_targets_terminal_task(prompt: &str, status: TaskStatus)
         .flatten()
 }
 
+/// A spawn-time assignment is stale once the addressed worker has already
+/// moved its assigned task past `Open`. This is separate from terminal-task
+/// suppression: an in-progress or parked task is still valid work, but its
+/// original `task start` boilerplate is no longer an actionable instruction.
+/// Require the same assignee so another worker's progress cannot suppress a
+/// message that this recipient may still need.
+pub(crate) fn assignment_targets_started_task(
+    prompt: &str,
+    status: TaskStatus,
+    assignee: Option<&str>,
+    recipient: &str,
+) -> Option<String> {
+    matches!(
+        status,
+        TaskStatus::InProgress
+            | TaskStatus::Blocked
+            | TaskStatus::PendingSupervisorReview
+            | TaskStatus::AwaitingMerge
+    )
+    .then(|| assignment_solicited_task_id(prompt))
+    .flatten()
+    .filter(|_| assignee.is_some_and(|owner| owner.eq_ignore_ascii_case(recipient)))
+}
+
 fn first_task_id_token(text: &str) -> Option<String> {
     text.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-'))
         .find(|token| {
@@ -688,7 +712,10 @@ pub(crate) fn revalidate_lifecycle_prompt(
 
 #[cfg(test)]
 mod cas_8aee_assignment_delivery_tests {
-    use super::{assignment_solicited_task_id, assignment_targets_terminal_task};
+    use super::{
+        assignment_solicited_task_id, assignment_targets_started_task,
+        assignment_targets_terminal_task,
+    };
     use cas_types::TaskStatus;
 
     #[test]
@@ -726,6 +753,43 @@ mod cas_8aee_assignment_delivery_tests {
                 "a terminal spawn intro must not reach any renderer with task-start guidance"
             );
         }
+    }
+
+    #[test]
+    fn queued_spawn_intro_is_stale_after_the_addressed_worker_started_it() {
+        let prompt = "You were spawned for task cas-bc5c — \"Customer communications\" — and it is assigned to you now.\n\
+                      Start with `mcp__cas__task action=show id=cas-bc5c`, then \
+                      `mcp__cas__task action=start id=cas-bc5c` before you change any code.";
+        assert_eq!(
+            assignment_targets_started_task(
+                prompt,
+                TaskStatus::InProgress,
+                Some("worker-1"),
+                "worker-1",
+            )
+            .as_deref(),
+            Some("cas-bc5c")
+        );
+        assert!(
+            assignment_targets_started_task(
+                prompt,
+                TaskStatus::InProgress,
+                Some("worker-2"),
+                "worker-1",
+            )
+            .is_none(),
+            "another worker starting the task is not evidence for this recipient"
+        );
+        assert!(
+            assignment_targets_started_task(
+                prompt,
+                TaskStatus::Open,
+                Some("worker-1"),
+                "worker-1",
+            )
+            .is_none(),
+            "an open task still needs its assignment instruction"
+        );
     }
 }
 

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -951,13 +951,12 @@ fn fast_forward_epic_base_from_parent(
     )))
 }
 
-/// Explain why a declared-parent refresh could not be completed without
-/// hiding the branch pair that needs reconciliation. The caller may still cut
-/// the worker from the existing base, but it must not emit the generic stale
-/// warning as though the refresh path had never been attempted.
-fn epic_base_refresh_impossible_notice(error: &str) -> String {
+/// Turn a declared-parent refresh failure into a hard spawn refusal. The
+/// branch pair in `error` is intentionally preserved so the operator knows
+/// exactly which histories must be reconciled before another cut.
+fn epic_base_refresh_refusal(error: &str) -> String {
     format!(
-        "⚠️ EPIC BASE REFRESH IMPOSSIBLE: {error}. The worker will be cut from the existing base; reconcile the named branches before relying on its history."
+        "EPIC BASE REFRESH REFUSED: {error}. Reconcile the named branches before spawning a worker."
     )
 }
 
@@ -1728,19 +1727,15 @@ impl FactoryApp {
                     .or_else(|| {
                         recorded_epic_parent_branch_for_resolved_base(&self.cas_dir, &parent_branch)
                     });
-                let mut declared_parent_refresh_warned = false;
                 if let Some((epic_branch, recorded_parent)) = recorded_base_parent {
-                    match fast_forward_epic_base_from_parent(
+                    let refresh = fast_forward_epic_base_from_parent(
                         manager.repo_root(),
                         &epic_branch,
                         &recorded_parent,
-                    ) {
-                        Ok(Some(notice)) => notices.push(notice),
-                        Ok(None) => {}
-                        Err(error) => {
-                            declared_parent_refresh_warned = true;
-                            notices.push(epic_base_refresh_impossible_notice(&error));
-                        }
+                    )
+                    .map_err(|error| anyhow::anyhow!("{}", epic_base_refresh_refusal(&error)))?;
+                    if let Some(notice) = refresh {
+                        notices.push(notice);
                     }
                 }
                 // cas-d897 (GH #146): the winning branch name still has to be
@@ -1809,9 +1804,8 @@ impl FactoryApp {
                 // branch it names can be far behind trunk. Surface that at
                 // spawn time instead of leaving it to whoever happens to read
                 // `behind:` in worker_status.
-                if !declared_parent_refresh_warned
-                    && let Some(notice) =
-                        stale_spawn_base_notice(manager.repo_root(), effective_base, &trunk)
+                if let Some(notice) =
+                    stale_spawn_base_notice(manager.repo_root(), effective_base, &trunk)
                 {
                     notices.push(notice);
                 }
@@ -3716,6 +3710,12 @@ mod spawn_base_tests {
             .unwrap();
 
         commit(&origin, "parent-advance.txt", "parent advanced upstream");
+        std::fs::create_dir_all(origin.join(".claude/workflows")).unwrap();
+        commit(
+            &origin,
+            ".claude/workflows/current-support-playbook.md",
+            "current support playbook",
+        );
         let parent_tip = head_sha(&origin, "main");
 
         let notice = fast_forward_epic_base_from_parent(&repo, "epic/behind", "main")
@@ -3758,6 +3758,14 @@ mod spawn_base_tests {
         assert!(
             worker_path.join("parent-advance.txt").exists(),
             "the spawned worktree must include the parent branch advance"
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                worker_path.join(".claude/workflows/current-support-playbook.md"),
+            )
+            .unwrap(),
+            "current support playbook",
+            "a no-code worker must receive the current playbook from the refreshed parent"
         );
     }
 
@@ -4051,16 +4059,20 @@ mod spawn_base_tests {
         let error = fast_forward_epic_base_from_parent(&repo, "epic/diverged", "main")
             .expect_err("divergent epic/parent history cannot be fast-forwarded");
         assert!(error.contains("have diverged"), "{error}");
-        let warning = epic_base_refresh_impossible_notice(&error);
+        let refusal = epic_base_refresh_refusal(&error);
         assert!(
-            warning.contains("EPIC BASE REFRESH IMPOSSIBLE"),
-            "{warning}"
+            refusal.contains("EPIC BASE REFRESH REFUSED"),
+            "{refusal}"
         );
-        assert!(warning.contains("epic/diverged"), "{warning}");
-        assert!(warning.contains("main"), "{warning}");
+        assert!(refusal.contains("epic/diverged"), "{refusal}");
+        assert!(refusal.contains("main"), "{refusal}");
         assert!(
-            !warning.contains("STALE WORKER BASE"),
-            "the irreconcilable base must receive its specific warning, not a duplicate generic warning: {warning}"
+            !refusal.contains("will be cut"),
+            "a divergence refusal must never promise a stale worker cut: {refusal}"
+        );
+        assert!(
+            !refusal.contains("STALE WORKER BASE"),
+            "the irreconcilable base must receive its specific refusal, not a duplicate generic warning: {refusal}"
         );
         assert_eq!(
             head_sha(&repo, "epic/diverged"),
@@ -4070,6 +4082,104 @@ mod spawn_base_tests {
         assert!(
             stale_spawn_base_notice(&repo, "epic/diverged", "main").is_some(),
             "the divergence remains explicitly diagnosable to the spawning caller"
+        );
+    }
+
+    /// GH #584 / cas-a075: the production spawn-preparation seam must stop
+    /// before `WorkerSpawnPrep` can cut a no-code worker from a diverged epic.
+    #[test]
+    fn no_code_spawn_refuses_diverged_epic_before_worktree_cut_cas_a075() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        init_repo(&repo);
+
+        Command::new("git")
+            .args(["checkout", "-q", "-b", "epic/diverged-support"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+        commit(&repo, "epic-only.txt", "support epic work");
+        Command::new("git")
+            .args(["checkout", "-q", "main"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+        commit(&repo, "parent-only.txt", "current support playbook parent");
+
+        let cas_dir = crate::store::init_cas_dir(&repo).unwrap();
+        let store = crate::store::open_task_store(&cas_dir).unwrap();
+        let mut epic = cas_types::Task::new("cas-support-epic".into(), "support epic".into());
+        epic.task_type = cas_types::TaskType::Epic;
+        epic.branch = Some("epic/diverged-support".into());
+        epic.deliverables.work_target = Some(cas_types::WorkTarget {
+            repo_selector: "project:test".into(),
+            target_branch: "main".into(),
+        });
+        store.add(&epic).unwrap();
+        let mut child = cas_types::Task::new("cas-support-child".into(), "support task".into());
+        child.execution_note = Some("no-code".into());
+        store.add(&child).unwrap();
+        store
+            .add_dependency(&cas_types::Dependency {
+                from_id: child.id.clone(),
+                to_id: epic.id.clone(),
+                dep_type: cas_types::DependencyType::ParentChild,
+                created_at: chrono::Utc::now(),
+                created_by: None,
+            })
+            .unwrap();
+
+        let worktree_root = repo.join(".cas").join("worktrees");
+        let manager = WorktreeManager::new(
+            &repo,
+            WorktreeConfig {
+                enabled: true,
+                base_path: worktree_root.to_string_lossy().to_string(),
+                branch_prefix: "factory/".to_string(),
+                auto_merge: false,
+                cleanup_on_close: false,
+                promote_entries_on_merge: false,
+            },
+        )
+        .unwrap();
+        let worker_path = manager.worktree_path_for_worker("diverged-support-worker");
+        let mut app = FactoryApp::from_init_result(
+            cas_dir.clone(),
+            Mux::new(40, 120),
+            Some(manager),
+            DirectorData::load_fast(&cas_dir).unwrap(),
+            "support-supervisor".into(),
+            Vec::new(),
+            crate::ui::factory::notification::NotifyConfig::default(),
+            false,
+            AutoPromptConfig::default(),
+            cas_mux::SupervisorCli::Claude,
+            cas_mux::SupervisorCli::Claude,
+            120,
+            40,
+            false,
+            None,
+            None,
+            repo,
+        )
+        .unwrap();
+
+        let error = match app.prepare_worker_spawn(
+            Some("diverged-support-worker"),
+            true,
+            Some("cas-support-child"),
+        ) {
+            Ok(_) => panic!("diverged no-code epic must refuse before preparing a cut"),
+            Err(error) => error,
+        };
+        let error = error.to_string();
+        assert!(error.contains("EPIC BASE REFRESH REFUSED"), "{error}");
+        assert!(error.contains("epic/diverged-support"), "{error}");
+        assert!(error.contains("main"), "{error}");
+        assert!(
+            !worker_path.exists(),
+            "refused spawn must not create the worker worktree"
         );
     }
 

--- a/cas-cli/src/ui/factory/daemon/runtime/delivery.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/delivery.rs
@@ -18,8 +18,26 @@
 
 use cas_mux::{InjectOutcome, SupervisorCli};
 use cas_store::WakeAttempt;
+use std::path::Path;
 
 use super::super::FactoryDaemon;
+
+/// Wake the daemon after a producer appends to `prompt_queue`.
+///
+/// The MCP message path has always sent this best-effort datagram, but daemon
+/// lifecycle producers used to rely on the timer poll. That left a spawn brief
+/// and other internally generated prompts at the mercy of the next unrelated
+/// wake. The queue remains durable when no daemon is listening; this helper is
+/// only the low-latency handoff signal.
+pub(crate) fn wake_daemon_after_enqueue(cas_dir: &Path) {
+    if let Err(error) = cas_factory::notify_daemon(cas_dir) {
+        tracing::debug!(
+            target: "cas::coordination",
+            %error,
+            "prompt_queue enqueue wake signal could not reach the daemon"
+        );
+    }
+}
 
 /// The result of a delivery that may carry a wake nudge (cas-7a01, GH #155).
 ///
@@ -284,13 +302,15 @@ pub(crate) fn enqueue_director_prompt(
     text: &str,
 ) -> anyhow::Result<i64> {
     let queue = crate::store::open_prompt_queue_store(cas_dir)?;
-    Ok(queue.enqueue_with_summary(
+    let id = queue.enqueue_with_summary(
         super::teams::DIRECTOR_AGENT_NAME,
         target,
         text,
         Some(factory_session),
         Some("Task assignment"),
-    )?)
+    )?;
+    wake_daemon_after_enqueue(cas_dir);
+    Ok(id)
 }
 
 /// Prefix PTY-delivered text with literal sender attribution.
@@ -536,7 +556,7 @@ impl FactoryDaemon {
         // Match coordination's best-effort wake signal. This daemon will also
         // observe the row on its next queue pass if signaling is unavailable.
         if matches!(outcome, cas_store::EnqueueOutcome::Created(_)) {
-            let _ = cas_factory::notify_daemon(self.app.cas_dir());
+            wake_daemon_after_enqueue(self.app.cas_dir());
         }
         Ok(outcome)
     }

--- a/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
@@ -220,6 +220,7 @@ pub(super) fn enqueue_merge_queue_ejection_relay(
     {
         return WorkerAttentionRelayOutcome::Pending;
     }
+    super::delivery::wake_daemon_after_enqueue(cas_dir);
     WorkerAttentionRelayOutcome::Persisted { notification_id }
 }
 
@@ -323,6 +324,7 @@ fn enqueue_worker_attention_relay_detail(
         tracing::error!(worker = %worker, kind, notification_id, %error, "worker attention relay prompt enqueue failed");
         return WorkerAttentionRelayOutcome::Pending;
     }
+    super::delivery::wake_daemon_after_enqueue(cas_dir);
     if let Err(error) = supervisor_queue.mark_prompt_delivered(notification_id) {
         tracing::warn!(notification_id, %error, "worker attention relay prompt stamp failed; idempotent replay remains safe");
         return WorkerAttentionRelayOutcome::Pending;
@@ -1007,13 +1009,18 @@ impl FactoryDaemon {
                                                 &self.session_name,
                                                 &failure,
                                             ) {
-                                                Ok(true) => tracing::warn!(
-                                                    branch = %failure.branch,
-                                                    head_sha = %failure.head_sha,
-                                                    run_url = %failure.run_url,
-                                                    failing_job = %failure.failing_job,
-                                                    "queued CI red-run lifecycle wake for supervisor"
-                                                ),
+                                                Ok(true) => {
+                                                    super::delivery::wake_daemon_after_enqueue(
+                                                        self.app.cas_dir(),
+                                                    );
+                                                    tracing::warn!(
+                                                        branch = %failure.branch,
+                                                        head_sha = %failure.head_sha,
+                                                        run_url = %failure.run_url,
+                                                        failing_job = %failure.failing_job,
+                                                        "queued CI red-run lifecycle wake for supervisor"
+                                                    )
+                                                }
                                                 Ok(false) => tracing::debug!(
                                                     branch = %failure.branch,
                                                     head_sha = %failure.head_sha,

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -308,13 +308,15 @@ fn deliver_worker_task_brief(
         message.push_str("\n\n");
         message.push_str(&instruction);
     }
-    Ok(queue.enqueue_with_summary(
+    let id = queue.enqueue_with_summary(
         "director",
         worker_name,
         &message,
         Some(factory_session),
         Some(&summary),
-    )?)
+    )?;
+    super::delivery::wake_daemon_after_enqueue(cas_dir);
+    Ok(id)
 }
 
 /// Surface stale output-path instructions before a worker acts on them. This is
@@ -462,13 +464,15 @@ fn enqueue_spawn_cancelled_notice(
         "Factory spawn for worker '{worker_name}' was cancelled by a shutdown that arrived \
          while it was still building. No worker pane was registered. {cleanup_status}"
     );
-    Ok(queue.enqueue_with_summary(
+    let id = queue.enqueue_with_summary(
         "director",
         supervisor_name,
         &message,
         Some(factory_session),
         Some(&summary),
-    )?)
+    )?;
+    super::delivery::wake_daemon_after_enqueue(cas_dir);
+    Ok(id)
 }
 
 fn append_spawn_audit(
@@ -587,13 +591,15 @@ fn enqueue_spawn_warning_notice(
         .unwrap_or_else(|| "direct spawn".to_string());
     let summary = format!("Worker spawn base warning: {worker_name}");
     let message = format!("Factory spawn {request} for worker '{worker_name}': {warning}");
-    Ok(queue.enqueue_with_summary(
+    let id = queue.enqueue_with_summary(
         "director",
         supervisor_name,
         &message,
         Some(factory_session),
         Some(&summary),
-    )?)
+    )?;
+    super::delivery::wake_daemon_after_enqueue(cas_dir);
+    Ok(id)
 }
 
 /// Drain spawn-prep warnings into the audit trail + the supervisor inbox.
@@ -658,13 +664,15 @@ fn enqueue_spawn_outcome_notice(
             ),
         )
     };
-    Ok(queue.enqueue_with_summary(
+    let id = queue.enqueue_with_summary(
         "director",
         supervisor_name,
         &message,
         Some(factory_session),
         Some(&summary),
-    )?)
+    )?;
+    super::delivery::wake_daemon_after_enqueue(cas_dir);
+    Ok(id)
 }
 
 /// cas-2327 (GH #170): a booted worker whose promised task did not bind is a
@@ -701,10 +709,12 @@ fn enqueue_preassign_failure_lifecycle_relay(
         Some(crate::store::NotificationPriority::High),
         &format!("spawn-preassign-failed:{request}:{worker_name}:{task_id}"),
     )?;
-    Ok(match result {
+    let id = match result {
         cas_store::EnqueueIdempotentResult::Created(id)
         | cas_store::EnqueueIdempotentResult::AlreadyExists(id) => id,
-    })
+    };
+    super::delivery::wake_daemon_after_enqueue(cas_dir);
+    Ok(id)
 }
 
 fn take_unverified_spawn_on_exit(
@@ -1542,6 +1552,8 @@ impl FactoryDaemon {
                         &self.session_name,
                     ) {
                         tracing::error!(%error, message_id = row_id, "failed to queue normal delivery watchdog flag");
+                    } else {
+                        super::delivery::wake_daemon_after_enqueue(self.app.cas_dir());
                     }
                     tracing::warn!(
                         target: "cas::coordination",
@@ -2985,6 +2997,7 @@ impl FactoryDaemon {
                         false,
                     ) {
                         Ok(_) => {
+                            super::delivery::wake_daemon_after_enqueue(self.app.cas_dir());
                             tracing::info!(
                                 target: "cas::coordination",
                                 stage = "suppress_stale_merge_request",
@@ -3145,6 +3158,45 @@ impl FactoryDaemon {
                     task_id = %task_id,
                     status = %task.status,
                     "cas-8aee: suppressed a queued assignment/start instruction for a terminal task"
+                );
+                continue;
+            }
+
+            // A registration-time spawn brief is historical once the same
+            // addressed worker has already started or parked its task. This
+            // closes the other side of GH #589: if the queue wake was delayed,
+            // do not inject a stale `task start` imperative after the worker
+            // has already acted on the assignment through another turn.
+            if queued.source.eq_ignore_ascii_case("director")
+                && queued
+                    .summary
+                    .as_deref()
+                    .is_some_and(|summary| summary.starts_with("Assigned task:"))
+                && let Some(task_id) =
+                    crate::prompt_revalidation::assignment_solicited_task_id(&queued.prompt)
+                && let Ok(store) = crate::store::open_task_store_local(self.app.cas_dir())
+                && let Ok(task) = store.get(&task_id)
+                && let Some(task_id) = crate::prompt_revalidation::assignment_targets_started_task(
+                    &queued.prompt,
+                    task.status,
+                    task.assignee.as_deref(),
+                    &queued.target,
+                )
+            {
+                let detail = format!(
+                    "withdrawn before transport: spawn assignment for {task_id} is stale because the addressed worker already moved the task to {}",
+                    task.status
+                );
+                let _ = queue.mark_superseded(queued.id, &detail);
+                self.forget_row_delivery_state(queued.id);
+                tracing::info!(
+                    target: "cas::coordination",
+                    stage = "suppress_started_assignment",
+                    prompt_id = queued.id,
+                    task_id = %task_id,
+                    status = %task.status,
+                    target_agent = %queued.target,
+                    "cas-589: suppressed a delayed spawn assignment after the addressed worker started the task"
                 );
                 continue;
             }
@@ -4215,12 +4267,19 @@ impl FactoryDaemon {
                                      </system-notice>",
                                     queued.source, pane_target, &queued.prompt
                                 );
-                                let _ = queue.enqueue_with_session(
+                                if let Err(error) = queue.enqueue_with_session(
                                     super::teams::DIRECTOR_AGENT_NAME,
                                     self.app.supervisor_name(),
                                     &notice,
                                     &self.session_name,
-                                );
+                                ) {
+                                    tracing::error!(
+                                        %error,
+                                        "failed to re-queue undelivered message notice"
+                                    );
+                                } else {
+                                    super::delivery::wake_daemon_after_enqueue(self.app.cas_dir());
+                                }
                             }
                         }
                     }
@@ -5704,6 +5763,7 @@ fn fire_reminder(
         {
             tracing::error!("Failed to enqueue reminder prompt: {}", e);
         } else {
+            super::delivery::wake_daemon_after_enqueue(cas_dir);
             tracing::info!(
                 "Fired reminder #{} → {} ({}): {}",
                 reminder.id,
@@ -5878,6 +5938,38 @@ mod tests {
         assert_eq!(tail.chars().count(), 2_000, "tail must remain bounded");
         assert!(tail.ends_with("tail from Claude"), "tail: {tail}");
         assert!(!tail.contains("\x1b["), "ANSI must be stripped: {tail}");
+    }
+
+    /// GH #589: the registration-time assignment brief must wake the daemon
+    /// in the same enqueue transaction boundary as an MCP message. A queued
+    /// row without this signal is only picked up by the fallback timer and,
+    /// once written to a Teams inbox, may wait for an unrelated turn boundary.
+    #[tokio::test]
+    async fn spawn_assignment_brief_wakes_daemon_within_transport_budget() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let cas_dir = crate::store::init_cas_dir(temp.path()).unwrap();
+        let mut notifier = cas_factory::DaemonNotifier::bind(&cas_dir).unwrap();
+
+        let message_id = deliver_worker_task_brief(
+            &cas_dir,
+            "factory-session",
+            "worker-1",
+            "cas-5890",
+            "wake the worker",
+        )
+        .unwrap();
+
+        tokio::time::timeout(Duration::from_millis(100), notifier.recv())
+            .await
+            .expect("spawn assignment enqueue must wake the daemon promptly")
+            .expect("daemon notification socket must receive the wake datagram");
+        let queued = crate::store::open_prompt_queue_store(&cas_dir)
+            .unwrap()
+            .peek_all(10)
+            .unwrap();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].id, message_id);
+        assert_eq!(queued[0].target, "worker-1");
     }
 
     #[test]

--- a/cas-cli/tests/delivery_target_cas_test.rs
+++ b/cas-cli/tests/delivery_target_cas_test.rs
@@ -293,7 +293,12 @@ async fn arm_delivery(slug: &str, repo_host: &str) -> DeliveryFixture {
         artifact_path: Some(artifact.display().to_string()),
     };
 
-    // Worker submits the immutable receipt, supervisor approves it.
+    // cas-2b667 / GH #588: a worker receipt now projects the task into
+    // PendingSupervisorReview, so the public path must reject this unmerged
+    // source tip before persisting any delivery state. Keep that regression
+    // assertion here, then seed the post-acceptance boundary directly so the
+    // tests below can continue exercising worktree_merge's target CAS and
+    // drift handling independently of the review-queue gate.
     let worker_service = delivery_service(&cas_root, &worker_id);
     let close = worker_service
         .task(Parameters(task_req(serde_json::json!({
@@ -305,10 +310,53 @@ async fn arm_delivery(slug: &str, repo_host: &str) -> DeliveryFixture {
         .await
         .expect("receipt submission");
     assert!(
-        get_text(&close).contains("Worker delivery receipt accepted idempotently"),
+        get_text(&close).contains("DELIVERY RECEIPT REJECTED")
+            && get_text(&close).contains("current factory branch tip"),
         "{}",
         get_text(&close)
     );
+
+    let lease = open_agent_store(&cas_root)
+        .expect("agent store")
+        .get_lease(&task.id)
+        .expect("fixture lease lookup")
+        .expect("worker lease remains after merge-gate rejection");
+    let durable_receipt = cas_store::build_worker_completion_receipt(
+        &receipt,
+        slug,
+        chrono::Utc::now(),
+    );
+    cas_store::create_worker_delivery_with_dispatch_for_lease(
+        &cas_root,
+        &durable_receipt,
+        WorkerDeliveryState::AwaitingVerification,
+        &worker_id,
+        lease.epoch,
+        &supervisor_id,
+        chrono::Utc::now() + chrono::Duration::minutes(10),
+    )
+    .expect("seed the delivery boundary after the explicit #588 rejection");
+    let mut pending = open_task_store(&cas_root)
+        .expect("task store")
+        .get(&task.id)
+        .expect("task after receipt rejection");
+    pending.status = TaskStatus::PendingSupervisorReview;
+    pending.pending_verification = true;
+    pending.close_reason = Some("worker handoff".to_string());
+    pending.deliverables.factory_branch_anchor = Some(receipt.commit_sha.clone());
+    open_task_store(&cas_root)
+        .expect("task store")
+        .update(&pending)
+        .expect("project seeded delivery boundary as review-pending");
+    open_agent_store(&cas_root)
+        .expect("agent store")
+        .release_lease_if_owner_epoch(
+            &task.id,
+            &worker_id,
+            lease.epoch,
+            "Fixture receipt handoff after explicit merge-gate rejection",
+        )
+        .expect("release fixture lease");
 
     let dispatch = cas_store::get_latest_verification_dispatch(&cas_root, &task.id)
         .expect("dispatch lookup")

--- a/cas-cli/tests/mcp_tools_test/system_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/system_tools.rs
@@ -1,6 +1,8 @@
 use crate::support::*;
 use cas::mcp::CasService;
 use cas::mcp::tools::*;
+use cas::store::open_task_store;
+use cas::types::Task;
 use cas_mcp::{SearchContextRequest, SystemRequest};
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::ErrorCode;
@@ -212,6 +214,70 @@ async fn test_doctor() {
 
     let text = extract_text(result);
     assert!(text.contains("CAS Diagnostics") || text.contains("OK") || text.contains("healthy"));
+}
+
+/// GH #587: opening a stale index is not enough to call the search surface
+/// healthy. A task added after the last index build must make doctor name the
+/// count mismatch and the BM25 reindex remedy.
+#[tokio::test]
+async fn doctor_flags_stale_search_index_after_store_growth() {
+    let (temp, core) = setup_cas();
+    let cas_dir = temp.path().join(".cas");
+    let task_store = open_task_store(&cas_dir).expect("task store should open");
+
+    let indexed_task = Task::new("task-indexed".to_string(), "Indexed task".to_string());
+    task_store
+        .add(&indexed_task)
+        .expect("indexed task should be stored");
+
+    let search = cas::hybrid_search::SearchIndex::open(&cas_dir.join("index/tantivy"))
+        .expect("search index should open");
+    search
+        .index_task(&indexed_task)
+        .expect("indexed task should be searchable");
+
+    let stale_task = Task::new(
+        "task-stale".to_string(),
+        "Task added after reindex".to_string(),
+    );
+    task_store
+        .add(&stale_task)
+        .expect("stale task should be stored");
+
+    let result = core.cas_doctor().await.expect("doctor should succeed");
+    let text = extract_text(result);
+    assert!(
+        text.contains("Search Index: STALE"),
+        "doctor must flag a count mismatch: {text}"
+    );
+    assert!(
+        text.contains("run reindex"),
+        "doctor must name the reindex remedy: {text}"
+    );
+}
+
+#[tokio::test]
+async fn doctor_accepts_a_fresh_search_index() {
+    let (temp, core) = setup_cas();
+    let cas_dir = temp.path().join(".cas");
+    let task_store = open_task_store(&cas_dir).expect("task store should open");
+    let task = Task::new("task-fresh".to_string(), "Freshly indexed task".to_string());
+    task_store.add(&task).expect("task should be stored");
+
+    let search = cas::hybrid_search::SearchIndex::open(&cas_dir.join("index/tantivy"))
+        .expect("search index should open");
+    search.index_task(&task).expect("task should be indexed");
+
+    let result = core.cas_doctor().await.expect("doctor should succeed");
+    let text = extract_text(result);
+    assert!(
+        text.contains("Search Index: OK"),
+        "doctor should accept matching counts: {text}"
+    );
+    assert!(
+        !text.contains("Search Index: STALE"),
+        "fresh index was rejected: {text}"
+    );
 }
 
 #[tokio::test]

--- a/cas-cli/tests/mcp_tools_test/task_tools/depth_e2e.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/depth_e2e.rs
@@ -85,6 +85,17 @@ fn init_git_repo_with_staged_changes(project_root: &std::path::Path) {
     std::fs::write(project_root.join("base.rs"), "fn main() {}\n").expect("write base.rs");
     git(&["add", "base.rs"]);
     git(&["commit", "-m", "init"]);
+    // The close gate re-validates the current factory/test-agent tip before
+    // entering PendingSupervisorReview. Keep the worker branch at the
+    // integration base and add remote-tracking evidence that it was already
+    // published; this shared-checkout fixture exercises the review gate's
+    // staged change without modeling an unmerged worker branch.
+    git(&["branch", "factory/test-agent"]);
+    git(&[
+        "update-ref",
+        "refs/remotes/origin/factory/test-agent",
+        "factory/test-agent",
+    ]);
     std::fs::write(
         project_root.join("feature.rs"),
         "pub fn feature() -> u32 { 42 }\n",

--- a/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/depth_light_close.rs
@@ -96,6 +96,16 @@ fn init_git_repo_with_staged_changes(project_root: &std::path::Path) {
     std::fs::write(project_root.join("base.rs"), "fn main() {}\n").expect("write should succeed");
     git(&["add", "base.rs"]);
     git(&["commit", "-m", "init"]);
+    // The close gate re-validates the live factory/test-agent tip and the B2
+    // merge-reality check requires push evidence for a locally retained
+    // merged branch. Model that post-push/post-merge state while keeping the
+    // staged change below as the behavior under test.
+    git(&["branch", "factory/test-agent"]);
+    git(&[
+        "update-ref",
+        "refs/remotes/origin/factory/test-agent",
+        "factory/test-agent",
+    ]);
     std::fs::write(
         project_root.join("feature.rs"),
         "pub fn feature() -> u32 { 42 }\n",

--- a/cas-cli/tests/mcp_tools_test/task_tools/supervisor_review_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/supervisor_review_flow.rs
@@ -89,6 +89,17 @@ fn init_git_repo_with_staged_changes(project_root: &std::path::Path) {
     std::fs::write(project_root.join("base.rs"), "fn main() {}\n").expect("write should succeed");
     git(&["add", "base.rs"]);
     git(&["commit", "-m", "init"]);
+    // The close gate re-validates the current factory/test-agent tip before
+    // entering PendingSupervisorReview. Keep the worker branch at the
+    // integration base and add remote-tracking evidence that it was already
+    // published; these shared-checkout fixtures exercise review behavior
+    // without modeling an unmerged worker branch.
+    git(&["branch", "factory/test-agent"]);
+    git(&[
+        "update-ref",
+        "refs/remotes/origin/factory/test-agent",
+        "factory/test-agent",
+    ]);
     // Stage a reviewable Rust file so has_reviewable_changes() returns true
     std::fs::write(
         project_root.join("feature.rs"),

--- a/cas-cli/tests/worktree_surface_test.rs
+++ b/cas-cli/tests/worktree_surface_test.rs
@@ -1732,20 +1732,15 @@ async fn normal_close_lints_task_anchor_not_newer_same_worker_or_unrelated_workt
         .expect("normal close call");
     let text = get_text(&result);
     assert!(
-        text.contains("queued for supervisor review"),
-        "task A anchor must pass despite later bad task B and dirty pulse worktree: {text}"
+        text.contains("MERGE REQUIRED") && text.contains("current factory branch tip"),
+        "#588 must reject the later unmerged task-B tip before review queueing: {text}"
     );
     let persisted = task_store.get(&task.id).expect("persisted task");
-    let evidence = persisted
-        .deliverables
-        .pre_close_hook
-        .as_ref()
-        .expect("hook evidence");
     assert_eq!(
-        evidence.worktree_branch.as_deref(),
-        Some("factory/frontend")
+        persisted.status,
+        cas::types::TaskStatus::AwaitingMerge,
+        "the ancestry rejection must leave task A available for merge recovery"
     );
-    assert_eq!(evidence.task_tip.as_deref(), Some(task_a_tip.as_str()));
 }
 
 /// Negative case: when neither System A nor System B has a matching
@@ -3229,6 +3224,21 @@ async fn completion_receipt_authority_is_exact_active_lease_session() {
     std::fs::write(worker_path.join("authority.rs"), "pub fn authority() {}\n").unwrap();
     run_git(&["add", "authority.rs"], &worker_path);
     run_git(&["commit", "-m", "receipt authority fixture"], &worker_path);
+    // This test exercises exact lease-session authority after receipt
+    // validation. Keep the source tip in the already-merged/published state
+    // required by the #588 decision-time ancestry and B2 reality gates.
+    run_git(
+        &["merge", "--no-ff", "factory/alice", "-m", "merge receipt authority"],
+        &repo.root,
+    );
+    run_git(
+        &[
+            "update-ref",
+            "refs/remotes/origin/factory/alice",
+            "factory/alice",
+        ],
+        &repo.root,
+    );
 
     let task_store = open_task_store(&cas_root).expect("task store");
     let agent_store = open_agent_store(&cas_root).expect("agent store");

--- a/cas-cli/tests/worktree_surface_test.rs
+++ b/cas-cli/tests/worktree_surface_test.rs
@@ -3078,6 +3078,10 @@ async fn submit_and_verify_delivery(
             cas::types::ClaimResult::Success(_)
         ));
     }
+    let lease = agent_store
+        .get_lease(task_id)
+        .expect("delivery fixture lease lookup")
+        .expect("delivery fixture must retain its worker lease");
     let worker_service = delivery_service(cas_root, worker_id);
     let close = worker_service
         .task(Parameters(task_req(serde_json::json!({
@@ -3089,25 +3093,51 @@ async fn submit_and_verify_delivery(
         .await
         .expect("public task close receipt submission");
     assert!(
-        get_text(&close).contains("Worker delivery receipt accepted idempotently"),
+        get_text(&close).contains("DELIVERY RECEIPT REJECTED")
+            && get_text(&close).contains("current factory branch tip"),
         "{}",
         get_text(&close)
     );
-    let retry = worker_service
-        .task(Parameters(task_req(serde_json::json!({
-            "action": "close",
-            "id": task_id,
-            "reason": "exact active-cycle retry",
-            "completion_receipt": serde_json::to_string(receipt).unwrap(),
-        }))))
-        .await
-        .expect("same-cycle receipt retry");
-    assert!(
-        get_text(&retry).contains("Worker delivery receipt accepted idempotently")
-            && get_text(&retry).contains("State: awaiting_verification"),
-        "an exact retry must remain supported inside its original active proof cycle:\n{}",
-        get_text(&retry)
+
+    // Seed the state after the explicit #588 rejection so these tests retain
+    // their coverage of the supervisor's merge/reconcile path. The public
+    // receipt path cannot create this boundary until the source tip is merged.
+    let worker = agent_store.get(worker_id).expect("delivery worker");
+    let durable_receipt = cas_store::build_worker_completion_receipt(
+        receipt,
+        &worker.name,
+        chrono::Utc::now(),
     );
+    cas_store::create_worker_delivery_with_dispatch_for_lease(
+        cas_root,
+        &durable_receipt,
+        WorkerDeliveryState::AwaitingVerification,
+        worker_id,
+        lease.epoch,
+        supervisor_id,
+        chrono::Utc::now() + chrono::Duration::minutes(10),
+    )
+    .expect("seed delivery boundary after explicit merge-gate rejection");
+    let mut pending = open_task_store(cas_root)
+        .expect("task store")
+        .get(task_id)
+        .expect("task after receipt rejection");
+    pending.status = TaskStatus::PendingSupervisorReview;
+    pending.pending_verification = true;
+    pending.close_reason = Some("worker handoff".to_string());
+    pending.deliverables.factory_branch_anchor = Some(receipt.commit_sha.clone());
+    open_task_store(cas_root)
+        .expect("task store")
+        .update(&pending)
+        .expect("project seeded delivery boundary as review-pending");
+    agent_store
+        .release_lease_if_owner_epoch(
+            task_id,
+            worker_id,
+            lease.epoch,
+            "Fixture receipt handoff after explicit merge-gate rejection",
+        )
+        .expect("release fixture lease");
     let dispatch = cas_store::get_latest_verification_dispatch(cas_root, task_id)
         .expect("verification dispatch lookup")
         .expect("receipt-bound verification dispatch");

--- a/docs/RELEASE_SLACK_RUBRIC.md
+++ b/docs/RELEASE_SLACK_RUBRIC.md
@@ -3,10 +3,28 @@
 **This is a hard rule. Runtime releases and harness-diary updates each have a
 mandatory #cas-internal publication workflow. They are separate duties.**
 
-> This file defines **what** to post. For **how** to post it when the session has
-> no working Slack connection of its own — the Codex `codex_apps` Slack plugin,
-> and the stdin / approval / buffering traps that make it look broken — see
+> This file defines **what** to post. For transport preflight, the canonical
+> supervisor-owned route, and the designed handoff used when a worker has no
+> Slack connection of its own, see
 > [docs/SLACK_POSTING_RUNBOOK.md](SLACK_POSTING_RUNBOOK.md).
+
+## Transport ownership and worker handoff
+
+Run the runbook's cheap transport preflight before posting. For cas-src, the
+canonical route is the approved `pippenz@gmail.com` Claude profile's
+`claude.ai Slack` MCP, owned by the supervisor or an explicitly approved Claude
+posting owner. A `Connected` server listing is not a receipt; the read-only
+preflight must succeed before a post is attempted.
+
+Default Codex workers do not have a Slack transport. When a Codex worker reaches
+the release-notes duty, it saves the exact draft and hands the draft path,
+target channel, deploy target, and requested receipt back to the supervisor.
+The supervisor runs the canonical route and returns timestamps/permalinks for
+the worker to record. This is the designed path, not a failed fallback.
+
+If no approved transport passes preflight, leave the draft saved and report the
+duty blocked with the measured error. Do not post from an unapproved profile or
+mark the draft `POSTED` without returned timestamps and permalinks.
 
 ## Runtime releases: two top-level posts
 

--- a/docs/SLACK_POSTING_RUNBOOK.md
+++ b/docs/SLACK_POSTING_RUNBOOK.md
@@ -1,81 +1,116 @@
 # Slack posting runbook — how to actually publish release notes
 
-`docs/RELEASE_SLACK_RUBRIC.md` says *what* to post. This says *how*, when the
-posting session has no working Slack connection of its own.
+`docs/RELEASE_SLACK_RUBRIC.md` says *what* to post. This says *how* to verify
+and use a Slack transport when the current posting session does not expose one.
 
 **Target channel:** `#cas-internal` — channel ID `C0B44GUKDK2`.
 
-## Which transport is available
+Never use a `#cas-internal` post as a transport probe. During an operational
+embargo, use a designated test channel, a DM, or a read-only/dry-run seam. A
+transport preflight is runtime state and must be repeated for each posting
+session; this document does not turn an old `Connected` result into a receipt.
 
-| Transport | State | Use for |
+## Transport decision
+
+Use the first route whose preflight succeeds. The canonical cas-src route is
+the supervisor-owned Claude route because default Codex workers do not have a
+Slack tool surface.
+
+| Transport | Measured state on 2026-08-27 | Decision |
 |---|---|---|
-| Claude `claude.ai Slack` MCP connector | Per-Claude-account OAuth. Unauthorized on the `~/.claude-alt` profile — `~/.claude-alt/mcp-needs-auth-cache.json` lists `"claude.ai Slack"`. `authenticate` only returns "ask the user to run `/mcp`", which is a UI flow a tool call cannot drive. | Only if `/mcp` shows it authorized on the current profile. |
-| **Codex `codex_apps` Slack plugin** | Available without extra setup. Bound to the ChatGPT account, not to local config — `~/.codex/config.toml` has **no** `[mcp_servers]` section, so grepping it for "slack" finds nothing and proves nothing. | **Default path.** Works from any Claude profile. |
+| Claude `claude.ai Slack` MCP on the approved `pippenz@gmail.com` profile (`~/.claude-alt`) | `claude auth status --json` passed the exact account gate and `claude mcp list` reported the Slack server connected. A normal noninteractive read was permission-blocked, while the explicit one-shot mode completed a read and a smoke DM write; receipt: `D076VR4ATTK`, ts `1787836424.011069`, https://petra-stella.slack.com/archives/D076VR4ATTK/p1787836424011069. | **Canonical route.** |
+| Codex `codex_apps` Slack plugin | A bounded `codex exec` probe called `list_mcp_resources(server="codex_apps")` and returned no Slack resource, plugin name, or callable Slack tools. | Not available to default Codex workers; do not spend a turn searching for it. |
+| CAS Slack bridge (`cas-bridge-router`) | The router was inactive/not installed; `/etc/cas-bridge/config.json`, `/etc/cas-bridge/router.env`, its systemd unit, and `/opt/cas-bridge` were absent. | Not a configured route. |
 
-Do not conclude Codex lacks Slack because it has no MCP servers configured or
-because it answers "SLACK: no" when asked to list its tools. It answers that
-from its function list, which does not include plugin-backed tools. The
-connector shows up in `list_mcp_resources` as
-`title: "Slack"`, `plugin_name: "slack"`, under server `codex_apps`.
+### Cheap preflight
 
-**Tools:** `slack_send_message` (write), `slack_read_channel` (read),
-`slack_search_public_and_private` (read).
+Run the approved-account gate and server check without inspecting credentials:
 
-## The four gotchas that will cost you fifteen minutes each
+```bash
+CLAUDE_CONFIG_DIR=~/.claude-alt \
+  claude auth status --json | jq '{loggedIn,authMethod,apiProvider,email,subscriptionType}'
+CLAUDE_CONFIG_DIR=~/.claude-alt claude mcp list
+```
 
-1. **stdin must be closed.** `codex exec` prints `Reading additional input from
-   stdin...` and blocks forever when stdin is an open pipe that never reaches
-   EOF — which is exactly what a backgrounded shell gives it. Always append
-   `< /dev/null`. A run stuck at ~39 bytes of output with the process alive is
-   this, not slow reasoning.
-2. **Writes require approval; reads do not.** `slack_read_channel` runs
-   unattended. `slack_send_message` gets auto-cancelled with
-   `user cancelled MCP tool call` when nothing can approve it — which is
-   guaranteed once stdin is closed. Pass
-   `--dangerously-bypass-approvals-and-sandbox` and keep the prompt narrowly
-   scoped to posting.
-3. **Never pipe a long run through `tail`.** It buffers to zero bytes until
-   exit, so progress is invisible and a timeout kill destroys the output. Redirect
-   to a file and poll it instead.
-4. **Drop the reasoning effort.** `codex exec` defaults to `gpt-5.6-sol` at high
-   effort. Transcribing prewritten text does not need that; it turns ~40 seconds
-   into many minutes. Pass `-c model_reasoning_effort="low"`.
+The account gate is positive only for `loggedIn: true`, `authMethod:
+"claude.ai"`, `apiProvider: "firstParty"`, and
+`email: "pippenz@gmail.com"`. The server check must show
+`claude.ai Slack ... Connected`.
+
+For a Codex session, call `list_mcp_resources(server="codex_apps")`. Treat the
+plugin as available only when the result contains a Slack resource with its
+title/plugin name and the session can invoke its read/write tools. A missing
+resource is a definitive negative for that worker; do not infer availability
+from `~/.codex/config.toml`.
+
+## Canonical route: supervisor-owned approved Claude profile
+
+The posting owner uses a bounded Claude one-shot with the approved profile
+after the preflight above. `--permission-mode bypassPermissions` is required
+for a noninteractive one-shot whose Slack MCP calls would otherwise wait for a
+human approval; keep the prompt narrowly scoped to the saved draft and target
+channel. It does not make a failed account or server preflight positive.
+
+```bash
+CLAUDE_CONFIG_DIR=~/.claude-alt \
+  claude -p --permission-mode bypassPermissions --output-format text \
+  "Use the connected claude.ai Slack MCP. Read the 10 most recent messages in channel C0B44GUKDK2 to deduplicate, then post the exact bodies in /path/to/slack-msgs.md in rubric order. Return each Slack timestamp and permalink. Do not post anywhere else." \
+  < /dev/null > /path/to/slack-post.out 2>&1
+```
+
+The output file is the receipt source. Confirm that every post returned a
+timestamp and permalink, and that threaded replies carry their parent
+timestamp. During the embargo, replace the target with a pre-approved test
+channel or DM and use a smoke-test body; never substitute `#cas-internal`.
+
+If the approved Claude profile cannot complete a read-only preflight, stop
+after saving the draft. Report the exact command, exit status, and error in the
+task note, then ask the supervisor to restore authorization or provide a
+different approved route. Do not claim `POSTED` or invent a receipt.
+
+## Codex-worker handoff
+
+Default Codex workers have no Slack transport. This is a designed handoff, not
+a failed fallback:
+
+1. Save the exact user/dev bodies to `docs/release-notes/<date>-<topic>-slack.md`
+   or a separator-delimited handoff file.
+2. Tell the supervisor the draft path, target channel, deploy target, and that
+   the canonical approved Claude route must post on the worker's behalf.
+3. The supervisor (or an approved Claude posting owner) runs the preflight,
+   deduplicates, posts, and returns timestamps/permalinks.
+4. Add the returned receipt to the saved draft before closing the release task.
+
+If no approved transport exists, leave the draft saved and report the posting
+duty blocked with the measured preflight failure. Do not search for another
+profile, post from an unapproved account, or mark the draft `POSTED`.
 
 ## Procedure
 
-**1. Write the exact message bodies to a file first.** Codex should transcribe,
-not author — that keeps the rubric's wording intact and removes a slow reasoning
-step. Use `=== MESSAGE N ... ===` header lines as separators and tell Codex to
-exclude the headers.
+**1. Write the exact message bodies to a file first.** Transcription keeps the
+rubric wording intact. Use `=== MESSAGE N ... ===` header lines as separators
+and tell the posting owner to exclude the headers from sent text.
 
 **2. If a previous attempt died mid-run, verify before retrying.** A killed run
-may have posted some messages. Read the channel first and only retry if nothing
-landed:
+may have posted some messages. Read the target channel first and only retry if
+nothing landed. This read is permitted only after the transport preflight and
+must use the designated test channel/DM during an embargo.
 
-```
-codex exec --skip-git-repo-check --sandbox workspace-write \
-  -c model_reasoning_effort="low" \
-  "Using the codex_apps slack plugin, read the 10 most recent messages in channel C0B44GUKDK2. For each report timestamp, top-level vs thread reply, author, and first 100 characters. Do not post anything." \
-  < /dev/null > /tmp/slack-read.out 2>&1
-```
+**3. Post in rubric order.** User top-level → capture `ts` → user reply → Dev
+top-level → capture `ts` → Dev reply. A reply without its parent's `ts` is a
+stray top-level message.
 
-**3. Post.** This is the command that works:
+**4. Record the receipt.** Annotate the saved draft with a `## POSTED` block
+containing the UTC timestamp, channel, and permalink for every post/reply.
 
-```
-codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
-  -c model_reasoning_effort="low" \
-  "Post 4 messages to Slack channel C0B44GUKDK2 using the codex_apps slack plugin tool slack_send_message. The exact text is in /tmp/slack-msgs.md, separated by '=== MESSAGE N ... ===' header lines. Post each body VERBATIM, excluding the header lines. Message 1: new top-level. Message 2: thread reply to 1. Message 3: a NEW TOP-LEVEL message, NOT a reply. Message 4: thread reply to 3. Do only this; do not modify files or explore the repo. Report the 4 timestamps and confirm message 3 is top-level. If a post fails, report the exact error and which messages posted." \
-  < /dev/null > /tmp/slack-post.out 2>&1
-```
+## One-shot gotchas
 
-**4. Verify the report.** Codex returns four timestamps. Confirm it states the
-second top-level message is top-level and not a reply — that is the structural
-requirement most likely to be silently wrong, since messages 2 and 3 differ only
-by whether a thread ts was passed.
-
-## Delegation note
-
-A supervisor should spawn a worker with this as its task rather than blocking its
-own turn on `codex exec`. Blocking wastes the supervisor turn and leaves the
-operator staring at a silent session. See the Cassy memory
-"Supervisor: spawn workers, don't block on codex exec shell-outs".
+1. **Close stdin.** Always append `< /dev/null`; otherwise `claude -p` or
+   `codex exec` can wait for input indefinitely.
+2. **Keep writes narrow.** Noninteractive Slack writes need the explicit
+   permission mode above. Never grant a broad prompt permission to explore or
+   modify the repository.
+3. **Do not pipe through `tail`.** Redirect to a file and inspect it after the
+   process exits so the receipt is preserved.
+4. **Use low effort for transcription.** Prewritten release bodies do not need
+   a high-reasoning one-shot.

--- a/docs/release-notes/RUBRIC.md
+++ b/docs/release-notes/RUBRIC.md
@@ -16,6 +16,20 @@
 For **how** to post when the session has no Slack connection of its own, see
 [docs/SLACK_POSTING_RUNBOOK.md](../SLACK_POSTING_RUNBOOK.md).
 
+## Transport ownership
+
+Run the runbook's transport preflight before posting. The canonical cas-src
+route is the supervisor-owned `claude.ai Slack` MCP on the approved
+`pippenz@gmail.com` profile. Default Codex workers have no Slack transport, so
+their designed path is to save the exact draft and hand its path, target
+channel, deploy target, and receipt request to the supervisor. The supervisor
+posts through the canonical route and returns timestamps/permalinks for the
+worker to record.
+
+If preflight fails, leave the draft saved and report the duty blocked with the
+measured error. Never claim `POSTED` without returned timestamps and
+permalinks.
+
 ## When to post
 
 **Every PR merged to `staging` or `main`.** No exceptions: a revert, a hotfix, and


### PR DESCRIPTION
Seven fixes, each with issue evidence and scoped proof:

- **#589** Worker message delivery: enqueue-time daemon wake, age/stale provenance on delivered messages, assignee-scoped suppression of stale spawn assignments (superseded records, not silent drops).
- **#588** Close gate: fail-closed live-tip ancestry revalidation at both PendingSupervisorReview projection points; parked-anchor semantics preserved for final close; straggler-commit race reproduced in tests.
- **#586** Workspace-contract hook: containment now uses the registered clone-path binding with fail-closed canonicalization (cwd fallback only when unbound); sibling-subtree false rejections fixed with symlink/refresh/escape regressions.
- **#584** Worktree cuts: diverged epic base hard-refuses the cut before any worktree exists (was warn-then-cut-stale); behind-only fast-forwards; no-code workers get refreshed playbooks.
- **#587** doctor: search-index check verifies per-type counts + freshness against the store, failing with the exact reindex remedy instead of reporting OK on a stale index.
- **#590** report_cas_bug: explicit refusal naming the config key when issues.repo is unset; missing agent-reported label degrades to a labeless filing with stated degradation instead of aborting.
- **#571/#579** Slack release-notes transport: measured transport inventory (stale codex_apps claim corrected with probe evidence), canonical approved-Claude route with DM smoke receipt, codified supervisor handoff for codex workers; worker-guidance addition later trimmed to keep SessionStart protected context under its byte budget (regression caught by branch CI, amended).

Merge includes main reconciles (install-proof workflow, hub service, Luna spawn policy). Fixes #571, #579 auto-close via commit footers; #584, #586-#590 already closed with evidence comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)