### PR TITLE
feat(cas-1c67): cas-image-generate builtin skill — style-aware asset generation (Nano Banana)

### DIFF
--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -508,6 +508,12 @@ pub const BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/skills/cas-wizard/template.sh") },
     BuiltinFile { path: "skills/cas-resolving-merge-conflicts/SKILL.md", content: include_str!("builtins/skills/cas-resolving-merge-conflicts/SKILL.md") },
     BuiltinFile { path: "skills/cas-to-questionnaire/SKILL.md", content: include_str!("builtins/skills/cas-to-questionnaire/SKILL.md") },
+    BuiltinFile { path: "skills/cas-image-generate/SKILL.md", content: include_str!("builtins/skills/cas-image-generate/SKILL.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/asset-playbook.md", content: include_str!("builtins/skills/cas-image-generate/references/asset-playbook.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/style-harvest.md", content: include_str!("builtins/skills/cas-image-generate/references/style-harvest.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/output-checklist.md", content: include_str!("builtins/skills/cas-image-generate/references/output-checklist.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/providers.md", content: include_str!("builtins/skills/cas-image-generate/references/providers.md") },
+    BuiltinFile { path: "skills/cas-image-generate/scripts/generate-image.sh", content: include_str!("builtins/skills/cas-image-generate/scripts/generate-image.sh") },
 ];
 
 /// Built-in Workflow scripts shipped to `.claude/workflows/` on `cas update --sync`.
@@ -905,6 +911,12 @@ pub const CODEX_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/codex/skills/cas-wizard/template.sh") },
     BuiltinFile { path: "skills/cas-resolving-merge-conflicts/SKILL.md", content: include_str!("builtins/codex/skills/cas-resolving-merge-conflicts/SKILL.md") },
     BuiltinFile { path: "skills/cas-to-questionnaire/SKILL.md", content: include_str!("builtins/codex/skills/cas-to-questionnaire/SKILL.md") },
+    BuiltinFile { path: "skills/cas-image-generate/SKILL.md", content: include_str!("builtins/codex/skills/cas-image-generate/SKILL.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/asset-playbook.md", content: include_str!("builtins/codex/skills/cas-image-generate/references/asset-playbook.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/style-harvest.md", content: include_str!("builtins/codex/skills/cas-image-generate/references/style-harvest.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/output-checklist.md", content: include_str!("builtins/codex/skills/cas-image-generate/references/output-checklist.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/providers.md", content: include_str!("builtins/codex/skills/cas-image-generate/references/providers.md") },
+    BuiltinFile { path: "skills/cas-image-generate/scripts/generate-image.sh", content: include_str!("builtins/codex/skills/cas-image-generate/scripts/generate-image.sh") },
 ];
 
 /// All built-in agents managed by Cassy for Grok (EPIC cas-8888, Phase 5 /
@@ -1345,6 +1357,12 @@ pub const GROK_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile { path: "skills/cas-wizard/template.sh", content: include_str!("builtins/grok/skills/cas-wizard/template.sh") },
     BuiltinFile { path: "skills/cas-resolving-merge-conflicts/SKILL.md", content: include_str!("builtins/grok/skills/cas-resolving-merge-conflicts/SKILL.md") },
     BuiltinFile { path: "skills/cas-to-questionnaire/SKILL.md", content: include_str!("builtins/grok/skills/cas-to-questionnaire/SKILL.md") },
+    BuiltinFile { path: "skills/cas-image-generate/SKILL.md", content: include_str!("builtins/grok/skills/cas-image-generate/SKILL.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/asset-playbook.md", content: include_str!("builtins/grok/skills/cas-image-generate/references/asset-playbook.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/style-harvest.md", content: include_str!("builtins/grok/skills/cas-image-generate/references/style-harvest.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/output-checklist.md", content: include_str!("builtins/grok/skills/cas-image-generate/references/output-checklist.md") },
+    BuiltinFile { path: "skills/cas-image-generate/references/providers.md", content: include_str!("builtins/grok/skills/cas-image-generate/references/providers.md") },
+    BuiltinFile { path: "skills/cas-image-generate/scripts/generate-image.sh", content: include_str!("builtins/grok/skills/cas-image-generate/scripts/generate-image.sh") },
 ];
 
 /// OpenCode does not load a filesystem skill/agent home for its generated

--- a/cas-cli/src/builtins/codex/skills/cas-image-generate/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-image-generate/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: cas-image-generate
+description: Generate style-matched raster assets for apps, websites, and reports through Google Nano Banana. Use when a project needs a hero, background, logo, icon, card, illustration, or report artwork.
+managed_by: cas
+---
+
+# Style-aware image generation
+
+Use this skill when an image should belong to an existing product, site, or
+report rather than look like an unrelated stock asset. It covers logos, icon
+sets, heroes, backgrounds, textures, OG/social cards, report art, illustrations,
+and favicons. Read the relevant
+references before generating; keep the style decision reusable and inspect the
+result at its intended size.
+
+## Provider and invocation
+
+Google Nano Banana is the only wired hosted provider. It handles every raster
+asset type:
+
+- **NB2** (`gemini-3.1-flash-image`) for drafts, iteration, and ordinary scenes.
+- **NB Pro** (`gemini-3-pro-image`) for finals, report covers, and text-heavy
+  compositions.
+
+The helper uses the `GEMINI_API_KEY` environment variable and never accepts a
+key as a command-line argument. No CAS-managed image-provider secret store is
+currently available, so configure the key in the process environment (for
+example, from the operator's local secret manager). If it is absent, the
+helper stops before network access and prints the exact Google AI Studio setup
+guidance. Run it from the project root:
+
+```bash
+bash <harness-config-dir>/skills/cas-image-generate/scripts/generate-image.sh \
+  --tier draft --prompt "$PROMPT" --output assets/generated/hero.png
+```
+
+Use `--reference path/to/approved.png` once per reference image. Use
+`--dry-run` to validate routing and key presence without calling the API. The
+helper is a plain-curl adapter; see [providers.md](references/providers.md) for
+the request shape and the unwired alternatives.
+
+## Workflow
+
+1. Harvest the project's design context using
+   [style-harvest.md](references/style-harvest.md). Produce a concrete style
+   token block before writing the final prompt; reuse that style token block in
+   every request.
+2. Choose the asset row and preset in
+   [asset-playbook.md](references/asset-playbook.md). Put the token block in
+   every prompt; reference approved assets when consistency matters.
+3. Start with NB2 for a draft. Switch to NB Pro for the approved final or any
+   composition where exact copy matters. State what must remain unchanged when
+   editing a reference.
+4. Store the result using the naming and format rules in
+   [output-checklist.md](references/output-checklist.md), then complete its
+   review checklist. Record model, tier, prompt, references, and any seed or
+   style identifier in the project's asset note.
+
+Nano Banana produces raster output, not editable SVG. For logos, favicons, and
+icon sets, request a flat, high-contrast raster master with generous padding so
+manual vectorization is practical; do not promise production SVG paths or
+perfect small-size legibility. Derive favicon sizes from one approved master
+rather than regenerating each size.
+
+Do not use Imagen: Google retired that image path on 2026-08-17. Recraft,
+OpenAI, Ideogram, and hosted FLUX remain documented but unwired optional
+add-ons; do not invent a second credential or silently route a request to one.

--- a/cas-cli/src/builtins/codex/skills/cas-image-generate/references/asset-playbook.md
+++ b/cas-cli/src/builtins/codex/skills/cas-image-generate/references/asset-playbook.md
@@ -1,0 +1,80 @@
+# Asset playbook
+
+Research basis: the current [image-generation dossier](../../../../../../.cas/artifacts/cas-1c67/research/image-generation-dossier.md)
+was compiled 2026-08-29. The hosted route in this skill is Google Nano Banana;
+the dossier's other providers are retained as explicitly unwired references in
+[providers.md](providers.md).
+
+## Routing and presets
+
+All rows use Nano Banana. Pick NB2 for a draft or iteration and NB Pro for a
+final, cover, or dense in-image copy. The requested dimensions belong in the
+prompt and in the output review; the helper sends references and decodes the
+returned image but does not silently resize it.
+
+| Asset | Tier | Suggested output | Prompt emphasis |
+|---|---|---|---|
+| Logo / logomark | NB2 → NB Pro | square PNG, 1024px or larger | flat, simple mark, correct quoted wordmark, high contrast, generous clear space; manual vectorization required |
+| Icon set | NB2 → NB Pro | one square grid sheet, 1024–2048px | one locked 24px-grid spec sentence, uniform stroke, padding, one color; manually trace approved glyphs |
+| Hero image | NB2 → NB Pro | 16:9, up to 1920px wide | focal subject, camera, lighting, and negative space for copy |
+| Background / texture | NB2 | 16:9 or tileable square, 2K | low contrast, no focal object, exact palette, usable behind text |
+| OG / social card | NB Pro | 1200x630 PNG | exact quoted copy early, safe area, brand contrast, no gibberish |
+| Report cover / section art | NB Pro | A4 portrait or section banner, 2K+ | restrained palette, title placement, print-safe whitespace |
+| Spot illustration | NB2 → NB Pro | square 800–1600px PNG | simple silhouette, transparent-look isolation only if verified; consistent family style |
+| Favicon / app icon | derive from approved logo | 1024px square master, then 16/32/48/180/192/512px derivatives | centered mark inside the safe area; never generate six independent variants |
+
+## Prompt templates
+
+Replace every `{style_tokens}` slot with the complete block produced by
+[style-harvest.md](style-harvest.md). Keep the asset-specific sentence stable
+across a set and vary only `{subject}` or `{copy}`.
+
+### NB2 draft / iteration
+
+```text
+Create a {asset_type} for {project}.
+Subject: {subject}. Context: {context}. Composition: {composition}.
+Style tokens: {style_tokens}.
+Make this an exploratory draft with clean edges, coherent lighting, and no
+unrequested text. Preserve the supplied reference relationships: {references}.
+```
+
+### NB Pro final / text-heavy
+
+```text
+Create the final {asset_type} for {project}.
+Use these exact style tokens: {style_tokens}.
+Subject and action: {subject_action}. Context: {context}.
+Composition and safe area: {composition}. Exact displayed copy: "{copy}".
+References and what must stay unchanged: {references_and_invariants}.
+Return a polished raster asset with correct spelling, deliberate edges, and no
+extra lettering or decorative objects.
+```
+
+### Logo and icon limitation template
+
+```text
+Create a flat, high-contrast raster master for manual vectorization: {subject}.
+Use {style_tokens}; two colors maximum, simple geometric paths, centered on a
+plain background, generous clear space, no gradients, no shadows, and no extra
+lettering. If a wordmark is required, render exactly "{copy}".
+```
+
+### Locked icon-set sentence
+
+```text
+Create a single grid sheet of line icons: each glyph uses a 2px stroke,
+rounded caps and joins, a 24x24 grid with 2px padding, no fill, one color,
+centered composition, and the same {style_tokens}. Subjects: {subject_list}.
+```
+
+## Consistency rules
+
+- Generate related icons as one sheet where possible, then use the approved
+  sheet as a reference for later batches.
+- Keep the literal style token block, camera/framing language, and lighting
+  sentence unchanged across a set. Models do not carry state between calls.
+- Use a new aspect ratio as a crop or edit of an approved master, not a fresh
+  unrelated generation.
+- Lay the set out at true size and check backdrop tone, shadow direction, then
+  crop distance for drift.

--- a/cas-cli/src/builtins/codex/skills/cas-image-generate/references/output-checklist.md
+++ b/cas-cli/src/builtins/codex/skills/cas-image-generate/references/output-checklist.md
@@ -1,0 +1,56 @@
+# Output conventions and review
+
+## Where and how to save
+
+Keep generated files in the consuming project, normally
+`assets/generated/<asset-type>/<slug>.<ext>`, unless that project already has
+an asset convention. Use lowercase kebab-case names and keep the approved
+master separate from derived crops:
+
+```text
+assets/generated/hero/analytics-workspace-v1.png
+assets/generated/logo/cassy-mark-v1.png
+assets/generated/og/2026-performance-review-v1.png
+assets/generated/hero/analytics-workspace-v1.style.txt
+```
+
+Record the model (`gemini-3.1-flash-image` or `gemini-3-pro-image`), prompt,
+style token block, references, output dimensions, and review date in the asset
+note. Never commit an API key or a provider response containing credentials.
+
+## Format and size guidance
+
+- Use PNG when alpha or lossless edges matter; verify that a requested
+  transparent background is real alpha, not a baked checkerboard.
+- Use WebP or AVIF for web photography and large scenes after review; retain
+  the approved PNG master when practical. Use JPEG only where the consumer
+  requires it.
+- Logos and icons are raster in this wired path. Ask for a simple, flat master
+  suitable for manual vectorization; manually create SVG/ICO derivatives from
+  the approved mark when production requires them.
+- Use 1200x630 for OG/social cards. Keep copy inside a safe area and check the
+  rendered spelling at actual share-card size.
+- Use 16:9 or wider for heroes with explicit negative space for UI copy; keep
+  the focal subject away from the overlay region.
+- Use A4/Letter portrait and at least 2K for report covers; use 2K or larger
+  for print-ish artwork after confirming the document's actual resolution.
+- Derive favicon.ico, favicon.svg, apple-touch-icon 180x180, and manifest
+  icons 192x192/512x512 from one square logo master. Keep the glyph inside the
+  small-size safe area.
+
+## Post-generation checklist
+
+1. Compare the asset against the style token block: palette hexes, optical
+   weight, motif, lighting, crop, and contrast.
+2. Inspect text at target size for spelling, punctuation, safe-area placement,
+   and accidental lettering. Recompose rather than silently editing generated
+   copy.
+3. Confirm dimensions, color profile, file type, and genuine alpha where
+   requested. A checkerboard painted into pixels is not transparency.
+4. For a set, review all assets together at true size for backdrop, shadows,
+   framing, and stroke drift.
+5. For logos/icons, check legibility at 16px/24px/32px and manually vectorize
+   only after the raster master is approved.
+6. Add a license/usage note: record the provider, model, account/project, date,
+   references, and any restrictions. Do not assume generated output is free of
+   trademark or likeness obligations.

--- a/cas-cli/src/builtins/codex/skills/cas-image-generate/references/providers.md
+++ b/cas-cli/src/builtins/codex/skills/cas-image-generate/references/providers.md
@@ -1,0 +1,97 @@
+# Provider reference and boundaries
+
+Research basis: [image-generation-dossier.md](../../../../../../.cas/artifacts/cas-1c67/research/image-generation-dossier.md),
+compiled 2026-08-29. Verify live provider documentation before adding an
+integration; model names and pricing can change.
+
+## Wired: Google Nano Banana
+
+This skill currently wires only Google AI Studio's Gemini image endpoint. The
+key is `GEMINI_API_KEY`; it is read only from the environment by the helper.
+There is no image-provider key in CAS's existing config/secrets convention, so
+the missing-key message points the operator to Google AI Studio rather than
+creating a new config field. The endpoint is:
+
+```text
+POST https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent
+header: x-goog-api-key: $GEMINI_API_KEY
+```
+
+Use `gemini-3.1-flash-image` (Nano Banana 2) for drafts and ordinary raster
+work, or `gemini-3-pro-image` (Nano Banana Pro) for finals and dense copy. A
+minimal request is:
+
+```bash
+curl -sS "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent" \
+  -H "x-goog-api-key: $GEMINI_API_KEY" -H "Content-Type: application/json" \
+  -d '{"contents":[{"parts":[{"text":"{prompt with style tokens}"}]}]}'
+```
+
+The response carries base64 image data in an `inlineData` part. Reference
+images are additional `inlineData` parts. Nano Banana does not expose a
+first-class transparent-background flag; request isolation positively and
+verify alpha after decoding. All generated images carry Google's SynthID
+watermark. Imagen is retired as of 2026-08-17 and is not a valid fallback.
+
+## Optional and explicitly unwired add-ons
+
+The following snippets preserve the research escape hatches for a future,
+separately authorized integration. They are documentation only: this skill
+does not read their keys, call their endpoints, or route around a missing
+`GEMINI_API_KEY`.
+
+### Recraft V4 / V4.1 — unwired SVG specialist
+
+Recraft is the dossier's production-grade SVG/vector option and supports saved
+styles, vectorization, and background removal. It would use
+`RECRAFT_API_TOKEN` and an OpenAI-compatible endpoint, but it is intentionally
+unwired under the current no-new-paid-services scope:
+
+```bash
+curl -sS https://external.api.recraft.ai/v1/images/generations \
+  -H "Authorization: Bearer $RECRAFT_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"recraftv4_1_vector","style":"vector_illustration","prompt":"…"}'
+```
+
+### OpenAI GPT Image 2 — unwired transparency/OG option
+
+`gpt-image-2` is a strong raster and transparency option and would use
+`OPENAI_API_KEY`. It requires organization verification for image models. It
+is not called by this skill:
+
+```bash
+curl -sS https://api.openai.com/v1/images/generations \
+  -H "Authorization: Bearer $OPENAI_API_KEY" -H "Content-Type: application/json" \
+  -d '{"model":"gpt-image-2","prompt":"…","size":"1200x630","background":"transparent","output_format":"png"}'
+```
+
+### Ideogram 3.0 — unwired typography option
+
+Ideogram's `DESIGN` style, quoted copy, seed, palette, and style-reference
+parameters are useful for typography-heavy logos. It would use
+`IDEOGRAM_API_KEY` and multipart form data. It is not called by this skill:
+
+```bash
+curl -sS -X POST https://api.ideogram.ai/v1/ideogram-v3/generate \
+  -H "Api-Key: $IDEOGRAM_API_KEY" \
+  -F 'prompt=A logo with exact text "…"' -F style_type=DESIGN -F aspect_ratio=1x1
+```
+
+### Black Forest Labs FLUX.2 — unwired hosted option
+
+FLUX.2 offers strong hex-color control, seeds, and multi-reference editing;
+the hosted API would use `BFL_API_KEY`, submit asynchronously, and poll its
+`polling_url`. It is not called by this skill:
+
+```bash
+curl -sS -X POST https://api.bfl.ai/v1/flux-2-pro \
+  -H "x-key: $BFL_API_KEY" -H "Content-Type: application/json" \
+  -d '{"prompt":"…","width":1024,"height":1024}'
+```
+
+FLUX.2 klein's local open weights are a possible free path when a machine has
+roughly 13GB VRAM and the operator accepts local model setup. Hardware was not
+assumed or provisioned here, so this is documentation only. Midjourney has no
+official public API and Stability has pivoted away from a competitive image
+API; neither is a valid integration target.

--- a/cas-cli/src/builtins/codex/skills/cas-image-generate/references/style-harvest.md
+++ b/cas-cli/src/builtins/codex/skills/cas-image-generate/references/style-harvest.md
@@ -1,0 +1,41 @@
+# Style harvest
+
+Before generating, inspect the project rather than guessing its visual
+language. Read `DESIGN.md` or the output of the `design-spec` skill first;
+then inspect Tailwind/theme configuration, CSS custom properties, existing logo
+and palette assets, and a few approved images. Do not copy a prompt from an
+unrelated project.
+
+Distill the evidence into one short block and reuse it verbatim in every
+generation request:
+
+```text
+STYLE TOKENS
+palette: navy #0B3D91, gold #F2A900, off-white #F8F7F2
+typography: bold geometric sans-serif for headings; quiet humanist sans-serif for body
+motifs: ascending lines, generous whitespace, restrained geometric overlays
+tone: premium, calm, editorial, precise
+lighting: soft diffuse morning light; shadows fall down-right
+framing: medium distance; leave the left third open for copy
+references: assets/brand/logo-approved.svg, assets/brand/cover-approved.png
+```
+
+The block is an executable prompt input, not a report paragraph. Tie hex values
+to named objects (for example, “gold #F2A900 ribbon”) and describe typography by
+attributes rather than an unavailable font name. Preserve the project's actual
+case and values. If no design system exists, say so in the block and choose a
+small, explicit palette and tone with the operator rather than inventing brand
+history.
+
+For a reference image, state its role and the invariant: “use the approved
+cover for palette and framing; change only the subject.” Nano Banana supports
+multiple reference images, so add each approved logo, product shot, or prior
+asset with a relationship instruction. Remove sensitive or unrelated images
+from the request.
+
+## Harvest record
+
+Save the final block beside the generated assets or in the project's existing
+design documentation. The asset note should include the source files read,
+model tier, prompt, references, and review date. This makes a later revision a
+controlled edit instead of a new style decision.

--- a/cas-cli/src/builtins/codex/skills/cas-image-generate/scripts/generate-image.sh
+++ b/cas-cli/src/builtins/codex/skills/cas-image-generate/scripts/generate-image.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: generate-image.sh --prompt TEXT --output PATH [--tier draft|final]
+                         [--reference PATH]... [--dry-run]
+
+Generates a Google Nano Banana image. The credential is read from
+GEMINI_API_KEY; use --dry-run to validate routing without an API request.
+USAGE
+}
+
+prompt=""
+output=""
+tier="draft"
+dry_run=false
+references=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prompt)
+            [[ $# -ge 2 ]] || { echo "error: --prompt needs a value" >&2; usage; exit 2; }
+            prompt="$2"
+            shift 2
+            ;;
+        --output)
+            [[ $# -ge 2 ]] || { echo "error: --output needs a value" >&2; usage; exit 2; }
+            output="$2"
+            shift 2
+            ;;
+        --tier)
+            [[ $# -ge 2 ]] || { echo "error: --tier needs a value" >&2; usage; exit 2; }
+            tier="$2"
+            shift 2
+            ;;
+        --reference)
+            [[ $# -ge 2 ]] || { echo "error: --reference needs a value" >&2; usage; exit 2; }
+            references+=("$2")
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=true
+            shift
+            ;;
+        -h|--help)
+            usage >&1
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$prompt" || -z "$output" ]]; then
+    echo "error: --prompt and --output are required" >&2
+    usage
+    exit 2
+fi
+
+case "$tier" in
+    draft) model="gemini-3.1-flash-image" ;;
+    final) model="gemini-3-pro-image" ;;
+    *)
+        echo "error: --tier must be draft or final" >&2
+        exit 2
+        ;;
+esac
+
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+    cat >&2 <<'MISSING_KEY'
+error: GEMINI_API_KEY is not set; Nano Banana generation is unavailable.
+Create a Google AI Studio API key and export GEMINI_API_KEY in the process
+environment (or load it through your local secret manager), then retry.
+The helper does not read or store keys from project files.
+MISSING_KEY
+    exit 2
+fi
+
+if [[ "$dry_run" == true ]]; then
+    printf 'provider=google-nano-banana\nmodel=%s\ntier=%s\nreferences=%d\ndry_run=true\n' \
+        "$model" "$tier" "${#references[@]}"
+    exit 0
+fi
+
+for reference in "${references[@]}"; do
+    if [[ ! -f "$reference" ]]; then
+        echo "error: reference file does not exist: $reference" >&2
+        exit 2
+    fi
+done
+
+mime_type() {
+    case "${1,,}" in
+        *.png) printf 'image/png' ;;
+        *.webp) printf 'image/webp' ;;
+        *.gif) printf 'image/gif' ;;
+        *.jpg|*.jpeg) printf 'image/jpeg' ;;
+        *)
+            echo "error: unsupported reference type (use png, jpeg, webp, or gif): $1" >&2
+            exit 2
+            ;;
+    esac
+}
+
+parts="$(jq -n --arg prompt "$prompt" '[{text: $prompt}]')"
+for reference in "${references[@]}"; do
+    encoded="$(base64 --wrap=0 "$reference")"
+    reference_mime="$(mime_type "$reference")"
+    parts="$(jq --arg mime "$reference_mime" --arg data "$encoded" \
+        '. + [{inlineData: {mimeType: $mime, data: $data}}]' <<<"$parts")"
+done
+
+payload="$(jq -n --argjson parts "$parts" '{contents: [{parts: $parts}]}')"
+endpoint="https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent"
+response=""
+if ! response="$(curl -sS --connect-timeout 15 --max-time 180 \
+    -H "x-goog-api-key: $GEMINI_API_KEY" \
+    -H 'Content-Type: application/json' \
+    -d "$payload" "$endpoint")"; then
+    echo "error: Nano Banana request failed; check network access and Google AI Studio credentials" >&2
+    exit 1
+fi
+
+image_data="$(jq -r '
+    first(.candidates[]?.content.parts[]? | (.inlineData // .inline_data) | .data) // empty
+' <<<"$response")"
+if [[ -z "$image_data" ]]; then
+    api_error="$(jq -r '.error.message // empty' <<<"$response" 2>/dev/null || true)"
+    if [[ -n "$api_error" ]]; then
+        echo "error: Nano Banana returned an API error: $api_error" >&2
+    else
+        echo "error: Nano Banana response contained no image data" >&2
+    fi
+    exit 1
+fi
+
+mkdir -p "$(dirname "$output")"
+printf '%s' "$image_data" | base64 --decode > "$output"
+printf 'wrote=%s\nmodel=%s\n' "$output" "$model"

--- a/cas-cli/src/builtins/grok/skills/cas-image-generate/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-image-generate/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: cas-image-generate
+description: Generate style-matched raster assets for apps, websites, and reports through Google Nano Banana. Use when a project needs a hero, background, logo, icon, card, illustration, or report artwork.
+managed_by: cas
+---
+
+# Style-aware image generation
+
+Use this skill when an image should belong to an existing product, site, or
+report rather than look like an unrelated stock asset. It covers logos, icon
+sets, heroes, backgrounds, textures, OG/social cards, report art, illustrations,
+and favicons. Read the relevant
+references before generating; keep the style decision reusable and inspect the
+result at its intended size.
+
+## Provider and invocation
+
+Google Nano Banana is the only wired hosted provider. It handles every raster
+asset type:
+
+- **NB2** (`gemini-3.1-flash-image`) for drafts, iteration, and ordinary scenes.
+- **NB Pro** (`gemini-3-pro-image`) for finals, report covers, and text-heavy
+  compositions.
+
+The helper uses the `GEMINI_API_KEY` environment variable and never accepts a
+key as a command-line argument. No CAS-managed image-provider secret store is
+currently available, so configure the key in the process environment (for
+example, from the operator's local secret manager). If it is absent, the
+helper stops before network access and prints the exact Google AI Studio setup
+guidance. Run it from the project root:
+
+```bash
+bash <harness-config-dir>/skills/cas-image-generate/scripts/generate-image.sh \
+  --tier draft --prompt "$PROMPT" --output assets/generated/hero.png
+```
+
+Use `--reference path/to/approved.png` once per reference image. Use
+`--dry-run` to validate routing and key presence without calling the API. The
+helper is a plain-curl adapter; see [providers.md](references/providers.md) for
+the request shape and the unwired alternatives.
+
+## Workflow
+
+1. Harvest the project's design context using
+   [style-harvest.md](references/style-harvest.md). Produce a concrete style
+   token block before writing the final prompt; reuse that style token block in
+   every request.
+2. Choose the asset row and preset in
+   [asset-playbook.md](references/asset-playbook.md). Put the token block in
+   every prompt; reference approved assets when consistency matters.
+3. Start with NB2 for a draft. Switch to NB Pro for the approved final or any
+   composition where exact copy matters. State what must remain unchanged when
+   editing a reference.
+4. Store the result using the naming and format rules in
+   [output-checklist.md](references/output-checklist.md), then complete its
+   review checklist. Record model, tier, prompt, references, and any seed or
+   style identifier in the project's asset note.
+
+Nano Banana produces raster output, not editable SVG. For logos, favicons, and
+icon sets, request a flat, high-contrast raster master with generous padding so
+manual vectorization is practical; do not promise production SVG paths or
+perfect small-size legibility. Derive favicon sizes from one approved master
+rather than regenerating each size.
+
+Do not use Imagen: Google retired that image path on 2026-08-17. Recraft,
+OpenAI, Ideogram, and hosted FLUX remain documented but unwired optional
+add-ons; do not invent a second credential or silently route a request to one.

--- a/cas-cli/src/builtins/grok/skills/cas-image-generate/references/asset-playbook.md
+++ b/cas-cli/src/builtins/grok/skills/cas-image-generate/references/asset-playbook.md
@@ -1,0 +1,80 @@
+# Asset playbook
+
+Research basis: the current [image-generation dossier](../../../../../../.cas/artifacts/cas-1c67/research/image-generation-dossier.md)
+was compiled 2026-08-29. The hosted route in this skill is Google Nano Banana;
+the dossier's other providers are retained as explicitly unwired references in
+[providers.md](providers.md).
+
+## Routing and presets
+
+All rows use Nano Banana. Pick NB2 for a draft or iteration and NB Pro for a
+final, cover, or dense in-image copy. The requested dimensions belong in the
+prompt and in the output review; the helper sends references and decodes the
+returned image but does not silently resize it.
+
+| Asset | Tier | Suggested output | Prompt emphasis |
+|---|---|---|---|
+| Logo / logomark | NB2 → NB Pro | square PNG, 1024px or larger | flat, simple mark, correct quoted wordmark, high contrast, generous clear space; manual vectorization required |
+| Icon set | NB2 → NB Pro | one square grid sheet, 1024–2048px | one locked 24px-grid spec sentence, uniform stroke, padding, one color; manually trace approved glyphs |
+| Hero image | NB2 → NB Pro | 16:9, up to 1920px wide | focal subject, camera, lighting, and negative space for copy |
+| Background / texture | NB2 | 16:9 or tileable square, 2K | low contrast, no focal object, exact palette, usable behind text |
+| OG / social card | NB Pro | 1200x630 PNG | exact quoted copy early, safe area, brand contrast, no gibberish |
+| Report cover / section art | NB Pro | A4 portrait or section banner, 2K+ | restrained palette, title placement, print-safe whitespace |
+| Spot illustration | NB2 → NB Pro | square 800–1600px PNG | simple silhouette, transparent-look isolation only if verified; consistent family style |
+| Favicon / app icon | derive from approved logo | 1024px square master, then 16/32/48/180/192/512px derivatives | centered mark inside the safe area; never generate six independent variants |
+
+## Prompt templates
+
+Replace every `{style_tokens}` slot with the complete block produced by
+[style-harvest.md](style-harvest.md). Keep the asset-specific sentence stable
+across a set and vary only `{subject}` or `{copy}`.
+
+### NB2 draft / iteration
+
+```text
+Create a {asset_type} for {project}.
+Subject: {subject}. Context: {context}. Composition: {composition}.
+Style tokens: {style_tokens}.
+Make this an exploratory draft with clean edges, coherent lighting, and no
+unrequested text. Preserve the supplied reference relationships: {references}.
+```
+
+### NB Pro final / text-heavy
+
+```text
+Create the final {asset_type} for {project}.
+Use these exact style tokens: {style_tokens}.
+Subject and action: {subject_action}. Context: {context}.
+Composition and safe area: {composition}. Exact displayed copy: "{copy}".
+References and what must stay unchanged: {references_and_invariants}.
+Return a polished raster asset with correct spelling, deliberate edges, and no
+extra lettering or decorative objects.
+```
+
+### Logo and icon limitation template
+
+```text
+Create a flat, high-contrast raster master for manual vectorization: {subject}.
+Use {style_tokens}; two colors maximum, simple geometric paths, centered on a
+plain background, generous clear space, no gradients, no shadows, and no extra
+lettering. If a wordmark is required, render exactly "{copy}".
+```
+
+### Locked icon-set sentence
+
+```text
+Create a single grid sheet of line icons: each glyph uses a 2px stroke,
+rounded caps and joins, a 24x24 grid with 2px padding, no fill, one color,
+centered composition, and the same {style_tokens}. Subjects: {subject_list}.
+```
+
+## Consistency rules
+
+- Generate related icons as one sheet where possible, then use the approved
+  sheet as a reference for later batches.
+- Keep the literal style token block, camera/framing language, and lighting
+  sentence unchanged across a set. Models do not carry state between calls.
+- Use a new aspect ratio as a crop or edit of an approved master, not a fresh
+  unrelated generation.
+- Lay the set out at true size and check backdrop tone, shadow direction, then
+  crop distance for drift.

--- a/cas-cli/src/builtins/grok/skills/cas-image-generate/references/output-checklist.md
+++ b/cas-cli/src/builtins/grok/skills/cas-image-generate/references/output-checklist.md
@@ -1,0 +1,56 @@
+# Output conventions and review
+
+## Where and how to save
+
+Keep generated files in the consuming project, normally
+`assets/generated/<asset-type>/<slug>.<ext>`, unless that project already has
+an asset convention. Use lowercase kebab-case names and keep the approved
+master separate from derived crops:
+
+```text
+assets/generated/hero/analytics-workspace-v1.png
+assets/generated/logo/cassy-mark-v1.png
+assets/generated/og/2026-performance-review-v1.png
+assets/generated/hero/analytics-workspace-v1.style.txt
+```
+
+Record the model (`gemini-3.1-flash-image` or `gemini-3-pro-image`), prompt,
+style token block, references, output dimensions, and review date in the asset
+note. Never commit an API key or a provider response containing credentials.
+
+## Format and size guidance
+
+- Use PNG when alpha or lossless edges matter; verify that a requested
+  transparent background is real alpha, not a baked checkerboard.
+- Use WebP or AVIF for web photography and large scenes after review; retain
+  the approved PNG master when practical. Use JPEG only where the consumer
+  requires it.
+- Logos and icons are raster in this wired path. Ask for a simple, flat master
+  suitable for manual vectorization; manually create SVG/ICO derivatives from
+  the approved mark when production requires them.
+- Use 1200x630 for OG/social cards. Keep copy inside a safe area and check the
+  rendered spelling at actual share-card size.
+- Use 16:9 or wider for heroes with explicit negative space for UI copy; keep
+  the focal subject away from the overlay region.
+- Use A4/Letter portrait and at least 2K for report covers; use 2K or larger
+  for print-ish artwork after confirming the document's actual resolution.
+- Derive favicon.ico, favicon.svg, apple-touch-icon 180x180, and manifest
+  icons 192x192/512x512 from one square logo master. Keep the glyph inside the
+  small-size safe area.
+
+## Post-generation checklist
+
+1. Compare the asset against the style token block: palette hexes, optical
+   weight, motif, lighting, crop, and contrast.
+2. Inspect text at target size for spelling, punctuation, safe-area placement,
+   and accidental lettering. Recompose rather than silently editing generated
+   copy.
+3. Confirm dimensions, color profile, file type, and genuine alpha where
+   requested. A checkerboard painted into pixels is not transparency.
+4. For a set, review all assets together at true size for backdrop, shadows,
+   framing, and stroke drift.
+5. For logos/icons, check legibility at 16px/24px/32px and manually vectorize
+   only after the raster master is approved.
+6. Add a license/usage note: record the provider, model, account/project, date,
+   references, and any restrictions. Do not assume generated output is free of
+   trademark or likeness obligations.

--- a/cas-cli/src/builtins/grok/skills/cas-image-generate/references/providers.md
+++ b/cas-cli/src/builtins/grok/skills/cas-image-generate/references/providers.md
@@ -1,0 +1,97 @@
+# Provider reference and boundaries
+
+Research basis: [image-generation-dossier.md](../../../../../../.cas/artifacts/cas-1c67/research/image-generation-dossier.md),
+compiled 2026-08-29. Verify live provider documentation before adding an
+integration; model names and pricing can change.
+
+## Wired: Google Nano Banana
+
+This skill currently wires only Google AI Studio's Gemini image endpoint. The
+key is `GEMINI_API_KEY`; it is read only from the environment by the helper.
+There is no image-provider key in CAS's existing config/secrets convention, so
+the missing-key message points the operator to Google AI Studio rather than
+creating a new config field. The endpoint is:
+
+```text
+POST https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent
+header: x-goog-api-key: $GEMINI_API_KEY
+```
+
+Use `gemini-3.1-flash-image` (Nano Banana 2) for drafts and ordinary raster
+work, or `gemini-3-pro-image` (Nano Banana Pro) for finals and dense copy. A
+minimal request is:
+
+```bash
+curl -sS "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent" \
+  -H "x-goog-api-key: $GEMINI_API_KEY" -H "Content-Type: application/json" \
+  -d '{"contents":[{"parts":[{"text":"{prompt with style tokens}"}]}]}'
+```
+
+The response carries base64 image data in an `inlineData` part. Reference
+images are additional `inlineData` parts. Nano Banana does not expose a
+first-class transparent-background flag; request isolation positively and
+verify alpha after decoding. All generated images carry Google's SynthID
+watermark. Imagen is retired as of 2026-08-17 and is not a valid fallback.
+
+## Optional and explicitly unwired add-ons
+
+The following snippets preserve the research escape hatches for a future,
+separately authorized integration. They are documentation only: this skill
+does not read their keys, call their endpoints, or route around a missing
+`GEMINI_API_KEY`.
+
+### Recraft V4 / V4.1 — unwired SVG specialist
+
+Recraft is the dossier's production-grade SVG/vector option and supports saved
+styles, vectorization, and background removal. It would use
+`RECRAFT_API_TOKEN` and an OpenAI-compatible endpoint, but it is intentionally
+unwired under the current no-new-paid-services scope:
+
+```bash
+curl -sS https://external.api.recraft.ai/v1/images/generations \
+  -H "Authorization: Bearer $RECRAFT_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"recraftv4_1_vector","style":"vector_illustration","prompt":"…"}'
+```
+
+### OpenAI GPT Image 2 — unwired transparency/OG option
+
+`gpt-image-2` is a strong raster and transparency option and would use
+`OPENAI_API_KEY`. It requires organization verification for image models. It
+is not called by this skill:
+
+```bash
+curl -sS https://api.openai.com/v1/images/generations \
+  -H "Authorization: Bearer $OPENAI_API_KEY" -H "Content-Type: application/json" \
+  -d '{"model":"gpt-image-2","prompt":"…","size":"1200x630","background":"transparent","output_format":"png"}'
+```
+
+### Ideogram 3.0 — unwired typography option
+
+Ideogram's `DESIGN` style, quoted copy, seed, palette, and style-reference
+parameters are useful for typography-heavy logos. It would use
+`IDEOGRAM_API_KEY` and multipart form data. It is not called by this skill:
+
+```bash
+curl -sS -X POST https://api.ideogram.ai/v1/ideogram-v3/generate \
+  -H "Api-Key: $IDEOGRAM_API_KEY" \
+  -F 'prompt=A logo with exact text "…"' -F style_type=DESIGN -F aspect_ratio=1x1
+```
+
+### Black Forest Labs FLUX.2 — unwired hosted option
+
+FLUX.2 offers strong hex-color control, seeds, and multi-reference editing;
+the hosted API would use `BFL_API_KEY`, submit asynchronously, and poll its
+`polling_url`. It is not called by this skill:
+
+```bash
+curl -sS -X POST https://api.bfl.ai/v1/flux-2-pro \
+  -H "x-key: $BFL_API_KEY" -H "Content-Type: application/json" \
+  -d '{"prompt":"…","width":1024,"height":1024}'
+```
+
+FLUX.2 klein's local open weights are a possible free path when a machine has
+roughly 13GB VRAM and the operator accepts local model setup. Hardware was not
+assumed or provisioned here, so this is documentation only. Midjourney has no
+official public API and Stability has pivoted away from a competitive image
+API; neither is a valid integration target.

--- a/cas-cli/src/builtins/grok/skills/cas-image-generate/references/style-harvest.md
+++ b/cas-cli/src/builtins/grok/skills/cas-image-generate/references/style-harvest.md
@@ -1,0 +1,41 @@
+# Style harvest
+
+Before generating, inspect the project rather than guessing its visual
+language. Read `DESIGN.md` or the output of the `design-spec` skill first;
+then inspect Tailwind/theme configuration, CSS custom properties, existing logo
+and palette assets, and a few approved images. Do not copy a prompt from an
+unrelated project.
+
+Distill the evidence into one short block and reuse it verbatim in every
+generation request:
+
+```text
+STYLE TOKENS
+palette: navy #0B3D91, gold #F2A900, off-white #F8F7F2
+typography: bold geometric sans-serif for headings; quiet humanist sans-serif for body
+motifs: ascending lines, generous whitespace, restrained geometric overlays
+tone: premium, calm, editorial, precise
+lighting: soft diffuse morning light; shadows fall down-right
+framing: medium distance; leave the left third open for copy
+references: assets/brand/logo-approved.svg, assets/brand/cover-approved.png
+```
+
+The block is an executable prompt input, not a report paragraph. Tie hex values
+to named objects (for example, “gold #F2A900 ribbon”) and describe typography by
+attributes rather than an unavailable font name. Preserve the project's actual
+case and values. If no design system exists, say so in the block and choose a
+small, explicit palette and tone with the operator rather than inventing brand
+history.
+
+For a reference image, state its role and the invariant: “use the approved
+cover for palette and framing; change only the subject.” Nano Banana supports
+multiple reference images, so add each approved logo, product shot, or prior
+asset with a relationship instruction. Remove sensitive or unrelated images
+from the request.
+
+## Harvest record
+
+Save the final block beside the generated assets or in the project's existing
+design documentation. The asset note should include the source files read,
+model tier, prompt, references, and review date. This makes a later revision a
+controlled edit instead of a new style decision.

--- a/cas-cli/src/builtins/grok/skills/cas-image-generate/scripts/generate-image.sh
+++ b/cas-cli/src/builtins/grok/skills/cas-image-generate/scripts/generate-image.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: generate-image.sh --prompt TEXT --output PATH [--tier draft|final]
+                         [--reference PATH]... [--dry-run]
+
+Generates a Google Nano Banana image. The credential is read from
+GEMINI_API_KEY; use --dry-run to validate routing without an API request.
+USAGE
+}
+
+prompt=""
+output=""
+tier="draft"
+dry_run=false
+references=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prompt)
+            [[ $# -ge 2 ]] || { echo "error: --prompt needs a value" >&2; usage; exit 2; }
+            prompt="$2"
+            shift 2
+            ;;
+        --output)
+            [[ $# -ge 2 ]] || { echo "error: --output needs a value" >&2; usage; exit 2; }
+            output="$2"
+            shift 2
+            ;;
+        --tier)
+            [[ $# -ge 2 ]] || { echo "error: --tier needs a value" >&2; usage; exit 2; }
+            tier="$2"
+            shift 2
+            ;;
+        --reference)
+            [[ $# -ge 2 ]] || { echo "error: --reference needs a value" >&2; usage; exit 2; }
+            references+=("$2")
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=true
+            shift
+            ;;
+        -h|--help)
+            usage >&1
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$prompt" || -z "$output" ]]; then
+    echo "error: --prompt and --output are required" >&2
+    usage
+    exit 2
+fi
+
+case "$tier" in
+    draft) model="gemini-3.1-flash-image" ;;
+    final) model="gemini-3-pro-image" ;;
+    *)
+        echo "error: --tier must be draft or final" >&2
+        exit 2
+        ;;
+esac
+
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+    cat >&2 <<'MISSING_KEY'
+error: GEMINI_API_KEY is not set; Nano Banana generation is unavailable.
+Create a Google AI Studio API key and export GEMINI_API_KEY in the process
+environment (or load it through your local secret manager), then retry.
+The helper does not read or store keys from project files.
+MISSING_KEY
+    exit 2
+fi
+
+if [[ "$dry_run" == true ]]; then
+    printf 'provider=google-nano-banana\nmodel=%s\ntier=%s\nreferences=%d\ndry_run=true\n' \
+        "$model" "$tier" "${#references[@]}"
+    exit 0
+fi
+
+for reference in "${references[@]}"; do
+    if [[ ! -f "$reference" ]]; then
+        echo "error: reference file does not exist: $reference" >&2
+        exit 2
+    fi
+done
+
+mime_type() {
+    case "${1,,}" in
+        *.png) printf 'image/png' ;;
+        *.webp) printf 'image/webp' ;;
+        *.gif) printf 'image/gif' ;;
+        *.jpg|*.jpeg) printf 'image/jpeg' ;;
+        *)
+            echo "error: unsupported reference type (use png, jpeg, webp, or gif): $1" >&2
+            exit 2
+            ;;
+    esac
+}
+
+parts="$(jq -n --arg prompt "$prompt" '[{text: $prompt}]')"
+for reference in "${references[@]}"; do
+    encoded="$(base64 --wrap=0 "$reference")"
+    reference_mime="$(mime_type "$reference")"
+    parts="$(jq --arg mime "$reference_mime" --arg data "$encoded" \
+        '. + [{inlineData: {mimeType: $mime, data: $data}}]' <<<"$parts")"
+done
+
+payload="$(jq -n --argjson parts "$parts" '{contents: [{parts: $parts}]}')"
+endpoint="https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent"
+response=""
+if ! response="$(curl -sS --connect-timeout 15 --max-time 180 \
+    -H "x-goog-api-key: $GEMINI_API_KEY" \
+    -H 'Content-Type: application/json' \
+    -d "$payload" "$endpoint")"; then
+    echo "error: Nano Banana request failed; check network access and Google AI Studio credentials" >&2
+    exit 1
+fi
+
+image_data="$(jq -r '
+    first(.candidates[]?.content.parts[]? | (.inlineData // .inline_data) | .data) // empty
+' <<<"$response")"
+if [[ -z "$image_data" ]]; then
+    api_error="$(jq -r '.error.message // empty' <<<"$response" 2>/dev/null || true)"
+    if [[ -n "$api_error" ]]; then
+        echo "error: Nano Banana returned an API error: $api_error" >&2
+    else
+        echo "error: Nano Banana response contained no image data" >&2
+    fi
+    exit 1
+fi
+
+mkdir -p "$(dirname "$output")"
+printf '%s' "$image_data" | base64 --decode > "$output"
+printf 'wrote=%s\nmodel=%s\n' "$output" "$model"

--- a/cas-cli/src/builtins/skills/cas-image-generate/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-image-generate/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: cas-image-generate
+description: Generate style-matched raster assets for apps, websites, and reports through Google Nano Banana. Use when a project needs a hero, background, logo, icon, card, illustration, or report artwork.
+managed_by: cas
+---
+
+# Style-aware image generation
+
+Use this skill when an image should belong to an existing product, site, or
+report rather than look like an unrelated stock asset. It covers logos, icon
+sets, heroes, backgrounds, textures, OG/social cards, report art, illustrations,
+and favicons. Read the relevant
+references before generating; keep the style decision reusable and inspect the
+result at its intended size.
+
+## Provider and invocation
+
+Google Nano Banana is the only wired hosted provider. It handles every raster
+asset type:
+
+- **NB2** (`gemini-3.1-flash-image`) for drafts, iteration, and ordinary scenes.
+- **NB Pro** (`gemini-3-pro-image`) for finals, report covers, and text-heavy
+  compositions.
+
+The helper uses the `GEMINI_API_KEY` environment variable and never accepts a
+key as a command-line argument. No CAS-managed image-provider secret store is
+currently available, so configure the key in the process environment (for
+example, from the operator's local secret manager). If it is absent, the
+helper stops before network access and prints the exact Google AI Studio setup
+guidance. Run it from the project root:
+
+```bash
+bash <harness-config-dir>/skills/cas-image-generate/scripts/generate-image.sh \
+  --tier draft --prompt "$PROMPT" --output assets/generated/hero.png
+```
+
+Use `--reference path/to/approved.png` once per reference image. Use
+`--dry-run` to validate routing and key presence without calling the API. The
+helper is a plain-curl adapter; see [providers.md](references/providers.md) for
+the request shape and the unwired alternatives.
+
+## Workflow
+
+1. Harvest the project's design context using
+   [style-harvest.md](references/style-harvest.md). Produce a concrete style
+   token block before writing the final prompt; reuse that style token block in
+   every request.
+2. Choose the asset row and preset in
+   [asset-playbook.md](references/asset-playbook.md). Put the token block in
+   every prompt; reference approved assets when consistency matters.
+3. Start with NB2 for a draft. Switch to NB Pro for the approved final or any
+   composition where exact copy matters. State what must remain unchanged when
+   editing a reference.
+4. Store the result using the naming and format rules in
+   [output-checklist.md](references/output-checklist.md), then complete its
+   review checklist. Record model, tier, prompt, references, and any seed or
+   style identifier in the project's asset note.
+
+Nano Banana produces raster output, not editable SVG. For logos, favicons, and
+icon sets, request a flat, high-contrast raster master with generous padding so
+manual vectorization is practical; do not promise production SVG paths or
+perfect small-size legibility. Derive favicon sizes from one approved master
+rather than regenerating each size.
+
+Do not use Imagen: Google retired that image path on 2026-08-17. Recraft,
+OpenAI, Ideogram, and hosted FLUX remain documented but unwired optional
+add-ons; do not invent a second credential or silently route a request to one.

--- a/cas-cli/src/builtins/skills/cas-image-generate/references/asset-playbook.md
+++ b/cas-cli/src/builtins/skills/cas-image-generate/references/asset-playbook.md
@@ -1,0 +1,80 @@
+# Asset playbook
+
+Research basis: the current [image-generation dossier](../../../../../../.cas/artifacts/cas-1c67/research/image-generation-dossier.md)
+was compiled 2026-08-29. The hosted route in this skill is Google Nano Banana;
+the dossier's other providers are retained as explicitly unwired references in
+[providers.md](providers.md).
+
+## Routing and presets
+
+All rows use Nano Banana. Pick NB2 for a draft or iteration and NB Pro for a
+final, cover, or dense in-image copy. The requested dimensions belong in the
+prompt and in the output review; the helper sends references and decodes the
+returned image but does not silently resize it.
+
+| Asset | Tier | Suggested output | Prompt emphasis |
+|---|---|---|---|
+| Logo / logomark | NB2 → NB Pro | square PNG, 1024px or larger | flat, simple mark, correct quoted wordmark, high contrast, generous clear space; manual vectorization required |
+| Icon set | NB2 → NB Pro | one square grid sheet, 1024–2048px | one locked 24px-grid spec sentence, uniform stroke, padding, one color; manually trace approved glyphs |
+| Hero image | NB2 → NB Pro | 16:9, up to 1920px wide | focal subject, camera, lighting, and negative space for copy |
+| Background / texture | NB2 | 16:9 or tileable square, 2K | low contrast, no focal object, exact palette, usable behind text |
+| OG / social card | NB Pro | 1200x630 PNG | exact quoted copy early, safe area, brand contrast, no gibberish |
+| Report cover / section art | NB Pro | A4 portrait or section banner, 2K+ | restrained palette, title placement, print-safe whitespace |
+| Spot illustration | NB2 → NB Pro | square 800–1600px PNG | simple silhouette, transparent-look isolation only if verified; consistent family style |
+| Favicon / app icon | derive from approved logo | 1024px square master, then 16/32/48/180/192/512px derivatives | centered mark inside the safe area; never generate six independent variants |
+
+## Prompt templates
+
+Replace every `{style_tokens}` slot with the complete block produced by
+[style-harvest.md](style-harvest.md). Keep the asset-specific sentence stable
+across a set and vary only `{subject}` or `{copy}`.
+
+### NB2 draft / iteration
+
+```text
+Create a {asset_type} for {project}.
+Subject: {subject}. Context: {context}. Composition: {composition}.
+Style tokens: {style_tokens}.
+Make this an exploratory draft with clean edges, coherent lighting, and no
+unrequested text. Preserve the supplied reference relationships: {references}.
+```
+
+### NB Pro final / text-heavy
+
+```text
+Create the final {asset_type} for {project}.
+Use these exact style tokens: {style_tokens}.
+Subject and action: {subject_action}. Context: {context}.
+Composition and safe area: {composition}. Exact displayed copy: "{copy}".
+References and what must stay unchanged: {references_and_invariants}.
+Return a polished raster asset with correct spelling, deliberate edges, and no
+extra lettering or decorative objects.
+```
+
+### Logo and icon limitation template
+
+```text
+Create a flat, high-contrast raster master for manual vectorization: {subject}.
+Use {style_tokens}; two colors maximum, simple geometric paths, centered on a
+plain background, generous clear space, no gradients, no shadows, and no extra
+lettering. If a wordmark is required, render exactly "{copy}".
+```
+
+### Locked icon-set sentence
+
+```text
+Create a single grid sheet of line icons: each glyph uses a 2px stroke,
+rounded caps and joins, a 24x24 grid with 2px padding, no fill, one color,
+centered composition, and the same {style_tokens}. Subjects: {subject_list}.
+```
+
+## Consistency rules
+
+- Generate related icons as one sheet where possible, then use the approved
+  sheet as a reference for later batches.
+- Keep the literal style token block, camera/framing language, and lighting
+  sentence unchanged across a set. Models do not carry state between calls.
+- Use a new aspect ratio as a crop or edit of an approved master, not a fresh
+  unrelated generation.
+- Lay the set out at true size and check backdrop tone, shadow direction, then
+  crop distance for drift.

--- a/cas-cli/src/builtins/skills/cas-image-generate/references/output-checklist.md
+++ b/cas-cli/src/builtins/skills/cas-image-generate/references/output-checklist.md
@@ -1,0 +1,56 @@
+# Output conventions and review
+
+## Where and how to save
+
+Keep generated files in the consuming project, normally
+`assets/generated/<asset-type>/<slug>.<ext>`, unless that project already has
+an asset convention. Use lowercase kebab-case names and keep the approved
+master separate from derived crops:
+
+```text
+assets/generated/hero/analytics-workspace-v1.png
+assets/generated/logo/cassy-mark-v1.png
+assets/generated/og/2026-performance-review-v1.png
+assets/generated/hero/analytics-workspace-v1.style.txt
+```
+
+Record the model (`gemini-3.1-flash-image` or `gemini-3-pro-image`), prompt,
+style token block, references, output dimensions, and review date in the asset
+note. Never commit an API key or a provider response containing credentials.
+
+## Format and size guidance
+
+- Use PNG when alpha or lossless edges matter; verify that a requested
+  transparent background is real alpha, not a baked checkerboard.
+- Use WebP or AVIF for web photography and large scenes after review; retain
+  the approved PNG master when practical. Use JPEG only where the consumer
+  requires it.
+- Logos and icons are raster in this wired path. Ask for a simple, flat master
+  suitable for manual vectorization; manually create SVG/ICO derivatives from
+  the approved mark when production requires them.
+- Use 1200x630 for OG/social cards. Keep copy inside a safe area and check the
+  rendered spelling at actual share-card size.
+- Use 16:9 or wider for heroes with explicit negative space for UI copy; keep
+  the focal subject away from the overlay region.
+- Use A4/Letter portrait and at least 2K for report covers; use 2K or larger
+  for print-ish artwork after confirming the document's actual resolution.
+- Derive favicon.ico, favicon.svg, apple-touch-icon 180x180, and manifest
+  icons 192x192/512x512 from one square logo master. Keep the glyph inside the
+  small-size safe area.
+
+## Post-generation checklist
+
+1. Compare the asset against the style token block: palette hexes, optical
+   weight, motif, lighting, crop, and contrast.
+2. Inspect text at target size for spelling, punctuation, safe-area placement,
+   and accidental lettering. Recompose rather than silently editing generated
+   copy.
+3. Confirm dimensions, color profile, file type, and genuine alpha where
+   requested. A checkerboard painted into pixels is not transparency.
+4. For a set, review all assets together at true size for backdrop, shadows,
+   framing, and stroke drift.
+5. For logos/icons, check legibility at 16px/24px/32px and manually vectorize
+   only after the raster master is approved.
+6. Add a license/usage note: record the provider, model, account/project, date,
+   references, and any restrictions. Do not assume generated output is free of
+   trademark or likeness obligations.

--- a/cas-cli/src/builtins/skills/cas-image-generate/references/providers.md
+++ b/cas-cli/src/builtins/skills/cas-image-generate/references/providers.md
@@ -1,0 +1,97 @@
+# Provider reference and boundaries
+
+Research basis: [image-generation-dossier.md](../../../../../../.cas/artifacts/cas-1c67/research/image-generation-dossier.md),
+compiled 2026-08-29. Verify live provider documentation before adding an
+integration; model names and pricing can change.
+
+## Wired: Google Nano Banana
+
+This skill currently wires only Google AI Studio's Gemini image endpoint. The
+key is `GEMINI_API_KEY`; it is read only from the environment by the helper.
+There is no image-provider key in CAS's existing config/secrets convention, so
+the missing-key message points the operator to Google AI Studio rather than
+creating a new config field. The endpoint is:
+
+```text
+POST https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent
+header: x-goog-api-key: $GEMINI_API_KEY
+```
+
+Use `gemini-3.1-flash-image` (Nano Banana 2) for drafts and ordinary raster
+work, or `gemini-3-pro-image` (Nano Banana Pro) for finals and dense copy. A
+minimal request is:
+
+```bash
+curl -sS "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent" \
+  -H "x-goog-api-key: $GEMINI_API_KEY" -H "Content-Type: application/json" \
+  -d '{"contents":[{"parts":[{"text":"{prompt with style tokens}"}]}]}'
+```
+
+The response carries base64 image data in an `inlineData` part. Reference
+images are additional `inlineData` parts. Nano Banana does not expose a
+first-class transparent-background flag; request isolation positively and
+verify alpha after decoding. All generated images carry Google's SynthID
+watermark. Imagen is retired as of 2026-08-17 and is not a valid fallback.
+
+## Optional and explicitly unwired add-ons
+
+The following snippets preserve the research escape hatches for a future,
+separately authorized integration. They are documentation only: this skill
+does not read their keys, call their endpoints, or route around a missing
+`GEMINI_API_KEY`.
+
+### Recraft V4 / V4.1 — unwired SVG specialist
+
+Recraft is the dossier's production-grade SVG/vector option and supports saved
+styles, vectorization, and background removal. It would use
+`RECRAFT_API_TOKEN` and an OpenAI-compatible endpoint, but it is intentionally
+unwired under the current no-new-paid-services scope:
+
+```bash
+curl -sS https://external.api.recraft.ai/v1/images/generations \
+  -H "Authorization: Bearer $RECRAFT_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"recraftv4_1_vector","style":"vector_illustration","prompt":"…"}'
+```
+
+### OpenAI GPT Image 2 — unwired transparency/OG option
+
+`gpt-image-2` is a strong raster and transparency option and would use
+`OPENAI_API_KEY`. It requires organization verification for image models. It
+is not called by this skill:
+
+```bash
+curl -sS https://api.openai.com/v1/images/generations \
+  -H "Authorization: Bearer $OPENAI_API_KEY" -H "Content-Type: application/json" \
+  -d '{"model":"gpt-image-2","prompt":"…","size":"1200x630","background":"transparent","output_format":"png"}'
+```
+
+### Ideogram 3.0 — unwired typography option
+
+Ideogram's `DESIGN` style, quoted copy, seed, palette, and style-reference
+parameters are useful for typography-heavy logos. It would use
+`IDEOGRAM_API_KEY` and multipart form data. It is not called by this skill:
+
+```bash
+curl -sS -X POST https://api.ideogram.ai/v1/ideogram-v3/generate \
+  -H "Api-Key: $IDEOGRAM_API_KEY" \
+  -F 'prompt=A logo with exact text "…"' -F style_type=DESIGN -F aspect_ratio=1x1
+```
+
+### Black Forest Labs FLUX.2 — unwired hosted option
+
+FLUX.2 offers strong hex-color control, seeds, and multi-reference editing;
+the hosted API would use `BFL_API_KEY`, submit asynchronously, and poll its
+`polling_url`. It is not called by this skill:
+
+```bash
+curl -sS -X POST https://api.bfl.ai/v1/flux-2-pro \
+  -H "x-key: $BFL_API_KEY" -H "Content-Type: application/json" \
+  -d '{"prompt":"…","width":1024,"height":1024}'
+```
+
+FLUX.2 klein's local open weights are a possible free path when a machine has
+roughly 13GB VRAM and the operator accepts local model setup. Hardware was not
+assumed or provisioned here, so this is documentation only. Midjourney has no
+official public API and Stability has pivoted away from a competitive image
+API; neither is a valid integration target.

--- a/cas-cli/src/builtins/skills/cas-image-generate/references/style-harvest.md
+++ b/cas-cli/src/builtins/skills/cas-image-generate/references/style-harvest.md
@@ -1,0 +1,41 @@
+# Style harvest
+
+Before generating, inspect the project rather than guessing its visual
+language. Read `DESIGN.md` or the output of the `design-spec` skill first;
+then inspect Tailwind/theme configuration, CSS custom properties, existing logo
+and palette assets, and a few approved images. Do not copy a prompt from an
+unrelated project.
+
+Distill the evidence into one short block and reuse it verbatim in every
+generation request:
+
+```text
+STYLE TOKENS
+palette: navy #0B3D91, gold #F2A900, off-white #F8F7F2
+typography: bold geometric sans-serif for headings; quiet humanist sans-serif for body
+motifs: ascending lines, generous whitespace, restrained geometric overlays
+tone: premium, calm, editorial, precise
+lighting: soft diffuse morning light; shadows fall down-right
+framing: medium distance; leave the left third open for copy
+references: assets/brand/logo-approved.svg, assets/brand/cover-approved.png
+```
+
+The block is an executable prompt input, not a report paragraph. Tie hex values
+to named objects (for example, “gold #F2A900 ribbon”) and describe typography by
+attributes rather than an unavailable font name. Preserve the project's actual
+case and values. If no design system exists, say so in the block and choose a
+small, explicit palette and tone with the operator rather than inventing brand
+history.
+
+For a reference image, state its role and the invariant: “use the approved
+cover for palette and framing; change only the subject.” Nano Banana supports
+multiple reference images, so add each approved logo, product shot, or prior
+asset with a relationship instruction. Remove sensitive or unrelated images
+from the request.
+
+## Harvest record
+
+Save the final block beside the generated assets or in the project's existing
+design documentation. The asset note should include the source files read,
+model tier, prompt, references, and review date. This makes a later revision a
+controlled edit instead of a new style decision.

--- a/cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh
+++ b/cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: generate-image.sh --prompt TEXT --output PATH [--tier draft|final]
+                         [--reference PATH]... [--dry-run]
+
+Generates a Google Nano Banana image. The credential is read from
+GEMINI_API_KEY; use --dry-run to validate routing without an API request.
+USAGE
+}
+
+prompt=""
+output=""
+tier="draft"
+dry_run=false
+references=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prompt)
+            [[ $# -ge 2 ]] || { echo "error: --prompt needs a value" >&2; usage; exit 2; }
+            prompt="$2"
+            shift 2
+            ;;
+        --output)
+            [[ $# -ge 2 ]] || { echo "error: --output needs a value" >&2; usage; exit 2; }
+            output="$2"
+            shift 2
+            ;;
+        --tier)
+            [[ $# -ge 2 ]] || { echo "error: --tier needs a value" >&2; usage; exit 2; }
+            tier="$2"
+            shift 2
+            ;;
+        --reference)
+            [[ $# -ge 2 ]] || { echo "error: --reference needs a value" >&2; usage; exit 2; }
+            references+=("$2")
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=true
+            shift
+            ;;
+        -h|--help)
+            usage >&1
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$prompt" || -z "$output" ]]; then
+    echo "error: --prompt and --output are required" >&2
+    usage
+    exit 2
+fi
+
+case "$tier" in
+    draft) model="gemini-3.1-flash-image" ;;
+    final) model="gemini-3-pro-image" ;;
+    *)
+        echo "error: --tier must be draft or final" >&2
+        exit 2
+        ;;
+esac
+
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+    cat >&2 <<'MISSING_KEY'
+error: GEMINI_API_KEY is not set; Nano Banana generation is unavailable.
+Create a Google AI Studio API key and export GEMINI_API_KEY in the process
+environment (or load it through your local secret manager), then retry.
+The helper does not read or store keys from project files.
+MISSING_KEY
+    exit 2
+fi
+
+if [[ "$dry_run" == true ]]; then
+    printf 'provider=google-nano-banana\nmodel=%s\ntier=%s\nreferences=%d\ndry_run=true\n' \
+        "$model" "$tier" "${#references[@]}"
+    exit 0
+fi
+
+for reference in "${references[@]}"; do
+    if [[ ! -f "$reference" ]]; then
+        echo "error: reference file does not exist: $reference" >&2
+        exit 2
+    fi
+done
+
+mime_type() {
+    case "${1,,}" in
+        *.png) printf 'image/png' ;;
+        *.webp) printf 'image/webp' ;;
+        *.gif) printf 'image/gif' ;;
+        *.jpg|*.jpeg) printf 'image/jpeg' ;;
+        *)
+            echo "error: unsupported reference type (use png, jpeg, webp, or gif): $1" >&2
+            exit 2
+            ;;
+    esac
+}
+
+parts="$(jq -n --arg prompt "$prompt" '[{text: $prompt}]')"
+for reference in "${references[@]}"; do
+    encoded="$(base64 --wrap=0 "$reference")"
+    reference_mime="$(mime_type "$reference")"
+    parts="$(jq --arg mime "$reference_mime" --arg data "$encoded" \
+        '. + [{inlineData: {mimeType: $mime, data: $data}}]' <<<"$parts")"
+done
+
+payload="$(jq -n --argjson parts "$parts" '{contents: [{parts: $parts}]}')"
+endpoint="https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent"
+response=""
+if ! response="$(curl -sS --connect-timeout 15 --max-time 180 \
+    -H "x-goog-api-key: $GEMINI_API_KEY" \
+    -H 'Content-Type: application/json' \
+    -d "$payload" "$endpoint")"; then
+    echo "error: Nano Banana request failed; check network access and Google AI Studio credentials" >&2
+    exit 1
+fi
+
+image_data="$(jq -r '
+    first(.candidates[]?.content.parts[]? | (.inlineData // .inline_data) | .data) // empty
+' <<<"$response")"
+if [[ -z "$image_data" ]]; then
+    api_error="$(jq -r '.error.message // empty' <<<"$response" 2>/dev/null || true)"
+    if [[ -n "$api_error" ]]; then
+        echo "error: Nano Banana returned an API error: $api_error" >&2
+    else
+        echo "error: Nano Banana response contained no image data" >&2
+    fi
+    exit 1
+fi
+
+mkdir -p "$(dirname "$output")"
+printf '%s' "$image_data" | base64 --decode > "$output"
+printf 'wrote=%s\nmodel=%s\n' "$output" "$model"

--- a/cas-cli/tests/cas_image_generate_skill_test.rs
+++ b/cas-cli/tests/cas_image_generate_skill_test.rs
@@ -29,8 +29,14 @@ fn skill_mirrors_are_managed_and_cover_the_asset_workflow() {
     for path in skill_paths() {
         let body = load(path);
         assert!(body.starts_with("---\n"), "{path} lacks frontmatter");
-        assert!(body.contains("name: cas-image-generate"), "{path} has wrong name");
-        assert!(body.contains("managed_by: cas"), "{path} is not CAS-managed");
+        assert!(
+            body.contains("name: cas-image-generate"),
+            "{path} has wrong name"
+        );
+        assert!(
+            body.contains("managed_by: cas"),
+            "{path} is not CAS-managed"
+        );
         for marker in [
             "logo",
             "icon set",
@@ -46,17 +52,22 @@ fn skill_mirrors_are_managed_and_cover_the_asset_workflow() {
             "manual vectorization",
             "cas-image-generate/scripts/generate-image.sh",
         ] {
-            assert!(body.to_ascii_lowercase().contains(&marker.to_ascii_lowercase()),
-                "{path} missing workflow marker {marker:?}");
+            assert!(
+                body.to_ascii_lowercase()
+                    .contains(&marker.to_ascii_lowercase()),
+                "{path} missing workflow marker {marker:?}"
+            );
         }
     }
 }
 
 #[test]
 fn references_document_research_and_unwired_provider_boundaries() {
-    let playbook = load("cas-cli/src/builtins/skills/cas-image-generate/references/asset-playbook.md");
+    let playbook =
+        load("cas-cli/src/builtins/skills/cas-image-generate/references/asset-playbook.md");
     let providers = load("cas-cli/src/builtins/skills/cas-image-generate/references/providers.md");
-    let output = load("cas-cli/src/builtins/skills/cas-image-generate/references/output-checklist.md");
+    let output =
+        load("cas-cli/src/builtins/skills/cas-image-generate/references/output-checklist.md");
     let style = load("cas-cli/src/builtins/skills/cas-image-generate/references/style-harvest.md");
 
     for marker in [
@@ -70,14 +81,34 @@ fn references_document_research_and_unwired_provider_boundaries() {
         "unwired",
         "Imagen",
     ] {
-        assert!(providers.contains(marker) || playbook.contains(marker),
-            "research/provider reference missing {marker:?}");
+        assert!(
+            providers.contains(marker) || playbook.contains(marker),
+            "research/provider reference missing {marker:?}"
+        );
     }
-    for marker in ["DESIGN.md", "Tailwind", "--", "palette", "typography", "motif"] {
+    for marker in [
+        "DESIGN.md",
+        "Tailwind",
+        "CSS custom properties",
+        "palette",
+        "typography",
+        "motif",
+    ] {
         assert!(style.contains(marker), "style reference missing {marker:?}");
     }
-    for marker in ["1200x630", "transparent", "license", "favicon", "webp", "SVG"] {
-        assert!(output.contains(marker), "output reference missing {marker:?}");
+    let output_lower = output.to_ascii_lowercase();
+    for marker in [
+        "1200x630",
+        "transparent",
+        "license",
+        "favicon",
+        "webp",
+        "svg",
+    ] {
+        assert!(
+            output_lower.contains(marker),
+            "output reference missing {marker:?}"
+        );
     }
 }
 
@@ -95,7 +126,10 @@ fn builtin_catalog_registers_all_mirror_entries() {
         "builtins/codex/skills/cas-image-generate/scripts/generate-image.sh",
         "builtins/grok/skills/cas-image-generate/scripts/generate-image.sh",
     ] {
-        assert!(builtins.contains(include_path), "missing catalog include {include_path}");
+        assert!(
+            builtins.contains(include_path),
+            "missing catalog include {include_path}"
+        );
     }
 }
 
@@ -136,15 +170,18 @@ fn cas_update_syncs_the_skill_to_all_enabled_harnesses() {
             "skills/cas-image-generate/references/providers.md",
             "skills/cas-image-generate/scripts/generate-image.sh",
         ] {
-            assert!(project.path().join(harness).join(relative).is_file(),
-                "missing {harness}/{relative} after cas update --sync");
+            assert!(
+                project.path().join(harness).join(relative).is_file(),
+                "missing {harness}/{relative} after cas update --sync"
+            );
         }
     }
 }
 
 #[test]
 fn generation_helper_reports_missing_key_without_network_access() {
-    let script = repo_root().join("cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh");
+    let script = repo_root()
+        .join("cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh");
     Command::new("bash")
         .arg(&script)
         .args(["--prompt", "test", "--output", "out.png"])
@@ -158,10 +195,19 @@ fn generation_helper_reports_missing_key_without_network_access() {
 
 #[test]
 fn generation_helper_dry_run_validates_present_key_without_calling_api() {
-    let script = repo_root().join("cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh");
+    let script = repo_root()
+        .join("cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh");
     Command::new("bash")
         .arg(&script)
-        .args(["--tier", "final", "--prompt", "test", "--output", "out.png", "--dry-run"])
+        .args([
+            "--tier",
+            "final",
+            "--prompt",
+            "test",
+            "--output",
+            "out.png",
+            "--dry-run",
+        ])
         .env("GEMINI_API_KEY", "test-key-not-sent")
         .assert()
         .success()

--- a/cas-cli/tests/cas_image_generate_skill_test.rs
+++ b/cas-cli/tests/cas_image_generate_skill_test.rs
@@ -1,0 +1,172 @@
+//! Distribution and routing contracts for the built-in cas-image-generate skill.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn repo_root() -> PathBuf {
+    cas::test_paths::workspace_root()
+}
+
+fn load(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+fn skill_paths() -> [&'static str; 3] {
+    [
+        "cas-cli/src/builtins/skills/cas-image-generate/SKILL.md",
+        "cas-cli/src/builtins/codex/skills/cas-image-generate/SKILL.md",
+        "cas-cli/src/builtins/grok/skills/cas-image-generate/SKILL.md",
+    ]
+}
+
+#[test]
+fn skill_mirrors_are_managed_and_cover_the_asset_workflow() {
+    for path in skill_paths() {
+        let body = load(path);
+        assert!(body.starts_with("---\n"), "{path} lacks frontmatter");
+        assert!(body.contains("name: cas-image-generate"), "{path} has wrong name");
+        assert!(body.contains("managed_by: cas"), "{path} is not CAS-managed");
+        for marker in [
+            "logo",
+            "icon set",
+            "hero",
+            "background",
+            "texture",
+            "OG/social card",
+            "report cover",
+            "illustration",
+            "favicon",
+            "GEMINI_API_KEY",
+            "style token block",
+            "manual vectorization",
+            "cas-image-generate/scripts/generate-image.sh",
+        ] {
+            assert!(body.to_ascii_lowercase().contains(&marker.to_ascii_lowercase()),
+                "{path} missing workflow marker {marker:?}");
+        }
+    }
+}
+
+#[test]
+fn references_document_research_and_unwired_provider_boundaries() {
+    let playbook = load("cas-cli/src/builtins/skills/cas-image-generate/references/asset-playbook.md");
+    let providers = load("cas-cli/src/builtins/skills/cas-image-generate/references/providers.md");
+    let output = load("cas-cli/src/builtins/skills/cas-image-generate/references/output-checklist.md");
+    let style = load("cas-cli/src/builtins/skills/cas-image-generate/references/style-harvest.md");
+
+    for marker in [
+        "image-generation-dossier.md",
+        "gemini-3.1-flash-image",
+        "gemini-3-pro-image",
+        "Recraft",
+        "gpt-image-2",
+        "Ideogram 3.0",
+        "FLUX.2",
+        "unwired",
+        "Imagen",
+    ] {
+        assert!(providers.contains(marker) || playbook.contains(marker),
+            "research/provider reference missing {marker:?}");
+    }
+    for marker in ["DESIGN.md", "Tailwind", "--", "palette", "typography", "motif"] {
+        assert!(style.contains(marker), "style reference missing {marker:?}");
+    }
+    for marker in ["1200x630", "transparent", "license", "favicon", "webp", "SVG"] {
+        assert!(output.contains(marker), "output reference missing {marker:?}");
+    }
+}
+
+#[test]
+fn builtin_catalog_registers_all_mirror_entries() {
+    let builtins = load("cas-cli/src/builtins.rs");
+    for include_path in [
+        "builtins/skills/cas-image-generate/SKILL.md",
+        "builtins/codex/skills/cas-image-generate/SKILL.md",
+        "builtins/grok/skills/cas-image-generate/SKILL.md",
+        "builtins/skills/cas-image-generate/references/asset-playbook.md",
+        "builtins/codex/skills/cas-image-generate/references/asset-playbook.md",
+        "builtins/grok/skills/cas-image-generate/references/asset-playbook.md",
+        "builtins/skills/cas-image-generate/scripts/generate-image.sh",
+        "builtins/codex/skills/cas-image-generate/scripts/generate-image.sh",
+        "builtins/grok/skills/cas-image-generate/scripts/generate-image.sh",
+    ] {
+        assert!(builtins.contains(include_path), "missing catalog include {include_path}");
+    }
+}
+
+#[test]
+fn cas_update_syncs_the_skill_to_all_enabled_harnesses() {
+    let project = TempDir::new().unwrap();
+    let home = project.path().join("home");
+    let xdg = project.path().join("xdg");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&xdg).unwrap();
+
+    let mut command = Command::new(cas::test_paths::cas_binary());
+    command
+        .current_dir(project.path())
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .env_remove("CAS_ROOT")
+        .env_remove("GEMINI_API_KEY")
+        .args(["init", "--yes"])
+        .assert()
+        .success();
+
+    for harness in [".codex", ".grok"] {
+        fs::create_dir_all(project.path().join(harness)).unwrap();
+    }
+    let mut sync = Command::new(cas::test_paths::cas_binary());
+    sync.current_dir(project.path())
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", &xdg)
+        .env_remove("CAS_ROOT")
+        .args(["update", "--sync"])
+        .assert()
+        .success();
+
+    for harness in [".claude", ".codex", ".grok"] {
+        for relative in [
+            "skills/cas-image-generate/SKILL.md",
+            "skills/cas-image-generate/references/providers.md",
+            "skills/cas-image-generate/scripts/generate-image.sh",
+        ] {
+            assert!(project.path().join(harness).join(relative).is_file(),
+                "missing {harness}/{relative} after cas update --sync");
+        }
+    }
+}
+
+#[test]
+fn generation_helper_reports_missing_key_without_network_access() {
+    let script = repo_root().join("cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh");
+    Command::new("bash")
+        .arg(&script)
+        .args(["--prompt", "test", "--output", "out.png"])
+        .env_remove("GEMINI_API_KEY")
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("GEMINI_API_KEY"))
+        .stderr(predicate::str::contains("Google AI Studio"));
+}
+
+#[test]
+fn generation_helper_dry_run_validates_present_key_without_calling_api() {
+    let script = repo_root().join("cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh");
+    Command::new("bash")
+        .arg(&script)
+        .args(["--tier", "final", "--prompt", "test", "--output", "out.png", "--dry-run"])
+        .env("GEMINI_API_KEY", "test-key-not-sent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("provider=google-nano-banana"))
+        .stdout(predicate::str::contains("model=gemini-3-pro-image"))
+        .stdout(predicate::str::contains("dry_run=true"))
+        .stdout(predicate::str::contains("test-key-not-sent").not());
+}


### PR DESCRIPTION
Adds the cas-image-generate builtin skill (Claude/Codex/Grok mirrors + catalog registration):

- Asset-type playbook (logo, icons, hero/background, texture, OG card, report art, favicon) with per-type prompts and size/format presets
- Style-harvest step: distills the target project's DESIGN.md/theme/palette into a style token block injected into every prompt
- Nano Banana (Gemini) as the only wired provider via GEMINI_API_KEY — generate-image.sh with dry-run and explicit missing-key setup guidance; Recraft/OpenAI/Ideogram/BFL documented as unwired optional add-ons per operator's no-new-paid-services constraint
- References distilled from a cited Aug-2026 model-landscape research dossier

Proofs: cas_image_generate_skill_test 6/6; builtin_flavor_drift_test 10/10; cargo check clean; bash -n/rustfmt/diff-check clean. No live API calls in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)