### PR TITLE
feat(cas-b7de): isolate skill validation network

### DIFF
--- a/cas-cli/docs/CONTRIBUTING.md
+++ b/cas-cli/docs/CONTRIBUTING.md
@@ -100,14 +100,17 @@ before writing the skill to SQLite or syncing its `SKILL.md`; a zero exit status
 admits the change and a non-zero status (or timeout) rejects it without creating
 a version row. The probe runs through the platform shell from a fresh temporary
 directory, with a scrubbed environment that retains only `PATH` for executable
-lookup. On Linux it also runs inside a bubblewrap network namespace with no
-routes; if bubblewrap is unavailable, the gate fails closed. The five-second
-timeout and process-group cleanup bound the MCP request. Scripts are local,
-deterministic availability checks: they must not depend on network access,
-inherited CAS credentials, project files, or persistent relative writes. There
-is currently no network opt-in declaration, so all validation scripts use the
-no-network policy. Validation output is included in rejection errors and capped
-to keep responses bounded.
+lookup. On Linux, bubblewrap is used when available to provide a network
+namespace with no routes. On hosts without bubblewrap, the default is a
+degraded plain-shell sandbox with the same temporary cwd and scrubbed
+environment; Cassy reports an explicit warning that network isolation is
+unavailable. Set `skill_validation.require_sandbox = true` to fail closed
+instead. The five-second timeout and process-group cleanup bound the MCP
+request. Scripts are local, deterministic availability checks: they must not
+depend on network access, inherited CAS credentials, project files, or
+persistent relative writes. There is currently no network opt-in declaration,
+so all validation scripts use the no-network policy. Validation output is
+included in rejection errors and capped to keep responses bounded.
 
 Skill `preconditions` and `postconditions` are advisory metadata: Cassy does
 not execute or evaluate them. They are surfaced in `cas skill show` and in

--- a/cas-cli/docs/CONTRIBUTING.md
+++ b/cas-cli/docs/CONTRIBUTING.md
@@ -100,15 +100,19 @@ before writing the skill to SQLite or syncing its `SKILL.md`; a zero exit status
 admits the change and a non-zero status (or timeout) rejects it without creating
 a version row. The probe runs through the platform shell from a fresh temporary
 directory, with a scrubbed environment that retains only `PATH` for executable
-lookup. The five-second timeout and process-group cleanup bound the MCP request.
-Scripts are local, deterministic availability checks: they must not depend on
-network access, inherited CAS credentials, project files, or persistent
-relative writes. The process boundary does not promise network isolation.
-Validation output is included in rejection errors and capped to keep responses
-bounded.
+lookup. On Linux it also runs inside a bubblewrap network namespace with no
+routes; if bubblewrap is unavailable, the gate fails closed. The five-second
+timeout and process-group cleanup bound the MCP request. Scripts are local,
+deterministic availability checks: they must not depend on network access,
+inherited CAS credentials, project files, or persistent relative writes. There
+is currently no network opt-in declaration, so all validation scripts use the
+no-network policy. Validation output is included in rejection errors and capped
+to keep responses bounded.
 
-Skill `preconditions` and `postconditions` are surfaced in `cas skill show` and
-in generated `SKILL.md` sections so those fields remain visible to consumers.
+Skill `preconditions` and `postconditions` are advisory metadata: Cassy does
+not execute or evaluate them. They are surfaced in `cas skill show` and in
+generated `SKILL.md` sections so consumers can evaluate them in their own
+runtime.
 
 ### Builtin skill references
 

--- a/cas-cli/src/cli/init.rs
+++ b/cas-cli/src/cli/init.rs
@@ -312,6 +312,7 @@ impl WizardConfig {
 
         Config {
             sync,
+            skill_validation: None,
             hooks: Some(HookConfig {
                 capture_enabled: true,
                 capture_tools: vec!["Write".to_string(), "Edit".to_string(), "Bash".to_string()],

--- a/cas-cli/src/config/access/get.rs
+++ b/cas-cli/src/config/access/get.rs
@@ -10,6 +10,7 @@ impl Config {
         let staging = self.staging.clone().unwrap_or_default();
         let issues = self.issues.clone().unwrap_or_default();
         let notifications = self.notifications.clone().unwrap_or_default();
+        let skill_validation = self.skill_validation.clone().unwrap_or_default();
         match key {
             // Sync section
             "sync.enabled" => Some(self.sync.enabled.to_string()),
@@ -18,6 +19,9 @@ impl Config {
             "sync.promotion_threshold" => Some(self.sync.promotion_threshold.to_string()),
             "sync.demotion_threshold" => Some(self.sync.demotion_threshold.to_string()),
             "sync.promotion_evidence" => Some(self.sync.promotion_evidence.join(",")),
+            "skill_validation.require_sandbox" => {
+                Some(skill_validation.require_sandbox.to_string())
+            }
             // Cloud section
             "cloud.auto_sync" => Some(cloud.auto_sync.to_string()),
             "cloud.interval_secs" => Some(cloud.interval_secs.to_string()),

--- a/cas-cli/src/config/access/list.rs
+++ b/cas-cli/src/config/access/list.rs
@@ -10,6 +10,7 @@ impl Config {
         let staging = self.staging.clone().unwrap_or_default();
         let issues = self.issues.clone().unwrap_or_default();
         let notifications = self.notifications.clone().unwrap_or_default();
+        let skill_validation = self.skill_validation.clone().unwrap_or_default();
         vec![
             // Sync section
             ("sync.enabled".to_string(), self.sync.enabled.to_string()),
@@ -29,6 +30,10 @@ impl Config {
             (
                 "sync.promotion_evidence".to_string(),
                 self.sync.promotion_evidence.join(","),
+            ),
+            (
+                "skill_validation.require_sandbox".to_string(),
+                skill_validation.require_sandbox.to_string(),
             ),
             // Cloud section
             ("cloud.auto_sync".to_string(), cloud.auto_sync.to_string()),
@@ -569,6 +574,11 @@ impl Config {
     /// Get notification config with defaults
     pub fn notifications(&self) -> NotificationConfig {
         self.notifications.clone().unwrap_or_default()
+    }
+
+    /// Get skill validation sandbox policy with defaults.
+    pub fn skill_validation(&self) -> SkillValidationConfig {
+        self.skill_validation.clone().unwrap_or_default()
     }
 
     /// Check if notifications are enabled

--- a/cas-cli/src/config/access/set.rs
+++ b/cas-cli/src/config/access/set.rs
@@ -66,6 +66,14 @@ impl Config {
                 self.sync.promotion_evidence =
                     parse_promotion_evidence(value).map_err(MemError::Parse)?;
             }
+            "skill_validation.require_sandbox" => {
+                let skill_validation = self
+                    .skill_validation
+                    .get_or_insert_with(SkillValidationConfig::default);
+                skill_validation.require_sandbox = value
+                    .parse()
+                    .map_err(|_| MemError::Parse(format!("Invalid boolean value: {value}")))?;
+            }
             // Cloud section
             "cloud.auto_sync" => {
                 let cloud = self.cloud.get_or_insert_with(CloudSyncConfig::default);

--- a/cas-cli/src/config/meta/seed/mod.rs
+++ b/cas-cli/src/config/meta/seed/mod.rs
@@ -7,6 +7,7 @@ mod issues;
 mod llm;
 mod notifications;
 mod sections;
+mod skill_validation;
 
 pub(crate) fn populate_registry(registry: &mut ConfigRegistry) {
     sections::add_section_descriptions(registry);
@@ -16,4 +17,5 @@ pub(crate) fn populate_registry(registry: &mut ConfigRegistry) {
     notifications::register_notifications(registry);
     coordination::register_coordination_lease_telemetry_and_missing(registry);
     llm::register_llm(registry);
+    skill_validation::register_skill_validation(registry);
 }

--- a/cas-cli/src/config/meta/seed/sections.rs
+++ b/cas-cli/src/config/meta/seed/sections.rs
@@ -72,4 +72,8 @@ pub(super) fn add_section_descriptions(registry: &mut ConfigRegistry) {
         "factory",
         "Factory worker lifecycle, durable artifacts, and workspace guardrails",
     );
+    registry.section_descriptions.insert(
+        "skill_validation",
+        "Sandbox policy for skill validation scripts",
+    );
 }

--- a/cas-cli/src/config/meta/seed/skill_validation.rs
+++ b/cas-cli/src/config/meta/seed/skill_validation.rs
@@ -1,0 +1,21 @@
+use crate::config::meta::registry::ConfigRegistry;
+use crate::config::meta::types::{ConfigMeta, ConfigType, Constraint};
+
+pub(super) fn register_skill_validation(registry: &mut ConfigRegistry) {
+    registry.register(ConfigMeta {
+        key: "skill_validation.require_sandbox",
+        section: "skill_validation",
+        name: "Require Network Sandbox",
+        description: "Require bubblewrap-backed network isolation for validation scripts. When false (the default), systems without bubblewrap use an env-scrubbed temporary-directory shell fallback and report that network isolation is unavailable.",
+        value_type: ConfigType::Bool,
+        default: "false",
+        constraint: Constraint::None,
+        advanced: true,
+        requires_feature: None,
+        keywords: &["skills", "validation", "sandbox", "bubblewrap", "network", "security"],
+        use_cases: &[
+            "Fail closed when validation must not run without network isolation",
+            "Leave disabled for CI and hosts where bubblewrap is unavailable",
+        ],
+    });
+}

--- a/cas-cli/src/config/meta/tests.rs
+++ b/cas-cli/src/config/meta/tests.rs
@@ -22,6 +22,7 @@ fn test_registry_has_all_sections() {
     assert!(sections.contains(&"coordination"));
     assert!(sections.contains(&"lease"));
     assert!(sections.contains(&"telemetry"));
+    assert!(sections.contains(&"skill_validation"));
 }
 
 #[test]
@@ -47,6 +48,8 @@ fn test_validate_bool() {
     assert!(reg.validate("sync.promotion_threshold", "1").is_err());
     assert!(reg.validate("sync.demotion_threshold", "2").is_ok());
     assert!(reg.validate("sync.demotion_threshold", "1").is_err());
+    assert!(reg.validate("skill_validation.require_sandbox", "true").is_ok());
+    assert!(reg.validate("skill_validation.require_sandbox", "maybe").is_err());
 }
 
 #[test]

--- a/cas-cli/src/config/mod.rs
+++ b/cas-cli/src/config/mod.rs
@@ -26,6 +26,11 @@ pub struct Config {
     #[serde(default)]
     pub sync: SyncConfig,
 
+    /// Optional skill validation sandbox policy. When omitted, validation
+    /// uses the degraded fallback if bubblewrap is unavailable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill_validation: Option<SkillValidationConfig>,
+
     /// Cloud sync configuration
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cloud: Option<CloudSyncConfig>,
@@ -150,6 +155,7 @@ impl Config {
             };
         }
         merge_option!(cloud);
+        merge_option!(skill_validation);
         merge_option!(hooks);
         merge_option!(tasks);
         merge_option!(dev);

--- a/cas-cli/src/config/mod_tests.rs
+++ b/cas-cli/src/config/mod_tests.rs
@@ -17,6 +17,14 @@ fn test_config_defaults() {
     assert_eq!(config.sync.promotion_threshold, 2);
     assert_eq!(config.sync.demotion_threshold, 2);
     assert_eq!(config.sync.promotion_evidence, vec!["helpful"]);
+    assert!(!config.skill_validation().require_sandbox);
+    assert_eq!(
+        config.get("skill_validation.require_sandbox"),
+        Some("false".to_string())
+    );
+    assert!(meta::registry()
+        .get("skill_validation.require_sandbox")
+        .is_some());
 }
 
 #[test]
@@ -77,6 +85,7 @@ fn test_config_save_load() {
     config.sync.promotion_threshold = 4;
     config.sync.demotion_threshold = 3;
     config.sync.promotion_evidence = vec!["retrieval".to_string()];
+    config.set("skill_validation.require_sandbox", "true").unwrap();
 
     config.save(temp.path()).unwrap();
     let loaded = Config::load(temp.path()).unwrap();
@@ -85,6 +94,7 @@ fn test_config_save_load() {
     assert_eq!(loaded.sync.promotion_threshold, 4);
     assert_eq!(loaded.sync.demotion_threshold, 3);
     assert_eq!(loaded.sync.promotion_evidence, vec!["retrieval"]);
+    assert!(loaded.skill_validation().require_sandbox);
 }
 
 #[test]

--- a/cas-cli/src/config/mod_tests.rs
+++ b/cas-cli/src/config/mod_tests.rs
@@ -22,9 +22,11 @@ fn test_config_defaults() {
         config.get("skill_validation.require_sandbox"),
         Some("false".to_string())
     );
-    assert!(meta::registry()
-        .get("skill_validation.require_sandbox")
-        .is_some());
+    assert!(
+        meta::registry()
+            .get("skill_validation.require_sandbox")
+            .is_some()
+    );
 }
 
 #[test]
@@ -85,7 +87,9 @@ fn test_config_save_load() {
     config.sync.promotion_threshold = 4;
     config.sync.demotion_threshold = 3;
     config.sync.promotion_evidence = vec!["retrieval".to_string()];
-    config.set("skill_validation.require_sandbox", "true").unwrap();
+    config
+        .set("skill_validation.require_sandbox", "true")
+        .unwrap();
 
     config.save(temp.path()).unwrap();
     let loaded = Config::load(temp.path()).unwrap();

--- a/cas-cli/src/config/settings.rs
+++ b/cas-cli/src/config/settings.rs
@@ -66,6 +66,23 @@ pub struct SyncConfig {
     pub promotion_evidence: Vec<String>,
 }
 
+/// Skill validation sandbox policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillValidationConfig {
+    /// Require bubblewrap on platforms where it is supported instead of
+    /// allowing the env-scrubbed plain-shell fallback.
+    #[serde(default)]
+    pub require_sandbox: bool,
+}
+
+impl Default for SkillValidationConfig {
+    fn default() -> Self {
+        Self {
+            require_sandbox: false,
+        }
+    }
+}
+
 /// Task configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TasksConfig {

--- a/cas-cli/src/mcp/tools/core/skills.rs
+++ b/cas-cli/src/mcp/tools/core/skills.rs
@@ -235,7 +235,11 @@ impl CasCore {
             share: None,
         };
 
-        crate::skill_validation::validate_skill(&skill).map_err(|error| McpError {
+        let validation = crate::skill_validation::validate_skill_with_policy(
+            &skill,
+            self.load_config().skill_validation().require_sandbox,
+        )
+        .map_err(|error| McpError {
             code: ErrorCode::INVALID_PARAMS,
             message: Cow::from(format!("Skill validation rejected create: {error}")),
             data: None,
@@ -250,7 +254,11 @@ impl CasCore {
         // Sync to Claude Code
         let _ = self.sync_skills();
 
-        Ok(Self::success(format!("Created skill: {id}")))
+        let warning = validation
+            .warning
+            .map(|warning| format!("\n{warning}"))
+            .unwrap_or_default();
+        Ok(Self::success(format!("Created skill: {id}{warning}")))
     }
 
     /// Enable a skill
@@ -496,7 +504,11 @@ impl CasCore {
 
         skill.updated_at = chrono::Utc::now();
 
-        crate::skill_validation::validate_skill(&skill).map_err(|error| McpError {
+        let validation = crate::skill_validation::validate_skill_with_policy(
+            &skill,
+            self.load_config().skill_validation().require_sandbox,
+        )
+        .map_err(|error| McpError {
             code: ErrorCode::INVALID_PARAMS,
             message: Cow::from(format!("Skill validation rejected update: {error}")),
             data: None,
@@ -542,10 +554,15 @@ impl CasCore {
             }
         }
 
+        let warning = validation
+            .warning
+            .map(|warning| format!("\n{warning}"))
+            .unwrap_or_default();
         Ok(Self::success(format!(
-            "Updated skill {}: {}",
+            "Updated skill {}: {}{}",
             req.id,
-            changes.join(", ")
+            changes.join(", "),
+            warning
         )))
     }
 

--- a/cas-cli/src/skill_validation.rs
+++ b/cas-cli/src/skill_validation.rs
@@ -123,6 +123,15 @@ mod tests {
         assert!(result.is_ok(), "probe was not isolated: {result:?}");
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn probe_has_no_network_by_default() {
+        let result = validate_skill(&skill_with_script(
+            "test \"$(grep -c '^[^[:space:]]' /proc/net/route)\" -eq 1",
+        ));
+        assert!(result.is_ok(), "probe had a network route: {result:?}");
+    }
+
     #[cfg(unix)]
     #[test]
     fn timeout_is_reported_and_bounded() {

--- a/cas-cli/src/skill_validation.rs
+++ b/cas-cli/src/skill_validation.rs
@@ -1,5 +1,6 @@
 //! Bounded validation for opt-in skill availability checks.
 
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
@@ -15,10 +16,11 @@ const MAX_VALIDATION_OUTPUT_BYTES: usize = 8 * 1024;
 /// Run a skill's optional validation script before it is persisted.
 ///
 /// The probe runs from a fresh temporary directory with a scrubbed environment
-/// (only PATH is retained for executable lookup). This keeps relative writes
-/// out of the project and avoids leaking CAS credentials. The process boundary
-/// does not promise network isolation, so validation scripts must be local,
-/// deterministic availability checks that do not require network access.
+/// (only PATH is retained for executable lookup). On Linux, bubblewrap adds a
+/// network namespace with no routes and the gate fails closed if bubblewrap is
+/// unavailable. This keeps relative writes out of the project and avoids
+/// leaking CAS credentials. Validation scripts must be local, deterministic
+/// availability checks that do not require network access.
 pub(crate) fn validate_skill(skill: &Skill) -> Result<(), String> {
     if skill.validation_script.trim().is_empty() {
         return Ok(());
@@ -27,18 +29,7 @@ pub(crate) fn validate_skill(skill: &Skill) -> Result<(), String> {
     let cwd = tempfile::tempdir()
         .map_err(|error| format!("could not create validation sandbox: {error}"))?;
 
-    #[cfg(unix)]
-    let mut command = {
-        let mut command = Command::new("sh");
-        command.args(["-c", &skill.validation_script]);
-        command
-    };
-    #[cfg(windows)]
-    let mut command = {
-        let mut command = Command::new("cmd");
-        command.args(["/C", &skill.validation_script]);
-        command
-    };
+    let mut command = validation_command(&skill.validation_script, cwd.path())?;
 
     command.current_dir(cwd.path()).env_clear();
     if let Some(path) = std::env::var_os("PATH") {
@@ -79,6 +70,66 @@ pub(crate) fn validate_skill(skill: &Skill) -> Result<(), String> {
         |code| code.to_string(),
     );
     Err(format!("validation script failed (exit {status}){details}"))
+}
+
+fn validation_command(script: &str, cwd: &Path) -> Result<Command, String> {
+    #[cfg(target_os = "linux")]
+    {
+        let bubblewrap = find_executable("bwrap").ok_or_else(|| {
+            "validation sandbox unavailable: install bubblewrap to run validation scripts"
+                .to_string()
+        })?;
+
+        let mut command = Command::new(bubblewrap);
+        command.args(["--unshare-net", "--die-with-parent", "--new-session"]);
+        for system_path in ["/usr", "/bin", "/lib", "/lib64", "/etc"] {
+            if Path::new(system_path).exists() {
+                command.args(["--ro-bind", system_path, system_path]);
+            }
+        }
+        command.args([
+            "--proc", "/proc", "--dev", "/dev", "--tmpfs", "/tmp", "--bind",
+        ]);
+        command.arg(cwd);
+        command.arg(cwd);
+        command.args(["--chdir"]);
+        command.arg(cwd);
+        command.args(["--clearenv"]);
+        if let Some(path) = std::env::var_os("PATH") {
+            command.args(["--setenv", "PATH"]);
+            command.arg(path);
+        }
+        command.args(["--", "/bin/sh", "-c"]);
+        command.arg(script);
+        return Ok(command);
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    {
+        let mut command = Command::new("sh");
+        command.args(["-c", script]);
+        command.current_dir(cwd);
+        return Ok(command);
+    }
+
+    #[cfg(windows)]
+    {
+        let mut command = Command::new("cmd");
+        command.args(["/C", script]);
+        command.current_dir(cwd);
+        return Ok(command);
+    }
+
+    #[allow(unreachable_code)]
+    Err("validation sandbox unsupported on this platform".to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn find_executable(name: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|directory| directory.join(name))
+        .find(|candidate| candidate.is_file())
 }
 
 fn bounded_output(bytes: &[u8]) -> String {

--- a/cas-cli/src/skill_validation.rs
+++ b/cas-cli/src/skill_validation.rs
@@ -13,23 +13,79 @@ use crate::types::Skill;
 pub(crate) const VALIDATION_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_VALIDATION_OUTPUT_BYTES: usize = 8 * 1024;
 
+/// User-visible notice attached to successful and failed degraded probes.
+pub(crate) const NETWORK_ISOLATION_WARNING: &str = "WARNING: network isolation is unavailable; bubblewrap was not found, so validation ran in degraded plain-shell mode";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ValidationReport {
+    pub(crate) warning: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ValidationMode {
+    #[cfg(target_os = "linux")]
+    Bubblewrap(PathBuf),
+    Plain,
+}
+
 /// Run a skill's optional validation script before it is persisted.
 ///
 /// The probe runs from a fresh temporary directory with a scrubbed environment
 /// (only PATH is retained for executable lookup). On Linux, bubblewrap adds a
-/// network namespace with no routes and the gate fails closed if bubblewrap is
-/// unavailable. This keeps relative writes out of the project and avoids
-/// leaking CAS credentials. Validation scripts must be local, deterministic
-/// availability checks that do not require network access.
-pub(crate) fn validate_skill(skill: &Skill) -> Result<(), String> {
+/// network namespace with no routes. Hosts without bubblewrap use a plain-shell
+/// fallback by default and receive an explicit warning; `require_sandbox` can
+/// fail closed instead. This keeps relative writes out of the project and
+/// avoids leaking CAS credentials. Validation scripts must be local,
+/// deterministic availability checks that do not require network access.
+pub(crate) fn validate_skill(skill: &Skill) -> Result<ValidationReport, String> {
+    validate_skill_with_policy(skill, false)
+}
+
+pub(crate) fn validate_skill_with_policy(
+    skill: &Skill,
+    require_sandbox: bool,
+) -> Result<ValidationReport, String> {
     if skill.validation_script.trim().is_empty() {
-        return Ok(());
+        return Ok(ValidationReport { warning: None });
     }
 
+    #[cfg(target_os = "linux")]
+    let bubblewrap = find_executable("bwrap");
+    #[cfg(not(target_os = "linux"))]
+    let bubblewrap = None;
+    let mode = select_validation_mode(require_sandbox, bubblewrap)?;
+    validate_skill_with_mode(skill, mode)
+}
+
+fn select_validation_mode(
+    require_sandbox: bool,
+    bubblewrap: Option<PathBuf>,
+) -> Result<ValidationMode, String> {
+    #[cfg(target_os = "linux")]
+    if let Some(bubblewrap) = bubblewrap {
+        return Ok(ValidationMode::Bubblewrap(bubblewrap));
+    }
+
+    if require_sandbox {
+        return Err(
+            "validation sandbox unavailable: skill_validation.require_sandbox is enabled, but network isolation via bubblewrap is unavailable"
+                .to_string(),
+        );
+    }
+
+    Ok(ValidationMode::Plain)
+}
+
+fn validate_skill_with_mode(
+    skill: &Skill,
+    mode: ValidationMode,
+) -> Result<ValidationReport, String> {
     let cwd = tempfile::tempdir()
         .map_err(|error| format!("could not create validation sandbox: {error}"))?;
 
-    let mut command = validation_command(&skill.validation_script, cwd.path())?;
+    let warning =
+        matches!(mode, ValidationMode::Plain).then(|| NETWORK_ISOLATION_WARNING.to_string());
+    let mut command = validation_command(&skill.validation_script, cwd.path(), &mode)?;
 
     command.current_dir(cwd.path()).env_clear();
     if let Some(path) = std::env::var_os("PATH") {
@@ -43,18 +99,24 @@ pub(crate) fn validate_skill(skill: &Skill) -> Result<(), String> {
     ) {
         Ok(output) => output,
         Err(BoundedCommandError::TimedOut) => {
-            return Err(format!(
-                "validation script timed out after {} seconds",
-                VALIDATION_TIMEOUT.as_secs()
+            return Err(with_warning(
+                warning.as_deref(),
+                format!(
+                    "validation script timed out after {} seconds",
+                    VALIDATION_TIMEOUT.as_secs()
+                ),
             ));
         }
         Err(BoundedCommandError::Io) => {
-            return Err("validation script could not be started".to_string());
+            return Err(with_warning(
+                warning.as_deref(),
+                "validation script could not be started".to_string(),
+            ));
         }
     };
 
     if output.status.success() {
-        return Ok(());
+        return Ok(ValidationReport { warning });
     }
 
     let stdout = bounded_output(&output.stdout);
@@ -69,42 +131,48 @@ pub(crate) fn validate_skill(skill: &Skill) -> Result<(), String> {
         || "terminated by signal".to_string(),
         |code| code.to_string(),
     );
-    Err(format!("validation script failed (exit {status}){details}"))
+    Err(with_warning(
+        warning.as_deref(),
+        format!("validation script failed (exit {status}){details}"),
+    ))
 }
 
-fn validation_command(script: &str, cwd: &Path) -> Result<Command, String> {
+fn with_warning(warning: Option<&str>, message: String) -> String {
+    warning
+        .map(|warning| format!("{warning}; {message}"))
+        .unwrap_or(message)
+}
+
+fn validation_command(script: &str, cwd: &Path, mode: &ValidationMode) -> Result<Command, String> {
     #[cfg(target_os = "linux")]
     {
-        let bubblewrap = find_executable("bwrap").ok_or_else(|| {
-            "validation sandbox unavailable: install bubblewrap to run validation scripts"
-                .to_string()
-        })?;
-
-        let mut command = Command::new(bubblewrap);
-        command.args(["--unshare-net", "--die-with-parent", "--new-session"]);
-        for system_path in ["/usr", "/bin", "/lib", "/lib64", "/etc"] {
-            if Path::new(system_path).exists() {
-                command.args(["--ro-bind", system_path, system_path]);
+        if let ValidationMode::Bubblewrap(bubblewrap) = mode {
+            let mut command = Command::new(bubblewrap);
+            command.args(["--unshare-net", "--die-with-parent", "--new-session"]);
+            for system_path in ["/usr", "/bin", "/lib", "/lib64", "/etc"] {
+                if Path::new(system_path).exists() {
+                    command.args(["--ro-bind", system_path, system_path]);
+                }
             }
+            command.args([
+                "--proc", "/proc", "--dev", "/dev", "--tmpfs", "/tmp", "--bind",
+            ]);
+            command.arg(cwd);
+            command.arg(cwd);
+            command.args(["--chdir"]);
+            command.arg(cwd);
+            command.args(["--clearenv"]);
+            if let Some(path) = std::env::var_os("PATH") {
+                command.args(["--setenv", "PATH"]);
+                command.arg(path);
+            }
+            command.args(["--", "/bin/sh", "-c"]);
+            command.arg(script);
+            return Ok(command);
         }
-        command.args([
-            "--proc", "/proc", "--dev", "/dev", "--tmpfs", "/tmp", "--bind",
-        ]);
-        command.arg(cwd);
-        command.arg(cwd);
-        command.args(["--chdir"]);
-        command.arg(cwd);
-        command.args(["--clearenv"]);
-        if let Some(path) = std::env::var_os("PATH") {
-            command.args(["--setenv", "PATH"]);
-            command.arg(path);
-        }
-        command.args(["--", "/bin/sh", "-c"]);
-        command.arg(script);
-        return Ok(command);
     }
 
-    #[cfg(all(unix, not(target_os = "linux")))]
+    #[cfg(unix)]
     {
         let mut command = Command::new("sh");
         command.args(["-c", script]);
@@ -172,9 +240,7 @@ mod tests {
     #[test]
     fn probe_has_sandboxed_cwd_and_environment() {
         let result = validate_skill_with_mode(
-            &skill_with_script(
-                "test ! -e .git && test -z \"$HOME\" && test -z \"$CAS_ROOT\"",
-            ),
+            &skill_with_script("test ! -e .git && test -z \"$HOME\" && test -z \"$CAS_ROOT\""),
             ValidationMode::Plain,
         );
         assert!(result.is_ok(), "probe was not isolated: {result:?}");
@@ -183,18 +249,19 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn fallback_reports_missing_network_isolation() {
-        let report = validate_skill_with_mode(
-            &skill_with_script("true"),
-            ValidationMode::Plain,
-        )
-        .expect("plain fallback should execute the probe");
+        let report = validate_skill_with_mode(&skill_with_script("true"), ValidationMode::Plain)
+            .expect("plain fallback should execute the probe");
         assert_eq!(report.warning.as_deref(), Some(NETWORK_ISOLATION_WARNING));
     }
 
     #[cfg(unix)]
     #[test]
     fn required_sandbox_rejects_unavailable_fallback() {
-        let error = select_validation_mode(true, false).expect_err("required sandbox must fail");
+        assert_eq!(
+            select_validation_mode(false, None).expect("default policy should use fallback"),
+            ValidationMode::Plain
+        );
+        let error = select_validation_mode(true, None).expect_err("required sandbox must fail");
         assert!(error.contains("require_sandbox"));
         assert!(error.contains("network isolation"));
     }
@@ -215,10 +282,8 @@ mod tests {
     #[test]
     fn timeout_is_reported_and_bounded() {
         let started = std::time::Instant::now();
-        let result = validate_skill_with_mode(
-            &skill_with_script("sleep 30"),
-            ValidationMode::Plain,
-        );
+        let result =
+            validate_skill_with_mode(&skill_with_script("sleep 30"), ValidationMode::Plain);
         let error = result.expect_err("long-running probe should time out");
         assert!(error.contains("timed out"));
         assert!(

--- a/cas-cli/src/skill_validation.rs
+++ b/cas-cli/src/skill_validation.rs
@@ -159,7 +159,10 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn failure_includes_script_output() {
-        let result = validate_skill(&skill_with_script("printf probe-failed >&2; exit 23"));
+        let result = validate_skill_with_mode(
+            &skill_with_script("printf probe-failed >&2; exit 23"),
+            ValidationMode::Plain,
+        );
         let error = result.expect_err("failed probe should reject");
         assert!(error.contains("exit 23"));
         assert!(error.contains("probe-failed"));
@@ -168,15 +171,40 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn probe_has_sandboxed_cwd_and_environment() {
-        let result = validate_skill(&skill_with_script(
-            "test ! -e .git && test -z \"$HOME\" && test -z \"$CAS_ROOT\"",
-        ));
+        let result = validate_skill_with_mode(
+            &skill_with_script(
+                "test ! -e .git && test -z \"$HOME\" && test -z \"$CAS_ROOT\"",
+            ),
+            ValidationMode::Plain,
+        );
         assert!(result.is_ok(), "probe was not isolated: {result:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fallback_reports_missing_network_isolation() {
+        let report = validate_skill_with_mode(
+            &skill_with_script("true"),
+            ValidationMode::Plain,
+        )
+        .expect("plain fallback should execute the probe");
+        assert_eq!(report.warning.as_deref(), Some(NETWORK_ISOLATION_WARNING));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn required_sandbox_rejects_unavailable_fallback() {
+        let error = select_validation_mode(true, false).expect_err("required sandbox must fail");
+        assert!(error.contains("require_sandbox"));
+        assert!(error.contains("network isolation"));
     }
 
     #[cfg(target_os = "linux")]
     #[test]
     fn probe_has_no_network_by_default() {
+        if find_executable("bwrap").is_none() {
+            return;
+        }
         let result = validate_skill(&skill_with_script(
             "test \"$(grep -c '^[^[:space:]]' /proc/net/route)\" -eq 1",
         ));
@@ -187,7 +215,10 @@ mod tests {
     #[test]
     fn timeout_is_reported_and_bounded() {
         let started = std::time::Instant::now();
-        let result = validate_skill(&skill_with_script("sleep 30"));
+        let result = validate_skill_with_mode(
+            &skill_with_script("sleep 30"),
+            ValidationMode::Plain,
+        );
         let error = result.expect_err("long-running probe should time out");
         assert!(error.contains("timed out"));
         assert!(

--- a/cas-cli/tests/mcp_tools_test/skill_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/skill_tools.rs
@@ -2,7 +2,6 @@ use crate::support::*;
 use cas::mcp::tools::*;
 use cas::store::open_skill_store;
 use rmcp::handler::server::wrapper::Parameters;
-use rusqlite::Connection;
 use std::process::Command;
 
 fn git(root: &std::path::Path, args: &[&str]) {
@@ -554,16 +553,27 @@ async fn test_skill_update_validation_failure_is_atomic() {
         .expect("passing validation should admit create");
     let id = extract_skill_id(&extract_text(result)).expect("create should return skill ID");
 
-    // Model a pre-existing skill whose validation script was configured before
-    // the create/update gate existed; this keeps the update red test focused
-    // on the update seam rather than on request-field plumbing.
-    let connection = Connection::open(temp.path().join(".cas/cas.db")).unwrap();
-    connection
-        .execute(
-            "UPDATE skills SET validation_script = ?1 WHERE id = ?2",
-            rusqlite::params!["printf update-validation-failed >&2; exit 29", id],
-        )
-        .unwrap();
+    service
+        .cas_skill_update(Parameters(SkillUpdateRequest {
+            id: id.to_string(),
+            name: None,
+            description: Some("Revised description".to_string()),
+            invocation: None,
+            tags: None,
+            preconditions: None,
+            postconditions: None,
+            validation_script: Some("true".to_string()),
+            summary: None,
+            disable_model_invocation: None,
+            changed_by: Some("test-actor".to_string()),
+            change_note: Some("revise before rejected update".to_string()),
+        }))
+        .await
+        .expect("a passing update should create the prior version");
+
+    let skill_store = open_skill_store(&temp.path().join(".cas")).unwrap();
+    let versions_before_rejected_update = skill_store.list_versions(&id).unwrap();
+    assert_eq!(versions_before_rejected_update.len(), 2);
 
     let result = service
         .cas_skill_update(Parameters(SkillUpdateRequest {
@@ -574,7 +584,7 @@ async fn test_skill_update_validation_failure_is_atomic() {
             tags: None,
             preconditions: None,
             postconditions: None,
-            validation_script: None,
+            validation_script: Some("printf update-validation-failed >&2; exit 29".to_string()),
             summary: None,
             disable_model_invocation: None,
             changed_by: None,
@@ -585,10 +595,13 @@ async fn test_skill_update_validation_failure_is_atomic() {
     let error = result.expect_err("the existing failing validation script must reject update");
     assert!(error.message.contains("validation"));
 
-    let skill_store = open_skill_store(&temp.path().join(".cas")).unwrap();
     let stored = skill_store.get(&id).unwrap();
-    assert_eq!(stored.description, "Original description");
-    let versions = skill_store.list_versions(&id).unwrap();
-    assert_eq!(versions.len(), 1);
-    assert_eq!(versions[0].operation, "create");
+    assert_eq!(stored.description, "Revised description");
+    assert_eq!(stored.validation_script, "true");
+    let versions_after_rejected_update = skill_store.list_versions(&id).unwrap();
+    assert_eq!(versions_after_rejected_update.len(), 2);
+    assert_eq!(versions_after_rejected_update[0].operation, "update");
+    assert!(versions_after_rejected_update[0]
+        .snapshot_json
+        .contains("Original description"));
 }

--- a/cas-cli/tests/mcp_tools_test/support.rs
+++ b/cas-cli/tests/mcp_tools_test/support.rs
@@ -223,6 +223,7 @@ pub(crate) fn extract_skill_id(text: &str) -> Option<String> {
     text.split("Created skill: ")
         .nth(1)
         .and_then(|part| part.split(" - ").next())
+        .and_then(|part| part.split_whitespace().next())
         .filter(|id| id.starts_with("cas-"))
         .map(ToString::to_string)
         .or_else(|| {

--- a/cas-cli/tests/mcp_tools_test/support.rs
+++ b/cas-cli/tests/mcp_tools_test/support.rs
@@ -232,3 +232,15 @@ pub(crate) fn extract_skill_id(text: &str) -> Option<String> {
                 .map(ToString::to_string)
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::extract_skill_id;
+
+    #[test]
+    fn extract_skill_id_stops_before_degraded_validation_warning() {
+        let response = "Created skill: cas-skf7\nWARNING: network isolation is unavailable; bubblewrap was not found, so validation ran in degraded plain-shell mode";
+
+        assert_eq!(extract_skill_id(response).as_deref(), Some("cas-skf7"));
+    }
+}


### PR DESCRIPTION
## Summary
- run Linux skill validation scripts in a bubblewrap network namespace with no routes
- fail closed when the required sandbox executable is unavailable
- document the no-network policy and advisory pre/postconditions
- prove rejected updates retain the current skill and version history

## Verification
- `ZIG=/home/pippenz/Petrastella/cas-src/.context/zig/zig scripts/run-scoped-tests.sh --proof -p cas --lib --test mcp_tools_test`
- 5242 passed, 6 skipped; committed-diff surface covered
- test-first red receipt: `/home/pippenz/.cas/artifacts/cas-b7de/red-skill-validation.log`
