### PR TITLE
fix(cas-7bc2): scope personal delete requests by project

### DIFF
--- a/cas-cli/src/cloud/syncer/push.rs
+++ b/cas-cli/src/cloud/syncer/push.rs
@@ -501,10 +501,11 @@ impl CloudSyncer {
             }
 
             let delete_url = format!(
-                "{}/api/sync/{}/{}",
+                "{}/api/sync/{}/{}?project_id={}",
                 self.cloud_config.endpoint,
                 item.entity_type.as_str(),
-                cas_id
+                cas_id,
+                self.personal_push_project_id()?.replace('/', "%2F")
             );
 
             let response = ureq::delete(&delete_url)

--- a/cas-cli/tests/push_queue_scoping_test.rs
+++ b/cas-cli/tests/push_queue_scoping_test.rs
@@ -14,7 +14,7 @@ use cas::store::{open_store_local, open_task_store_local};
 use cas::types::{Entry, Task};
 use flate2::read::GzDecoder;
 use tempfile::TempDir;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn seed_project(root: &TempDir, endpoint: &str, canonical_id: &str) {
@@ -91,12 +91,14 @@ async fn personal_deletes_use_singular_task_and_entry_paths() {
     let server = MockServer::start().await;
     Mock::given(method("DELETE"))
         .and(path("/api/sync/task/absent-task"))
+        .and(query_param("project_id", "delete-project"))
         .respond_with(ResponseTemplate::new(204))
         .expect(1)
         .mount(&server)
         .await;
     Mock::given(method("DELETE"))
         .and(path("/api/sync/entry/absent-entry"))
+        .and(query_param("project_id", "delete-project"))
         .respond_with(ResponseTemplate::new(204))
         .expect(1)
         .mount(&server)


### PR DESCRIPTION
## Summary

- Include the resolved project_id query parameter on personal DELETE requests.
- URL-encode slash separators in project IDs consistently with the team delete path.
- Add wire-level regression coverage for task and entry personal tombstones.

## Tests

- `cargo check -p cas --lib --tests`
- `scripts/run-scoped-tests.sh --proof -p cas --lib push --test push_queue_scoping_test` (66 passed, 4842 skipped)
