### PR TITLE
docs: release prep rides the integration PR (playbook + release rubric)

### DIFF
--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/epic-driving.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/epic-driving.md
@@ -7,5 +7,6 @@
 - Cap workers; issue one spawn request per task with `task_id` pre-assignment; create blocked follow-ups before their dependency completes.
 - Set `confirm_warning=true` for intentional late additions to an active epic.
 - Set `proof_scope_fix=true` and bind `known-repos` when a receipt names the wrong repository.
+- Carry the version bump, CHANGELOG section, and release-notes draft as the epic branch’s final commit; land them through its single integration PR before tagging for one tree, one queue cycle; reserve `release/vX-prepare` for multi-PR batch releases (version lives in the tree; the merge queue revalidates every tree).
 - Own the release cut; wait for Release Prebuild completion before tagging or publishing.
 - Mirror this skill/reference change into Claude, Codex, and Grok builtin trees; run flavor-drift and sync tests.

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor/references/epic-driving.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor/references/epic-driving.md
@@ -7,5 +7,6 @@
 - Cap workers; issue one spawn request per task with `task_id` pre-assignment; create blocked follow-ups before their dependency completes.
 - Set `confirm_warning=true` for intentional late additions to an active epic.
 - Set `proof_scope_fix=true` and bind `known-repos` when a receipt names the wrong repository.
+- Carry the version bump, CHANGELOG section, and release-notes draft as the epic branch’s final commit; land them through its single integration PR before tagging for one tree, one queue cycle; reserve `release/vX-prepare` for multi-PR batch releases (version lives in the tree; the merge queue revalidates every tree).
 - Own the release cut; wait for Release Prebuild completion before tagging or publishing.
 - Mirror this skill/reference change into Claude, Codex, and Grok builtin trees; run flavor-drift and sync tests.

--- a/cas-cli/src/builtins/reference-history.json
+++ b/cas-cli/src/builtins/reference-history.json
@@ -183,7 +183,8 @@
       "c06fd0ddd8e51fd0c77865a1ae6563413f12807a6723ec335fdfdc1d314fa0fa"
     ],
     "skills/cas-supervisor/references/epic-driving.md": [
-      "eb744fd4f41d6b08f84a3d3394f57a8d84cea9ef8aaf0bc9b8b290320bcb197b"
+      "eb744fd4f41d6b08f84a3d3394f57a8d84cea9ef8aaf0bc9b8b290320bcb197b",
+      "f46d8104c66be30f9e6bfdfb26d0c720944f0ec22db0aeb2d836146db3039214"
     ],
     "skills/cas-supervisor/references/filing-cas-bugs.md": [
       "1cc4cd3402cb9f06972b026f1727ff735ab007c860396fc12fe248db85aa3ed4",
@@ -365,6 +366,9 @@
     ],
     "skills/cas-supervisor/references/reminders.md": [
       "2a68b6b63af597702bae3682d0127260263c48306f9353e94f16b46076807dd9",
+      "4258884d8f44b185e4161cbdffa77deb95e1ee81ab9aab09b7dc2a31980dbb59",
+      "6288602afa0bb3c0e36e1579244390567108a120b8a9676521c6da29e8f22956",
+      "8cde55d6991991e4a8213f33e3078a8fb9a1bd91523b81206ca91fd87eec2393",
       "cb5b8c9b8472acd2ee8383b508828fe6cd466be5936baeb9b0e89066801db898",
       "f847fd0dc15bc47004edb86b16e5e7697bb44a4a2db93f42612270a687fa8df1"
     ],

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/epic-driving.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/epic-driving.md
@@ -7,5 +7,6 @@
 - Cap workers; issue one spawn request per task with `task_id` pre-assignment; create blocked follow-ups before their dependency completes.
 - Set `confirm_warning=true` for intentional late additions to an active epic.
 - Set `proof_scope_fix=true` and bind `known-repos` when a receipt names the wrong repository.
+- Carry the version bump, CHANGELOG section, and release-notes draft as the epic branch’s final commit; land them through its single integration PR before tagging for one tree, one queue cycle; reserve `release/vX-prepare` for multi-PR batch releases (version lives in the tree; the merge queue revalidates every tree).
 - Own the release cut; wait for Release Prebuild completion before tagging or publishing.
 - Mirror this skill/reference change into Claude, Codex, and Grok builtin trees; run flavor-drift and sync tests.

--- a/cas-cli/tests/factory_codex_skill_guardrails.rs
+++ b/cas-cli/tests/factory_codex_skill_guardrails.rs
@@ -181,6 +181,11 @@ fn supervisor_epic_driving_reference_is_compact_and_three_way_mirrored() {
             "confirm_warning=true",
             "proof_scope_fix=true",
             "known-repos",
+            "CHANGELOG",
+            "release-notes draft",
+            "integration PR",
+            "one tree, one queue cycle",
+            "release/vX-prepare",
             "Release Prebuild",
         ] {
             assert!(

--- a/docs/RELEASE_SLACK_RUBRIC.md
+++ b/docs/RELEASE_SLACK_RUBRIC.md
@@ -39,6 +39,8 @@ After a release is pushed + tagged, post to **#cas-internal** (`C0B44GUKDK2`). A
 and release-note draft on a source branch; do not merge or push that commit
 directly to `main`, and do not create the release tag before the PR lands.
 
+When a release follows an epic, carry the version bump, CHANGELOG section, and release-note draft as the epic branch’s final commit and land them through its single integration PR before tagging for one tree, one queue cycle; reserve a standalone `release/vX-prepare` PR for multi-PR batch releases, because the version lives in the tree and the merge queue revalidates every new tree.
+
 1. Push the source branch: `git push -u origin <source-branch>`.
 2. Open the release PR: `PR_URL=$(gh pr create --base main --head <source-branch> --fill)`.
 3. Surface its URL and required checks to the operator/supervisor:


### PR DESCRIPTION
Encodes the operator-confirmed release-process rule from the v3.7.0 cut: when a release cuts immediately after an epic, the version bump + CHANGELOG + notes draft ride the epic branch as its final commit before the single integration PR; the standalone release/vX-prepare PR is for multi-PR batch releases only. One imperative line in the epic-driving playbook reference (Claude/Codex/Grok flavors, within its 2KB budget) and one paragraph in the release process doc. Docs-only. (cas-9a54)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017A1PGKScxSbTxjUPdnofCy