### PR TITLE
Append-only trace archive with bounded retention [cas-2b42]

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Doctor reports which cloud bucket the project resolves to and why, warns when tw
 ├── cas.db          # SQLite — memories, tasks, rules, skills, entities, agents
 ├── config.toml     # project configuration
 ├── knowledge/      # distilled wiki pages (markdown)
+├── archive/        # compressed, write-once event/recording trace archives
 ├── index/          # tantivy/ (BM25), code/ (symbols), knowledge-vectors/
 ├── logs/           # daily rolling logs
 └── worktrees/      # factory worker checkouts
@@ -342,6 +343,10 @@ One binary crate (`cas-cli`) plus 16 libraries under `crates/`:
 Built with Rust, SQLite, Tantivy, Ratatui, Ghostty VT and rmcp.
 
 Deeper material: [ARCHITECTURE.md](cas-cli/docs/ARCHITECTURE.md) (crates, stores, hook scoring, search reality check) · [CONTRIBUTING.md](cas-cli/docs/CONTRIBUTING.md) (adding commands, MCP tools, migrations, tests) · [CODEMAP.md](.claude/CODEMAP.md) (module-level navigation) · [CHANGELOG.md](CHANGELOG.md).
+
+Trace retention: [TRACE-ARCHIVES.md](docs/TRACE-ARCHIVES.md) describes the
+30-day live window, compressed archive format, finite byte cap, read API, and
+upgrade behavior for traces removed by older versions.
 
 ## Cloud (optional)
 

--- a/cas-cli/src/config/access/get.rs
+++ b/cas-cli/src/config/access/get.rs
@@ -54,6 +54,7 @@ impl Config {
             "dev.trace_claude_api" => Some(dev.trace_claude_api.to_string()),
             "dev.trace_hooks" => Some(dev.trace_hooks.to_string()),
             "dev.trace_retention_days" => Some(dev.trace_retention_days.to_string()),
+            "daemon.archive_max_bytes" => Some(daemon.archive_max_bytes.to_string()),
             "daemon.archive_retention_days" => Some(daemon.archive_retention_days.to_string()),
             // Code section
             "code.enabled" => Some(self.code.clone().unwrap_or_default().enabled.to_string()),

--- a/cas-cli/src/config/access/list.rs
+++ b/cas-cli/src/config/access/list.rs
@@ -137,6 +137,10 @@ impl Config {
                 dev.trace_retention_days.to_string(),
             ),
             (
+                "daemon.archive_max_bytes".to_string(),
+                daemon.archive_max_bytes.to_string(),
+            ),
+            (
                 "daemon.archive_retention_days".to_string(),
                 daemon.archive_retention_days.to_string(),
             ),

--- a/cas-cli/src/config/access/set.rs
+++ b/cas-cli/src/config/access/set.rs
@@ -243,6 +243,12 @@ impl Config {
                     .map_err(|_| MemError::Parse(format!("Invalid integer value: {value}")))?;
             }
             // Daemon section
+            "daemon.archive_max_bytes" => {
+                let daemon = self.daemon.get_or_insert_with(DaemonSettings::default);
+                daemon.archive_max_bytes = value
+                    .parse()
+                    .map_err(|_| MemError::Parse(format!("Invalid integer value: {value}")))?;
+            }
             "daemon.archive_retention_days" => {
                 let daemon = self.daemon.get_or_insert_with(DaemonSettings::default);
                 daemon.archive_retention_days = value

--- a/cas-cli/src/config/meta/seed/daemon.rs
+++ b/cas-cli/src/config/meta/seed/daemon.rs
@@ -3,10 +3,27 @@ use crate::config::meta::types::{ConfigMeta, ConfigType, Constraint};
 
 pub(super) fn register_daemon(registry: &mut ConfigRegistry) {
     registry.register(ConfigMeta {
+        key: "daemon.archive_max_bytes",
+        section: "daemon",
+        name: "Trace Archive Size Cap",
+        description: "Maximum total bytes for compressed event and recording archives. Oldest files are evicted first; the default is 1 GiB. Set a positive value; zero is rejected.",
+        value_type: ConfigType::Int,
+        default: "1073741824",
+        constraint: Constraint::Min(1),
+        advanced: true,
+        requires_feature: None,
+        keywords: &["daemon", "archive", "size", "cap", "events", "recordings", "storage"],
+        use_cases: &[
+            "Bound trace archive disk usage with a finite compressed-byte cap",
+            "Raise the cap when Wiki-Maintainer sampling needs a longer history",
+        ],
+    });
+
+    registry.register(ConfigMeta {
         key: "daemon.archive_retention_days",
         section: "daemon",
-        name: "Trace Archive Retention",
-        description: "Days to retain compressed event and recording archives. Zero keeps archives forever.",
+        name: "Legacy Trace Archive Age",
+        description: "Legacy compatibility setting; archive retention is now bounded by daemon.archive_max_bytes and oldest files are evicted first.",
         value_type: ConfigType::Int,
         default: "0",
         constraint: Constraint::Min(0),
@@ -14,8 +31,7 @@ pub(super) fn register_daemon(registry: &mut ConfigRegistry) {
         requires_feature: None,
         keywords: &["daemon", "archive", "retention", "events", "recordings", "storage"],
         use_cases: &[
-            "Keep the default zero for append-only archives",
-            "Set a positive value to reclaim old archive files",
+            "Retain this key while migrating older config files",
         ],
     });
 }

--- a/cas-cli/src/config/mod_tests.rs
+++ b/cas-cli/src/config/mod_tests.rs
@@ -9,6 +9,10 @@ fn test_config_defaults() {
     assert!(config.sync.enabled);
     assert_eq!(config.sync.target, ".claude/rules/cas");
     assert_eq!(config.sync.min_helpful, 1);
+    assert_eq!(
+        config.daemon().archive_max_bytes,
+        cas_store::DEFAULT_TRACE_ARCHIVE_MAX_BYTES
+    );
     assert_eq!(config.daemon().archive_retention_days, 0);
     assert_eq!(config.sync.promotion_threshold, 2);
     assert_eq!(config.sync.promotion_evidence, vec!["helpful"]);
@@ -38,6 +42,30 @@ fn daemon_archive_retention_is_configurable_and_round_trips() {
     config.save(temp.path()).unwrap();
     let loaded = Config::load(temp.path()).unwrap();
     assert_eq!(loaded.daemon().archive_retention_days, 90);
+}
+
+#[test]
+fn daemon_archive_size_cap_is_configurable_and_rejects_zero() {
+    let temp = TempDir::new().unwrap();
+    let mut config = Config::default();
+
+    assert_eq!(
+        config.get("daemon.archive_max_bytes"),
+        Some(cas_store::DEFAULT_TRACE_ARCHIVE_MAX_BYTES.to_string())
+    );
+    config.set("daemon.archive_max_bytes", "4096").unwrap();
+    assert_eq!(config.daemon().archive_max_bytes, 4096);
+    assert!(
+        config
+            .list()
+            .contains(&("daemon.archive_max_bytes".to_string(), "4096".to_string()))
+    );
+    assert!(meta::registry().get("daemon.archive_max_bytes").is_some());
+    assert!(config.set("daemon.archive_max_bytes", "0").is_err());
+
+    config.save(temp.path()).unwrap();
+    let loaded = Config::load(temp.path()).unwrap();
+    assert_eq!(loaded.daemon().archive_max_bytes, 4096);
 }
 
 #[test]

--- a/cas-cli/src/config/settings.rs
+++ b/cas-cli/src/config/settings.rs
@@ -729,15 +729,25 @@ impl Default for DevConfig {
 /// Daemon maintenance configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DaemonSettings {
+    /// Maximum total bytes for compressed event/recording archives. Oldest
+    /// archive files are evicted first when this cap is exceeded.
+    #[serde(default = "default_archive_max_bytes")]
+    pub archive_max_bytes: u64,
+
     /// Days to retain compressed event/recording archives. Zero keeps them
-    /// forever (the default).
+    /// forever (legacy compatibility; maintenance now uses archive_max_bytes).
     #[serde(default)]
     pub archive_retention_days: u64,
+}
+
+fn default_archive_max_bytes() -> u64 {
+    cas_store::DEFAULT_TRACE_ARCHIVE_MAX_BYTES
 }
 
 impl Default for DaemonSettings {
     fn default() -> Self {
         Self {
+            archive_max_bytes: default_archive_max_bytes(),
             archive_retention_days: 0,
         }
     }

--- a/cas-cli/src/daemon/maintenance.rs
+++ b/cas-cli/src/daemon/maintenance.rs
@@ -50,6 +50,7 @@ pub fn run_maintenance(config: &DaemonConfig) -> Result<DaemonRunResult, CasErro
     let mut events_pruned = 0;
     let mut lease_history_pruned = 0;
     let mut recordings_pruned = 0;
+    let mut trace_archives_evicted = 0;
 
     let store = open_store(&config.cas_root)?;
 
@@ -250,9 +251,9 @@ pub fn run_maintenance(config: &DaemonConfig) -> Result<DaemonRunResult, CasErro
     }
 
     if config.auto_prune {
-        match cas_store::prune_trace_archives(&config.cas_root, config.archive_retention_days) {
-            Ok(_) => {}
-            Err(error) => errors.push(format!("Trace archive retention failed: {error}")),
+        match cas_store::enforce_trace_archive_size(&config.cas_root, config.archive_max_bytes) {
+            Ok(eviction) => trace_archives_evicted = eviction.files_evicted,
+            Err(error) => errors.push(format!("Trace archive size cap failed: {error}")),
         }
     }
 
@@ -297,6 +298,7 @@ pub fn run_maintenance(config: &DaemonConfig) -> Result<DaemonRunResult, CasErro
         events_pruned,
         lease_history_pruned,
         recordings_pruned,
+        trace_archives_evicted,
         agents_cleaned,
         agents_purged,
         tasks_interrupted,

--- a/cas-cli/src/daemon/tests.rs
+++ b/cas-cli/src/daemon/tests.rs
@@ -441,6 +441,16 @@ fn test_maintenance_archives_old_events_and_recordings() {
         .iter()
         .any(|name| name.starts_with("recordings-")));
 
+    let listed =
+        crate::store::list_archived_traces(&cas_root, old - Duration::seconds(1), Utc::now())
+            .unwrap();
+    assert_eq!(listed.len(), 2);
+    assert!(listed.iter().all(|trace| trace.archive_path.exists()));
+    let sample =
+        crate::store::sample_archived_traces(&cas_root, old - Duration::seconds(1), Utc::now(), 1)
+            .unwrap();
+    assert_eq!(sample.len(), 1);
+
     let read_archive = |prefix: &str| {
         let name = archive_names
             .iter()
@@ -461,6 +471,47 @@ fn test_maintenance_archives_old_events_and_recordings() {
     assert_eq!(recording_archive["agents"].as_array().unwrap().len(), 1);
     assert_eq!(recording_archive["events"].as_array().unwrap().len(), 1);
     assert_eq!(recording_archive["fts"][0]["content"], "old transcript");
+}
+
+#[test]
+fn test_maintenance_enforces_trace_archive_size_cap() {
+    use crate::store::{init_cas_dir, open_event_store};
+    use cas_types::{Event, EventEntityType, EventType};
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let cas_root = init_cas_dir(temp.path()).unwrap();
+    let event_store = open_event_store(&cas_root).unwrap();
+    let mut event = Event::new(
+        EventType::TaskStarted,
+        EventEntityType::Task,
+        "cas-2b42",
+        "size-capped event",
+    );
+    event.created_at = Utc::now() - Duration::days(31);
+    event_store.record(&event).unwrap();
+
+    let result = run_once(&DaemonConfig {
+        cas_root: cas_root.clone(),
+        auto_prune: true,
+        archive_max_bytes: 1,
+        process_observations: false,
+        consolidate_memories: false,
+        apply_decay: false,
+        index_bm25: false,
+        update_entity_summaries: false,
+        agent_purge_age_hours: 0,
+        ..DaemonConfig::default()
+    })
+    .expect("maintenance cycle should succeed");
+
+    assert_eq!(result.events_pruned, 1);
+    assert_eq!(result.trace_archives_evicted, 1);
+    assert_eq!(
+        crate::store::trace_archive_stats(&cas_root).unwrap().bytes,
+        0
+    );
+    assert!(event_store.list_recent(10).unwrap().is_empty());
 }
 
 // ===== cas-499c: symbol index revival =====

--- a/cas-cli/src/daemon/types.rs
+++ b/cas-cli/src/daemon/types.rs
@@ -33,7 +33,10 @@ pub struct DaemonConfig {
     pub code_index_interval_secs: u64,
     /// Age (in hours) after which stale/shutdown agents are deleted (0 = never delete)
     pub agent_purge_age_hours: u64,
+    /// Maximum compressed bytes retained by immutable event/recording archives.
+    pub archive_max_bytes: u64,
     /// Days to retain immutable event/recording archives (0 = keep forever)
+    /// (legacy compatibility; size cap is the active retention policy).
     pub archive_retention_days: u64,
     /// Enable incremental BM25 indexing
     pub index_bm25: bool,
@@ -62,6 +65,7 @@ impl Default for DaemonConfig {
             code_watch_paths: vec![],
             code_index_interval_secs: 30,
             agent_purge_age_hours: 24,
+            archive_max_bytes: cas_store::DEFAULT_TRACE_ARCHIVE_MAX_BYTES,
             archive_retention_days: 0,
             index_bm25: true,
             index_batch_size: 32,
@@ -121,6 +125,8 @@ pub struct DaemonRunResult {
     pub lease_history_pruned: usize,
     /// Recordings pruned (older than retention period)
     pub recordings_pruned: usize,
+    /// Immutable trace archive files evicted to enforce the size cap.
+    pub trace_archives_evicted: usize,
     /// Stale agents cleaned (marked dead and leases reclaimed)
     pub agents_cleaned: usize,
     /// Old stale/shutdown agents permanently deleted

--- a/cas-cli/src/mcp/daemon.rs
+++ b/cas-cli/src/mcp/daemon.rs
@@ -271,6 +271,7 @@ impl EmbeddedDaemonConfigExt for EmbeddedDaemonConfig {
             code_watch_paths: self.code_watch_paths.clone(),
             code_index_interval_secs: self.code_index_interval_secs,
             agent_purge_age_hours: 24, // Delete stale agents after 24 hours
+            archive_max_bytes: self.archive_max_bytes,
             archive_retention_days: self.archive_retention_days,
             // BM25 indexing
             index_bm25: true,

--- a/cas-cli/src/mcp/daemon_tests/tests.rs
+++ b/cas-cli/src/mcp/daemon_tests/tests.rs
@@ -33,6 +33,7 @@ fn test_daemon_config_conversion() {
     let daemon_config = config.to_daemon_config();
     assert_eq!(daemon_config.interval_minutes, 30);
     assert_eq!(daemon_config.cas_root, PathBuf::from("/tmp/cas"));
+    assert_eq!(daemon_config.archive_max_bytes, config.archive_max_bytes);
     assert_eq!(daemon_config.archive_retention_days, 90);
 }
 

--- a/cas-cli/src/mcp/server/mod.rs
+++ b/cas-cli/src/mcp/server/mod.rs
@@ -388,8 +388,11 @@ impl CasCore {
                 data: None,
             })?;
             Ok(format!(
-                "Maintenance completed in {:.2}s:\n- Observations: {}\n- Decay applied: {}",
-                result.duration_secs, result.observations_processed, result.decay_applied
+                "Maintenance completed in {:.2}s:\n- Observations: {}\n- Decay applied: {}\n- Trace archives evicted: {}",
+                result.duration_secs,
+                result.observations_processed,
+                result.decay_applied,
+                result.trace_archives_evicted
             ))
         } else {
             Err(McpError {

--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -253,6 +253,7 @@ async fn run_server_impl() -> anyhow::Result<()> {
             code_exclude_patterns: code_config.exclude_patterns.clone(),
             code_index_interval_secs: code_config.index_interval_secs,
             code_debounce_ms: code_config.debounce_ms,
+            archive_max_bytes: daemon_config.archive_max_bytes,
             archive_retention_days: daemon_config.archive_retention_days,
             ..Default::default()
         };

--- a/cas-cli/src/mcp/tools/core/maintenance.rs
+++ b/cas-cli/src/mcp/tools/core/maintenance.rs
@@ -68,17 +68,23 @@ impl CasCore {
             Ok(result) => Ok(Self::success(result)),
             Err(e) => {
                 // Fallback: run maintenance directly if daemon not available
+                let archive_max_bytes = crate::config::Config::load(&self.cas_root)
+                    .unwrap_or_default()
+                    .daemon()
+                    .archive_max_bytes;
                 let daemon_config = crate::daemon::DaemonConfig {
                     cas_root: self.cas_root.clone(),
+                    archive_max_bytes,
                     ..Default::default()
                 };
 
                 match crate::daemon::run_maintenance(&daemon_config) {
                     Ok(result) => Ok(Self::success(format!(
-                        "Maintenance completed in {:.2}s:\n- Observations: {}\n- Decay applied: {}\n- Errors: {}",
+                        "Maintenance completed in {:.2}s:\n- Observations: {}\n- Decay applied: {}\n- Trace archives evicted: {}\n- Errors: {}",
                         result.duration_secs,
                         result.observations_processed,
                         result.decay_applied,
+                        result.trace_archives_evicted,
                         result.errors.len()
                     ))),
                     Err(run_err) => Err(Self::error(

--- a/cas-cli/src/store/mod.rs
+++ b/cas-cli/src/store/mod.rs
@@ -129,9 +129,12 @@ pub use cas_store::{
     // Prompt store helpers
     add_prompt_with_conn,
     get_current_prompt_for_session,
+    list_archived_traces,
     layered,
     // Modules
     markdown,
+    sample_archived_traces,
+    trace_archive_stats,
 };
 
 // Local modules (not in cas-store)

--- a/crates/cas-mcp/src/daemon.rs
+++ b/crates/cas-mcp/src/daemon.rs
@@ -109,7 +109,10 @@ pub struct EmbeddedDaemonConfig {
     pub cloud_sync_enabled: bool,
     /// Batch size for operations
     pub batch_size: usize,
+    /// Maximum compressed bytes retained by immutable event/recording archives.
+    pub archive_max_bytes: u64,
     /// Days to retain immutable event/recording archives (0 = keep forever)
+    /// (legacy compatibility; size cap is the active retention policy).
     pub archive_retention_days: u64,
     // === Code indexing configuration ===
     /// Enable background code indexing
@@ -156,6 +159,7 @@ impl Default for EmbeddedDaemonConfig {
             process_observations: true,
             cloud_sync_enabled: true, // Auto-sync enabled by default
             batch_size: 20,
+            archive_max_bytes: cas_store::DEFAULT_TRACE_ARCHIVE_MAX_BYTES,
             archive_retention_days: 0,
             // Code indexing defaults
             index_code: false, // Disabled by default (opt-in)

--- a/crates/cas-store/src/lib.rs
+++ b/crates/cas-store/src/lib.rs
@@ -91,8 +91,10 @@ mod worktree_lease_test;
 pub use error::{Result, StoreError};
 
 pub use trace_archive::{
-    RecordingArchive, RecordingFtsEntry, TraceArchiveStats, prune_trace_archives,
-    trace_archive_stats, write_jsonl_archive,
+    ArchivedTrace, ArchivedTraceRecord, DEFAULT_TRACE_ARCHIVE_MAX_BYTES, RecordingArchive,
+    RecordingFtsEntry, TraceArchiveEviction, TraceArchiveStats, enforce_trace_archive_size,
+    list_archived_traces, prune_trace_archives, sample_archived_traces, trace_archive_stats,
+    write_jsonl_archive,
 };
 
 // Agent store for multi-agent coordination

--- a/crates/cas-store/src/trace_archive.rs
+++ b/crates/cas-store/src/trace_archive.rs
@@ -5,11 +5,11 @@
 //! rewrite an earlier archive.  The JSONL format keeps individual records
 //! recoverable without making the archive a live query surface.
 
-use cas_types::{Recording, RecordingAgent, RecordingEvent};
-use chrono::Utc;
-use serde::{Deserialize, Serialize};
+use cas_types::{Event, Recording, RecordingAgent, RecordingEvent};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
@@ -18,6 +18,13 @@ use crate::Result;
 
 const TRACE_ARCHIVE_EXTENSION: &str = ".jsonl.zst";
 const TRACE_ARCHIVE_DIR: &str = "archive";
+
+/// Default total on-disk size for immutable event and recording archives.
+///
+/// A finite default is intentional: archive retention is size-bounded even
+/// when users do not add a daemon section to their config file.
+pub const DEFAULT_TRACE_ARCHIVE_MAX_BYTES: u64 = 1024 * 1024 * 1024;
+
 static ARCHIVE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 /// A recording row and its relational children as one archive record.
@@ -46,6 +53,35 @@ pub struct RecordingFtsEntry {
 pub struct TraceArchiveStats {
     pub files: usize,
     pub bytes: u64,
+}
+
+/// Result of enforcing the trace archive size cap.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TraceArchiveEviction {
+    /// Number of oldest archive files removed.
+    pub files_evicted: usize,
+    /// Compressed bytes removed from the archive directory.
+    pub bytes_evicted: u64,
+    /// Compressed bytes remaining after eviction.
+    pub remaining_bytes: u64,
+}
+
+/// One trace recovered from an immutable archive file.
+#[derive(Debug, Clone)]
+pub enum ArchivedTraceRecord {
+    Event(Event),
+    Recording(RecordingArchive),
+}
+
+/// A trace record plus the provenance needed to inspect its archive source.
+#[derive(Debug, Clone)]
+pub struct ArchivedTrace {
+    /// Event `created_at` or recording `created_at`, used for range queries.
+    pub recorded_at: DateTime<Utc>,
+    /// Immutable archive file containing this record.
+    pub archive_path: PathBuf,
+    /// Decoded event or recording payload.
+    pub record: ArchivedTraceRecord,
 }
 
 /// Write serialized records to a newly-created compressed JSONL archive.
@@ -135,9 +171,196 @@ pub fn trace_archive_stats(cas_root: &Path) -> Result<TraceArchiveStats> {
     Ok(stats)
 }
 
+/// Enforce a finite compressed-byte cap on immutable trace archives.
+///
+/// Files are sorted by modification time and removed oldest-first until the
+/// archive is at or below `max_bytes`. A zero cap is rejected so callers
+/// cannot accidentally configure silent unlimited retention; use the finite
+/// default or an explicit positive value instead.
+pub fn enforce_trace_archive_size(cas_root: &Path, max_bytes: u64) -> Result<TraceArchiveEviction> {
+    if max_bytes == 0 {
+        return Err(crate::StoreError::Other(
+            "trace archive size cap must be greater than zero".to_string(),
+        ));
+    }
+
+    let archive_dir = cas_root.join(TRACE_ARCHIVE_DIR);
+    let entries = match fs::read_dir(archive_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(TraceArchiveEviction::default());
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    let mut files = Vec::new();
+    let mut total_bytes = 0u64;
+    for entry in entries {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if !metadata.is_file() || !is_trace_archive_name(&entry.file_name()) {
+            continue;
+        }
+        let size = metadata.len();
+        total_bytes = total_bytes.saturating_add(size);
+        files.push((entry.path(), size, metadata.modified()?));
+    }
+
+    files.sort_by(|left, right| left.2.cmp(&right.2).then_with(|| left.0.cmp(&right.0)));
+
+    let mut eviction = TraceArchiveEviction {
+        remaining_bytes: total_bytes,
+        ..TraceArchiveEviction::default()
+    };
+    for (path, size, _) in files {
+        if eviction.remaining_bytes <= max_bytes {
+            break;
+        }
+
+        fs::remove_file(&path)?;
+        eviction.files_evicted += 1;
+        eviction.bytes_evicted = eviction.bytes_evicted.saturating_add(size);
+        eviction.remaining_bytes = eviction.remaining_bytes.saturating_sub(size);
+        tracing::info!(
+            path = %path.display(),
+            bytes = size,
+            cap_bytes = max_bytes,
+            remaining_bytes = eviction.remaining_bytes,
+            "evicted trace archive to enforce size cap"
+        );
+    }
+
+    Ok(eviction)
+}
+
+fn validate_archive_range(from: DateTime<Utc>, to: DateTime<Utc>) -> Result<()> {
+    if from > to {
+        return Err(crate::StoreError::Other(
+            "trace archive range start must not be after its end".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn read_jsonl_archive<T: DeserializeOwned>(path: &Path) -> Result<Vec<T>> {
+    let file = File::open(path)?;
+    let decoder = zstd::stream::read::Decoder::new(file)?;
+    let reader = BufReader::new(decoder);
+    let mut records = Vec::new();
+    for (line_number, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record = serde_json::from_str(&line).map_err(|error| {
+            crate::StoreError::Other(format!(
+                "invalid trace archive record in {} at line {}: {error}",
+                path.display(),
+                line_number + 1
+            ))
+        })?;
+        records.push(record);
+    }
+    Ok(records)
+}
+
+/// List archived event and recording traces in an inclusive time range.
+///
+/// Results are ordered oldest-first by their event/recording timestamp, with
+/// archive path as a deterministic tie-breaker. The JSONL records are decoded
+/// on demand, so callers can inspect the original payload without restoring
+/// it to a mutable live table.
+pub fn list_archived_traces(
+    cas_root: &Path,
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+) -> Result<Vec<ArchivedTrace>> {
+    validate_archive_range(from, to)?;
+
+    let archive_dir = cas_root.join(TRACE_ARCHIVE_DIR);
+    let entries = match fs::read_dir(archive_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.is_file() && is_trace_archive_name(&entry.file_name()) {
+            paths.push(entry.path());
+        }
+    }
+    paths.sort();
+
+    let mut traces = Vec::new();
+    for path in paths {
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if name.starts_with("events-") {
+            for event in read_jsonl_archive::<Event>(&path)? {
+                if (from..=to).contains(&event.created_at) {
+                    traces.push(ArchivedTrace {
+                        recorded_at: event.created_at,
+                        archive_path: path.clone(),
+                        record: ArchivedTraceRecord::Event(event),
+                    });
+                }
+            }
+        } else if name.starts_with("recordings-") {
+            for recording in read_jsonl_archive::<RecordingArchive>(&path)? {
+                if (from..=to).contains(&recording.recording.created_at) {
+                    traces.push(ArchivedTrace {
+                        recorded_at: recording.recording.created_at,
+                        archive_path: path.clone(),
+                        record: ArchivedTraceRecord::Recording(recording),
+                    });
+                }
+            }
+        }
+    }
+
+    traces.sort_by(|left, right| {
+        left.recorded_at
+            .cmp(&right.recorded_at)
+            .then_with(|| left.archive_path.cmp(&right.archive_path))
+    });
+    Ok(traces)
+}
+
+/// Return a deterministic, evenly-spread sample of archived traces in a time
+/// range. A zero `limit` returns no records; otherwise the first and last
+/// matching records are retained when the range has more records than the
+/// requested sample size.
+pub fn sample_archived_traces(
+    cas_root: &Path,
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+    limit: usize,
+) -> Result<Vec<ArchivedTrace>> {
+    let traces = list_archived_traces(cas_root, from, to)?;
+    if limit == 0 || traces.len() <= limit {
+        return Ok(if limit == 0 { Vec::new() } else { traces });
+    }
+    if limit == 1 {
+        return Ok(vec![traces[traces.len() / 2].clone()]);
+    }
+
+    let last = traces.len() - 1;
+    let denominator = limit - 1;
+    Ok((0..limit)
+        .map(|index| traces[index * last / denominator].clone())
+        .collect())
+}
+
 /// Remove archived trace files older than the configured retention period.
 ///
-/// A value of zero means keep forever.  Retention is based on the immutable
+/// This compatibility helper is retained for callers of the original
+/// cas-62a6 API. Daemon maintenance uses [`enforce_trace_archive_size`]
+/// instead, so active retention is bounded by bytes rather than archive age.
+/// A value of zero means keep forever. Retention is based on the immutable
 /// archive file's modification time, not on any mutable database state.
 pub fn prune_trace_archives(cas_root: &Path, retention_days: u64) -> Result<usize> {
     if retention_days == 0 {
@@ -185,6 +408,8 @@ fn is_trace_archive_name(name: &std::ffi::OsStr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cas_types::{Event, EventEntityType, EventType, Recording};
+    use chrono::Duration;
     use serde_json::Value;
     use std::io::Read;
     use tempfile::TempDir;
@@ -229,18 +454,11 @@ mod tests {
     fn archive_retention_zero_keeps_files_and_positive_days_removes_old_files() {
         let temp = TempDir::new().unwrap();
         let archive_dir = temp.path().join("archive");
-        let old = write_jsonl_archive(
-            &archive_dir,
-            "events",
-            &[serde_json::json!({"id": 1})],
-        )
-        .unwrap();
-        let recent = write_jsonl_archive(
-            &archive_dir,
-            "recordings",
-            &[serde_json::json!({"id": 2})],
-        )
-        .unwrap();
+        let old =
+            write_jsonl_archive(&archive_dir, "events", &[serde_json::json!({"id": 1})]).unwrap();
+        let recent =
+            write_jsonl_archive(&archive_dir, "recordings", &[serde_json::json!({"id": 2})])
+                .unwrap();
 
         assert_eq!(prune_trace_archives(temp.path(), 0).unwrap(), 0);
         assert!(old.exists());
@@ -251,5 +469,116 @@ mod tests {
         assert_eq!(prune_trace_archives(temp.path(), 1).unwrap(), 1);
         assert!(!old.exists());
         assert!(recent.exists());
+    }
+
+    #[test]
+    fn size_cap_evicts_oldest_archive_files_and_reports_evictions() {
+        let temp = TempDir::new().unwrap();
+        let archive_dir = temp.path().join("archive");
+        let oldest = write_jsonl_archive(
+            &archive_dir,
+            "events",
+            &[serde_json::json!({"id": "oldest", "payload": "a"})],
+        )
+        .unwrap();
+        let middle = write_jsonl_archive(
+            &archive_dir,
+            "events",
+            &[serde_json::json!({"id": "middle", "payload": "b"})],
+        )
+        .unwrap();
+        let newest = write_jsonl_archive(
+            &archive_dir,
+            "recordings",
+            &[serde_json::json!({"id": "newest", "payload": "c"})],
+        )
+        .unwrap();
+
+        let oldest_time = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1);
+        let middle_time = oldest_time + std::time::Duration::from_secs(1);
+        let newest_time = middle_time + std::time::Duration::from_secs(1);
+        File::open(&oldest)
+            .unwrap()
+            .set_modified(oldest_time)
+            .unwrap();
+        File::open(&middle)
+            .unwrap()
+            .set_modified(middle_time)
+            .unwrap();
+        File::open(&newest)
+            .unwrap()
+            .set_modified(newest_time)
+            .unwrap();
+
+        let oldest_size = fs::metadata(&oldest).unwrap().len();
+        let cap = fs::metadata(&middle).unwrap().len() + fs::metadata(&newest).unwrap().len();
+        let eviction = enforce_trace_archive_size(temp.path(), cap).unwrap();
+
+        assert_eq!(eviction.files_evicted, 1);
+        assert_eq!(eviction.bytes_evicted, oldest_size);
+        assert!(!oldest.exists());
+        assert!(middle.exists());
+        assert!(newest.exists());
+        assert_eq!(eviction.remaining_bytes, cap);
+    }
+
+    #[test]
+    fn archived_traces_can_be_listed_and_sampled_by_time_range() {
+        let temp = TempDir::new().unwrap();
+        let archive_dir = temp.path().join("archive");
+        let now = Utc::now();
+        let first_time = now - Duration::days(3);
+        let second_time = now - Duration::days(2);
+        let third_time = now - Duration::days(1);
+
+        let mut first = Event::new(
+            EventType::TaskStarted,
+            EventEntityType::Task,
+            "task-first",
+            "first",
+        );
+        first.created_at = first_time;
+        let mut second = Event::new(
+            EventType::TaskCompleted,
+            EventEntityType::Task,
+            "task-second",
+            "second",
+        );
+        second.created_at = second_time;
+        let mut third = Event::new(
+            EventType::TaskBlocked,
+            EventEntityType::Task,
+            "task-third",
+            "third",
+        );
+        third.created_at = third_time;
+
+        write_jsonl_archive(&archive_dir, "events", &[first, second, third]).unwrap();
+
+        let mut recording = Recording::new("/tmp/third.trace".to_string());
+        recording.created_at = third_time;
+        write_jsonl_archive(
+            &archive_dir,
+            "recordings",
+            &[RecordingArchive {
+                recording,
+                agents: Vec::new(),
+                events: Vec::new(),
+                fts: Vec::new(),
+            }],
+        )
+        .unwrap();
+
+        let listed = list_archived_traces(temp.path(), second_time, third_time).unwrap();
+        assert_eq!(listed.len(), 3);
+        assert_eq!(listed[0].recorded_at, second_time);
+        assert_eq!(listed[1].recorded_at, third_time);
+        assert_eq!(listed[2].recorded_at, third_time);
+        assert!(listed.iter().all(|trace| trace.archive_path.exists()));
+
+        let sampled = sample_archived_traces(temp.path(), first_time, third_time, 2).unwrap();
+        assert_eq!(sampled.len(), 2);
+        assert_eq!(sampled[0].recorded_at, first_time);
+        assert_eq!(sampled[1].recorded_at, third_time);
     }
 }

--- a/docs/TRACE-ARCHIVES.md
+++ b/docs/TRACE-ARCHIVES.md
@@ -1,0 +1,37 @@
+# Trace archives
+
+Cassy keeps the raw event and terminal-recording layer available after the
+30-day live-retention window. During daemon maintenance, old rows are first
+written as new zstd-compressed JSONL files under `.cas/archive/`; only after a
+successful write are the live rows removed. Archive files are write-once and
+are never opened for append or update, so each file is a stable sampling unit.
+
+The archive directory is bounded by compressed bytes, not by an age or
+existence window. Configure the finite cap in `.cas/config.toml`:
+
+```toml
+[daemon]
+archive_max_bytes = 1073741824 # 1 GiB (the default)
+```
+
+When the cap is exceeded, maintenance removes the oldest archive files first
+and emits a `trace archive` eviction log line for every file removed. A cap of
+zero is rejected; this prevents an accidental unlimited archive. The legacy
+`daemon.archive_retention_days` key is still accepted for config-file
+compatibility, but it no longer controls archive retention.
+
+The storage API provides `list_archived_traces` for an inclusive timestamp
+range and `sample_archived_traces` for a deterministic, evenly-spread sample
+of that range. Event timestamps use `created_at`; recording timestamps use the
+record's `created_at`. The decoded result keeps its source archive path so a
+maintainer can inspect or stratify samples by archive file without restoring
+data into the mutable live database.
+
+## Upgrade note
+
+This change is forward-only. Events or recordings that an older Cassy version
+already hard-deleted cannot be reconstructed by an upgrade. Once the new
+daemon runs, rows that cross the 30-day live-retention boundary are archived
+before removal. Existing live rows remain available until their next
+maintenance cycle, and the configured byte cap applies to newly-created and
+pre-existing `.jsonl.zst` archive files alike.


### PR DESCRIPTION
## Summary
- keep aged events and recordings in write-once zstd JSONL archives under `.cas/archive/`
- enforce a configurable finite byte cap with oldest-first eviction and logging
- expose inclusive range listing and deterministic sampling APIs
- document configuration and forward-only upgrade behavior

## Verification
- `scripts/run-scoped-tests.sh -p cas-store --lib trace_archive` (4 passed)
- `ZIG=/home/pippenz/Petrastella/cas-src/.context/zig/zig cargo check -p cas --lib --tests`
- `ZIG=/home/pippenz/Petrastella/cas-src/.context/zig/zig scripts/run-scoped-tests.sh --proof -p cas --lib` (4,891 passed, 6 skipped)

Task: cas-2b42