### PR TITLE
feat(cas-a9be): track surfaced artifact impact

### DIFF
--- a/cas-cli/src/hooks/context.rs
+++ b/cas-cli/src/hooks/context.rs
@@ -13,7 +13,7 @@
 //! The core logic lives in `cas-core::hooks::context`.
 
 use std::process::Command;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use cas_code::{CodeSymbol, SymbolKind};
 use cas_core::hooks::{
@@ -22,7 +22,8 @@ use cas_core::hooks::{
     token_display, truncate,
 };
 use cas_store::{
-    AgentStore, KnowledgeStore, RuleStore, SkillStore, SqliteKnowledgeStore, Store, TaskStore,
+    AgentStore, KnowledgeStore, RuleStore, SkillStore, SqliteKnowledgeStore,
+    SqliteSurfacedArtifactStore, Store, SurfacedArtifact, TaskStore,
 };
 use cas_types::{Entry, Rule, RuleStatus, Skill, Task, TaskStatus};
 
@@ -123,19 +124,27 @@ pub fn build_context_with_token_budget(
 
     let start_time = std::time::Instant::now();
 
-    // Create surfaced item callback for feedback tracking
-    let surfaced_callback: Option<SurfacedItemCallback> =
-        if crate::tracing::DevTracer::get().is_some() {
-            Some(Box::new(
-                |id: &str, item_type: &str, preview: Option<&str>| {
-                    if let Some(tracer) = crate::tracing::DevTracer::get() {
-                        let _ = tracer.record_surfaced_item(id, item_type, preview);
-                    }
-                },
-            ))
-        } else {
-            None
-        };
+    // Collect rule/skill surfaces in memory so the CLI can persist all rows
+    // and rule counter increments in one transaction after context builds.
+    // The existing DevTracer receives every surfaced item, including memory.
+    let surfaced_artifacts = Arc::new(Mutex::new(Vec::<SurfacedArtifact>::new()));
+    let surfaced_artifacts_for_callback = Arc::clone(&surfaced_artifacts);
+    let surfaced_callback: Option<SurfacedItemCallback> = Some(Box::new(
+        move |id: &str, item_type: &str, preview: Option<&str>| {
+            if let Some(tracer) = crate::tracing::DevTracer::get() {
+                let _ = tracer.record_surfaced_item(id, item_type, preview);
+            }
+            if matches!(item_type, "rule" | "skill")
+                && let Ok(mut artifacts) = surfaced_artifacts_for_callback.lock()
+            {
+                artifacts.push(SurfacedArtifact {
+                    artifact_id: id.to_string(),
+                    artifact_type: item_type.to_string(),
+                    preview: preview.map(str::to_string),
+                });
+            }
+        },
+    ));
 
     // Build context using cas-core
     let (context, stats) = build_context_with_stores(
@@ -147,6 +156,18 @@ pub fn build_context_with_token_budget(
         crate::harness_policy::own_tool_prefix(),
     )
     .map_err(|e| MemError::Other(e.to_string()))?;
+
+    let surfaced_artifacts = surfaced_artifacts
+        .lock()
+        .map(|mut artifacts| std::mem::take(&mut *artifacts))
+        .unwrap_or_default();
+    if !surfaced_artifacts.is_empty()
+        && let Ok(store) = SqliteSurfacedArtifactStore::open(cas_root)
+    {
+        // Impact bookkeeping is observational and must never make the
+        // context hook fail after successfully building the prompt.
+        let _ = store.record_batch(&input.session_id, &surfaced_artifacts);
+    }
 
     let context = {
         let mut ctx = context;

--- a/cas-cli/src/mcp/tools/service/agent_search_system/search_context.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/search_context.rs
@@ -93,6 +93,26 @@ impl CasService {
         ))
     }
 
+    pub(in crate::mcp::tools::service) async fn skill_impact_impl(
+        &self,
+        req: SearchContextRequest,
+    ) -> Result<CallToolResult, McpError> {
+        use cas_store::SqliteSurfacedArtifactStore;
+
+        let store = SqliteSurfacedArtifactStore::open(&self.inner.cas_root)
+            .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?;
+        let artifacts = store
+            .aggregate(req.limit.unwrap_or(100).clamp(1, 1_000))
+            .map_err(|error| Self::error(ErrorCode::INTERNAL_ERROR, error.to_string()))?;
+        Ok(Self::success(
+            serde_json::json!({
+                "version": 1,
+                "artifacts": artifacts,
+            })
+            .to_string(),
+        ))
+    }
+
     pub(in crate::mcp::tools::service) async fn context_impl(
         &self,
         req: SearchContextRequest,

--- a/cas-cli/src/mcp/tools/service/mod.rs
+++ b/cas-cli/src/mcp/tools/service/mod.rs
@@ -796,7 +796,7 @@ impl CasService {
     // ========================================================================
 
     #[tool(
-        description = "Search and context operations. Actions: search (BM25 full-text), retrieval_feedback (explicit retrieval outcome), retrieval_metrics (offline outcome aggregation), context (session context), context_for_subagent, observe (record observation), entity_list, entity_show, entity_extract, code_search (search code symbols), code_show (show symbol details), grep, blame, history (search indexed git commits by text/path/time; every response carries an index_status block stating freshness and what is not yet supported)."
+        description = "Search and context operations. Actions: search (BM25 full-text), retrieval_feedback (explicit retrieval outcome), retrieval_metrics (offline outcome aggregation), skill_impact (surface and session-outcome impact report; impact_report alias), context (session context), context_for_subagent, observe (record observation), entity_list, entity_show, entity_extract, code_search (search code symbols), code_show (show symbol details), grep, blame, history (search indexed git commits by text/path/time; every response carries an index_status block stating freshness and what is not yet supported)."
     )]
     pub async fn search(
         &self,
@@ -809,6 +809,7 @@ impl CasService {
                 "search" => this.search_impl(req).await,
                 "retrieval_feedback" => this.retrieval_feedback_impl(req).await,
                 "retrieval_metrics" => this.retrieval_metrics_impl().await,
+                "skill_impact" | "impact_report" => this.skill_impact_impl(req).await,
                 "context" => this.context_impl(req).await,
                 "context_for_subagent" => this.context_for_subagent_impl(req).await,
                 "observe" => this.observe_impl(req).await,
@@ -823,7 +824,7 @@ impl CasService {
                 _ => Err(Self::error(
                     ErrorCode::INVALID_PARAMS,
                     format!(
-                        "Unknown search action: {}. Valid: search, retrieval_feedback, retrieval_metrics, context, context_for_subagent, observe, entity_list, entity_show, entity_extract, code_search, code_show, grep, blame, history",
+                        "Unknown search action: {}. Valid: search, retrieval_feedback, retrieval_metrics, skill_impact, context, context_for_subagent, observe, entity_list, entity_show, entity_extract, code_search, code_show, grep, blame, history",
                         req.action
                     ),
                 )),

--- a/cas-cli/src/migration/migrations/m243_surfaced_artifacts_create_table.rs
+++ b/cas-cli/src/migration/migrations/m243_surfaced_artifacts_create_table.rs
@@ -1,0 +1,52 @@
+//! Migration: durable per-session rule and skill injection records.
+
+use crate::migration::{Migration, Subsystem};
+
+pub const MIGRATION: Migration = Migration {
+    id: 243,
+    name: "surfaced_artifacts_create_table",
+    subsystem: Subsystem::Events,
+    description: "Record injected rules and skills for session-outcome impact reports (cas-a9be)",
+    up: cas_store::SURFACED_ARTIFACT_SCHEMA_STATEMENTS,
+    detect: Some(
+        "SELECT CASE WHEN
+            EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'surfaced_artifacts')
+            AND EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_surfaced_artifacts_session')
+            AND EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_surfaced_artifacts_artifact')
+         THEN 1 ELSE 0 END",
+    ),
+};
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    #[test]
+    fn migration_creates_and_detects_surface_ledger() {
+        let conn = Connection::open_in_memory().unwrap();
+        let detect = super::MIGRATION.detect.unwrap();
+        assert_eq!(
+            conn.query_row(detect, [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            0
+        );
+
+        for statement in super::MIGRATION.up {
+            conn.execute(statement, []).unwrap();
+        }
+        assert_eq!(
+            conn.query_row(detect, [], |row| row.get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('surfaced_artifacts')",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            6
+        );
+    }
+}

--- a/cas-cli/src/migration/migrations/mod.rs
+++ b/cas-cli/src/migration/migrations/mod.rs
@@ -217,6 +217,7 @@ mod m238_skills_add_source_ids;
 mod m239_task_execution_states_create_table;
 mod m240_rule_skill_versions;
 mod m241_tasks_add_origin_project;
+mod m243_surfaced_artifacts_create_table;
 
 /// All migrations in order. IDs must be sequential and never reused.
 pub const MIGRATIONS: &[Migration] = &[
@@ -467,6 +468,7 @@ pub const MIGRATIONS: &[Migration] = &[
     m239_task_execution_states_create_table::MIGRATION,
     m240_rule_skill_versions::MIGRATION,
     m241_tasks_add_origin_project::MIGRATION,
+    m243_surfaced_artifacts_create_table::MIGRATION,
 ];
 
 #[cfg(test)]

--- a/cas-cli/src/migration/mod.rs
+++ b/cas-cli/src/migration/mod.rs
@@ -994,7 +994,7 @@ mod tests {
 
     fn assert_repaired_v225_knowledge_gap(cas_dir: &Path, expected_m226_ledger: &str) {
         let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
-        for id in [225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242] {
+        for id in [225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243] {
             assert_eq!(
                 conn.query_row(
                     "SELECT COUNT(*) FROM cas_migrations WHERE id = ?1",
@@ -1061,7 +1061,7 @@ mod tests {
         assert_eq!(pages[0].origin_project_id, None);
 
         let status = check_migrations(cas_dir).unwrap();
-        assert_eq!(status.current_version, 242);
+        assert_eq!(status.current_version, 243);
         assert!(status.pending.is_empty());
         let second = run_migrations(cas_dir, false).unwrap();
         assert_eq!(second.applied_count, 0, "repeated open must be idempotent");
@@ -1083,7 +1083,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242],
+                vec![225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243],
                 "recorded m225 and missing m226 must order all later work behind them"
             );
 
@@ -1167,7 +1167,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 226, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242]
+                vec![225, 226, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();
@@ -1206,7 +1206,7 @@ mod tests {
                     .iter()
                     .map(|migration| migration.id)
                     .collect::<Vec<_>>(),
-                vec![225, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242]
+                vec![225, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243]
             );
 
             let first = run_migrations(&cas_dir, false).unwrap();

--- a/cas-cli/src/store/mod.rs
+++ b/cas-cli/src/store/mod.rs
@@ -59,6 +59,9 @@ pub use cas_store::{
     EntityStore,
     EventStore,
     FileChangeStore,
+    // Known-repo registry (host-scoped cross-repo discovery, EPIC cas-7c88)
+    KnownRepo,
+    KnownRepoStore,
     LayeredEntryStore,
     LayeredRuleStore,
     LayeredSkillStore,
@@ -93,6 +96,7 @@ pub use cas_store::{
     SqliteEntityStore,
     SqliteEventStore,
     SqliteFileChangeStore,
+    SqliteKnownRepoStore,
     SqliteLoopStore,
     SqlitePromptQueueStore,
     SqlitePromptStore,
@@ -105,13 +109,10 @@ pub use cas_store::{
     // SQLite implementations
     SqliteStore,
     SqliteSupervisorQueueStore,
+    SqliteSurfacedArtifactStore,
     SqliteTaskStore,
     SqliteVerificationStore,
     SqliteWorktreeStore,
-    // Known-repo registry (host-scoped cross-repo discovery, EPIC cas-7c88)
-    KnownRepo,
-    KnownRepoStore,
-    SqliteKnownRepoStore,
     // Traits
     Store,
     // Error types
@@ -119,6 +120,8 @@ pub use cas_store::{
     // Supervisor queue types
     SupervisorNotification,
     SupervisorQueueStore,
+    SurfacedArtifact,
+    SurfacedArtifactImpact,
     TaskStore,
     VerificationStore,
     WorktreeStore,

--- a/cas-cli/tests/mcp_tools_test/search_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/search_tools.rs
@@ -139,6 +139,84 @@ async fn test_search_with_content() {
 }
 
 #[tokio::test]
+async fn skill_impact_reports_surface_rows_and_session_outcomes() {
+    use cas_store::{RuleStore, SkillStore, SqliteRuleStore, SqliteSkillStore, SqliteStore};
+    use cas_types::{Rule, RuleStatus, Session, SessionOutcome, Skill, SkillStatus};
+
+    let (temp, core) = setup_cas();
+    let cas_dir = temp.path().join(".cas");
+
+    let rule_store = SqliteRuleStore::open(&cas_dir).unwrap();
+    let mut rule = Rule::new("rule-impact".to_string(), "Impact rule".to_string());
+    rule.status = RuleStatus::Proven;
+    rule.helpful_count = 2;
+    rule.harmful_count = 1;
+    rule_store.add(&rule).unwrap();
+
+    let skill_store = SqliteSkillStore::open(&cas_dir).unwrap();
+    let mut skill = Skill::new("skill-impact".to_string(), "Impact skill".to_string());
+    skill.status = SkillStatus::Enabled;
+    skill.usage_count = 4;
+    skill_store.add(&skill).unwrap();
+
+    let session_store = SqliteStore::open(&cas_dir).unwrap();
+    let session = Session::new("impact-session".to_string(), "/repo".to_string(), None);
+    session_store.start_session(&session).unwrap();
+    session_store
+        .update_session_outcome("impact-session", SessionOutcome::TasksCompleted)
+        .unwrap();
+
+    let surface_store = cas_store::SqliteSurfacedArtifactStore::open(&cas_dir).unwrap();
+    surface_store
+        .record_batch(
+            "impact-session",
+            &[
+                cas_store::SurfacedArtifact {
+                    artifact_id: "rule-impact".to_string(),
+                    artifact_type: "rule".to_string(),
+                    preview: Some("Impact rule".to_string()),
+                },
+                cas_store::SurfacedArtifact {
+                    artifact_id: "skill-impact".to_string(),
+                    artifact_type: "skill".to_string(),
+                    preview: Some("Impact skill".to_string()),
+                },
+            ],
+        )
+        .unwrap();
+
+    let service = CasService::new(core, None);
+    let request: SearchContextRequest = serde_json::from_value(serde_json::json!({
+        "action": "skill_impact",
+        "limit": 10
+    }))
+    .unwrap();
+    let response = service
+        .search(Parameters(request))
+        .await
+        .expect("skill impact report should succeed");
+    let report: serde_json::Value =
+        serde_json::from_str(&extract_text(response)).expect("impact response should be JSON");
+
+    assert_eq!(report["version"], 1);
+    let artifacts = report["artifacts"].as_array().unwrap();
+    let rule_impact = artifacts
+        .iter()
+        .find(|artifact| artifact["artifact_id"] == "rule-impact")
+        .unwrap();
+    assert_eq!(rule_impact["surfaced_count"], 1);
+    assert_eq!(rule_impact["outcome_counts"]["tasks_completed"], 1);
+    assert_eq!(rule_impact["helpful_count"], 2);
+    assert_eq!(rule_impact["harmful_count"], 1);
+    let skill_impact = artifacts
+        .iter()
+        .find(|artifact| artifact["artifact_id"] == "skill-impact")
+        .unwrap();
+    assert_eq!(skill_impact["usage_count"], 4);
+    assert_eq!(skill_impact["outcome_counts"]["tasks_completed"], 1);
+}
+
+#[tokio::test]
 async fn cas_57e5_colon_bearing_free_text_queries_return_results() {
     let (_temp, service) = setup_cas();
     service

--- a/cas-cli/tests/session_start_memory_hygiene_test.rs
+++ b/cas-cli/tests/session_start_memory_hygiene_test.rs
@@ -1,9 +1,14 @@
 use assert_cmd::Command;
+use cas::hooks::build_context_with_token_budget;
 use cas::types::{Entry, EntryType};
 use cas_core::hooks::context::{ContextStores, build_context_with_stores};
 use cas_core::hooks::{DefaultHooksConfig, HookInput};
 use cas_core::memory::{contamination_patterns, find_contaminated_entries};
-use cas_store::{SqliteStore, Store};
+use cas_store::{
+    RuleStore, SkillStore, SqliteRuleStore, SqliteSkillStore, SqliteStore,
+    SqliteSurfacedArtifactStore, Store,
+};
+use cas_types::{Rule, RuleStatus, Session, SessionOutcome, Skill, SkillStatus};
 use std::fs;
 
 fn session_start_input() -> HookInput {
@@ -12,6 +17,62 @@ fn session_start_input() -> HookInput {
         hook_event_name: "SessionStart".to_string(),
         ..Default::default()
     }
+}
+
+#[test]
+fn cli_session_start_persists_surface_ledger_for_injected_rules_and_skills() {
+    let temp = tempfile::tempdir().unwrap();
+    let cas_root = temp.path().join(".cas");
+    fs::create_dir_all(&cas_root).unwrap();
+
+    let entry_store = SqliteStore::open(&cas_root).unwrap();
+    entry_store.init().unwrap();
+    let session = Session::new("surface-session".to_string(), "/project".to_string(), None);
+    entry_store.start_session(&session).unwrap();
+
+    let rule_store = SqliteRuleStore::open(&cas_root).unwrap();
+    rule_store.init().unwrap();
+    let mut rule = Rule::new("surface-rule".to_string(), "Surface this rule".to_string());
+    rule.status = RuleStatus::Proven;
+    rule_store.add(&rule).unwrap();
+
+    let skill_store = SqliteSkillStore::open(&cas_root).unwrap();
+    skill_store.init().unwrap();
+    let mut skill = Skill::new(
+        "surface-skill".to_string(),
+        "Surface this skill".to_string(),
+    );
+    skill.status = SkillStatus::Enabled;
+    skill_store.add(&skill).unwrap();
+
+    let input = HookInput {
+        session_id: "surface-session".to_string(),
+        cwd: "/project".to_string(),
+        hook_event_name: "SessionStart".to_string(),
+        ..Default::default()
+    };
+    let context = build_context_with_token_budget(&input, 10, &cas_root, None).unwrap();
+    assert!(context.contains("Surface this rule"));
+    assert!(context.contains("Surface this skill"));
+
+    let surface_store = SqliteSurfacedArtifactStore::open(&cas_root).unwrap();
+    assert_eq!(
+        surface_store.count_for_session("surface-session").unwrap(),
+        2
+    );
+    assert_eq!(rule_store.get("surface-rule").unwrap().surface_count, 1);
+    entry_store
+        .update_session_outcome("surface-session", SessionOutcome::TasksCompleted)
+        .unwrap();
+    let impacts = surface_store.aggregate(10).unwrap();
+    assert_eq!(
+        impacts
+            .iter()
+            .find(|impact| impact.artifact_id == "surface-rule")
+            .unwrap()
+            .outcome_counts["tasks_completed"],
+        1
+    );
 }
 
 #[test]

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -1,16 +1,16 @@
 ---
 source: cas-cli/tests/component_output_test.rs
-assertion_line: 192
+assertion_line: 200
 expression: redacted
 ---
 cas doctor
 ──────────────────────────────────────────────────
 [OK] cas directory: Found at [TEMP_PATH]
 [OK] database: SQLite database found
-[OK] schema: v242 (up to date)
+[OK] schema: v243 (up to date)
 [OK] supervisor relay: no undelivered lifecycle relays
 [OK] delivery retries: no pending message has spent 3+ attempts
-[OK] tables: [N] tables, 780 columns, 205 rows total
+[OK] tables: [N] tables, 786 columns, 206 rows total
 [OK] entry store: [N] entries accessible
 [WARN] search index: Index not found. Will be created on first search.
 [WARN] symbol index: nothing indexed for this project (0 symbol(s) in the store across all repositories); the code search index is missing. The daemon only indexes while idle — run `cas index code` to catch up now.

--- a/crates/cas-core/src/hooks/context/build_start.rs
+++ b/crates/cas-core/src/hooks/context/build_start.rs
@@ -39,6 +39,23 @@ fn increment_rule_surface_count(stores: &ContextStores, rule: &Rule) {
     }
 }
 
+/// Report a surfaced rule through the caller-owned callback when available.
+/// The callback lets the CLI batch its durable counter and audit-row writes;
+/// the direct store update remains as a compatibility fallback for callers
+/// that use the core builder without a callback.
+fn report_rule_surface(
+    stores: &ContextStores,
+    rule: &Rule,
+    on_surfaced: Option<&SurfacedItemCallback>,
+    preview: &str,
+) {
+    if let Some(callback) = on_surfaced {
+        callback(&rule.id, "rule", Some(preview));
+    } else {
+        increment_rule_surface_count(stores, rule);
+    }
+}
+
 /// Render the distilled-knowledge index: one line per page, no bodies.
 ///
 /// This is the "inject the index, toolize the body" shape. Every line carries
@@ -490,10 +507,7 @@ pub fn build_context_with_stores(
                 total_tokens += item.tokens;
                 stats.rules_included += 1;
 
-                increment_rule_surface_count(stores, rule);
-                if let Some(callback) = on_surfaced {
-                    callback(&item.id, "rule", Some(&item.summary));
-                }
+                report_rule_surface(stores, rule, on_surfaced, &item.summary);
             }
         }
 
@@ -572,10 +586,7 @@ pub fn build_context_with_stores(
                     }
                     stats.rules_included += 1;
 
-                    increment_rule_surface_count(stores, rule);
-                    if let Some(callback) = on_surfaced {
-                        callback(&item.id, "rule", Some(&item.summary));
-                    }
+                    report_rule_surface(stores, rule, on_surfaced, &item.summary);
                 }
                 stats.items_omitted += regular_rules
                     .len()
@@ -658,6 +669,9 @@ pub fn build_context_with_stores(
                     ));
                     total_tokens += estimate_tokens(&item.summary) + 20;
                     stats.skills_included += 1;
+                    if let Some(callback) = on_surfaced {
+                        callback(&item.id, "skill", Some(&item.summary));
+                    }
                 }
                 stats.items_omitted += enabled_skills
                     .len()

--- a/crates/cas-core/src/hooks/context/mod.rs
+++ b/crates/cas-core/src/hooks/context/mod.rs
@@ -629,7 +629,11 @@ pub struct ContextStats {
     pub items_omitted: usize,
 }
 
-/// Optional callback for surfaced items (for feedback tracking)
+/// Optional callback for surfaced items (for feedback tracking).
+///
+/// Rule stores are updated directly when this is `None`. When a callback is
+/// supplied, the caller owns durable recording of surfaced rules; this lets
+/// the CLI batch rule counters with per-session audit rows.
 pub type SurfacedItemCallback = Box<dyn Fn(&str, &str, Option<&str>)>;
 
 mod build_start;

--- a/crates/cas-mcp/src/types/ops_secondary.rs
+++ b/crates/cas-mcp/src/types/ops_secondary.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct SearchContextRequest {
     /// Action to perform
     #[schemars(
-        description = "Action: 'search', 'retrieval_feedback', 'retrieval_metrics', 'context', 'context_for_subagent', 'observe', 'entity_list', 'entity_show', 'entity_extract', 'code_search', 'code_show', 'grep', 'blame', 'history'"
+        description = "Action: 'search', 'retrieval_feedback', 'retrieval_metrics', 'skill_impact' (impact_report alias), 'context', 'context_for_subagent', 'observe', 'entity_list', 'entity_show', 'entity_extract', 'code_search', 'code_show', 'grep', 'blame', 'history'"
     )]
     pub action: String,
 

--- a/crates/cas-store/src/lib.rs
+++ b/crates/cas-store/src/lib.rs
@@ -68,11 +68,12 @@ mod spec_store;
 mod sqlite;
 mod sqlite_code_store;
 mod supervisor_queue_store;
+mod surfaced_artifact_store;
 mod task_store;
 pub mod trace_archive;
-mod version_store;
 pub mod tracing;
 mod verification_store;
+mod version_store;
 mod viktor_inbound_store;
 mod viktor_watch_store;
 mod worktree_store;
@@ -221,6 +222,11 @@ pub use supervisor_queue_store::{
     SupervisorNotification, SupervisorQueueStore,
 };
 
+pub use surfaced_artifact_store::{
+    SURFACED_ARTIFACT_SCHEMA, SURFACED_ARTIFACT_SCHEMA_STATEMENTS, SqliteSurfacedArtifactStore,
+    SurfacedArtifact, SurfacedArtifactImpact,
+};
+
 // Prompt queue store for supervisor → worker communication
 // (includes enqueue outcomes for message dedup and cas-ecff lifecycle outbox)
 pub use prompt_queue_store::{
@@ -279,13 +285,13 @@ pub use recording_text_store::{
 pub use layered::{LayeredEntryStore, LayeredRuleStore, LayeredSkillStore};
 pub use markdown::{MarkdownRuleStore, MarkdownStore};
 pub use skill_store::{SKILL_SCHEMA, SqliteSkillStore};
+pub use spec_store::{SpecStore, SqliteSpecStore};
+pub use sqlite::{ENTRIES_RULES_SCHEMA, SqliteRuleStore, SqliteStore};
+pub use task_store::{SqliteTaskStore, TASK_SCHEMA, clear_pending_verification_with_conn};
 pub use version_store::{
     RULE_AND_SKILL_VERSIONS_SCHEMA_STATEMENTS, RULE_VERSIONS_SCHEMA_STATEMENTS, RuleVersion,
     SKILL_VERSIONS_SCHEMA_STATEMENTS, SkillVersion,
 };
-pub use spec_store::{SpecStore, SqliteSpecStore};
-pub use sqlite::{ENTRIES_RULES_SCHEMA, SqliteRuleStore, SqliteStore};
-pub use task_store::{SqliteTaskStore, TASK_SCHEMA, clear_pending_verification_with_conn};
 
 use cas_types::{
     Dependency, DependencyType, Entity, EntityMention, EntityType, Entry, RelationType,

--- a/crates/cas-store/src/surfaced_artifact_store.rs
+++ b/crates/cas-store/src/surfaced_artifact_store.rs
@@ -1,0 +1,336 @@
+//! Durable context-injection records and artifact impact aggregates.
+
+use chrono::Utc;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use crate::error::StoreError;
+use crate::shared_db::ImmediateTx;
+use crate::{Result, shared_db};
+
+/// SQLite DDL for the append-only session-to-artifact injection ledger.
+///
+/// The table intentionally does not foreign-key artifact IDs: retired or
+/// deleted rules and skills still need their historical impact rows.
+pub const SURFACED_ARTIFACT_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS surfaced_artifacts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    artifact_id TEXT NOT NULL,
+    artifact_type TEXT NOT NULL CHECK (artifact_type IN ('rule', 'skill')),
+    artifact_preview TEXT,
+    surfaced_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_surfaced_artifacts_session
+    ON surfaced_artifacts(session_id, surfaced_at);
+CREATE INDEX IF NOT EXISTS idx_surfaced_artifacts_artifact
+    ON surfaced_artifacts(artifact_type, artifact_id, surfaced_at);
+"#;
+
+/// Statement-level form used by the numbered migration runner.
+pub const SURFACED_ARTIFACT_SCHEMA_STATEMENTS: &[&str] = &[
+    "CREATE TABLE IF NOT EXISTS surfaced_artifacts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        artifact_id TEXT NOT NULL,
+        artifact_type TEXT NOT NULL CHECK (artifact_type IN ('rule', 'skill')),
+        artifact_preview TEXT,
+        surfaced_at TEXT NOT NULL
+    )",
+    "CREATE INDEX IF NOT EXISTS idx_surfaced_artifacts_session
+        ON surfaced_artifacts(session_id, surfaced_at)",
+    "CREATE INDEX IF NOT EXISTS idx_surfaced_artifacts_artifact
+        ON surfaced_artifacts(artifact_type, artifact_id, surfaced_at)",
+];
+
+/// One artifact selected for context injection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SurfacedArtifact {
+    pub artifact_id: String,
+    pub artifact_type: String,
+    pub preview: Option<String>,
+}
+
+/// Impact summary for one injected rule or skill.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SurfacedArtifactImpact {
+    pub artifact_id: String,
+    pub artifact_type: String,
+    pub surfaced_count: u64,
+    pub session_count: u64,
+    /// Counts distinct sessions by their eventual `sessions.outcome`.
+    pub outcome_counts: BTreeMap<String, u64>,
+    /// Rule feedback counters. Skills currently expose usage_count instead;
+    /// their feedback fields remain zero until the skill feedback contract is
+    /// added, rather than treating usage as unverified helpfulness.
+    pub helpful_count: u64,
+    pub harmful_count: u64,
+    pub usage_count: u64,
+}
+
+/// SQLite store for batched SessionStart surface writes and impact reports.
+pub struct SqliteSurfacedArtifactStore {
+    conn: Arc<Mutex<rusqlite::Connection>>,
+}
+
+impl SqliteSurfacedArtifactStore {
+    pub fn open(cas_dir: &Path) -> Result<Self> {
+        let conn = shared_db::shared_connection(&cas_dir.join("cas.db"))?;
+        let store = Self { conn };
+        store.init()?;
+        Ok(store)
+    }
+
+    pub fn init(&self) -> Result<()> {
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        conn.execute_batch(SURFACED_ARTIFACT_SCHEMA)?;
+        Ok(())
+    }
+
+    /// Persist all artifacts from one context build in one write transaction.
+    /// Rule counters are updated in the same transaction as their audit rows,
+    /// avoiding one SQLite write/fsync per injected rule.
+    pub fn record_batch(&self, session_id: &str, artifacts: &[SurfacedArtifact]) -> Result<usize> {
+        if session_id.trim().is_empty() {
+            return Err(StoreError::Parse(
+                "surface records require a non-empty session ID".to_string(),
+            ));
+        }
+        for artifact in artifacts {
+            if !matches!(artifact.artifact_type.as_str(), "rule" | "skill") {
+                return Err(StoreError::Parse(format!(
+                    "unsupported surfaced artifact type: {}",
+                    artifact.artifact_type
+                )));
+            }
+            if artifact.artifact_id.trim().is_empty() {
+                return Err(StoreError::Parse(
+                    "surface records require a non-empty artifact ID".to_string(),
+                ));
+            }
+        }
+        if artifacts.is_empty() {
+            return Ok(0);
+        }
+
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        let tx = ImmediateTx::new(&conn)?;
+        let surfaced_at = Utc::now().to_rfc3339();
+        for artifact in artifacts {
+            tx.execute(
+                "INSERT INTO surfaced_artifacts
+                 (session_id, artifact_id, artifact_type, artifact_preview, surfaced_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    session_id,
+                    artifact.artifact_id,
+                    artifact.artifact_type,
+                    artifact.preview,
+                    surfaced_at,
+                ],
+            )?;
+            if artifact.artifact_type == "rule" {
+                tx.execute(
+                    "UPDATE rules
+                     SET surface_count = MIN(surface_count + 1, 2147483647)
+                     WHERE id = ?1",
+                    params![artifact.artifact_id],
+                )?;
+            }
+        }
+        tx.commit()?;
+        Ok(artifacts.len())
+    }
+
+    /// Return the number of persisted rows for one session.
+    pub fn count_for_session(&self, session_id: &str) -> Result<u64> {
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        conn.query_row(
+            "SELECT COUNT(*) FROM surfaced_artifacts WHERE session_id = ?1",
+            params![session_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|count| count.max(0) as u64)
+        .map_err(StoreError::Database)
+    }
+
+    /// Aggregate injected artifacts and join each row to its session outcome.
+    pub fn aggregate(&self, limit: usize) -> Result<Vec<SurfacedArtifactImpact>> {
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        let mut stmt = conn.prepare(
+            "SELECT sa.artifact_id, sa.artifact_type,
+                    COUNT(*) AS surfaced_count,
+                    COUNT(DISTINCT sa.session_id) AS session_count,
+                    CASE WHEN sa.artifact_type = 'rule'
+                         THEN COALESCE(MAX(r.helpful_count), 0) ELSE 0 END,
+                    CASE WHEN sa.artifact_type = 'rule'
+                         THEN COALESCE(MAX(r.harmful_count), 0) ELSE 0 END,
+                    CASE WHEN sa.artifact_type = 'skill'
+                         THEN COALESCE(MAX(sk.usage_count), 0) ELSE 0 END
+             FROM surfaced_artifacts sa
+             LEFT JOIN rules r
+               ON sa.artifact_type = 'rule' AND r.id = sa.artifact_id
+             LEFT JOIN skills sk
+               ON sa.artifact_type = 'skill' AND sk.id = sa.artifact_id
+             GROUP BY sa.artifact_id, sa.artifact_type
+             ORDER BY surfaced_count DESC, sa.artifact_type, sa.artifact_id
+             LIMIT ?1",
+        )?;
+        let mut impacts = stmt
+            .query_map(params![limit as i64], |row| {
+                Ok(SurfacedArtifactImpact {
+                    artifact_id: row.get(0)?,
+                    artifact_type: row.get(1)?,
+                    surfaced_count: row.get::<_, i64>(2)?.max(0) as u64,
+                    session_count: row.get::<_, i64>(3)?.max(0) as u64,
+                    outcome_counts: BTreeMap::new(),
+                    helpful_count: row.get::<_, i64>(4)?.max(0) as u64,
+                    harmful_count: row.get::<_, i64>(5)?.max(0) as u64,
+                    usage_count: row.get::<_, i64>(6)?.max(0) as u64,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let impact_indexes: HashMap<(String, String), usize> = impacts
+            .iter()
+            .enumerate()
+            .map(|(index, impact)| {
+                (
+                    (impact.artifact_id.clone(), impact.artifact_type.clone()),
+                    index,
+                )
+            })
+            .collect();
+
+        let mut outcome_stmt = conn.prepare(
+            "SELECT sa.artifact_id, sa.artifact_type, s.outcome,
+                    COUNT(DISTINCT sa.session_id)
+             FROM surfaced_artifacts sa
+             JOIN sessions s ON s.session_id = sa.session_id
+             WHERE s.outcome IS NOT NULL
+             GROUP BY sa.artifact_id, sa.artifact_type, s.outcome",
+        )?;
+        let outcome_rows = outcome_stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?.max(0) as u64,
+            ))
+        })?;
+        for row in outcome_rows {
+            let (artifact_id, artifact_type, outcome, count) = row?;
+            if let Some(index) = impact_indexes.get(&(artifact_id, artifact_type)) {
+                impacts[*index].outcome_counts.insert(outcome, count);
+            }
+        }
+        Ok(impacts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RuleStore, SkillStore, SqliteRuleStore, SqliteStore, Store};
+    use cas_types::{Rule, RuleStatus, Session, SessionOutcome, Skill, SkillStatus};
+    use tempfile::TempDir;
+
+    fn surfaced(artifact_id: &str, artifact_type: &str) -> SurfacedArtifact {
+        SurfacedArtifact {
+            artifact_id: artifact_id.to_string(),
+            artifact_type: artifact_type.to_string(),
+            preview: Some(format!("preview for {artifact_id}")),
+        }
+    }
+
+    #[test]
+    fn records_surfaces_and_batches_rule_counter_updates() {
+        let temp = TempDir::new().unwrap();
+        let rule_store = SqliteRuleStore::open(temp.path()).unwrap();
+        rule_store.init().unwrap();
+        let mut rule = Rule::new("rule-1".to_string(), "Always test".to_string());
+        rule.status = RuleStatus::Proven;
+        rule_store.add(&rule).unwrap();
+
+        let store = SqliteSurfacedArtifactStore::open(temp.path()).unwrap();
+        let written = store
+            .record_batch(
+                "session-1",
+                &[surfaced("rule-1", "rule"), surfaced("skill-1", "skill")],
+            )
+            .unwrap();
+
+        assert_eq!(written, 2);
+        assert_eq!(rule_store.get("rule-1").unwrap().surface_count, 1);
+        assert_eq!(store.count_for_session("session-1").unwrap(), 2);
+    }
+
+    #[test]
+    fn impact_aggregate_joins_surface_rows_to_session_outcomes_and_feedback() {
+        let temp = TempDir::new().unwrap();
+        let entry_store = SqliteStore::open(temp.path()).unwrap();
+        entry_store.init().unwrap();
+        let rule_store = SqliteRuleStore::open(temp.path()).unwrap();
+        rule_store.init().unwrap();
+
+        let mut rule = Rule::new("rule-1".to_string(), "Always test".to_string());
+        rule.status = RuleStatus::Proven;
+        rule.helpful_count = 3;
+        rule.harmful_count = 1;
+        rule_store.add(&rule).unwrap();
+
+        let mut skill = Skill::new("skill-1".to_string(), "Test skill".to_string());
+        skill.description = "Run tests".to_string();
+        skill.status = SkillStatus::Enabled;
+        skill.usage_count = 2;
+        let skill_store = crate::SqliteSkillStore::open(temp.path()).unwrap();
+        skill_store.init().unwrap();
+        skill_store.add(&skill).unwrap();
+
+        let completed = Session::new("session-completed".to_string(), "/repo".to_string(), None);
+        entry_store.start_session(&completed).unwrap();
+        entry_store
+            .update_session_outcome("session-completed", SessionOutcome::TasksCompleted)
+            .unwrap();
+        let abandoned = Session::new("session-abandoned".to_string(), "/repo".to_string(), None);
+        entry_store.start_session(&abandoned).unwrap();
+        entry_store
+            .update_session_outcome("session-abandoned", SessionOutcome::Abandoned)
+            .unwrap();
+
+        let store = SqliteSurfacedArtifactStore::open(temp.path()).unwrap();
+        store
+            .record_batch(
+                "session-completed",
+                &[surfaced("rule-1", "rule"), surfaced("skill-1", "skill")],
+            )
+            .unwrap();
+        store
+            .record_batch("session-abandoned", &[surfaced("rule-1", "rule")])
+            .unwrap();
+
+        let impacts = store.aggregate(10).unwrap();
+        let rule_impact = impacts
+            .iter()
+            .find(|impact| impact.artifact_id == "rule-1")
+            .unwrap();
+        assert_eq!(rule_impact.surfaced_count, 2);
+        assert_eq!(rule_impact.session_count, 2);
+        assert_eq!(rule_impact.outcome_counts["tasks_completed"], 1);
+        assert_eq!(rule_impact.outcome_counts["abandoned"], 1);
+        assert_eq!(rule_impact.helpful_count, 3);
+        assert_eq!(rule_impact.harmful_count, 1);
+
+        let skill_impact = impacts
+            .iter()
+            .find(|impact| impact.artifact_id == "skill-1")
+            .unwrap();
+        assert_eq!(skill_impact.surfaced_count, 1);
+        assert_eq!(skill_impact.session_count, 1);
+        assert_eq!(skill_impact.outcome_counts["tasks_completed"], 1);
+        assert_eq!(skill_impact.usage_count, 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Persist rule and skill surfaces per session in the m243 ledger.
- Batch rule surface_count updates with audit rows at SessionStart injection.
- Add cas_search skill_impact report joined to session outcomes and existing feedback/usage counters.

## Verification
- nextest scoped proof: 4 passed, 5,248 skipped; proof surface complete.
- cas-store ledger tests: 2 passed.
- cas-core legacy surface-count test: 1 passed.
- migration ledger and registry tests: 2 passed.
- ZIG=/home/pippenz/Petrastella/cas-src/.context/zig/zig