### PR TITLE
docs(release-notes): embargoed v3.4.2 runtime release announcement

### DIFF
--- a/docs/release-notes/2026-08-27-v3.4.2-slack.md
+++ b/docs/release-notes/2026-08-27-v3.4.2-slack.md
@@ -1,0 +1,73 @@
+# 2026-08-27 — Cassy v3.4.2 runtime release — #cas-internal
+
+> EMBARGO: do not post before 2026-08-31 (operator confirmation required).
+> Runtime release per docs/RELEASE_SLACK_RUBRIC.md: two distinct top-level
+> posts (User, Dev), each with one threaded reply. Append POSTED receipts
+> after publication.
+
+## Post 1 — User thread
+
+**Top-level (Live on production · User):**
+
+🚀 Cassy v3.4.2 is out: workers can now run on Qwen through a QwenCloud
+subscription, model routing picks the right AI for each kind of job on
+whatever accounts your machine actually has, and the Commander hub runs as an
+always-on service — with the installer now proven on real machines before we
+say it works.
+
+**Reply (Was → Now):**
+
+Was (v3.4.1): three AI backends, model choice by convention, a hand-launched
+hub, and install instructions verified by review rather than execution.
+
+Now (v3.4.2): a QwenCloud Token Plan subscription powers real factory work on
+Qwen 3.8 Max — proven end-to-end before being called supported. Work is
+routed by lane (light / standard / taste / heavy) to vetted models, machines
+missing an account get a clear substitute or a clear answer instead of a
+confusing failure, and asking for an exact model is never silently swapped.
+The Commander hub installs as a proper background service that survives
+reboots and restarts itself. Every release now installs itself on a fresh Mac
+and a bare Linux box in CI and keeps the transcripts as proof. Plus seven
+reliability fixes: messages between coordinator and workers arrive when sent,
+finished-looking work can't skip its merge check, workers' own files are
+never wrongly blocked, health checks stop calling a dead search index
+healthy, and bug filing no longer trips over a missing label.
+
+## Post 2 — Dev thread
+
+**Top-level (Live on production · Dev):**
+
+⚙️ v3.4.2: `cli=opencode` harness (QwenCloud Token Plan route, live
+conformance receipt), typed lane registry + `cas_factory::routing`
+enforcement on every spawn path, tri-state capability snapshots, `cas hub
+service install`, `Install path proof` workflow, and the v22 burn-down
+(GH #571, #579, #584, #586–#590). Assets: cas-x86_64-unknown-linux-gnu
+`f8c4d3fd…`, cas-aarch64-apple-darwin `0bd0e461…`.
+
+**Reply (Was → Now):**
+
+Was: three-harness matrix with policy hand-coded in one MCP handler; no route
+concept for model serving; manual hub process; installer verified by unit
+fixtures only; tag-to-publish ~2 min on the adopt path.
+
+Now: OpenCode is the fourth harness — explicit provider/model routes
+(`qwencloud/…` default, `alibaba/…` PAYG, `local/…`), key-prefix/lane
+mismatch guards, per-route effort tables (rejection, never remapping), and a
+route-stamped conformance receipt (`opencode-1.18.23-hosted-token-plan`)
+gating the support claim; unreceipted routes are refused pre-queue. Routing
+policy lives in an embedded, schema-versioned TOML registry enforced by
+`cas_factory::routing::validate_explicit` across MCP, direct CLI, daemon
+respawn, doctor, and queue paths; `lane=` requests resolve against tri-state
+capability snapshots with warned fallback and fail-closed Unknown; docs'
+route tables are generated from the registry with golden tests. `cas hub
+service install|uninstall|status --dry-run` ships systemd-user/launchd
+supervision with a live Linux receipt. The `Install path proof` workflow runs
+the published installer on hosted macOS ARM + clean Linux on every
+release.published — v3.4.2's run is green on both jobs with transcripts
+retained. Release latency receipt: 690s tag-to-publish (over the 600s budget;
+the tag preceded the prebuild so CI built inline — the adopt path remains
+available when the prebuild is allowed to finish first).
+
+## POSTED
+
+(to be filled at publication — permalinks + timestamps for both threads and replies)


### PR DESCRIPTION
Runtime-release announce duty for tag v3.4.2 under the 2026-08-31 Slack embargo: two-top-level-post draft per RELEASE_SLACK_RUBRIC, receipts included (asset digests, latency, install-proof run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)