### PR TITLE
Epic: knowledge-loop hardening + team-sync field fixes

### DIFF
--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -584,13 +584,17 @@ impl CloudSyncer {
             // timestamp-gated upsert.
             let web_close = is_web_close_tombstone(&raw_task);
             render_task_proposal_provenance(&mut raw_task);
-            let remote_task: Task = match deserialize_pulled_entity(raw_task, "task") {
+            let mut remote_task: Task = match deserialize_pulled_entity(raw_task, "task") {
                 Ok(t) => t,
                 Err(e) => {
                     result.errors.push(e);
                     continue;
                 }
             };
+            // The scoped response proves which project supplied the row; use
+            // that same resolved identity as the local ownership stamp rather
+            // than trusting an optional payload field from an older server.
+            remote_task.origin_project = Some(current_project_id.to_string());
             let previous_status = task_store.get(&remote_task.id).ok().map(|task| task.status);
             let task_outcome = if web_close {
                 reconcile_web_close(
@@ -1402,13 +1406,17 @@ impl CloudSyncer {
                 continue;
             }
             render_task_proposal_provenance(&mut raw_task);
-            let remote_task: Task = match deserialize_pulled_entity(raw_task, "task") {
+            let mut remote_task: Task = match deserialize_pulled_entity(raw_task, "task") {
                 Ok(t) => t,
                 Err(e) => {
                     result.errors.push(e);
                     continue;
                 }
             };
+            // Team pulls are already filtered by the scoped project ID; stamp
+            // the accepted row explicitly so subsequent local surfaces cannot
+            // mistake an unscoped legacy payload for a local task.
+            remote_task.origin_project = Some(current_project_id.to_string());
             let previous_status = task_store.get(&remote_task.id).ok().map(|task| task.status);
             match self.upsert_task_with_strategy(
                 task_store,

--- a/cas-cli/src/cloud/syncer/team_push.rs
+++ b/cas-cli/src/cloud/syncer/team_push.rs
@@ -8,6 +8,15 @@ use crate::cloud::{EntityType, QueuedSync, SyncOperation, get_project_canonical_
 use crate::error::CasError;
 use chrono::Utc;
 
+fn stamp_task_origin_project(value: &mut serde_json::Value, project_id: &str) {
+    if let Some(task) = value.as_object_mut() {
+        task.insert(
+            "origin_project".to_string(),
+            serde_json::Value::String(project_id.to_string()),
+        );
+    }
+}
+
 impl CloudSyncer {
     pub fn push_team(&self, team_id: &str) -> Result<SyncResult, CasError> {
         let mut result = SyncResult::default();
@@ -186,7 +195,16 @@ impl CloudSyncer {
         }) {
             match item.payload.as_deref() {
                 Some(payload) => match serde_json::from_str::<serde_json::Value>(payload) {
-                    Ok(value) => upserts.push((item, value)),
+                    Ok(mut value) => {
+                        // Rows queued before origin_project existed still need
+                        // the current scoped identity when they are retried.
+                        // The outer project_canonical_id is not a substitute:
+                        // task consumers also rely on the row-level field.
+                        if entity_type == EntityType::Task {
+                            stamp_task_origin_project(&mut value, project_id);
+                        }
+                        upserts.push((item, value));
+                    }
                     Err(_) => {
                         let _ = self
                             .queue
@@ -751,5 +769,18 @@ impl CloudSyncer {
             }
             Err(ureq::Error::Transport(e)) => Err(CasError::Other(format!("Network error: {e}"))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn queued_task_payloads_receive_current_project_identity() {
+        let mut value = serde_json::json!({"id": "cas-legacy", "title": "old payload"});
+        super::stamp_task_origin_project(&mut value, "acme/accounting");
+        assert_eq!(
+            value.get("origin_project").and_then(|value| value.as_str()),
+            Some("acme/accounting")
+        );
     }
 }

--- a/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
@@ -16,6 +16,8 @@ impl CasCore {
             data: None,
         })?;
 
+        super::super::task::ensure_task_origin(&task, &self.cas_root, "claim")?;
+
         if task.is_terminal() {
             return Err(McpError {
                 code: ErrorCode::INVALID_PARAMS,
@@ -594,8 +596,10 @@ impl CasCore {
             active_leases.iter().map(|l| l.task_id.as_str()).collect();
 
         // Filter to unclaimed tasks
+        let project_id = super::super::task::current_project_id(&self.cas_root);
         let mut available: Vec<_> = ready_tasks
             .iter()
+            .filter(|t| super::super::task::task_belongs_to_project(t, project_id.as_deref()))
             .filter(|t| !claimed_ids.contains(t.id.as_str()))
             .collect();
 
@@ -918,10 +922,12 @@ impl CasCore {
         }
 
         let leases = agent_store.list_agent_leases(&agent_id).unwrap_or_default();
+        let project_id = super::super::task::current_project_id(&self.cas_root);
         let mut assigned: Vec<Task> = task_store
             .list(None)
             .unwrap_or_default()
             .into_iter()
+            .filter(|t| super::super::task::task_belongs_to_project(t, project_id.as_deref()))
             .filter(|t| {
                 if t.is_terminal() {
                     return false;

--- a/cas-cli/src/mcp/tools/core/task.rs
+++ b/cas-cli/src/mcp/tools/core/task.rs
@@ -6,6 +6,64 @@ mod query;
 pub(crate) mod repo_context;
 mod update;
 
+/// Return the canonical identity of the project represented by a Cassy root.
+/// Task surfaces must fail closed when the identity cannot be derived: an
+/// unassigned legacy row cannot safely be ranked as local in that case.
+pub(crate) fn current_project_id(cas_root: &std::path::Path) -> Option<String> {
+    crate::cloud::resolve_canonical_id(cas_root)
+}
+
+pub(crate) fn task_belongs_to_project(task: &cas_types::Task, project_id: Option<&str>) -> bool {
+    project_id.is_some_and(|project_id| task.origin_project.as_deref() == Some(project_id))
+}
+
+#[cfg(test)]
+mod origin_project_tests {
+    use super::task_belongs_to_project;
+    use cas_types::Task;
+
+    #[test]
+    fn ownership_filter_accepts_only_exact_current_project() {
+        let mut local = Task::new("local".to_string(), "Local".to_string());
+        local.origin_project = Some("acme/accounting".to_string());
+        assert!(task_belongs_to_project(&local, Some("acme/accounting")));
+
+        local.origin_project = Some("acme/other".to_string());
+        assert!(!task_belongs_to_project(&local, Some("acme/accounting")));
+
+        local.origin_project = None;
+        assert!(!task_belongs_to_project(&local, Some("acme/accounting")));
+        assert!(!task_belongs_to_project(&local, None));
+    }
+}
+
+pub(crate) fn ensure_task_origin(
+    task: &cas_types::Task,
+    cas_root: &std::path::Path,
+    action: &str,
+) -> Result<(), rmcp::ErrorData> {
+    let project_id = current_project_id(cas_root);
+    if task_belongs_to_project(task, project_id.as_deref()) {
+        return Ok(());
+    }
+
+    let origin = task
+        .origin_project
+        .as_deref()
+        .unwrap_or("unassigned legacy row");
+    let current = project_id
+        .as_deref()
+        .unwrap_or("unresolved current project");
+    Err(rmcp::ErrorData {
+        code: rmcp::model::ErrorCode::INVALID_PARAMS,
+        message: std::borrow::Cow::from(format!(
+            "Cannot {action} task {}: origin project `{origin}` does not match current project `{current}`. Foreign or unassigned legacy tasks are excluded from this project; use an authorized supervisor task update to reassign the origin explicitly.",
+            task.id
+        )),
+        data: None,
+    })
+}
+
 /// Reject lifecycle actions while a task still has open `blocks` dependencies.
 ///
 /// `TaskStore::get_blockers` deliberately filters to `dep_type = 'blocks'`, so

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -438,6 +438,7 @@ impl CasCore {
         let task = Task {
             id: id.clone(),
             scope: crate::types::Scope::Project, // MCP tasks are project-scoped
+            origin_project: crate::cloud::resolve_canonical_id(&self.cas_root),
             title: req.title,
             description: req.description.unwrap_or_default(),
             design: req.design.unwrap_or_default(),
@@ -709,6 +710,9 @@ impl CasCore {
             })?
         };
 
+        let project_id = super::current_project_id(&self.cas_root);
+        tasks.retain(|task| super::task_belongs_to_project(task, project_id.as_deref()));
+
         // Apply sorting. cas-06f9 (GH #104): unspecified means priority order
         // here, not creation order — this is the "what should I pick up next"
         // surface, and incidental ordering combined with the cap below is what
@@ -772,6 +776,8 @@ impl CasCore {
             message: Cow::from(format!("Task not found: {e}")),
             data: None,
         })?;
+
+        super::ensure_task_origin(&task, &self.cas_root, "start")?;
 
         if task.is_terminal() {
             // cas-3c23: this message used to tell EVERY caller "Use reopen

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/proof_scope.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/proof_scope.rs
@@ -350,6 +350,7 @@ mod tests {
             execution_note: None,
             external_ref: None,
             assignee: None,
+            origin_project: None,
             status: None,
             epic: None,
             epic_verification_owner: None,

--- a/cas-cli/src/mcp/tools/core/task/query.rs
+++ b/cas-cli/src/mcp/tools/core/task/query.rs
@@ -21,7 +21,7 @@ impl CasCore {
             .unwrap_or_else(|| "(none — trunk fallback)".to_string());
 
         let mut output = format!(
-            "Task: {}\n{}\n\nTitle: {}\nStatus: {:?}\nPriority: P{}\nType: {}\nDepth: {}\nTarget: {}\n",
+            "Task: {}\n{}\n\nTitle: {}\nStatus: {:?}\nPriority: P{}\nType: {}\nDepth: {}\nOrigin project: {}\nTarget: {}\n",
             task.id,
             "=".repeat(task.id.len() + 6),
             task.title,
@@ -29,6 +29,9 @@ impl CasCore {
             task.priority.0,
             task.task_type,
             task.depth,
+            task.origin_project
+                .as_deref()
+                .unwrap_or("unassigned legacy row"),
             target
         );
 
@@ -437,6 +440,9 @@ impl CasCore {
             })?
         };
 
+        let project_id = super::current_project_id(&self.cas_root);
+        blocked.retain(|(task, _)| super::task_belongs_to_project(task, project_id.as_deref()));
+
         // Apply sorting to the task field of each tuple. cas-06f9 (GH #104):
         // same defaulting as `ready` — this is the same triage surface, and it
         // carried the identical silent cap.
@@ -509,8 +515,7 @@ impl CasCore {
                 "Task scope must be `project` or `all`; global tasks are unsupported.",
             ));
         }
-        let project_id = crate::cloud::get_project_canonical_id()
-            .unwrap_or_else(|| "(unresolved current project)".to_string());
+        let project_id = super::current_project_id(&self.cas_root);
 
         let task_store = self.open_task_store()?;
 
@@ -532,6 +537,7 @@ impl CasCore {
         // Apply filters
         let mut filtered: Vec<_> = tasks
             .into_iter()
+            .filter(|task| super::task_belongs_to_project(task, project_id.as_deref()))
             .filter(|task| {
                 // Status filter — use Display (snake_case) for matching so
                 // "pending_supervisor_review", "in_progress", etc. all round-trip
@@ -578,10 +584,18 @@ impl CasCore {
 
         let scope_note = if scope == "all" {
             format!(
-                "Scope: all (currently equivalent to the current project database `{project_id}`; no multi-project aggregator exists)"
+                "Scope: all (currently equivalent to the current project database `{}`; no multi-project aggregator exists)",
+                project_id
+                    .as_deref()
+                    .unwrap_or("unresolved current project")
             )
         } else {
-            format!("Scope: project `{project_id}` (current Cassy database)")
+            format!(
+                "Scope: project `{}` (current Cassy database)",
+                project_id
+                    .as_deref()
+                    .unwrap_or("unresolved current project")
+            )
         };
         if filtered.is_empty() {
             return Ok(Self::success(format!(

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -29,6 +29,7 @@ fn requested_update_fields(
     supplied!(execution_note);
     supplied!(external_ref);
     supplied!(assignee);
+    supplied!(origin_project);
     supplied!(status);
     supplied!(epic);
     supplied!(epic_verification_owner);
@@ -305,6 +306,32 @@ impl CasCore {
             message: Cow::from(format!("Task not found: {e}")),
             data: None,
         })?;
+        let origin_project = req
+            .origin_project
+            .as_deref()
+            .map(|raw| {
+                crate::cloud::normalize_project_canonical_id(raw).ok_or_else(|| {
+                    McpError {
+                        code: ErrorCode::INVALID_PARAMS,
+                        message: Cow::from(
+                            "TASK UPDATE REJECTED: origin_project must be a non-empty canonical project identity.",
+                        ),
+                        data: None,
+                    }
+                })
+            })
+            .transpose()?;
+        if req.origin_project.is_some() {
+            self.resolve_live_supervisor_authority().map_err(|error| {
+                McpError {
+                    code: ErrorCode::INVALID_PARAMS,
+                    message: Cow::from(format!(
+                        "TASK UPDATE REJECTED: origin_project reassignment requires a live registered supervisor: {error:?}"
+                    )),
+                    data: None,
+                }
+            })?;
+        }
         // Validate before applying any ordinary task fields. The store repeats
         // this validation while holding its write lock, so a malformed patch
         // cannot corrupt an existing state even if another writer races us.
@@ -371,6 +398,7 @@ impl CasCore {
                     "epic_verification_owner",
                     req.epic_verification_owner.is_some(),
                 ),
+                ("origin_project", req.origin_project.is_some()),
                 ("depth", req.depth.is_some()),
                 ("state_patch", state_patch.is_some()),
             ]
@@ -671,6 +699,27 @@ impl CasCore {
         let prior_assignee = task.assignee.clone();
 
         let mut changes = Vec::new();
+        if let Some(origin_project) = origin_project {
+            if task.origin_project.as_deref() != Some(origin_project.as_str()) {
+                let previous = task
+                    .origin_project
+                    .as_deref()
+                    .unwrap_or("unassigned legacy row");
+                let audit = format!(
+                    "[{}] DECISION: origin_project reassigned {} → {} by live supervisor (cas-e0c5)",
+                    chrono::Utc::now().format("%Y-%m-%d %H:%M"),
+                    previous,
+                    origin_project,
+                );
+                task.notes = if task.notes.is_empty() {
+                    audit
+                } else {
+                    format!("{}\n\n{}", task.notes, audit)
+                };
+                task.origin_project = Some(origin_project);
+                changes.push("origin_project");
+            }
+        }
         if let Some(title) = req.title {
             task.title = title;
             changes.push("title");

--- a/cas-cli/src/mcp/tools/service/core.rs
+++ b/cas-cli/src/mcp/tools/service/core.rs
@@ -388,6 +388,7 @@ impl CasService {
             execution_note: req.execution_note,
             external_ref: req.external_ref,
             assignee: req.assignee,
+            origin_project: req.origin_project,
             status: req.status,
             epic: req.epic,
             epic_verification_owner: req.epic_verification_owner,

--- a/cas-cli/src/mcp/tools/types/task.rs
+++ b/cas-cli/src/mcp/tools/types/task.rs
@@ -398,6 +398,14 @@ pub struct TaskUpdateRequest {
     #[serde(default)]
     pub assignee: Option<String>,
 
+    /// Reassign the owning project identity. Only a live registered
+    /// supervisor may use this field; omit it to leave the origin unchanged.
+    #[schemars(
+        description = "Canonical origin project identity for this task; supervisor-only reassignment of a foreign or legacy row"
+    )]
+    #[serde(default)]
+    pub origin_project: Option<String>,
+
     /// Update status
     #[schemars(description = "New status: 'open', 'in_progress', 'closed', 'blocked'")]
     #[serde(default)]

--- a/cas-cli/src/migration/migrations/m241_tasks_add_origin_project.rs
+++ b/cas-cli/src/migration/migrations/m241_tasks_add_origin_project.rs
@@ -1,0 +1,59 @@
+//! Migration: persist the canonical project that owns each task.
+
+use crate::migration::{Migration, Subsystem};
+
+pub const MIGRATION: Migration = Migration {
+    id: 241,
+    name: "tasks_add_origin_project",
+    subsystem: Subsystem::Tasks,
+    description: "Add nullable canonical origin-project identity to tasks (cas-e0c5)",
+    up: &[
+        "ALTER TABLE tasks ADD COLUMN origin_project TEXT",
+        "CREATE INDEX IF NOT EXISTS idx_tasks_origin_project ON tasks(origin_project)",
+    ],
+    detect: Some(
+        "SELECT CASE WHEN (SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='tasks') = 0 THEN 1 ELSE (SELECT COUNT(*) FROM pragma_table_info('tasks') WHERE name = 'origin_project') * (SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_tasks_origin_project') END",
+    ),
+};
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    #[test]
+    fn migration_adds_nullable_column_without_guessing_legacy_identity() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE tasks (id TEXT PRIMARY KEY, status TEXT NOT NULL);
+             INSERT INTO tasks (id, status) VALUES
+               ('legacy-closed', 'closed'),
+               ('legacy-open', 'open');",
+        )
+        .unwrap();
+
+        assert_eq!(
+            conn.query_row(super::MIGRATION.detect.unwrap(), [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        for statement in super::MIGRATION.up {
+            conn.execute(statement, []).unwrap();
+        }
+        assert_eq!(
+            conn.query_row(super::MIGRATION.detect.unwrap(), [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM tasks WHERE origin_project IS NOT NULL",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0,
+        );
+    }
+}

--- a/cas-cli/src/migration/migrations/mod.rs
+++ b/cas-cli/src/migration/migrations/mod.rs
@@ -216,6 +216,7 @@ mod m237_entries_add_source_ids;
 mod m238_skills_add_source_ids;
 mod m239_task_execution_states_create_table;
 mod m240_rule_skill_versions;
+mod m241_tasks_add_origin_project;
 
 /// All migrations in order. IDs must be sequential and never reused.
 pub const MIGRATIONS: &[Migration] = &[
@@ -465,6 +466,7 @@ pub const MIGRATIONS: &[Migration] = &[
     m238_skills_add_source_ids::MIGRATION,
     m239_task_execution_states_create_table::MIGRATION,
     m240_rule_skill_versions::MIGRATION,
+    m241_tasks_add_origin_project::MIGRATION,
 ];
 
 #[cfg(test)]

--- a/cas-cli/src/migration/mod.rs
+++ b/cas-cli/src/migration/mod.rs
@@ -669,6 +669,26 @@ fn is_db_initialized(conn: &Connection) -> bool {
     count >= 3
 }
 
+/// Assign the current project's canonical identity to legacy task rows that
+/// predate m241. A nullable column is intentional: a caller may have a
+/// database without enough project configuration to derive an identity, and
+/// such rows must remain excluded from project-scoped task surfaces until an
+/// operator resolves them.
+fn backfill_task_origin_project(conn: &Connection, cas_dir: &Path) -> Result<()> {
+    if !cas_store::shared_db::column_exists(conn, "tasks", "origin_project") {
+        return Ok(());
+    }
+    let Some(project_id) = crate::cloud::resolve_canonical_id(cas_dir) else {
+        return Ok(());
+    };
+    conn.execute(
+        "UPDATE tasks SET origin_project = ?1
+         WHERE origin_project IS NULL OR trim(origin_project) = ''",
+        [project_id],
+    )?;
+    Ok(())
+}
+
 /// Run all pending migrations
 ///
 /// If `dry_run` is true, returns what would be done without applying.
@@ -822,6 +842,8 @@ pub fn run_migrations(cas_dir: &Path, dry_run: bool) -> Result<MigrationResult> 
         }
     }
 
+    backfill_task_origin_project(&conn, cas_dir)?;
+
     Ok(result)
 }
 
@@ -972,7 +994,7 @@ mod tests {
 
     fn assert_repaired_v225_knowledge_gap(cas_dir: &Path, expected_m226_ledger: &str) {
         let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
-        for id in [225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240] {
+        for id in [225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241] {
             assert_eq!(
                 conn.query_row(
                     "SELECT COUNT(*) FROM cas_migrations WHERE id = ?1",
@@ -1039,7 +1061,7 @@ mod tests {
         assert_eq!(pages[0].origin_project_id, None);
 
         let status = check_migrations(cas_dir).unwrap();
-        assert_eq!(status.current_version, 240);
+        assert_eq!(status.current_version, 241);
         assert!(status.pending.is_empty());
         let second = run_migrations(cas_dir, false).unwrap();
         assert_eq!(second.applied_count, 0, "repeated open must be idempotent");
@@ -1061,7 +1083,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240],
+                vec![225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241],
                 "recorded m225 and missing m226 must order all later work behind them"
             );
 
@@ -1145,7 +1167,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240]
+                vec![225, 226, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();
@@ -1184,7 +1206,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240]
+                vec![225, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();
@@ -1296,6 +1318,48 @@ mod tests {
             )
             .unwrap(),
             0
+        );
+    }
+
+    #[test]
+    fn m241_backfills_blank_task_origins_from_current_project() {
+        let home = TempDir::new().unwrap();
+        let project = home.path().join("accounting");
+        let cas_dir = project.join(".cas");
+        std::fs::create_dir_all(&cas_dir).unwrap();
+        let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE tasks (
+                 id TEXT PRIMARY KEY,
+                 origin_project TEXT
+             );
+             INSERT INTO tasks (id, origin_project) VALUES
+                 ('legacy-null', NULL),
+                 ('legacy-blank', '  '),
+                 ('already-assigned', 'acme/other');
+             CREATE INDEX idx_tasks_origin_project ON tasks(origin_project);",
+        )
+        .unwrap();
+
+        let expected = crate::cloud::resolve_canonical_id(&cas_dir).unwrap();
+        super::backfill_task_origin_project(&conn, &cas_dir).unwrap();
+        let origins = conn
+            .prepare("SELECT id, origin_project FROM tasks ORDER BY id")
+            .unwrap()
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(
+            origins,
+            vec![
+                ("already-assigned".to_string(), "acme/other".to_string()),
+                ("legacy-blank".to_string(), expected.clone()),
+                ("legacy-null".to_string(), expected),
+            ]
         );
     }
 

--- a/cas-cli/src/store/detect.rs
+++ b/cas-cli/src/store/detect.rs
@@ -371,7 +371,8 @@ pub fn open_store_local(cas_dir: &Path) -> Result<Arc<dyn Store>> {
 fn open_task_store_base(cas_dir: &Path) -> Result<Arc<dyn TaskStore>> {
     let config = Config::load(cas_dir).unwrap_or_default();
 
-    let store = SqliteTaskStore::open(cas_dir)?;
+    let origin_project = crate::cloud::resolve_canonical_id(cas_dir);
+    let store = SqliteTaskStore::open_with_origin_project(cas_dir, origin_project.as_deref())?;
     store.init()?;
     let base_store: Arc<dyn TaskStore> = Arc::new(store);
 

--- a/cas-cli/src/store/syncing_task.rs
+++ b/cas-cli/src/store/syncing_task.rs
@@ -97,7 +97,8 @@ impl TaskStore for SyncingTaskStore {
 
     fn add(&self, task: &Task) -> Result<()> {
         self.inner.add(task)?;
-        self.queue_upsert(task);
+        let persisted = self.inner.get(&task.id)?;
+        self.queue_upsert(&persisted);
         Ok(())
     }
 
@@ -110,7 +111,8 @@ impl TaskStore for SyncingTaskStore {
     ) -> Result<()> {
         self.inner
             .create_atomic(task, blocked_by, epic_id, created_by)?;
-        self.queue_upsert(task);
+        let persisted = self.inner.get(&task.id)?;
+        self.queue_upsert(&persisted);
         Ok(())
     }
 

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -6521,6 +6521,7 @@ async fn test_062d_lifecycle_start_and_blocked_push_session_isolated() {
             assignee: None,
             status: Some("blocked".to_string()),
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
             depth: None,
         }))

--- a/cas-cli/tests/mcp_tools_test/search_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/search_tools.rs
@@ -464,6 +464,7 @@ async fn test_versioned_provenance_feedback_and_offline_metrics_flow() {
         assignee: None,
         status: Some("blocked".to_string()),
         epic: None,
+        origin_project: None,
         epic_verification_owner: None,
     }))
     .await

--- a/cas-cli/tests/mcp_tools_test/task_tools/create_and_epic.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/create_and_epic.rs
@@ -510,6 +510,7 @@ async fn test_task_update_depth_to_light() {
                 assignee: None,
                 status: None,
                 epic: None,
+                origin_project: None,
                 epic_verification_owner: None,
                 depth: Some("light".to_string()),
             }))

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -559,6 +559,7 @@ async fn test_execution_note_update_sets_value() {
             assignee: None,
             status: None,
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -612,6 +613,7 @@ async fn test_execution_note_update_empty_string_clears() {
             assignee: None,
             status: None,
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -679,6 +681,7 @@ async fn test_task_update() {
         assignee: None,
         status: None,
         epic: None,
+        origin_project: None,
         epic_verification_owner: None,
     };
 
@@ -740,6 +743,7 @@ async fn test_task_update_design_and_acceptance_criteria() {
         assignee: None,
         status: None,
         epic: None,
+        origin_project: None,
         epic_verification_owner: None,
     };
 
@@ -1089,6 +1093,64 @@ async fn test_task_ready() {
 
     let text = extract_text(result);
     assert!(text.contains("Ready task") || text.contains("ready") || text.contains("Tasks"));
+}
+
+#[tokio::test]
+async fn test_task_ready_excludes_foreign_origin_project_and_show_exposes_it() {
+    let (temp, service) = setup_cas();
+
+    let local = service
+        .cas_task_create(Parameters(basic_create("Local origin task", None)))
+        .await
+        .expect("create local task");
+    let local_id = extract_task_id(&extract_text(local))
+        .expect("local task id")
+        .to_string();
+    let foreign = service
+        .cas_task_create(Parameters(basic_create("Foreign origin task", None)))
+        .await
+        .expect("create foreign fixture");
+    let foreign_id = extract_task_id(&extract_text(foreign))
+        .expect("foreign task id")
+        .to_string();
+
+    let task_store = open_task_store(&temp.path().join(".cas")).expect("task store");
+    let mut foreign_task = task_store.get(&foreign_id).expect("foreign task row");
+    foreign_task.origin_project = Some("acme/other".to_string());
+    task_store.update(&foreign_task).expect("mark foreign task");
+
+    let text = extract_text(
+        service
+            .cas_task_ready(Parameters(TaskReadyBlockedRequest {
+                scope: "all".to_string(),
+                limit: Some(20),
+                sort: None,
+                sort_order: None,
+                epic: None,
+            }))
+            .await
+            .expect("task_ready should succeed"),
+    );
+    assert!(
+        text.contains(&local_id),
+        "local task must remain visible: {text}"
+    );
+    assert!(
+        !text.contains(&foreign_id),
+        "foreign task must be excluded from ready: {text}"
+    );
+
+    let shown = service
+        .cas_task_show(Parameters(TaskShowRequest {
+            id: foreign_id,
+            with_deps: false,
+        }))
+        .await
+        .expect("show foreign task");
+    assert!(
+        extract_text(shown).contains("Origin project: acme/other"),
+        "show must expose foreign origin for diagnosis"
+    );
 }
 
 /// cas-06f9 (GH #104): `ready` capped at 10 with a header that printed only
@@ -2355,6 +2417,7 @@ async fn test_close_auto_unblocks_blocked_dependents() {
             assignee: None,
             status: Some("blocked".to_string()),
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -2486,6 +2549,7 @@ async fn test_task_update_invalid_epic_keeps_original_parent_dependency() {
             assignee: None,
             status: None,
             epic: Some("cas-does-not-exist".to_string()),
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await;
@@ -2597,6 +2661,7 @@ async fn test_task_update_surfaces_epic_dependency_delete_failure() {
             assignee: None,
             status: None,
             epic: Some(String::new()),
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await;
@@ -3031,6 +3096,7 @@ async fn test_task_mine_matches_env_worker_name_during_spawn_race() {
         assignee: Some(worker_name.to_string()),
         status: None,
         epic: None,
+        origin_project: None,
         epic_verification_owner: None,
     };
     service
@@ -3212,6 +3278,7 @@ async fn test_release_autorecovers_lease_less_in_progress_task() {
             assignee: None,
             status: Some("in_progress".to_string()),
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -3340,6 +3407,7 @@ async fn test_reset_clears_lease_assignee_and_forces_open() {
             assignee: None,
             status: Some("in_progress".to_string()),
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -3423,6 +3491,7 @@ async fn test_reset_refuses_closed_task() {
             assignee: None,
             status: Some("closed".to_string()),
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -3490,6 +3559,7 @@ async fn test_show_after_update_reflects_new_status_without_lag() {
             assignee: None,
             status: Some("in_progress".to_string()),
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -3527,6 +3597,7 @@ async fn test_show_after_update_reflects_new_status_without_lag() {
             assignee: Some("new-worker".to_string()),
             status: Some("open".to_string()),
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -3600,6 +3671,7 @@ async fn test_task_mine_matches_case_insensitive_and_trimmed() {
         assignee: Some("  TEST-Agent  ".to_string()),
         status: None,
         epic: None,
+        origin_project: None,
         epic_verification_owner: None,
     };
     service
@@ -4493,6 +4565,7 @@ async fn rejected_assignee_reports_that_the_whole_multi_field_update_was_aborted
             assignee: Some("stale-worker".to_string()),
             status: None,
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -4569,6 +4642,7 @@ async fn test_factory_mode_normalizes_session_uuid_assignee_to_display_name() {
             assignee: Some(WORKER_SESSION.to_string()),
             status: None,
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -4662,6 +4736,7 @@ async fn test_factory_mode_empty_assignee_clears_without_remapping_to_live_worke
             assignee: Some(PRIOR_ASSIGNEE.to_string()),
             status: None,
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -4692,6 +4767,7 @@ async fn test_factory_mode_empty_assignee_clears_without_remapping_to_live_worke
             assignee: Some(String::new()),
             status: None,
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -4745,6 +4821,7 @@ async fn test_factory_mode_empty_assignee_clears_without_remapping_to_live_worke
             assignee: Some(PRIOR_ASSIGNEE.to_string()),
             status: None,
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await
@@ -4769,6 +4846,7 @@ async fn test_factory_mode_empty_assignee_clears_without_remapping_to_live_worke
             assignee: Some("   \t  ".to_string()),
             status: None,
             epic: None,
+            origin_project: None,
             epic_verification_owner: None,
         }))
         .await

--- a/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
@@ -1050,6 +1050,7 @@ fn task_status_update(id: &str, status: Option<&str>, notes: Option<&str>) -> Ta
         assignee: None,
         status: status.map(str::to_string),
         epic: None,
+        origin_project: None,
         epic_verification_owner: None,
     }
 }

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -7,10 +7,10 @@ cas doctor
 ──────────────────────────────────────────────────
 [OK] cas directory: Found at [TEMP_PATH]
 [OK] database: SQLite database found
-[OK] schema: v236 (up to date)
+[OK] schema: v241 (up to date)
 [OK] supervisor relay: no undelivered lifecycle relays
 [OK] delivery retries: no pending message has spent 3+ attempts
-[OK] tables: [N] tables, 753 columns, 199 rows total
+[OK] tables: [N] tables, 778 columns, 204 rows total
 [OK] entry store: [N] entries accessible
 [WARN] search index: Index not found. Will be created on first search.
 [WARN] symbol index: nothing indexed for this project (0 symbol(s) in the store across all repositories); the code search index is missing. The daemon only indexes while idle — run `cas index code` to catch up now.

--- a/cas-cli/tests/worktree_surface_test.rs
+++ b/cas-cli/tests/worktree_surface_test.rs
@@ -300,6 +300,7 @@ fn close_update_request(id: String) -> TaskUpdateRequest {
         assignee: None,
         status: Some("closed".to_string()),
         epic: None,
+        origin_project: None,
         epic_verification_owner: None,
         depth: None,
     }

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -173,6 +173,15 @@ pub struct TaskRequest {
     #[serde(default)]
     pub project: Option<String>,
 
+    /// Canonical owning project identity for a local task update. Unlike
+    /// `project`, this does not select a cross-project proposal; it is an
+    /// explicit supervisor-authorized origin reassignment.
+    #[schemars(
+        description = "For update: canonical origin project identity; only a live registered supervisor may reassign it"
+    )]
+    #[serde(default)]
+    pub origin_project: Option<String>,
+
     /// Cloud proposal ID for accept/reject.
     #[schemars(description = "Cloud proposal ID for proposal_accept or proposal_reject")]
     #[serde(default)]

--- a/crates/cas-store/src/task_store.rs
+++ b/crates/cas-store/src/task_store.rs
@@ -65,7 +65,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- unaffected: nothing selects them and they all have defaults.
     share TEXT,
     depth TEXT,
-    terminal_outcome TEXT
+    terminal_outcome TEXT,
+    origin_project TEXT
 );
 
 -- cas-4adb: sparse, bounded machine resume state. Keeping this separate from
@@ -79,6 +80,7 @@ CREATE TABLE IF NOT EXISTS task_execution_states (
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_priority ON tasks(priority);
 CREATE INDEX IF NOT EXISTS idx_tasks_created ON tasks(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tasks_origin_project ON tasks(origin_project);
 
 CREATE TABLE IF NOT EXISTS dependencies (
     from_id TEXT NOT NULL,
@@ -123,15 +125,30 @@ CREATE TABLE IF NOT EXISTS task_proposal_request_keys (
 /// SQLite-based task store
 pub struct SqliteTaskStore {
     conn: Arc<Mutex<Connection>>,
+    origin_project: Option<String>,
 }
 
 impl SqliteTaskStore {
     /// Open or create a SQLite task store
     pub fn open(cas_dir: &Path) -> Result<Self> {
+        Self::open_with_origin_project(cas_dir, None)
+    }
+
+    /// Open a task store with the canonical project identity used to stamp
+    /// newly-created local rows. Existing rows are never rewritten here;
+    /// migration/backfill owns that transition.
+    pub fn open_with_origin_project(cas_dir: &Path, origin_project: Option<&str>) -> Result<Self> {
         let db_path = cas_dir.join("cas.db");
         let conn = crate::shared_db::shared_connection(&db_path)?;
 
-        Ok(Self { conn })
+        let origin_project = origin_project
+            .map(str::trim)
+            .filter(|project| !project.is_empty())
+            .map(ToOwned::to_owned);
+        Ok(Self {
+            conn,
+            origin_project,
+        })
     }
 
     fn parse_datetime(s: &str) -> Option<DateTime<Utc>> {
@@ -180,6 +197,14 @@ impl SqliteTaskStore {
             .and_then(|outcome| serde_json::to_string(outcome).ok())
     }
 
+    fn task_with_default_origin(&self, task: &Task) -> Task {
+        let mut task = task.clone();
+        if task.origin_project.is_none() {
+            task.origin_project = self.origin_project.clone();
+        }
+        task
+    }
+
     /// Compare-and-swap reopen: rewrite the row only if it still carries
     /// `expected_status` / `expected_updated_at`.
     ///
@@ -206,8 +231,8 @@ impl SqliteTaskStore {
              pending_verification = ?18, pending_worktree_merge = ?19,
              epic_verification_owner = ?20, team_id = ?21, deliverables = ?22,
              demo_statement = ?23, execution_note = ?24, share = ?25, depth = ?26,
-             terminal_outcome = ?27
-             WHERE id = ?28 AND status = ?29 AND updated_at = ?30",
+             terminal_outcome = ?27, origin_project = ?28
+             WHERE id = ?29 AND status = ?30 AND updated_at = ?31",
             params![
                 task.title,
                 task.description,
@@ -236,6 +261,7 @@ impl SqliteTaskStore {
                 task.share.as_ref().map(|s| s.to_string()),
                 task.depth.to_string(),
                 Self::terminal_outcome_to_string(&task.terminal_outcome),
+                task.origin_project,
                 task.id,
                 expected_status.to_string(),
                 expected_updated_at.to_rfc3339(),
@@ -322,6 +348,7 @@ impl SqliteTaskStore {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or_default(),
             terminal_outcome: Self::parse_terminal_outcome(row.get(28)?),
+            origin_project: row.get(29)?,
         })
     }
 
@@ -357,8 +384,8 @@ impl SqliteTaskStore {
             "INSERT INTO tasks (id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29)",
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome, origin_project)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30)",
             params![
                 task.id,
                 task.title,
@@ -389,6 +416,7 @@ impl SqliteTaskStore {
                 task.share.as_ref().map(|s| s.to_string()),
                 task.depth.to_string(),
                 Self::terminal_outcome_to_string(&task.terminal_outcome),
+                task.origin_project,
             ],
         )?;
 
@@ -470,7 +498,7 @@ impl SqliteTaskStore {
                 "SELECT id, title, description, design, acceptance_criteria, notes,
                  status, priority, task_type, assignee, labels, created_at, updated_at,
                  closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
+                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome, origin_project
                  FROM tasks ORDER BY priority, created_at DESC",
             )?;
             stmt.query_map([], Self::task_from_row)?
@@ -537,9 +565,10 @@ impl TaskStore for SqliteTaskStore {
     }
 
     fn add(&self, task: &Task) -> Result<()> {
+        let task = self.task_with_default_origin(task);
         crate::shared_db::with_write_retry(|| {
             let conn = crate::shared_db::lock_connection(&self.conn)?;
-            Self::add_with_conn(&conn, task, None)
+            Self::add_with_conn(&conn, &task, None)
         })
     }
 
@@ -550,6 +579,7 @@ impl TaskStore for SqliteTaskStore {
         epic_id: Option<&str>,
         created_by: Option<&str>,
     ) -> Result<()> {
+        let task = self.task_with_default_origin(task);
         crate::shared_db::with_write_retry(|| {
             let conn = crate::shared_db::lock_connection(&self.conn)?;
             let tx = crate::shared_db::ImmediateTx::new(&conn)?;
@@ -577,7 +607,7 @@ impl TaskStore for SqliteTaskStore {
                 }
             }
 
-            Self::add_with_conn(&tx, task, created_by)?;
+            Self::add_with_conn(&tx, &task, created_by)?;
 
             for blocker_id in blocked_by
                 .iter()
@@ -616,7 +646,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome, origin_project
              FROM tasks WHERE id = ?",
             params![id],
             Self::task_from_row,
@@ -730,6 +760,11 @@ impl TaskStore for SqliteTaskStore {
                 persisted_deliverables.merge_conflicted = false;
             }
 
+            let persisted_origin_project = task
+                .origin_project
+                .as_ref()
+                .or(self.origin_project.as_ref());
+
             let rows = conn.execute(
             "UPDATE tasks SET title = ?1, description = ?2, design = ?3,
              acceptance_criteria = ?4, notes = ?5, status = ?6, priority = ?7,
@@ -738,8 +773,8 @@ impl TaskStore for SqliteTaskStore {
              branch = ?16, worktree_id = ?17,
              pending_verification = ?18, pending_worktree_merge = ?19, epic_verification_owner = ?20, team_id = ?21,
              deliverables = ?22, demo_statement = ?23, execution_note = ?24, share = ?25, depth = ?26,
-             terminal_outcome = ?27
-             WHERE id = ?28",
+             terminal_outcome = ?27, origin_project = ?28
+             WHERE id = ?29",
             params![
                 task.title,
                 task.description,
@@ -768,6 +803,7 @@ impl TaskStore for SqliteTaskStore {
                 task.share.as_ref().map(|s| s.to_string()),
                 task.depth.to_string(),
                 Self::terminal_outcome_to_string(&persisted_terminal_outcome),
+                persisted_origin_project,
                 task.id,
             ],
         )?;
@@ -890,7 +926,7 @@ impl TaskStore for SqliteTaskStore {
                 "SELECT id, title, description, design, acceptance_criteria, notes,
                  status, priority, task_type, assignee, labels, created_at, updated_at,
                  closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
+                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome, origin_project
                  FROM tasks WHERE status = ? ORDER BY priority, created_at DESC",
                 vec![s.to_string()],
             ),
@@ -898,7 +934,7 @@ impl TaskStore for SqliteTaskStore {
                 "SELECT id, title, description, design, acceptance_criteria, notes,
                  status, priority, task_type, assignee, labels, created_at, updated_at,
                  closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
+                 pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome, origin_project
                  FROM tasks ORDER BY priority, created_at DESC",
                 vec![],
             ),
@@ -924,7 +960,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome, t.origin_project
              FROM tasks t
              WHERE t.status = 'open'
              AND NOT EXISTS (
@@ -958,7 +994,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT DISTINCT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome, t.origin_project
              FROM tasks t
              WHERE t.status NOT IN ('closed', 'cancelled')
              AND (
@@ -994,7 +1030,7 @@ impl TaskStore for SqliteTaskStore {
              t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome, t.origin_project
              FROM dependencies d
              JOIN tasks t ON d.to_id = t.id
              WHERE d.from_id IN ({placeholders})
@@ -1052,6 +1088,7 @@ impl TaskStore for SqliteTaskStore {
                     .and_then(|s| s.parse().ok())
                     .unwrap_or_default(),
                 terminal_outcome: Self::parse_terminal_outcome(row.get(29)?),
+                origin_project: row.get(30)?,
             };
             Ok((from_id, task))
         })?;
@@ -1081,7 +1118,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome, origin_project
              FROM tasks WHERE pending_verification = 1",
         )?;
         let tasks = stmt
@@ -1096,7 +1133,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT id, title, description, design, acceptance_criteria, notes,
              status, priority, task_type, assignee, labels, created_at, updated_at,
              closed_at, close_reason, external_ref, content_hash, branch, worktree_id,
-             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome
+             pending_verification, pending_worktree_merge, epic_verification_owner, team_id, deliverables, demo_statement, execution_note, share, depth, terminal_outcome, origin_project
              FROM tasks WHERE pending_worktree_merge = 1",
         )?;
         let tasks = stmt
@@ -1174,7 +1211,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome, t.origin_project
              FROM tasks t
              JOIN dependencies d ON d.to_id = t.id
              WHERE d.from_id = ? AND d.dep_type = 'blocks' AND t.status NOT IN ('closed', 'cancelled')",
@@ -1249,7 +1286,7 @@ impl TaskStore for SqliteTaskStore {
              SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome, t.origin_project
              FROM tasks t
              JOIN subtree s ON t.id = s.task_id",
         )?;
@@ -1302,7 +1339,7 @@ impl TaskStore for SqliteTaskStore {
             "SELECT t.id, t.title, t.description, t.design, t.acceptance_criteria, t.notes,
              t.status, t.priority, t.task_type, t.assignee, t.labels, t.created_at, t.updated_at,
              t.closed_at, t.close_reason, t.external_ref, t.content_hash, t.branch, t.worktree_id,
-             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome
+             t.pending_verification, t.pending_worktree_merge, t.epic_verification_owner, t.team_id, t.deliverables, t.demo_statement, t.execution_note, t.share, t.depth, t.terminal_outcome, t.origin_project
              FROM tasks t
              JOIN dependencies d ON d.to_id = t.id
              WHERE d.from_id = ? AND d.dep_type = 'parent-child' AND t.task_type = 'epic'

--- a/crates/cas-store/src/task_store_tests/tests.rs
+++ b/crates/cas-store/src/task_store_tests/tests.rs
@@ -50,6 +50,35 @@ fn test_task_crud() {
 }
 
 #[test]
+fn task_origin_project_round_trips_and_store_identity_stamps_new_rows() {
+    let temp = TempDir::new().unwrap();
+    let store =
+        SqliteTaskStore::open_with_origin_project(temp.path(), Some("acme/accounting")).unwrap();
+    store.init().unwrap();
+
+    let local_id = store.generate_id().unwrap();
+    store
+        .add(&Task::new(
+            local_id.clone(),
+            "Stamped local task".to_string(),
+        ))
+        .unwrap();
+    assert_eq!(
+        store.get(&local_id).unwrap().origin_project.as_deref(),
+        Some("acme/accounting")
+    );
+
+    let foreign_id = store.generate_id().unwrap();
+    let mut foreign = Task::new(foreign_id.clone(), "Explicit foreign task".to_string());
+    foreign.origin_project = Some("acme/other".to_string());
+    store.add(&foreign).unwrap();
+    assert_eq!(
+        store.get(&foreign_id).unwrap().origin_project.as_deref(),
+        Some("acme/other")
+    );
+}
+
+#[test]
 fn task_execution_state_patch_merges_and_deletes_fields() {
     let (_temp, store) = create_test_store();
     let id = store.generate_id().unwrap();

--- a/crates/cas-types/src/task.rs
+++ b/crates/cas-types/src/task.rs
@@ -558,6 +558,11 @@ pub struct Task {
     #[serde(default)]
     pub scope: Scope,
 
+    /// Canonical project identity that owns this task. Legacy rows may be
+    /// `None` until the origin-project migration has been run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_project: Option<String>,
+
     /// Task title
     pub title: String,
 
@@ -688,6 +693,7 @@ impl Task {
         Self {
             id,
             scope: Scope::default(), // Project scope by default
+            origin_project: None,
             title,
             description: String::new(),
             design: String::new(),
@@ -800,6 +806,7 @@ impl Default for Task {
         Self {
             id: String::new(),
             scope: Scope::default(),
+            origin_project: None,
             title: String::new(),
             description: String::new(),
             design: String::new(),
@@ -841,6 +848,18 @@ mod tests {
         let deliverables: TaskDeliverables = serde_json::from_str("{}").unwrap();
         assert!(deliverables.work_target.is_none());
         assert!(deliverables.pre_close_hook.is_none());
+    }
+
+    #[test]
+    fn task_origin_project_is_optional_for_legacy_json() {
+        let task = Task::new("cas-origin".to_string(), "Origin test".to_string());
+        assert_eq!(task.origin_project, None);
+
+        let encoded = serde_json::to_value(&task).unwrap();
+        assert!(encoded.get("origin_project").is_none());
+
+        let decoded: Task = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded.origin_project, None);
     }
 
     #[test]


### PR DESCRIPTION
Fourteen-lane epic. Knowledge-loop hardening informed by this week's research (evidence-gated rule promotion with demotion; version history + tombstone deletes and restore for rules/skills; validation_script executed as a create/update gate; end-to-end provenance via source_ids incl. consolidation links; real surface_count impact tracking; append-only zstd trace archive replacing 30-day hard deletes; structured task execution state as the worker resume surface; high-importance memory previews un-truncated at SessionStart + memory content hygiene; origin_project identity keeping foreign tasks out of ready surfaces). Field fixes: project_id on team sync deletes (unparks silent 400 rejections), test-isolation escape that wrote mock cloud configs into real projects (guarded at the write boundary), close-gate acceptance of supervisor union-merge evolution (Fixes #597).

Gate: full suite 6034/6035 (single red is a pre-existing checkout-location-sensitive test tracked separately, green in CI all day), doctests green, schema chain m237–m241 verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)