### PR TITLE
chore(release): prepare v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-08-29
+
+### Fixed
+- Team sync deletes now send the project-scoped identity (`project_id`), unparking
+  deletions that older servers' project-aware DELETE contract had permanently
+  rejected; parked rejections requeue and flush after upgrade.
+- Close-gate tree-effect check honors its "present or explicitly evolved" contract:
+  union-merged parallel deliveries pass via token-level per-added-line containment,
+  and the rejection message names the supervisor merge-receipt recovery path (GH #597).
+
+### Added
+- Skill persistence gated on `validation_script` execution at create/update.
+- Measured rule promotion: Draft→Proven driven by outcome evidence instead of a
+  single call; real rule impact tracking increments `surface_count` at injection.
+- Provenance end-to-end: `Entry.source_ids` populated through `Rule.source_ids`.
+- Version history with tombstone deletes for rules and skills (rollback capability).
+- Append-only trace archive: events/recordings past 30 days compress instead of
+  hard-deleting.
+- Structured task execution state: schema'd patchable state blob on tasks.
+- SessionStart memory injection carries the full first line for high-importance
+  memories; hardened session memory hygiene.
+
 ## [3.4.2] - 2026-08-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.4.2"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.4.2"
+version = "3.5.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.4.2"
+version = "3.5.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.4.2"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.4.2"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.4.2"
+version = "3.5.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.4.2"
+version = "3.5.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.4.2"
+version = "3.5.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.4.2"
+version = "3.5.0"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.4.2"
+version = "3.5.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.4.2"
+version = "3.5.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.4.2"
+version = "3.5.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"


### PR DESCRIPTION
Version bump + changelog for v3.5.0 (six release-train crates). Tag v3.5.0 goes on this PR's merge commit after its Release Prebuild completes — see #603 for why the prebuild must finish before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)