### PR TITLE
release: prepare v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-08-30
+
+### Added
+- `cas cloud unlink [--purge-remote]`: sever a project's cloud link locally
+  and, with the flag, remove that project's remote records (entries, tasks,
+  knowledge pages) — scoped discovery through the single `CloudSyncer` pull
+  builder, dry-run support, fail-closed handling for record types the server
+  cannot delete, and the local database left byte-untouched.
+- Cassy-managed `.gitignore` blocks: consumer-project skill sync now maintains
+  an idempotent managed block covering the distributed builtin files
+  (`.claude`/`.codex`/`.grok`), preserving user entries, skipping the cas-src
+  authoring tree, and surfacing `git rm --cached` remediation when a managed
+  file is already tracked.
+- Durable external-condition wake triggers for parked work:
+  `branch_contained_in` and `tag_exists` reminders persist across sessions,
+  are probed by the daemon with bounded git commands, and deliver a
+  supervisor notification once on the false→true transition (GH #624).
+- Trace archives: bounded, range-readable archive retention in the daemon,
+  with archive readers exposed through the CLI store.
+- Versioned rule and skill creates with create-history snapshots (m242), rule
+  lifecycle gated on measured outcomes, and surfaced-artifact impact tracking
+  (m243).
+- `cas-supervisor` epic-driving playbook reference: one-integration-PR
+  discipline, target pinning, merge sweep, and spawn conventions in a 1.1KB
+  imperative reference mirrored to all three harness flavors.
+
+### Fixed
+- Team-sync deserialization: `TaskDeliverables` tolerates the legacy
+  JSON-string encoding on pull and canonicalizes on serialization, and the
+  cross-DB relocation writers normalize payloads before push — ends the
+  "Team pull encountered N error(s)" partial pulls (98 cloud rows were
+  repaired server-side alongside this release).
+- Release workflow: a tag pushed before its Release Prebuild completes now
+  waits (bounded, exact-SHA) instead of silently falling back to cold builds,
+  and any cold fallback is loudly reported (GH #603).
+- Factory: a child task whose WorkTarget equals the parent epic's default no
+  longer silently delivers to trunk — it inherits the live epic lane with a
+  durable decision note; explicit non-default targets remain authoritative
+  (GH #625).
+- Skill validation runs network-isolated with a degraded-validation fallback,
+  and skill-id parsing tolerates warning-suffixed ids.
+- Sync scoping: personal deletes and legacy team task upserts are
+  project-scoped; dangling cloud fixture symlinks are rejected.
+- Knowledge loop preserves provenance across sync, including synced skills.
+
 ## [3.6.0] - 2026-08-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-30-v3.7.0-slack.md
+++ b/docs/release-notes/2026-08-30-v3.7.0-slack.md
@@ -1,0 +1,25 @@
+# Release notes — 2026-08-30 — CAS v3.7.0
+
+**Channel:** `#cas-internal` · **Deploy:** Live on production · **POSTING EMBARGOED until 2026-08-31 (operator hold)**
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — your task list is finally trustworthy everywhere: cross-project mix-ups are cleaned up for good, syncing never half-fails anymore, and any project can go fully local-only with one command.
+
+**Reply:**
+- **Was** → a months-old syncing quirk had quietly scattered tasks between projects (telehealth work showing up in the tooling backlog, accounting tasks in product queues), and a batch of cloud records was so garbled that every machine silently skipped them during sync. **Now** → the misfiled tasks are gone, the garbled records are repaired, and syncing reports a clean zero-error pull on every project.
+- **Was** → there was no way to take a project off the cloud — once linked, it synced forever. **Now** → one command unlinks a project and optionally removes its records from the cloud, while everything on your machine stays exactly as it was.
+- **Was** → Cassy's helper files inside each project could end up committed to git or edited by hand, drifting out of date. **Now** → Cassy marks them as its own: git ignores them automatically and Cassy keeps them current itself.
+- **Was** → work waiting on something external (a release going out, a change landing) could sit unnoticed for hours. **Now** → Cassy sets itself a durable wake-up call and acts the moment the thing it's waiting for actually happens.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — CAS v3.7.0: TaskDeliverables string-decode tolerance + cloud row repair, `cas cloud unlink --purge-remote`, managed .gitignore blocks, exact-SHA prebuild gate in release.yml, durable branch/tag wake triggers, and epic-lane inheritance for default child WorkTargets.
+
+**Reply:**
+- **Was** → cross-DB relocation double-encoded `deliverables`, so 98 cloud task rows failed struct deserialization and every team pull applied partial results (8 projects × 98 error lines per update run). **Now** → pull tolerates one legacy string layer and canonicalizes on write, the relocation writers normalize before push, and a one-time repair re-pushed 70 canonicals and deleted 28 orphaned tombstones — scoped pulls verify 0 errors.
+- **Was** → no unlink surface existed; removing a project from the cloud meant manual API surgery. **Now** → `cas cloud unlink [--purge-remote]` with scoped discovery through the single `CloudSyncer` pull builder (guard-enforced), dry-run, fail-closed unsupported-type handling, and a byte-identical local DB.
+- **Was** → distributed builtin files sat unignored in consumer repos and drifted. **Now** → sync maintains an idempotent managed .gitignore block, preserves user entries, skips the authoring repo, and flags already-tracked files with remediation.
+- **Was** → a tag racing its Release Prebuild silently cold-built (11m34s vs 2m49s), parked work had no wake signal (14h stall), and a child task defaulting to trunk defeated the pinned epic into N serial PRs. **Now** → release.yml waits bounded on the exact SHA and shouts on cold fallback; `branch_contained_in`/`tag_exists` triggers persist and fire once on flip; default child targets inherit the live epic lane while explicit targets stay authoritative.


### PR DESCRIPTION
Version bump 3.6.0 → 3.7.0 across workspace crates, CHANGELOG for the post-v3.6.0 delta, embargoed Slack release-notes draft. Tag v3.7.0 follows on the merge commit after Release Prebuild completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017A1PGKScxSbTxjUPdnofCy