### PR TITLE
feat: version rule and skill lifecycle changes

### DIFF
--- a/cas-cli/src/mcp/tools/core/rules.rs
+++ b/cas-cli/src/mcp/tools/core/rules.rs
@@ -211,10 +211,10 @@ impl CasCore {
         rule_store
             .update_with_metadata(&rule, None, None)
             .map_err(|e| McpError {
-            code: ErrorCode::INTERNAL_ERROR,
-            message: Cow::from(format!("Failed to update: {e}")),
-            data: None,
-        })?;
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(format!("Failed to update: {e}")),
+                data: None,
+            })?;
 
         if promoted || demoted {
             let _ = self.sync_rules();
@@ -508,16 +508,12 @@ impl CasCore {
         }
 
         rule_store
-            .update_with_metadata(
-                &rule,
-                req.changed_by.as_deref(),
-                req.change_note.as_deref(),
-            )
+            .update_with_metadata(&rule, req.changed_by.as_deref(), req.change_note.as_deref())
             .map_err(|e| McpError {
-            code: ErrorCode::INTERNAL_ERROR,
-            message: Cow::from(format!("Failed to update: {e}")),
-            data: None,
-        })?;
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(format!("Failed to update: {e}")),
+                data: None,
+            })?;
 
         // Re-sync if proven
         if rule.status == RuleStatus::Proven {
@@ -546,13 +542,18 @@ impl CasCore {
             return Ok(Self::success(format!("No history for rule {}", req.id)));
         }
 
-        let mut output = format!("Rule history for {} ({} versions):\n\n", req.id, versions.len());
+        let mut output = format!(
+            "Rule history for {} ({} versions):\n\n",
+            req.id,
+            versions.len()
+        );
         for version in versions {
             let preview: String = version.content.chars().take(120).collect();
             output.push_str(&format!(
-                "- v{} [{}] {} by {} at {}\n  {}\n",
+                "- v{} [{}: {}] {} by {} at {}\n  {}\n",
                 version.version,
                 version.status,
+                version.operation,
                 version.change_note,
                 version.changed_by.as_deref().unwrap_or("unknown actor"),
                 version.changed_at.format("%Y-%m-%d %H:%M:%S UTC"),
@@ -590,7 +591,9 @@ impl CasCore {
         Ok(Self::success(format!(
             "Restored rule {}{} (status: {})",
             req.id,
-            version.map(|v| format!(" to version {v}")).unwrap_or_default(),
+            version
+                .map(|v| format!(" to version {v}"))
+                .unwrap_or_default(),
             restored.status
         )))
     }

--- a/cas-cli/src/mcp/tools/core/skills.rs
+++ b/cas-cli/src/mcp/tools/core/skills.rs
@@ -531,10 +531,10 @@ impl CasCore {
                     req.change_note.as_deref(),
                 )
                 .map_err(|e| McpError {
-                code: ErrorCode::INTERNAL_ERROR,
-                message: Cow::from(format!("Failed to update: {e}")),
-                data: None,
-            })?;
+                    code: ErrorCode::INTERNAL_ERROR,
+                    message: Cow::from(format!("Failed to update: {e}")),
+                    data: None,
+                })?;
 
             // Re-sync if enabled
             if skill.status == SkillStatus::Enabled {
@@ -564,13 +564,18 @@ impl CasCore {
             return Ok(Self::success(format!("No history for skill {}", req.id)));
         }
 
-        let mut output = format!("Skill history for {} ({} versions):\n\n", req.id, versions.len());
+        let mut output = format!(
+            "Skill history for {} ({} versions):\n\n",
+            req.id,
+            versions.len()
+        );
         for version in versions {
             let preview: String = version.description.chars().take(120).collect();
             output.push_str(&format!(
-                "- v{} [{}] {} by {} at {}\n  {}\n",
+                "- v{} [{}: {}] {} by {} at {}\n  {}\n",
                 version.version,
                 version.status,
+                version.operation,
                 version.change_note,
                 version.changed_by.as_deref().unwrap_or("unknown actor"),
                 version.changed_at.format("%Y-%m-%d %H:%M:%S UTC"),
@@ -608,7 +613,9 @@ impl CasCore {
         Ok(Self::success(format!(
             "Restored skill {}{} (status: {})",
             req.id,
-            version.map(|v| format!(" to version {v}")).unwrap_or_default(),
+            version
+                .map(|v| format!(" to version {v}"))
+                .unwrap_or_default(),
             restored.status
         )))
     }

--- a/cas-cli/src/migration/migrations/m240_rule_skill_versions.rs
+++ b/cas-cli/src/migration/migrations/m240_rule_skill_versions.rs
@@ -42,12 +42,22 @@ mod tests {
             1
         );
         assert_eq!(
-            conn.query_row("SELECT COUNT(*) FROM pragma_table_info('rule_versions')", [], |row| row.get::<_, i64>(0)).unwrap(),
-            9
+            conn.query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('rule_versions')",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+            10
         );
         assert_eq!(
-            conn.query_row("SELECT COUNT(*) FROM pragma_table_info('skill_versions')", [], |row| row.get::<_, i64>(0)).unwrap(),
-            10
+            conn.query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('skill_versions')",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+            11
         );
     }
 }

--- a/cas-cli/src/migration/migrations/m242_rule_skill_versions_operations.rs
+++ b/cas-cli/src/migration/migrations/m242_rule_skill_versions_operations.rs
@@ -1,0 +1,94 @@
+//! Migration: record the lifecycle operation for every rule and skill version.
+
+use crate::migration::{Migration, Subsystem};
+
+pub const MIGRATION: Migration = Migration {
+    id: 242,
+    name: "rule_skill_versions_operations",
+    subsystem: Subsystem::Rules,
+    description: "Record create, update, delete, and restore operations in knowledge history (cas-ef20)",
+    up: &[
+        "ALTER TABLE rule_versions ADD COLUMN operation TEXT NOT NULL DEFAULT 'update'",
+        "ALTER TABLE skill_versions ADD COLUMN operation TEXT NOT NULL DEFAULT 'update'",
+    ],
+    detect: Some(
+        "SELECT CASE WHEN
+            EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'rule_versions')
+            AND EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'skill_versions')
+            AND EXISTS (SELECT 1 FROM pragma_table_info('rule_versions') WHERE name = 'operation')
+            AND EXISTS (SELECT 1 FROM pragma_table_info('skill_versions') WHERE name = 'operation')
+         THEN 1 ELSE 0 END",
+    ),
+};
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    #[test]
+    fn migration_adds_operation_to_existing_history_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE rule_versions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                rule_id TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                snapshot_json TEXT NOT NULL,
+                content TEXT NOT NULL,
+                status TEXT NOT NULL,
+                changed_by TEXT,
+                changed_at TEXT NOT NULL,
+                change_note TEXT NOT NULL,
+                UNIQUE(rule_id, version)
+             );
+             CREATE TABLE skill_versions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                skill_id TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                snapshot_json TEXT NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT NOT NULL,
+                status TEXT NOT NULL,
+                changed_by TEXT,
+                changed_at TEXT NOT NULL,
+                change_note TEXT NOT NULL,
+                UNIQUE(skill_id, version)
+             );",
+        )
+        .unwrap();
+
+        assert_eq!(
+            conn.query_row(super::MIGRATION.detect.unwrap(), [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+        for statement in super::MIGRATION.up {
+            conn.execute(statement, []).unwrap();
+        }
+        assert_eq!(
+            conn.query_row(super::MIGRATION.detect.unwrap(), [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT dflt_value FROM pragma_table_info('rule_versions') WHERE name = 'operation'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+            "'update'"
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT dflt_value FROM pragma_table_info('skill_versions') WHERE name = 'operation'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+            "'update'"
+        );
+    }
+}

--- a/cas-cli/src/migration/migrations/mod.rs
+++ b/cas-cli/src/migration/migrations/mod.rs
@@ -217,6 +217,7 @@ mod m238_skills_add_source_ids;
 mod m239_task_execution_states_create_table;
 mod m240_rule_skill_versions;
 mod m241_tasks_add_origin_project;
+mod m242_rule_skill_versions_operations;
 
 /// All migrations in order. IDs must be sequential and never reused.
 pub const MIGRATIONS: &[Migration] = &[
@@ -467,6 +468,7 @@ pub const MIGRATIONS: &[Migration] = &[
     m239_task_execution_states_create_table::MIGRATION,
     m240_rule_skill_versions::MIGRATION,
     m241_tasks_add_origin_project::MIGRATION,
+    m242_rule_skill_versions_operations::MIGRATION,
 ];
 
 #[cfg(test)]

--- a/cas-cli/src/migration/mod.rs
+++ b/cas-cli/src/migration/mod.rs
@@ -994,7 +994,7 @@ mod tests {
 
     fn assert_repaired_v225_knowledge_gap(cas_dir: &Path, expected_m226_ledger: &str) {
         let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
-        for id in [225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241] {
+        for id in [225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242] {
             assert_eq!(
                 conn.query_row(
                     "SELECT COUNT(*) FROM cas_migrations WHERE id = ?1",
@@ -1061,7 +1061,7 @@ mod tests {
         assert_eq!(pages[0].origin_project_id, None);
 
         let status = check_migrations(cas_dir).unwrap();
-        assert_eq!(status.current_version, 241);
+        assert_eq!(status.current_version, 242);
         assert!(status.pending.is_empty());
         let second = run_migrations(cas_dir, false).unwrap();
         assert_eq!(second.applied_count, 0, "repeated open must be idempotent");
@@ -1083,7 +1083,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241],
+                vec![225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242],
                 "recorded m225 and missing m226 must order all later work behind them"
             );
 
@@ -1167,7 +1167,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241]
+                vec![225, 226, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();
@@ -1206,7 +1206,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241]
+                vec![225, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();

--- a/cas-cli/tests/mcp_tools_test/rule_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/rule_tools.rs
@@ -216,6 +216,7 @@ async fn test_rule_update() {
         .await
         .expect("rule_history should succeed");
     let history_text = extract_text(history);
+    assert!(history_text.contains("create"));
     assert!(history_text.contains("revise wording"));
     assert!(history_text.contains("Original rule content"));
 

--- a/cas-cli/tests/mcp_tools_test/skill_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/skill_tools.rs
@@ -314,6 +314,7 @@ async fn test_skill_update() {
         .await
         .expect("skill_history should succeed");
     let history_text = extract_text(history);
+    assert!(history_text.contains("create"));
     assert!(history_text.contains("revise description"));
     assert!(history_text.contains("Original description"));
 
@@ -587,5 +588,7 @@ async fn test_skill_update_validation_failure_is_atomic() {
     let skill_store = open_skill_store(&temp.path().join(".cas")).unwrap();
     let stored = skill_store.get(&id).unwrap();
     assert_eq!(stored.description, "Original description");
-    assert!(skill_store.list_versions(&id).unwrap().is_empty());
+    let versions = skill_store.list_versions(&id).unwrap();
+    assert_eq!(versions.len(), 1);
+    assert_eq!(versions[0].operation, "create");
 }

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -7,10 +7,10 @@ cas doctor
 ──────────────────────────────────────────────────
 [OK] cas directory: Found at [TEMP_PATH]
 [OK] database: SQLite database found
-[OK] schema: v241 (up to date)
+[OK] schema: v242 (up to date)
 [OK] supervisor relay: no undelivered lifecycle relays
 [OK] delivery retries: no pending message has spent 3+ attempts
-[OK] tables: [N] tables, 778 columns, 204 rows total
+[OK] tables: [N] tables, 780 columns, 205 rows total
 [OK] entry store: [N] entries accessible
 [WARN] search index: Index not found. Will be created on first search.
 [WARN] symbol index: nothing indexed for this project (0 symbol(s) in the store across all repositories); the code search index is missing. The daemon only indexes while idle — run `cas index code` to catch up now.

--- a/crates/cas-store/src/skill_store.rs
+++ b/crates/cas-store/src/skill_store.rs
@@ -1,7 +1,7 @@
 //! SQLite-based skill storage
 
 use chrono::{DateTime, TimeZone, Utc};
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -80,6 +80,43 @@ pub struct SqliteSkillStore {
 }
 
 impl SqliteSkillStore {
+    fn insert_version(
+        tx: &Transaction<'_>,
+        skill_id: &str,
+        snapshot_json: &str,
+        name: &str,
+        description: &str,
+        status: SkillStatus,
+        changed_by: &Option<String>,
+        changed_at: &str,
+        change_note: &str,
+        operation: &str,
+    ) -> Result<()> {
+        let next_version: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(version), 0) + 1 FROM skill_versions WHERE skill_id = ?1",
+            params![skill_id],
+            |row| row.get(0),
+        )?;
+        tx.execute(
+            "INSERT INTO skill_versions
+             (skill_id, version, snapshot_json, name, description, status, changed_by, changed_at, change_note, operation)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                skill_id,
+                next_version,
+                snapshot_json,
+                name,
+                description,
+                status.to_string(),
+                changed_by,
+                changed_at,
+                change_note,
+                operation,
+            ],
+        )?;
+        Ok(())
+    }
+
     /// Open or create a SQLite skill store
     pub fn open(cas_dir: &Path) -> Result<Self> {
         let db_path = cas_dir.join("cas.db");
@@ -226,6 +263,7 @@ impl SqliteSkillStore {
         skill: &Skill,
         changed_by: Option<&str>,
         change_note: Option<&str>,
+        operation: &str,
     ) -> Result<()> {
         let previous = self.get(&skill.id)?;
         let snapshot_json = serde_json::to_string(&previous).map_err(|error| {
@@ -239,26 +277,17 @@ impl SqliteSkillStore {
 
         let mut conn = crate::shared_db::lock_connection(&self.conn)?;
         let tx = conn.transaction()?;
-        let next_version: i64 = tx.query_row(
-            "SELECT COALESCE(MAX(version), 0) + 1 FROM skill_versions WHERE skill_id = ?1",
-            params![&skill.id],
-            |row| row.get(0),
-        )?;
-        tx.execute(
-            "INSERT INTO skill_versions
-             (skill_id, version, snapshot_json, name, description, status, changed_by, changed_at, change_note)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            params![
-                &skill.id,
-                next_version,
-                snapshot_json,
-                previous.name,
-                previous.description,
-                previous.status.to_string(),
-                changed_by,
-                changed_at,
-                change_note,
-            ],
+        Self::insert_version(
+            &tx,
+            &skill.id,
+            &snapshot_json,
+            &previous.name,
+            &previous.description,
+            previous.status,
+            &changed_by,
+            &changed_at,
+            change_note,
+            operation,
         )?;
         let rows = tx.execute(
             "UPDATE skills SET name = ?1, description = ?2, skill_type = ?3,
@@ -301,7 +330,10 @@ impl SqliteSkillStore {
             ],
         )?;
         if rows == 0 {
-            return Err(StoreError::NotFound(format!("skill not found: {}", skill.id)));
+            return Err(StoreError::NotFound(format!(
+                "skill not found: {}",
+                skill.id
+            )));
         }
         tx.commit()?;
         Ok(())
@@ -323,6 +355,7 @@ impl SqliteSkillStore {
             &retired,
             changed_by,
             Some(change_note.unwrap_or("tombstone delete")),
+            "delete",
         )
     }
 
@@ -330,7 +363,7 @@ impl SqliteSkillStore {
         let conn = crate::shared_db::lock_connection(&self.conn)?;
         let mut stmt = conn.prepare_cached(
             "SELECT id, skill_id, version, snapshot_json, name, description, status,
-                    changed_by, changed_at, change_note
+                    changed_by, changed_at, change_note, operation
              FROM skill_versions WHERE skill_id = ?1 ORDER BY version DESC",
         )?;
         let versions = stmt
@@ -349,6 +382,7 @@ impl SqliteSkillStore {
                     changed_by: row.get(7)?,
                     changed_at: parse_datetime(&row.get::<_, String>(8)?),
                     change_note: row.get(9)?,
+                    operation: row.get(10)?,
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -387,7 +421,9 @@ impl SqliteSkillStore {
             StoreError::Parse(format!("invalid skill history for {id}: {error}"))
         })?;
         if restored.id != id {
-            return Err(StoreError::Parse(format!("skill history ID mismatch for: {id}")));
+            return Err(StoreError::Parse(format!(
+                "skill history ID mismatch for: {id}"
+            )));
         }
         let default_note;
         let note = match (change_note, version) {
@@ -398,7 +434,7 @@ impl SqliteSkillStore {
             }
             (None, None) => Some("restore latest version"),
         };
-        self.update_recorded(&restored, changed_by, note)
+        self.update_recorded(&restored, changed_by, note, "restore")
     }
 }
 
@@ -418,8 +454,14 @@ impl SkillStore for SqliteSkillStore {
     }
 
     fn add(&self, skill: &Skill) -> Result<()> {
-        let conn = crate::shared_db::lock_connection(&self.conn)?;
-        conn.execute(
+        let snapshot_json = serde_json::to_string(skill).map_err(|error| {
+            StoreError::Parse(format!("failed to serialize skill history: {error}"))
+        })?;
+        let changed_by = default_changed_by();
+        let changed_at = Utc::now().to_rfc3339();
+        let mut conn = crate::shared_db::lock_connection(&self.conn)?;
+        let tx = conn.transaction()?;
+        tx.execute(
             "INSERT INTO skills (id, name, description, skill_type, invocation, parameters_schema,
              example, preconditions, postconditions, validation_script, status, tags, summary,
              usage_count, created_at, updated_at, last_used, invokable, argument_hint,
@@ -457,6 +499,19 @@ impl SkillStore for SqliteSkillStore {
                 Self::tags_to_string(&skill.source_ids),
             ],
         )?;
+        Self::insert_version(
+            &tx,
+            &skill.id,
+            &snapshot_json,
+            &skill.name,
+            &skill.description,
+            skill.status,
+            &changed_by,
+            &changed_at,
+            "create",
+            "create",
+        )?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -477,7 +532,7 @@ impl SkillStore for SqliteSkillStore {
     }
 
     fn update(&self, skill: &Skill) -> Result<()> {
-        self.update_recorded(skill, None, None)
+        self.update_recorded(skill, None, None, "update")
     }
 
     fn update_with_metadata(
@@ -486,7 +541,7 @@ impl SkillStore for SqliteSkillStore {
         changed_by: Option<&str>,
         change_note: Option<&str>,
     ) -> Result<()> {
-        self.update_recorded(skill, changed_by, change_note)
+        self.update_recorded(skill, changed_by, change_note, "update")
     }
 
     fn delete(&self, id: &str) -> Result<()> {
@@ -690,8 +745,9 @@ mod tests {
             .unwrap();
 
         let versions = store.list_versions("skill-history-01").unwrap();
-        assert_eq!(versions.len(), 1);
+        assert_eq!(versions.len(), 2);
         assert_eq!(versions[0].description, "");
+        assert_eq!(versions[0].operation, "update");
         assert_eq!(versions[0].changed_by.as_deref(), Some("test-actor"));
         assert_eq!(versions[0].change_note, "revise instructions");
 
@@ -715,7 +771,15 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version_count, 2);
+        assert_eq!(version_count, 3);
+        let operation: String = conn
+            .query_row(
+                "SELECT operation FROM skill_versions WHERE skill_id = 'skill-history-01' AND version = 3",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(operation, "delete");
 
         store
             .restore_version("skill-history-01", Some(1), Some("restorer"), None)

--- a/crates/cas-store/src/skill_store.rs
+++ b/crates/cas-store/src/skill_store.rs
@@ -725,6 +725,37 @@ mod tests {
         assert_eq!(restored.status, SkillStatus::Enabled);
     }
 
+    /// cas-ef20: creating a skill is an auditable lifecycle mutation too. The
+    /// initial snapshot must be restorable and identify the create operation.
+    #[test]
+    fn test_skill_create_is_versioned() {
+        let temp = TempDir::new().unwrap();
+        let store = SqliteSkillStore::open(temp.path()).unwrap();
+        store.init().unwrap();
+
+        let skill = Skill::new(
+            "skill-create-history-01".to_string(),
+            "Created Skill".to_string(),
+        );
+        store.add(&skill).unwrap();
+
+        let versions = store.list_versions(&skill.id).unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, 1);
+        assert_eq!(versions[0].name, skill.name);
+        assert_eq!(versions[0].status, skill.status);
+
+        let conn = Connection::open(temp.path().join("cas.db")).unwrap();
+        let operation: String = conn
+            .query_row(
+                "SELECT operation FROM skill_versions WHERE skill_id = ?1",
+                [&skill.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(operation, "create");
+    }
+
     #[test]
     fn test_skill_invokable() {
         let (_temp, store) = create_test_store();

--- a/crates/cas-store/src/sqlite/rule_store_trait.rs
+++ b/crates/cas-store/src/sqlite/rule_store_trait.rs
@@ -7,19 +7,56 @@ use crate::version_store::{
 use crate::{Result, RuleStore};
 use cas_types::{Rule, RuleStatus};
 use chrono::Utc;
-use rusqlite::{OptionalExtension, params};
+use rusqlite::{OptionalExtension, Transaction, params};
 
 impl SqliteRuleStore {
+    fn insert_version(
+        tx: &Transaction<'_>,
+        rule_id: &str,
+        snapshot_json: &str,
+        content: &str,
+        status: RuleStatus,
+        changed_by: &Option<String>,
+        changed_at: &str,
+        change_note: &str,
+        operation: &str,
+    ) -> Result<()> {
+        let next_version: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(version), 0) + 1 FROM rule_versions WHERE rule_id = ?1",
+            params![rule_id],
+            |row| row.get(0),
+        )?;
+        tx.execute(
+            "INSERT INTO rule_versions
+             (rule_id, version, snapshot_json, content, status, changed_by, changed_at, change_note, operation)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                rule_id,
+                next_version,
+                snapshot_json,
+                content,
+                status.to_string(),
+                changed_by,
+                changed_at,
+                change_note,
+                operation,
+            ],
+        )?;
+        Ok(())
+    }
+
     fn update_recorded(
         &self,
         rule: &Rule,
         changed_by: Option<&str>,
         change_note: Option<&str>,
+        operation: &str,
     ) -> Result<()> {
         let timer = TraceTimer::new();
         let previous = self.get(&rule.id)?;
-        let snapshot_json = serde_json::to_string(&previous)
-            .map_err(|error| StoreError::Parse(format!("failed to serialize rule history: {error}")))?;
+        let snapshot_json = serde_json::to_string(&previous).map_err(|error| {
+            StoreError::Parse(format!("failed to serialize rule history: {error}"))
+        })?;
         let changed_by = changed_by
             .map(ToOwned::to_owned)
             .or_else(default_changed_by);
@@ -29,25 +66,16 @@ impl SqliteRuleStore {
         let result = (|| -> Result<()> {
             let mut conn = crate::shared_db::lock_connection(&self.conn)?;
             let tx = conn.transaction()?;
-            let next_version: i64 = tx.query_row(
-                "SELECT COALESCE(MAX(version), 0) + 1 FROM rule_versions WHERE rule_id = ?1",
-                params![&rule.id],
-                |row| row.get(0),
-            )?;
-            tx.execute(
-                "INSERT INTO rule_versions
-                 (rule_id, version, snapshot_json, content, status, changed_by, changed_at, change_note)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                params![
-                    &rule.id,
-                    next_version,
-                    snapshot_json,
-                    previous.content,
-                    previous.status.to_string(),
-                    changed_by,
-                    changed_at,
-                    change_note,
-                ],
+            Self::insert_version(
+                &tx,
+                &rule.id,
+                &snapshot_json,
+                &previous.content,
+                previous.status,
+                &changed_by,
+                &changed_at,
+                change_note,
+                operation,
             )?;
             let rows = tx.execute(
                 "UPDATE rules SET source_ids = ?1, helpful_count = ?2, harmful_count = ?3,
@@ -118,6 +146,7 @@ impl SqliteRuleStore {
             &retired,
             changed_by,
             Some(change_note.unwrap_or("tombstone delete")),
+            "delete",
         )
     }
 
@@ -125,7 +154,7 @@ impl SqliteRuleStore {
         let conn = crate::shared_db::lock_connection(&self.conn)?;
         let mut stmt = conn.prepare_cached(
             "SELECT id, rule_id, version, snapshot_json, content, status,
-                    changed_by, changed_at, change_note
+                    changed_by, changed_at, change_note, operation
              FROM rule_versions WHERE rule_id = ?1 ORDER BY version DESC",
         )?;
         let versions = stmt
@@ -143,6 +172,7 @@ impl SqliteRuleStore {
                     changed_by: row.get(6)?,
                     changed_at: parse_datetime(&row.get::<_, String>(7)?),
                     change_note: row.get(8)?,
+                    operation: row.get(9)?,
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -181,7 +211,9 @@ impl SqliteRuleStore {
             StoreError::Parse(format!("invalid rule history for {id}: {error}"))
         })?;
         if restored.id != id {
-            return Err(StoreError::Parse(format!("rule history ID mismatch for: {id}")));
+            return Err(StoreError::Parse(format!(
+                "rule history ID mismatch for: {id}"
+            )));
         }
         let default_note;
         let note = match (change_note, version) {
@@ -192,7 +224,7 @@ impl SqliteRuleStore {
             }
             (None, None) => Some("restore latest version"),
         };
-        self.update_recorded(&restored, changed_by, note)
+        self.update_recorded(&restored, changed_by, note, "restore")
     }
 }
 
@@ -248,35 +280,56 @@ impl RuleStore for SqliteRuleStore {
 
     fn add(&self, rule: &Rule) -> Result<()> {
         let timer = TraceTimer::new();
-        let conn = crate::shared_db::lock_connection(&self.conn)?;
-        let result = conn.execute(
-            "INSERT INTO rules (id, created, source_ids, helpful_count, harmful_count,
-             tags, paths, content, status, last_accessed, review_after, hook_command,
-             category, priority, surface_count, scope, auto_approve_tools, auto_approve_paths, team_id, share)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
-            params![
-                rule.id,
-                rule.created.to_rfc3339(),
-                Self::source_ids_to_string(&rule.source_ids),
-                rule.helpful_count,
-                rule.harmful_count,
-                Self::tags_to_string(&rule.tags),
-                rule.paths,
-                rule.content,
-                rule.status.to_string(),
-                rule.last_accessed.map(|t| t.to_rfc3339()),
-                rule.review_after.map(|t| t.to_rfc3339()),
-                rule.hook_command.as_ref(),
-                rule.category.to_string(),
-                rule.priority,
-                rule.surface_count,
-                rule.scope.to_string(),
-                rule.auto_approve_tools.as_ref(),
-                rule.auto_approve_paths.as_ref(),
-                rule.team_id.as_ref(),
-                rule.share.as_ref().map(|s| s.to_string()),
-            ],
-        );
+        let snapshot_json = serde_json::to_string(rule).map_err(|error| {
+            StoreError::Parse(format!("failed to serialize rule history: {error}"))
+        });
+        let result = snapshot_json.and_then(|snapshot_json| {
+            let changed_by = default_changed_by();
+            let changed_at = Utc::now().to_rfc3339();
+            let mut conn = crate::shared_db::lock_connection(&self.conn)?;
+            let tx = conn.transaction()?;
+            tx.execute(
+                "INSERT INTO rules (id, created, source_ids, helpful_count, harmful_count,
+                 tags, paths, content, status, last_accessed, review_after, hook_command,
+                 category, priority, surface_count, scope, auto_approve_tools, auto_approve_paths, team_id, share)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
+                params![
+                    rule.id,
+                    rule.created.to_rfc3339(),
+                    Self::source_ids_to_string(&rule.source_ids),
+                    rule.helpful_count,
+                    rule.harmful_count,
+                    Self::tags_to_string(&rule.tags),
+                    rule.paths,
+                    rule.content,
+                    rule.status.to_string(),
+                    rule.last_accessed.map(|t| t.to_rfc3339()),
+                    rule.review_after.map(|t| t.to_rfc3339()),
+                    rule.hook_command.as_ref(),
+                    rule.category.to_string(),
+                    rule.priority,
+                    rule.surface_count,
+                    rule.scope.to_string(),
+                    rule.auto_approve_tools.as_ref(),
+                    rule.auto_approve_paths.as_ref(),
+                    rule.team_id.as_ref(),
+                    rule.share.as_ref().map(|s| s.to_string()),
+                ],
+            )?;
+            Self::insert_version(
+                &tx,
+                &rule.id,
+                &snapshot_json,
+                &rule.content,
+                rule.status,
+                &changed_by,
+                &changed_at,
+                "create",
+                "create",
+            )?;
+            tx.commit()?;
+            Ok(())
+        });
 
         // Record trace
         if let Some(tracer) = DevTracer::get() {
@@ -353,7 +406,7 @@ impl RuleStore for SqliteRuleStore {
     }
 
     fn update(&self, rule: &Rule) -> Result<()> {
-        self.update_recorded(rule, None, None)
+        self.update_recorded(rule, None, None, "update")
     }
 
     fn update_with_metadata(
@@ -362,7 +415,7 @@ impl RuleStore for SqliteRuleStore {
         changed_by: Option<&str>,
         change_note: Option<&str>,
     ) -> Result<()> {
-        self.update_recorded(rule, changed_by, change_note)
+        self.update_recorded(rule, changed_by, change_note, "update")
     }
 
     fn increment_surface_count(&self, id: &str) -> Result<()> {

--- a/crates/cas-store/src/sqlite/tests.rs
+++ b/crates/cas-store/src/sqlite/tests.rs
@@ -283,7 +283,10 @@ fn test_rule_history_and_tombstone_delete() {
     let store = SqliteRuleStore::open(temp.path()).unwrap();
     store.init().unwrap();
 
-    let rule = Rule::new("rule-history-01".to_string(), "original content".to_string());
+    let rule = Rule::new(
+        "rule-history-01".to_string(),
+        "original content".to_string(),
+    );
     store.add(&rule).unwrap();
     let mut updated = rule.clone();
     updated.content = "updated content".to_string();
@@ -292,8 +295,9 @@ fn test_rule_history_and_tombstone_delete() {
         .unwrap();
 
     let versions = store.list_versions("rule-history-01").unwrap();
-    assert_eq!(versions.len(), 1);
+    assert_eq!(versions.len(), 2);
     assert_eq!(versions[0].content, "original content");
+    assert_eq!(versions[0].operation, "update");
     assert_eq!(versions[0].changed_by.as_deref(), Some("test-actor"));
     assert_eq!(versions[0].change_note, "revise wording");
 
@@ -317,7 +321,15 @@ fn test_rule_history_and_tombstone_delete() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(version_count, 2);
+    assert_eq!(version_count, 3);
+    let operation: String = conn
+        .query_row(
+            "SELECT operation FROM rule_versions WHERE rule_id = 'rule-history-01' AND version = 3",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(operation, "delete");
 
     store
         .restore_version("rule-history-01", Some(1), Some("restorer"), None)
@@ -335,7 +347,10 @@ fn test_rule_create_is_versioned() {
     let store = SqliteRuleStore::open(temp.path()).unwrap();
     store.init().unwrap();
 
-    let rule = Rule::new("rule-create-history-01".to_string(), "created content".to_string());
+    let rule = Rule::new(
+        "rule-create-history-01".to_string(),
+        "created content".to_string(),
+    );
     store.add(&rule).unwrap();
 
     let versions = store.list_versions(&rule.id).unwrap();

--- a/crates/cas-store/src/sqlite/tests.rs
+++ b/crates/cas-store/src/sqlite/tests.rs
@@ -327,6 +327,34 @@ fn test_rule_history_and_tombstone_delete() {
     assert_eq!(restored.status, cas_types::RuleStatus::Draft);
 }
 
+/// cas-ef20: creating a rule is an auditable lifecycle mutation too. The
+/// initial snapshot must be restorable and identify the create operation.
+#[test]
+fn test_rule_create_is_versioned() {
+    let temp = TempDir::new().unwrap();
+    let store = SqliteRuleStore::open(temp.path()).unwrap();
+    store.init().unwrap();
+
+    let rule = Rule::new("rule-create-history-01".to_string(), "created content".to_string());
+    store.add(&rule).unwrap();
+
+    let versions = store.list_versions(&rule.id).unwrap();
+    assert_eq!(versions.len(), 1);
+    assert_eq!(versions[0].version, 1);
+    assert_eq!(versions[0].content, rule.content);
+    assert_eq!(versions[0].status, rule.status);
+
+    let conn = rusqlite::Connection::open(temp.path().join("cas.db")).unwrap();
+    let operation: String = conn
+        .query_row(
+            "SELECT operation FROM rule_versions WHERE rule_id = ?1",
+            [&rule.id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(operation, "create");
+}
+
 /// T5 cas-07d7: Skill.share must round-trip. First code-review round
 /// found the skill SELECT/INSERT/UPDATE had silently skipped the
 /// `share` column; this test exists to catch that regression class.

--- a/crates/cas-store/src/version_store.rs
+++ b/crates/cas-store/src/version_store.rs
@@ -1,21 +1,21 @@
 //! Shared schema and records for rule/skill lifecycle history.
 
-use chrono::{DateTime, Utc};
 use cas_types::{RuleStatus, SkillStatus};
+use chrono::{DateTime, Utc};
 
 /// Statements used by the numbered migration and lazy SQLite store bootstrap.
 pub const RULE_VERSIONS_SCHEMA_STATEMENTS: &[&str] = &[
-    "CREATE TABLE IF NOT EXISTS rule_versions (id INTEGER PRIMARY KEY AUTOINCREMENT, rule_id TEXT NOT NULL, version INTEGER NOT NULL, snapshot_json TEXT NOT NULL, content TEXT NOT NULL, status TEXT NOT NULL, changed_by TEXT, changed_at TEXT NOT NULL, change_note TEXT NOT NULL, UNIQUE(rule_id, version))",
+    "CREATE TABLE IF NOT EXISTS rule_versions (id INTEGER PRIMARY KEY AUTOINCREMENT, rule_id TEXT NOT NULL, version INTEGER NOT NULL, snapshot_json TEXT NOT NULL, content TEXT NOT NULL, status TEXT NOT NULL, changed_by TEXT, changed_at TEXT NOT NULL, change_note TEXT NOT NULL, operation TEXT NOT NULL DEFAULT 'update', UNIQUE(rule_id, version))",
     "CREATE INDEX IF NOT EXISTS idx_rule_versions_rule ON rule_versions(rule_id, version DESC)",
 ];
 
 /// Statements used by the numbered migration and lazy SQLite store bootstrap.
 pub const SKILL_VERSIONS_SCHEMA_STATEMENTS: &[&str] = &[
-    "CREATE TABLE IF NOT EXISTS skill_versions (id INTEGER PRIMARY KEY AUTOINCREMENT, skill_id TEXT NOT NULL, version INTEGER NOT NULL, snapshot_json TEXT NOT NULL, name TEXT NOT NULL, description TEXT NOT NULL, status TEXT NOT NULL, changed_by TEXT, changed_at TEXT NOT NULL, change_note TEXT NOT NULL, UNIQUE(skill_id, version))",
+    "CREATE TABLE IF NOT EXISTS skill_versions (id INTEGER PRIMARY KEY AUTOINCREMENT, skill_id TEXT NOT NULL, version INTEGER NOT NULL, snapshot_json TEXT NOT NULL, name TEXT NOT NULL, description TEXT NOT NULL, status TEXT NOT NULL, changed_by TEXT, changed_at TEXT NOT NULL, change_note TEXT NOT NULL, operation TEXT NOT NULL DEFAULT 'update', UNIQUE(skill_id, version))",
     "CREATE INDEX IF NOT EXISTS idx_skill_versions_skill ON skill_versions(skill_id, version DESC)",
 ];
 
-/// Combined statements for migration m237.
+/// Combined statements for migration m240 and lazy SQLite store bootstrap.
 pub const RULE_AND_SKILL_VERSIONS_SCHEMA_STATEMENTS: &[&str] = &[
     RULE_VERSIONS_SCHEMA_STATEMENTS[0],
     RULE_VERSIONS_SCHEMA_STATEMENTS[1],
@@ -34,6 +34,9 @@ pub struct RuleVersion {
     pub changed_by: Option<String>,
     pub changed_at: DateTime<Utc>,
     pub change_note: String,
+    /// Lifecycle operation that produced this snapshot (`create`, `update`,
+    /// `delete`, or `restore`).
+    pub operation: String,
     pub snapshot_json: String,
 }
 
@@ -49,6 +52,9 @@ pub struct SkillVersion {
     pub changed_by: Option<String>,
     pub changed_at: DateTime<Utc>,
     pub change_note: String,
+    /// Lifecycle operation that produced this snapshot (`create`, `update`,
+    /// `delete`, or `restore`).
+    pub operation: String,
     pub snapshot_json: String,
 }
 
@@ -56,7 +62,11 @@ pub struct SkillVersion {
 pub(crate) fn default_changed_by() -> Option<String> {
     ["CAS_AGENT_NAME", "CAS_AGENT_ID", "USER"]
         .into_iter()
-        .find_map(|key| std::env::var(key).ok().filter(|value| !value.trim().is_empty()))
+        .find_map(|key| {
+            std::env::var(key)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
 }
 
 pub(crate) fn parse_datetime(value: &str) -> DateTime<Utc> {


### PR DESCRIPTION
## Summary
- record create, update, delete, and restore snapshots for rules and skills
- add operation metadata and migration m242 for existing version ledgers
- preserve tombstone and restore history through MCP, with retired rules excluded from sync

## Verification
- scripts/run-scoped-tests.sh --proof --workspace --lib --test mcp_tools_test
- 7319 tests passed, 6 skipped
- scoped proof surface covered committed diff from origin/main