### PR TITLE
fix(cas-9afa): image-generate helper — file-backed reference payloads, MIME-honest output, playbook wording

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-image-generate/references/asset-playbook.md
+++ b/cas-cli/src/builtins/codex/skills/cas-image-generate/references/asset-playbook.md
@@ -14,7 +14,7 @@ returned image but does not silently resize it.
 
 | Asset | Tier | Suggested output | Prompt emphasis |
 |---|---|---|---|
-| Logo / logomark | NB2 → NB Pro | square PNG, 1024px or larger | flat, simple mark, correct quoted wordmark, high contrast, generous clear space; manual vectorization required |
+| Logo / logomark | NB2 → NB Pro | square PNG, 1024px or larger | flat, simple mark, the wordmark TEXT (spelled exactly, no quotation marks), high contrast, generous clear space; manual vectorization required |
 | Icon set | NB2 → NB Pro | one square grid sheet, 1024–2048px | one locked 24px-grid spec sentence, uniform stroke, padding, one color; manually trace approved glyphs |
 | Hero image | NB2 → NB Pro | 16:9, up to 1920px wide | focal subject, camera, lighting, and negative space for copy |
 | Background / texture | NB2 | 16:9 or tileable square, 2K | low contrast, no focal object, exact palette, usable behind text |
@@ -45,7 +45,7 @@ unrequested text. Preserve the supplied reference relationships: {references}.
 Create the final {asset_type} for {project}.
 Use these exact style tokens: {style_tokens}.
 Subject and action: {subject_action}. Context: {context}.
-Composition and safe area: {composition}. Exact displayed copy: "{copy}".
+Composition and safe area: {composition}. Exact displayed copy: {copy} (spelled exactly; no quotation marks unless explicitly requested).
 References and what must stay unchanged: {references_and_invariants}.
 Return a polished raster asset with correct spelling, deliberate edges, and no
 extra lettering or decorative objects.
@@ -57,7 +57,7 @@ extra lettering or decorative objects.
 Create a flat, high-contrast raster master for manual vectorization: {subject}.
 Use {style_tokens}; two colors maximum, simple geometric paths, centered on a
 plain background, generous clear space, no gradients, no shadows, and no extra
-lettering. If a wordmark is required, render exactly "{copy}".
+lettering. If a wordmark is required, render the wordmark TEXT (spelled {copy}, no quotation marks).
 ```
 
 ### Locked icon-set sentence

--- a/cas-cli/src/builtins/codex/skills/cas-image-generate/scripts/generate-image.sh
+++ b/cas-cli/src/builtins/codex/skills/cas-image-generate/scripts/generate-image.sh
@@ -93,7 +93,7 @@ for reference in "${references[@]}"; do
     fi
 done
 
-mime_type() {
+reference_mime_type() {
     case "${1,,}" in
         *.png) printf 'image/png' ;;
         *.webp) printf 'image/webp' ;;
@@ -106,30 +106,58 @@ mime_type() {
     esac
 }
 
-parts="$(jq -n --arg prompt "$prompt" '[{text: $prompt}]')"
+output_extension_for_mime() {
+    case "${1,,}" in
+        image/png) printf 'png' ;;
+        image/jpeg|image/jpg) printf 'jpg' ;;
+        image/webp) printf 'webp' ;;
+        image/gif) printf 'gif' ;;
+        *) return 1 ;;
+    esac
+}
+
+extension_matches_mime() {
+    case "${1,,}:${2,,}" in
+        image/png:png|image/jpeg:jpg|image/jpeg:jpeg|image/jpg:jpg|image/jpg:jpeg|image/webp:webp|image/gif:gif)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+printf '%s' "$prompt" > "$work/prompt.txt"
+jq -n --rawfile prompt "$work/prompt.txt" '[{text: $prompt}]' > "$work/parts.json"
+reference_index=0
 for reference in "${references[@]}"; do
-    encoded="$(base64 --wrap=0 "$reference")"
-    reference_mime="$(mime_type "$reference")"
-    parts="$(jq --arg mime "$reference_mime" --arg data "$encoded" \
-        '. + [{inlineData: {mimeType: $mime, data: $data}}]' <<<"$parts")"
+    base64 --wrap=0 "$reference" | tr -d '\r\n' > "$work/reference-$reference_index.b64"
+    reference_mime="$(reference_mime_type "$reference")"
+    jq --arg mime "$reference_mime" --rawfile data "$work/reference-$reference_index.b64" \
+        '. + [{inlineData: {mimeType: $mime, data: $data}}]' \
+        "$work/parts.json" > "$work/parts.next.json"
+    mv "$work/parts.next.json" "$work/parts.json"
+    reference_index=$((reference_index + 1))
 done
 
-payload="$(jq -n --argjson parts "$parts" '{contents: [{parts: $parts}]}')"
+jq '{contents: [{parts: .}]}' "$work/parts.json" > "$work/payload.json"
 endpoint="https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent"
-response=""
-if ! response="$(curl -sS --connect-timeout 15 --max-time 180 \
+if ! curl -sS --connect-timeout 15 --max-time 180 \
     -H "x-goog-api-key: $GEMINI_API_KEY" \
     -H 'Content-Type: application/json' \
-    -d "$payload" "$endpoint")"; then
+    --data-binary "@$work/payload.json" "$endpoint" > "$work/response.json"; then
     echo "error: Nano Banana request failed; check network access and Google AI Studio credentials" >&2
     exit 1
 fi
 
 image_data="$(jq -r '
     first(.candidates[]?.content.parts[]? | (.inlineData // .inline_data) | .data) // empty
-' <<<"$response")"
+' "$work/response.json")"
 if [[ -z "$image_data" ]]; then
-    api_error="$(jq -r '.error.message // empty' <<<"$response" 2>/dev/null || true)"
+    api_error="$(jq -r '.error.message // empty' "$work/response.json" 2>/dev/null || true)"
     if [[ -n "$api_error" ]]; then
         echo "error: Nano Banana returned an API error: $api_error" >&2
     else
@@ -138,6 +166,39 @@ if [[ -z "$image_data" ]]; then
     exit 1
 fi
 
-mkdir -p "$(dirname "$output")"
-printf '%s' "$image_data" | base64 --decode > "$output"
-printf 'wrote=%s\nmodel=%s\n' "$output" "$model"
+returned_mime="$(jq -r '
+    first(.candidates[]?.content.parts[]? | (.inlineData // .inline_data) |
+        (.mimeType // .mime_type)) // empty
+' "$work/response.json")"
+final_output="$output"
+if [[ -n "$returned_mime" ]]; then
+    returned_mime="${returned_mime%%;*}"
+    if actual_extension="$(output_extension_for_mime "$returned_mime")"; then
+        output_name="$(basename "$output")"
+        requested_extension=""
+        if [[ "$output_name" == *.* ]]; then
+            requested_extension="${output_name##*.}"
+        fi
+        if ! extension_matches_mime "$returned_mime" "$requested_extension"; then
+            output_stem="${output_name%.*}"
+            if [[ "$output_name" != *.* ]]; then
+                output_stem="$output_name"
+            fi
+            output_dir="$(dirname "$output")"
+            if [[ "$output_dir" == "." ]]; then
+                final_output="$output_stem.$actual_extension"
+            else
+                final_output="$output_dir/$output_stem.$actual_extension"
+            fi
+            echo "warning: MIME mismatch: API returned $returned_mime but requested output '$output'; writing '$final_output'" >&2
+        fi
+    else
+        echo "warning: API returned unsupported image MIME '$returned_mime'; writing requested output '$output'" >&2
+    fi
+else
+    echo "warning: API response omitted image MIME type; writing requested output '$output'" >&2
+fi
+
+mkdir -p "$(dirname "$final_output")"
+printf '%s' "$image_data" | base64 --decode > "$final_output"
+printf 'wrote=%s\nmodel=%s\n' "$final_output" "$model"

--- a/cas-cli/src/builtins/grok/skills/cas-image-generate/references/asset-playbook.md
+++ b/cas-cli/src/builtins/grok/skills/cas-image-generate/references/asset-playbook.md
@@ -14,7 +14,7 @@ returned image but does not silently resize it.
 
 | Asset | Tier | Suggested output | Prompt emphasis |
 |---|---|---|---|
-| Logo / logomark | NB2 → NB Pro | square PNG, 1024px or larger | flat, simple mark, correct quoted wordmark, high contrast, generous clear space; manual vectorization required |
+| Logo / logomark | NB2 → NB Pro | square PNG, 1024px or larger | flat, simple mark, the wordmark TEXT (spelled exactly, no quotation marks), high contrast, generous clear space; manual vectorization required |
 | Icon set | NB2 → NB Pro | one square grid sheet, 1024–2048px | one locked 24px-grid spec sentence, uniform stroke, padding, one color; manually trace approved glyphs |
 | Hero image | NB2 → NB Pro | 16:9, up to 1920px wide | focal subject, camera, lighting, and negative space for copy |
 | Background / texture | NB2 | 16:9 or tileable square, 2K | low contrast, no focal object, exact palette, usable behind text |
@@ -45,7 +45,7 @@ unrequested text. Preserve the supplied reference relationships: {references}.
 Create the final {asset_type} for {project}.
 Use these exact style tokens: {style_tokens}.
 Subject and action: {subject_action}. Context: {context}.
-Composition and safe area: {composition}. Exact displayed copy: "{copy}".
+Composition and safe area: {composition}. Exact displayed copy: {copy} (spelled exactly; no quotation marks unless explicitly requested).
 References and what must stay unchanged: {references_and_invariants}.
 Return a polished raster asset with correct spelling, deliberate edges, and no
 extra lettering or decorative objects.
@@ -57,7 +57,7 @@ extra lettering or decorative objects.
 Create a flat, high-contrast raster master for manual vectorization: {subject}.
 Use {style_tokens}; two colors maximum, simple geometric paths, centered on a
 plain background, generous clear space, no gradients, no shadows, and no extra
-lettering. If a wordmark is required, render exactly "{copy}".
+lettering. If a wordmark is required, render the wordmark TEXT (spelled {copy}, no quotation marks).
 ```
 
 ### Locked icon-set sentence

--- a/cas-cli/src/builtins/grok/skills/cas-image-generate/scripts/generate-image.sh
+++ b/cas-cli/src/builtins/grok/skills/cas-image-generate/scripts/generate-image.sh
@@ -93,7 +93,7 @@ for reference in "${references[@]}"; do
     fi
 done
 
-mime_type() {
+reference_mime_type() {
     case "${1,,}" in
         *.png) printf 'image/png' ;;
         *.webp) printf 'image/webp' ;;
@@ -106,30 +106,58 @@ mime_type() {
     esac
 }
 
-parts="$(jq -n --arg prompt "$prompt" '[{text: $prompt}]')"
+output_extension_for_mime() {
+    case "${1,,}" in
+        image/png) printf 'png' ;;
+        image/jpeg|image/jpg) printf 'jpg' ;;
+        image/webp) printf 'webp' ;;
+        image/gif) printf 'gif' ;;
+        *) return 1 ;;
+    esac
+}
+
+extension_matches_mime() {
+    case "${1,,}:${2,,}" in
+        image/png:png|image/jpeg:jpg|image/jpeg:jpeg|image/jpg:jpg|image/jpg:jpeg|image/webp:webp|image/gif:gif)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+printf '%s' "$prompt" > "$work/prompt.txt"
+jq -n --rawfile prompt "$work/prompt.txt" '[{text: $prompt}]' > "$work/parts.json"
+reference_index=0
 for reference in "${references[@]}"; do
-    encoded="$(base64 --wrap=0 "$reference")"
-    reference_mime="$(mime_type "$reference")"
-    parts="$(jq --arg mime "$reference_mime" --arg data "$encoded" \
-        '. + [{inlineData: {mimeType: $mime, data: $data}}]' <<<"$parts")"
+    base64 --wrap=0 "$reference" | tr -d '\r\n' > "$work/reference-$reference_index.b64"
+    reference_mime="$(reference_mime_type "$reference")"
+    jq --arg mime "$reference_mime" --rawfile data "$work/reference-$reference_index.b64" \
+        '. + [{inlineData: {mimeType: $mime, data: $data}}]' \
+        "$work/parts.json" > "$work/parts.next.json"
+    mv "$work/parts.next.json" "$work/parts.json"
+    reference_index=$((reference_index + 1))
 done
 
-payload="$(jq -n --argjson parts "$parts" '{contents: [{parts: $parts}]}')"
+jq '{contents: [{parts: .}]}' "$work/parts.json" > "$work/payload.json"
 endpoint="https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent"
-response=""
-if ! response="$(curl -sS --connect-timeout 15 --max-time 180 \
+if ! curl -sS --connect-timeout 15 --max-time 180 \
     -H "x-goog-api-key: $GEMINI_API_KEY" \
     -H 'Content-Type: application/json' \
-    -d "$payload" "$endpoint")"; then
+    --data-binary "@$work/payload.json" "$endpoint" > "$work/response.json"; then
     echo "error: Nano Banana request failed; check network access and Google AI Studio credentials" >&2
     exit 1
 fi
 
 image_data="$(jq -r '
     first(.candidates[]?.content.parts[]? | (.inlineData // .inline_data) | .data) // empty
-' <<<"$response")"
+' "$work/response.json")"
 if [[ -z "$image_data" ]]; then
-    api_error="$(jq -r '.error.message // empty' <<<"$response" 2>/dev/null || true)"
+    api_error="$(jq -r '.error.message // empty' "$work/response.json" 2>/dev/null || true)"
     if [[ -n "$api_error" ]]; then
         echo "error: Nano Banana returned an API error: $api_error" >&2
     else
@@ -138,6 +166,39 @@ if [[ -z "$image_data" ]]; then
     exit 1
 fi
 
-mkdir -p "$(dirname "$output")"
-printf '%s' "$image_data" | base64 --decode > "$output"
-printf 'wrote=%s\nmodel=%s\n' "$output" "$model"
+returned_mime="$(jq -r '
+    first(.candidates[]?.content.parts[]? | (.inlineData // .inline_data) |
+        (.mimeType // .mime_type)) // empty
+' "$work/response.json")"
+final_output="$output"
+if [[ -n "$returned_mime" ]]; then
+    returned_mime="${returned_mime%%;*}"
+    if actual_extension="$(output_extension_for_mime "$returned_mime")"; then
+        output_name="$(basename "$output")"
+        requested_extension=""
+        if [[ "$output_name" == *.* ]]; then
+            requested_extension="${output_name##*.}"
+        fi
+        if ! extension_matches_mime "$returned_mime" "$requested_extension"; then
+            output_stem="${output_name%.*}"
+            if [[ "$output_name" != *.* ]]; then
+                output_stem="$output_name"
+            fi
+            output_dir="$(dirname "$output")"
+            if [[ "$output_dir" == "." ]]; then
+                final_output="$output_stem.$actual_extension"
+            else
+                final_output="$output_dir/$output_stem.$actual_extension"
+            fi
+            echo "warning: MIME mismatch: API returned $returned_mime but requested output '$output'; writing '$final_output'" >&2
+        fi
+    else
+        echo "warning: API returned unsupported image MIME '$returned_mime'; writing requested output '$output'" >&2
+    fi
+else
+    echo "warning: API response omitted image MIME type; writing requested output '$output'" >&2
+fi
+
+mkdir -p "$(dirname "$final_output")"
+printf '%s' "$image_data" | base64 --decode > "$final_output"
+printf 'wrote=%s\nmodel=%s\n' "$final_output" "$model"

--- a/cas-cli/src/builtins/skills/cas-image-generate/references/asset-playbook.md
+++ b/cas-cli/src/builtins/skills/cas-image-generate/references/asset-playbook.md
@@ -14,7 +14,7 @@ returned image but does not silently resize it.
 
 | Asset | Tier | Suggested output | Prompt emphasis |
 |---|---|---|---|
-| Logo / logomark | NB2 → NB Pro | square PNG, 1024px or larger | flat, simple mark, correct quoted wordmark, high contrast, generous clear space; manual vectorization required |
+| Logo / logomark | NB2 → NB Pro | square PNG, 1024px or larger | flat, simple mark, the wordmark TEXT (spelled exactly, no quotation marks), high contrast, generous clear space; manual vectorization required |
 | Icon set | NB2 → NB Pro | one square grid sheet, 1024–2048px | one locked 24px-grid spec sentence, uniform stroke, padding, one color; manually trace approved glyphs |
 | Hero image | NB2 → NB Pro | 16:9, up to 1920px wide | focal subject, camera, lighting, and negative space for copy |
 | Background / texture | NB2 | 16:9 or tileable square, 2K | low contrast, no focal object, exact palette, usable behind text |
@@ -45,7 +45,7 @@ unrequested text. Preserve the supplied reference relationships: {references}.
 Create the final {asset_type} for {project}.
 Use these exact style tokens: {style_tokens}.
 Subject and action: {subject_action}. Context: {context}.
-Composition and safe area: {composition}. Exact displayed copy: "{copy}".
+Composition and safe area: {composition}. Exact displayed copy: {copy} (spelled exactly; no quotation marks unless explicitly requested).
 References and what must stay unchanged: {references_and_invariants}.
 Return a polished raster asset with correct spelling, deliberate edges, and no
 extra lettering or decorative objects.
@@ -57,7 +57,7 @@ extra lettering or decorative objects.
 Create a flat, high-contrast raster master for manual vectorization: {subject}.
 Use {style_tokens}; two colors maximum, simple geometric paths, centered on a
 plain background, generous clear space, no gradients, no shadows, and no extra
-lettering. If a wordmark is required, render exactly "{copy}".
+lettering. If a wordmark is required, render the wordmark TEXT (spelled {copy}, no quotation marks).
 ```
 
 ### Locked icon-set sentence

--- a/cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh
+++ b/cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh
@@ -93,7 +93,7 @@ for reference in "${references[@]}"; do
     fi
 done
 
-mime_type() {
+reference_mime_type() {
     case "${1,,}" in
         *.png) printf 'image/png' ;;
         *.webp) printf 'image/webp' ;;
@@ -106,30 +106,58 @@ mime_type() {
     esac
 }
 
-parts="$(jq -n --arg prompt "$prompt" '[{text: $prompt}]')"
+output_extension_for_mime() {
+    case "${1,,}" in
+        image/png) printf 'png' ;;
+        image/jpeg|image/jpg) printf 'jpg' ;;
+        image/webp) printf 'webp' ;;
+        image/gif) printf 'gif' ;;
+        *) return 1 ;;
+    esac
+}
+
+extension_matches_mime() {
+    case "${1,,}:${2,,}" in
+        image/png:png|image/jpeg:jpg|image/jpeg:jpeg|image/jpg:jpg|image/jpg:jpeg|image/webp:webp|image/gif:gif)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+printf '%s' "$prompt" > "$work/prompt.txt"
+jq -n --rawfile prompt "$work/prompt.txt" '[{text: $prompt}]' > "$work/parts.json"
+reference_index=0
 for reference in "${references[@]}"; do
-    encoded="$(base64 --wrap=0 "$reference")"
-    reference_mime="$(mime_type "$reference")"
-    parts="$(jq --arg mime "$reference_mime" --arg data "$encoded" \
-        '. + [{inlineData: {mimeType: $mime, data: $data}}]' <<<"$parts")"
+    base64 --wrap=0 "$reference" | tr -d '\r\n' > "$work/reference-$reference_index.b64"
+    reference_mime="$(reference_mime_type "$reference")"
+    jq --arg mime "$reference_mime" --rawfile data "$work/reference-$reference_index.b64" \
+        '. + [{inlineData: {mimeType: $mime, data: $data}}]' \
+        "$work/parts.json" > "$work/parts.next.json"
+    mv "$work/parts.next.json" "$work/parts.json"
+    reference_index=$((reference_index + 1))
 done
 
-payload="$(jq -n --argjson parts "$parts" '{contents: [{parts: $parts}]}')"
+jq '{contents: [{parts: .}]}' "$work/parts.json" > "$work/payload.json"
 endpoint="https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent"
-response=""
-if ! response="$(curl -sS --connect-timeout 15 --max-time 180 \
+if ! curl -sS --connect-timeout 15 --max-time 180 \
     -H "x-goog-api-key: $GEMINI_API_KEY" \
     -H 'Content-Type: application/json' \
-    -d "$payload" "$endpoint")"; then
+    --data-binary "@$work/payload.json" "$endpoint" > "$work/response.json"; then
     echo "error: Nano Banana request failed; check network access and Google AI Studio credentials" >&2
     exit 1
 fi
 
 image_data="$(jq -r '
     first(.candidates[]?.content.parts[]? | (.inlineData // .inline_data) | .data) // empty
-' <<<"$response")"
+' "$work/response.json")"
 if [[ -z "$image_data" ]]; then
-    api_error="$(jq -r '.error.message // empty' <<<"$response" 2>/dev/null || true)"
+    api_error="$(jq -r '.error.message // empty' "$work/response.json" 2>/dev/null || true)"
     if [[ -n "$api_error" ]]; then
         echo "error: Nano Banana returned an API error: $api_error" >&2
     else
@@ -138,6 +166,39 @@ if [[ -z "$image_data" ]]; then
     exit 1
 fi
 
-mkdir -p "$(dirname "$output")"
-printf '%s' "$image_data" | base64 --decode > "$output"
-printf 'wrote=%s\nmodel=%s\n' "$output" "$model"
+returned_mime="$(jq -r '
+    first(.candidates[]?.content.parts[]? | (.inlineData // .inline_data) |
+        (.mimeType // .mime_type)) // empty
+' "$work/response.json")"
+final_output="$output"
+if [[ -n "$returned_mime" ]]; then
+    returned_mime="${returned_mime%%;*}"
+    if actual_extension="$(output_extension_for_mime "$returned_mime")"; then
+        output_name="$(basename "$output")"
+        requested_extension=""
+        if [[ "$output_name" == *.* ]]; then
+            requested_extension="${output_name##*.}"
+        fi
+        if ! extension_matches_mime "$returned_mime" "$requested_extension"; then
+            output_stem="${output_name%.*}"
+            if [[ "$output_name" != *.* ]]; then
+                output_stem="$output_name"
+            fi
+            output_dir="$(dirname "$output")"
+            if [[ "$output_dir" == "." ]]; then
+                final_output="$output_stem.$actual_extension"
+            else
+                final_output="$output_dir/$output_stem.$actual_extension"
+            fi
+            echo "warning: MIME mismatch: API returned $returned_mime but requested output '$output'; writing '$final_output'" >&2
+        fi
+    else
+        echo "warning: API returned unsupported image MIME '$returned_mime'; writing requested output '$output'" >&2
+    fi
+else
+    echo "warning: API response omitted image MIME type; writing requested output '$output'" >&2
+fi
+
+mkdir -p "$(dirname "$final_output")"
+printf '%s' "$image_data" | base64 --decode > "$final_output"
+printf 'wrote=%s\nmodel=%s\n' "$final_output" "$model"

--- a/cas-cli/tests/cas_image_generate_helper_test.rs
+++ b/cas-cli/tests/cas_image_generate_helper_test.rs
@@ -1,0 +1,111 @@
+//! Offline behavior contracts for the cas-image-generate shell helper.
+
+use assert_cmd::Command;
+use base64::Engine;
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+fn repo_root() -> PathBuf {
+    cas::test_paths::workspace_root()
+}
+
+#[cfg(unix)]
+#[test]
+fn helper_streams_large_reference_and_honors_returned_mime() {
+    let project = TempDir::new().expect("temporary image-generation project");
+    let reference = project.path().join("reference.png");
+    let reference_bytes: Vec<u8> = (0..256 * 1024).map(|index| (index % 251) as u8).collect();
+    fs::write(&reference, &reference_bytes).expect("write large reference fixture");
+    assert!(
+        fs::metadata(&reference)
+            .expect("stat reference fixture")
+            .len()
+            > 200_000,
+        "reference fixture must exercise the large-file path"
+    );
+
+    let bin = project.path().join("bin");
+    fs::create_dir(&bin).expect("create fake provider bin");
+    let payload_capture = project.path().join("payload.json");
+    let fake_curl = bin.join("curl");
+    fs::write(
+        &fake_curl,
+        r##"#!/usr/bin/env bash
+set -euo pipefail
+payload=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --data-binary)
+            payload="${2#@}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+[[ -n "$payload" ]] || { echo "fake curl did not receive --data-binary" >&2; exit 1; }
+cp "$payload" "$CURL_PAYLOAD_CAPTURE"
+printf '%s' '{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/jpeg","data":"anBlZy1maXh0dXJl"}}]}}]}'
+"##,
+    )
+    .expect("write fake curl");
+    let mut permissions = fs::metadata(&fake_curl)
+        .expect("stat fake curl")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_curl, permissions).expect("make fake curl executable");
+
+    let script = repo_root()
+        .join("cas-cli/src/builtins/skills/cas-image-generate/scripts/generate-image.sh");
+    let requested_output = project.path().join("generated.png");
+    let actual_output = project.path().join("generated.jpg");
+    let path = format!("{}:/usr/bin:/bin", bin.display());
+    Command::new("bash")
+        .arg(&script)
+        .args([
+            "--prompt",
+            "preserve the supplied reference",
+            "--output",
+            requested_output.to_str().expect("requested output path"),
+            "--reference",
+            reference.to_str().expect("reference path"),
+        ])
+        .env("GEMINI_API_KEY", "offline-test-key")
+        .env("CURL_PAYLOAD_CAPTURE", &payload_capture)
+        .env("PATH", path)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(format!(
+            "wrote={}",
+            actual_output.display()
+        )))
+        .stderr(predicates::str::contains("MIME mismatch"));
+
+    assert!(
+        !requested_output.exists(),
+        "mismatched requested extension must not lie"
+    );
+    assert_eq!(
+        fs::read(&actual_output).expect("read generated JPEG fixture"),
+        b"jpeg-fixture"
+    );
+
+    let payload: Value =
+        serde_json::from_slice(&fs::read(&payload_capture).expect("read captured request payload"))
+            .expect("captured request is JSON");
+    let parts = payload["contents"][0]["parts"]
+        .as_array()
+        .expect("request has a parts array");
+    assert_eq!(parts.len(), 2, "prompt and one reference must be sent");
+    assert_eq!(parts[1]["inlineData"]["mimeType"], "image/png");
+    assert_eq!(
+        parts[1]["inlineData"]["data"],
+        base64::engine::general_purpose::STANDARD.encode(reference_bytes)
+    );
+}


### PR DESCRIPTION
Fixes three defects found in first real use of cas-image-generate:

- --reference no longer dies on ARG_MAX: payload parts are assembled via jq --rawfile from files and POSTed with --data-binary (regression test with a >200KB reference fixture, offline via fake curl)
- Output naming honors the returned inlineData.mimeType instead of silently writing JPEG bytes into a requested .png
- Playbook no longer says 'quoted wordmark' (NB Pro rendered literal quotation marks); template now spells the no-quotes instruction

Proofs: helper 1/1, skill suite 6/6, builtin flavor drift 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)