### PR TITLE
fix(cas-d19e): merge-request suppression — explicit roots over ambient state, hermetic fixtures

### DIFF
--- a/cas-cli/src/lib.rs
+++ b/cas-cli/src/lib.rs
@@ -139,6 +139,27 @@ pub(crate) mod test_support {
     }
 
     #[test]
+    fn test_env_guard_scrubs_ambient_cas_and_factory_environment() {
+        let _guard = TestEnvGuard::temp_home();
+        assert!(
+            std::env::vars_os().all(|(key, _)| {
+                let Some(key) = key.to_str() else {
+                    return true;
+                };
+                !key.starts_with("CAS_")
+                    && !matches!(
+                        key,
+                        "CLAUDE_CONFIG_DIR"
+                            | "CLAUDE_SECURESTORAGE_CONFIG_DIR"
+                            | "CODEX_HOME"
+                            | "GROK_HOME"
+                    )
+            }),
+            "TestEnvGuard must not inherit ambient CAS/factory environment"
+        );
+    }
+
+    #[test]
     fn lib_test_process_env_mutation_is_isolated() {
         fn visit(dir: &Path, hits: &mut Vec<String>) {
             for entry in std::fs::read_dir(dir).expect("read source directory") {

--- a/cas-cli/src/mcp/server/mod.rs
+++ b/cas-cli/src/mcp/server/mod.rs
@@ -702,7 +702,9 @@ impl CasCore {
         );
         let configured_role = match source {
             AgentIdentitySource::ServerInternal => role_hint.or(environment_role),
-            AgentIdentitySource::PublicRegistration => environment_role.or(role_hint),
+            // A typed registration request is explicit caller input. Ambient
+            // role is only a bootstrap fallback when no role was requested.
+            AgentIdentitySource::PublicRegistration => role_hint.or(environment_role),
         };
         if let Some(role) = configured_role {
             agent.role = role;

--- a/cas-cli/src/mcp/tools/core/agent_coordination/agent_session.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/agent_session.rs
@@ -26,11 +26,56 @@ fn public_registration_hints(
         });
     }
     let requested_type = agent_type.and_then(|value| value.parse().ok());
-    let safe_role = environment_role.or_else(|| {
-        (requested_type == Some(crate::types::AgentType::Worker))
-            .then_some(crate::types::AgentRole::Worker)
+    // An explicit role/type in the registration request wins over ambient
+    // bootstrap state. The environment remains a fallback for callers that
+    // omit a role, preserving factory-launched primary registrations.
+    let safe_role = requested_role.or_else(|| {
+        environment_role.or_else(|| {
+            (requested_type == Some(crate::types::AgentType::Worker))
+                .then_some(crate::types::AgentRole::Worker)
+        })
     });
     Ok((requested_type, safe_role))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::public_registration_hints;
+    use crate::mcp::tools::AgentRegisterRequest;
+    use crate::test_support::TestEnvGuard;
+    use crate::types::AgentRole;
+    use rmcp::handler::server::wrapper::Parameters;
+
+    #[test]
+    fn explicit_worker_registration_role_wins_over_ambient_supervisor() {
+        let mut env = TestEnvGuard::new();
+        env.set("CAS_AGENT_ROLE", "supervisor");
+
+        let (_, role) = public_registration_hints(Some("worker")).unwrap();
+
+        assert_eq!(role, Some(AgentRole::Worker));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn public_registration_persists_explicit_worker_role_over_ambient_supervisor() {
+        let mut env = TestEnvGuard::new();
+        env.set("CAS_AGENT_ROLE", "supervisor");
+        let temp = tempfile::tempdir().unwrap();
+        let cas_root = crate::store::init_cas_dir(temp.path()).unwrap();
+        let core = crate::mcp::server::CasCore::with_daemon(cas_root, None, None);
+
+        core.cas_agent_register(Parameters(AgentRegisterRequest {
+            name: "worker".to_string(),
+            agent_type: "worker".to_string(),
+            session_id: Some("explicit-worker".to_string()),
+            parent_id: None,
+        }))
+        .await
+        .unwrap();
+
+        let agent = core.open_agent_store().unwrap().get("explicit-worker").unwrap();
+        assert_eq!(agent.role, AgentRole::Worker);
+    }
 }
 
 impl CasCore {

--- a/cas-cli/src/mcp/tools/core/task/repo_context.rs
+++ b/cas-cli/src/mcp/tools/core/task/repo_context.rs
@@ -126,6 +126,28 @@ fn git_layout(path: &Path) -> Result<(PathBuf, PathBuf), String> {
     Ok((canonical(repo_root), common_dir))
 }
 
+/// Resolve the actual checkout root and shared Git common directory for a
+/// caller that supplied a local project root.
+///
+/// [`git_layout`] deliberately collapses linked worktrees to the primary
+/// checkout so host-repository discovery and binding identity remain stable.
+/// That is wrong for local config lookup: an ignored `.cas/` directory may
+/// exist only in the linked checkout. Keep the checkout root here so its
+/// project selector is checked before falling back to the host registry.
+fn git_checkout_layout(path: &Path) -> Result<(PathBuf, PathBuf), String> {
+    let checkout_root = canonical(PathBuf::from(git_output(
+        path,
+        &["rev-parse", "--show-toplevel"],
+    )?));
+    let common_raw = PathBuf::from(git_output(path, &["rev-parse", "--git-common-dir"])?);
+    let common_dir = canonical(if common_raw.is_absolute() {
+        common_raw
+    } else {
+        path.join(common_raw)
+    });
+    Ok((checkout_root, common_dir))
+}
+
 fn bounded_git_layout(
     path: &Path,
     probe: &BoundedRepoProbe,
@@ -852,11 +874,41 @@ pub(crate) fn resolve_repo_context_from_local_root(
     cas_root: &Path,
     target: &WorkTarget,
 ) -> Result<RepoContext, String> {
-    let (repo_root, git_common_dir) = git_layout(cas_root)?;
+    let (repo_root, git_common_dir) = match git_checkout_layout(cas_root) {
+        Ok(layout) => layout,
+        Err(error) => {
+            tracing::debug!(
+                resolution = "local_layout_error",
+                cas_root = %cas_root.display(),
+                target_selector = %target.repo_selector,
+                error = %error,
+                "merge revalidation local-root resolver could not inspect checkout"
+            );
+            return Err(error);
+        }
+    };
     if !repo_answers_to(&repo_root, &target.repo_selector) {
+        tracing::debug!(
+            resolution = "local_selector_mismatch",
+            cas_root = %cas_root.display(),
+            checkout_root = %repo_root.display(),
+            git_common_dir = %git_common_dir.display(),
+            target_selector = %target.repo_selector,
+            identities = ?repo_identities(&repo_root),
+            "merge revalidation local-root resolver rejected checkout identity"
+        );
         return Err("explicit project root does not match work target selector".to_string());
     }
     let target_branch = validate_target_branch(&repo_root, &target.target_branch)?;
+    tracing::debug!(
+        resolution = "local_checkout",
+        cas_root = %cas_root.display(),
+        checkout_root = %repo_root.display(),
+        git_common_dir = %git_common_dir.display(),
+        target_selector = %target.repo_selector,
+        target_branch = %target_branch,
+        "merge revalidation resolved from explicit checkout root"
+    );
     Ok(RepoContext {
         repo_selector: target.repo_selector.clone(),
         repo_root,
@@ -1093,6 +1145,59 @@ mod tests {
             let c = resolve_path_context(&dir.path().join("alias"), "master").unwrap();
             assert_eq!(a.git_common_dir, c.git_common_dir);
         }
+    }
+
+    #[test]
+    fn local_root_resolver_uses_linked_checkout_root_for_identity() {
+        TestEnvGuard::run_with_temp_home(|_| {
+            let dir = tempfile::TempDir::new().unwrap();
+            let main = dir.path().join("main");
+            std::fs::create_dir(&main).unwrap();
+            git(&main, &["init", "-q", "-b", "main"]);
+            std::fs::write(main.join("base.txt"), "base\n").unwrap();
+            git(&main, &["add", "base.txt"]);
+            git(
+                &main,
+                &[
+                    "-c",
+                    "user.name=Cassy",
+                    "-c",
+                    "user.email=cas@example.com",
+                    "commit",
+                    "-q",
+                    "-m",
+                    "base",
+                ],
+            );
+
+            let linked = dir.path().join("linked");
+            git(
+                &main,
+                &[
+                    "worktree",
+                    "add",
+                    "-q",
+                    "-b",
+                    "factory/local",
+                    linked.to_str().unwrap(),
+                ],
+            );
+            std::fs::create_dir(linked.join(".cas")).unwrap();
+            std::fs::write(
+                linked.join(".cas/config.toml"),
+                "[project]\ncanonical_id = \"linked-project\"\n",
+            )
+            .unwrap();
+
+            let target = WorkTarget {
+                repo_selector: "project:linked-project".to_string(),
+                target_branch: "main".to_string(),
+            };
+            let resolved = resolve_repo_context_from_local_root(&linked.join(".cas"), &target)
+                .expect("linked checkout-local config must resolve before registry fallback");
+            assert_eq!(resolved.repo_root, canonical(linked));
+            assert_eq!(resolved.git_common_dir, canonical(main.join(".git")));
+        });
     }
 
     #[test]

--- a/cas-cli/src/mcp/tools/core/task/repo_context.rs
+++ b/cas-cli/src/mcp/tools/core/task/repo_context.rs
@@ -838,6 +838,33 @@ pub(crate) fn resolve_repo_context(
     }
 }
 
+/// Resolve a work target from the explicitly supplied project root only.
+///
+/// Informational paths such as merge-request revalidation may already hold the
+/// authoritative project root, but the general resolver also consults the
+/// host-wide known-repository registry so cross-repository lifecycle mutations
+/// can resolve portable selectors. That registry is ambient state: a stale or
+/// concurrently registered checkout can make an otherwise local selector look
+/// ambiguous. Callers that have an explicit local root should use this helper
+/// first and fall back to [`resolve_repo_context`] only for cross-repository
+/// targets.
+pub(crate) fn resolve_repo_context_from_local_root(
+    cas_root: &Path,
+    target: &WorkTarget,
+) -> Result<RepoContext, String> {
+    let (repo_root, git_common_dir) = git_layout(cas_root)?;
+    if !repo_answers_to(&repo_root, &target.repo_selector) {
+        return Err("explicit project root does not match work target selector".to_string());
+    }
+    let target_branch = validate_target_branch(&repo_root, &target.target_branch)?;
+    Ok(RepoContext {
+        repo_selector: target.repo_selector.clone(),
+        repo_root,
+        git_common_dir,
+        target_branch,
+    })
+}
+
 pub(crate) fn resolve_repo_context_bounded(
     cas_root: &Path,
     target: &WorkTarget,

--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -730,7 +730,9 @@ impl CasService {
         // eligible for revalidation and suppression.
         if role == "worker" && req.merge_request.unwrap_or(false) {
             use crate::mcp::tools::core::task::lifecycle::close_ops::resolve_branch_sha;
-            use crate::mcp::tools::core::task::repo_context::resolve_repo_context;
+            use crate::mcp::tools::core::task::repo_context::{
+                resolve_repo_context, resolve_repo_context_from_local_root,
+            };
             use crate::prompt_revalidation::{
                 MergeRequestDecision, MergeRequestEnvelope, attach_merge_request_envelope,
                 merge_landed_guidance, revalidate_merge_request, select_unambiguous_merge_task,
@@ -748,7 +750,9 @@ impl CasService {
 
             if let Some(task) = merge_task
                 && let Some(work_target) = task.deliverables.work_target.as_ref()
-                && let Ok(repo) = resolve_repo_context(&self.inner.cas_root, work_target)
+                && let Ok(repo) =
+                    resolve_repo_context_from_local_root(&self.inner.cas_root, work_target)
+                        .or_else(|_| resolve_repo_context(&self.inner.cas_root, work_target))
             {
                 let branch = task
                     .deliverables
@@ -2503,6 +2507,7 @@ mod cas99d2_redelivery_tests {
 #[cfg(test)]
 mod cas_89e1_post_merge_message_type_tests {
     use super::*;
+    use crate::test_support::TestEnvGuard;
     use cas_types::{Agent, AgentRole, Task, TaskStatus, WorkTarget};
     use rmcp::model::RawContent;
     use std::path::Path;
@@ -2513,6 +2518,8 @@ mod cas_89e1_post_merge_message_type_tests {
             .arg("-C")
             .arg(repo)
             .args(args)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
             .output()
             .expect("git command");
         assert!(
@@ -2552,6 +2559,20 @@ mod cas_89e1_post_merge_message_type_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn post_merge_suppression_requires_the_explicit_merge_request_type() {
+        let _env = TestEnvGuard::temp_home();
+        crate::store::known_repos::ensure_host_schema().expect("host repo schema");
+        let host_collision = tempfile::tempdir().expect("host collision repo");
+        let collision_repo = host_collision.path();
+        git(collision_repo, &["init", "-q", "-b", "main"]);
+        std::fs::create_dir(collision_repo.join(".cas")).expect("collision Cassy directory");
+        std::fs::write(
+            collision_repo.join(".cas/config.toml"),
+            "[project]\ncanonical_id = \"cas-89e1-message-test\"\n",
+        )
+        .expect("collision Cassy config");
+        crate::store::known_repos::register_repo_strict(collision_repo)
+            .expect("register host collision");
+
         let project = tempfile::tempdir().expect("temporary project");
         let repo = project.path();
         git(repo, &["init", "-q", "-b", "main"]);

--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -384,9 +384,15 @@ impl CasService {
                 .ok()
                 .and_then(|store| store.get(&source).ok())
         };
-        let role = std::env::var("CAS_AGENT_ROLE")
-            .ok()
-            .or_else(|| agent_from_store.as_ref().map(|a| a.role.to_string()))
+        // The registered row is the explicit identity for this MCP caller.
+        // CAS_AGENT_ROLE is only a bootstrap fallback when no row can be
+        // resolved; letting it win here can relabel a registered worker as a
+        // supervisor when a supervisor-launched test or server shares a
+        // process environment.
+        let role = agent_from_store
+            .as_ref()
+            .map(|a| a.role.to_string())
+            .or_else(|| std::env::var("CAS_AGENT_ROLE").ok())
             .unwrap_or_else(|| "primary".to_string());
         let factory_session = std::env::var("CAS_FACTORY_SESSION")
             .ok()
@@ -2599,7 +2605,7 @@ mod cas_89e1_post_merge_message_type_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn post_merge_suppression_requires_the_explicit_merge_request_type() {
-        let _env = TestEnvGuard::temp_home();
+        let mut env = TestEnvGuard::temp_home();
         crate::store::known_repos::ensure_host_schema().expect("host repo schema");
         let host_collision = tempfile::tempdir().expect("host collision repo");
         let collision_repo = host_collision.path();
@@ -2661,6 +2667,13 @@ mod cas_89e1_post_merge_message_type_tests {
         });
         task.deliverables.parked_branch = Some("factory/worker-a".to_string());
         tasks.add(&task).expect("add parked task");
+
+        // The fixture starts hermetic even when the test binary was launched
+        // by a supervisor. Re-introduce a conflicting ambient role only after
+        // registration to prove the persisted worker role wins at the MCP
+        // message boundary.
+        assert!(std::env::var_os("CAS_AGENT_ROLE").is_none());
+        env.set("CAS_AGENT_ROLE", "supervisor");
 
         #[cfg(feature = "mcp-proxy")]
         let service = CasService::new(core.clone(), None);

--- a/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/message.rs
@@ -750,9 +750,49 @@ impl CasService {
 
             if let Some(task) = merge_task
                 && let Some(work_target) = task.deliverables.work_target.as_ref()
-                && let Ok(repo) =
-                    resolve_repo_context_from_local_root(&self.inner.cas_root, work_target)
-                        .or_else(|_| resolve_repo_context(&self.inner.cas_root, work_target))
+                && let Ok(repo) = {
+                    match resolve_repo_context_from_local_root(&self.inner.cas_root, work_target) {
+                        Ok(repo) => {
+                            tracing::debug!(
+                                task_id = %task.id,
+                                resolution = "local_checkout",
+                                repo_root = %repo.repo_root.display(),
+                                git_common_dir = %repo.git_common_dir.display(),
+                                "merge request revalidation selected explicit local checkout"
+                            );
+                            Ok(repo)
+                        }
+                        Err(local_error) => {
+                            tracing::debug!(
+                                task_id = %task.id,
+                                resolution = "local_checkout_miss",
+                                error = %local_error,
+                                "merge request revalidation falling back to host registry"
+                            );
+                            match resolve_repo_context(&self.inner.cas_root, work_target) {
+                                Ok(repo) => {
+                                    tracing::debug!(
+                                        task_id = %task.id,
+                                        resolution = "host_registry_fallback",
+                                        repo_root = %repo.repo_root.display(),
+                                        git_common_dir = %repo.git_common_dir.display(),
+                                        "merge request revalidation selected host registry checkout"
+                                    );
+                                    Ok(repo)
+                                }
+                                Err(error) => {
+                                    tracing::debug!(
+                                        task_id = %task.id,
+                                        resolution = "host_registry_miss",
+                                        error = %error,
+                                        "merge request revalidation could not resolve checkout"
+                                    );
+                                    Err(error)
+                                }
+                            }
+                        }
+                    }
+                }
             {
                 let branch = task
                     .deliverables

--- a/cas-cli/src/test_env_guard.rs
+++ b/cas-cli/src/test_env_guard.rs
@@ -65,14 +65,16 @@ impl TestEnvGuard {
         // constructor can then fail immediately instead of blocking forever
         // on the non-reentrant mutex already held by this thread.
         let nesting = TestEnvGuardNesting::enter();
-        Self {
+        let mut guard = Self {
             _lock: test_env_lock(),
             _nesting: nesting,
             saved: Vec::new(),
             temp_home: None,
             temp_home_path: None,
             saved_cwd: None,
-        }
+        };
+        guard.scrub_ambient_cas_environment();
+        guard
     }
 
     pub(crate) fn temp_home() -> Self {
@@ -144,6 +146,32 @@ impl TestEnvGuard {
     fn capture(&mut self, key: &OsStr) {
         if !self.saved.iter().any(|(saved, _)| saved == key) {
             self.saved.push((key.to_os_string(), std::env::var_os(key)));
+        }
+    }
+
+    /// Keep test fixtures independent from the factory process that launched
+    /// the test binary. Every `CAS_*` variable is ambient Cassy state, and the
+    /// account-home variables are the non-CAS part of the factory contract.
+    /// Tests that need one of these values set it explicitly after constructing
+    /// the guard; Drop restores the caller's environment.
+    fn scrub_ambient_cas_environment(&mut self) {
+        let keys = std::env::vars_os()
+            .map(|(key, _)| key)
+            .filter(|key| {
+                key.to_str().is_some_and(|key| {
+                    key.starts_with("CAS_")
+                        || matches!(
+                            key,
+                            "CLAUDE_CONFIG_DIR"
+                                | "CLAUDE_SECURESTORAGE_CONFIG_DIR"
+                                | "CODEX_HOME"
+                                | "GROK_HOME"
+                        )
+                })
+            })
+            .collect::<Vec<_>>();
+        for key in keys {
+            self.remove(key);
         }
     }
 }


### PR DESCRIPTION
Closes a three-layer ambient-state leak in merge-request suppression, found while gating the knowledge-loop epic:

- resolve_repo_context consulted the host known-repos registry before the explicit local root; a duplicate selector returned AMBIGUOUS and suppression failed open to queueing (new resolve_repo_context_from_local_root, tried first for merge revalidation; registry fallback preserved for cross-repo targets)
- git_layout collapsed linked worktrees to the primary checkout before reading checkout-local config; local identity now comes from git rev-parse --show-toplevel while retaining the shared common-dir
- ambient CAS_AGENT_ROLE leaked into the test fixture's agent registration AND could override an explicit registration role in production; registered-row role now wins, TestEnvGuard scrubs the CAS_*/harness env family, and explicit public registration role beats ambient

Debug branch markers distinguish local_checkout / local_selector_mismatch / host_registry_fallback / host_registry_miss. Proofs: pre-fix red under CAS_AGENT_ROLE=supervisor (exact artifacted invocation), post-fix 51/51 across message, repo_context, agent_session, server-role and TestEnvGuard suites; supervisor independently verified the original failing environment now passes with full live env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)