### PR TITLE
docs(release-notes): record v3.5.0 announcement + receipts

### DIFF
--- a/docs/release-notes/2026-08-29-v3.5.0-slack.md
+++ b/docs/release-notes/2026-08-29-v3.5.0-slack.md
@@ -1,0 +1,28 @@
+# Release notes — 2026-08-29 — CAS v3.5.0
+
+**Channel:** `#cas-internal` · **Deploy:** Live on production (cassy main `5f410fe3`, tag `v3.5.0`; paired cloud deploy petra-stella-cloud `2611eb9`)
+
+## Dev thread (joint with the cloud MIN_CLIENT_VERSION announcement)
+
+**Top-level:**
+Live on production — **Dev** — CAS v3.5.0 published (tag→downloadable in 2m19s) and the cloud's `MIN_CLIENT_VERSION` now points at it.
+
+**Reply:**
+CAS v3.5.0 (cassy main → release):
+- **Was** → the cas client omitted `project_id` on team DELETE URLs, so project-aware servers 400'd them and the client parked the deletes as permanent rejections. **Now** → deletes carry the project-scoped identity; parked rejections requeue and flush after upgrade.
+- **Was** → the close gate's tree-effect check rejected deliveries whose hunks a supervisor legitimately union-merged (#597). **Now** → token-level per-added-line containment recognizes union evolution, and the rejection names the merge-receipt recovery path.
+- Plus the knowledge-loop hardening wave: validation-gated skill persistence, outcome-evidence rule promotion, rule impact tracking, provenance end-to-end, version history + tombstones for rules/skills, append-only trace archive, structured task execution state, session memory hygiene.
+- Three environment-dependent tests that reddened the merge queue were made runtime-portable (synthetic fixture repo instead of real SHAs; runtime paths instead of build-host `CARGO_MANIFEST_DIR`; doctor snapshot at schema v240).
+
+Cloud half (petra-stella-cloud main `2611eb9`):
+- **Was** → `MIN_CLIENT_VERSION` stayed 2.20.0 when the DELETE contract broke, so old clients failed silently. **Now** → floor is 3.5.0, gates run before `project_id` validation on single-entity GET/DELETE, with a documented+tested convention tying breaking route changes to version bumps.
+- Receipts: v3.5.0 tag 18:59:18Z → published 19:01:37Z (builds skipped, prebuilt artifacts adopted).
+
+The user-facing half of this change was announced from the cloud side (upgrade signal instead of silent delete loss).
+
+## Posting receipts
+
+POSTED 2026-08-29 to #cas-internal (C0B44GUKDK2):
+- Dev top-level: ts `1788030394.582849`
+- Dev reply: ts `1788030405.913189`
+- Paired user thread (posted with the cloud release): ts `1788030386.509809` / `1788030390.947749`


### PR DESCRIPTION
Postable draft + posted receipts for the v3.5.0 announcement in #cas-internal, per the release-notes rubric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)