### PR TITLE
fix(cas-5e4a): stamp explicit project scope on legacy team task upserts

### DIFF
--- a/cas-cli/src/cloud/syncer/team_push.rs
+++ b/cas-cli/src/cloud/syncer/team_push.rs
@@ -10,6 +10,14 @@ use chrono::Utc;
 
 fn stamp_task_origin_project(value: &mut serde_json::Value, project_id: &str) {
     if let Some(task) = value.as_object_mut() {
+        // Team task rows are project-scoped. Legacy queue payloads may have
+        // been serialized before Task::scope existed, but the cloud contract
+        // requires the explicit field or it may accept the batch while
+        // silently skipping the row.
+        task.insert(
+            "scope".to_string(),
+            serde_json::Value::String("project".to_string()),
+        );
         task.insert(
             "origin_project".to_string(),
             serde_json::Value::String(project_id.to_string()),
@@ -778,6 +786,10 @@ mod tests {
     fn queued_task_payloads_receive_current_project_identity() {
         let mut value = serde_json::json!({"id": "cas-legacy", "title": "old payload"});
         super::stamp_task_origin_project(&mut value, "acme/accounting");
+        assert_eq!(
+            value.get("scope").and_then(|value| value.as_str()),
+            Some("project")
+        );
         assert_eq!(
             value.get("origin_project").and_then(|value| value.as_str()),
             Some("acme/accounting")

--- a/cas-cli/tests/team_sync_test.rs
+++ b/cas-cli/tests/team_sync_test.rs
@@ -472,6 +472,57 @@ async fn team_delete_uses_singular_entity_path() {
     assert!(queue.pending_for_team(TEST_TEAM, 10, 5).unwrap().is_empty());
 }
 
+/// Legacy queued tasks may predate the stored `scope` field. Team pushes must
+/// repair that wire identity before sending: the cloud accepts the batch with
+/// HTTP 200 but skips task rows whose explicit scope is absent.
+#[tokio::test]
+async fn team_task_upsert_includes_explicit_project_scope() {
+    let server = MockServer::start().await;
+    let expected_project_id =
+        get_project_canonical_id().expect("team task push test must resolve project identity");
+    Mock::given(method("POST"))
+        .and(path(format!("/api/teams/{TEST_TEAM}/sync/push")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "synced": {
+                "tasks": { "inserted": 1, "updated": 0, "skipped": 0 }
+            },
+            "canonical_id": expected_project_id,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let queue = Arc::new(SyncQueue::open(tmp.path()).unwrap());
+    queue.init().unwrap();
+    queue
+        .enqueue_for_team(
+            EntityType::Task,
+            "legacy-team-task",
+            SyncOperation::Upsert,
+            Some(r#"{"id":"legacy-team-task","title":"legacy payload"}"#),
+            TEST_TEAM,
+        )
+        .unwrap();
+
+    let syncer = CloudSyncer::new(
+        queue.clone(),
+        make_cloud_config(server.uri()),
+        CloudSyncerConfig::default(),
+    );
+    tokio::task::spawn_blocking(move || syncer.push_team(TEST_TEAM))
+        .await
+        .unwrap()
+        .expect("team task push should succeed");
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let payload = decode_gzip_json(&requests[0].body);
+    assert_eq!(payload["project_canonical_id"], expected_project_id);
+    assert_eq!(payload["tasks"][0]["scope"], "project");
+    assert_eq!(payload["tasks"][0]["origin_project"], expected_project_id);
+}
+
 /// Terminally parked rows are intentionally excluded from normal syncs. The
 /// existing `cas cloud queue --retry` recovery path requeues them so a fixed
 /// team-delete endpoint can flush the retained tombstone.


### PR DESCRIPTION
Team pushes now stamp legacy queued task payloads with explicit scope=project alongside origin_project before upsert. Without the field the cloud accepts the batch with HTTP 200 while silently skipping the rows (proven live during cas-02a7: 113- and 7-row batches all skipped; a direct retry with explicit Task.scope succeeded).

- cas-cli/src/cloud/syncer/team_push.rs: stamp_task_origin_project also inserts scope=project
- cas-cli/tests/team_sync_test.rs: gzip wire regression asserting outer project_canonical_id, task scope, and origin_project

Red proof: 1 failing on missing scope (artifacts/cas-5e4a/red-test-zig.log). Green proof: scoped runner exit 0, 4850 passed (green-proof.log), diff surface covered against b93d89f0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)