### PR TITLE
Make codemap refreshes predictably fast

### DIFF
--- a/.github/actions/classify-required-diff/action.yml
+++ b/.github/actions/classify-required-diff/action.yml
@@ -4,6 +4,10 @@ inputs:
   base-sha:
     description: Commit on the base side of the comparison.
     required: true
+  zero-base-ref:
+    description: Trusted comparison ref for branch-creation pushes whose before SHA is all-zero.
+    required: false
+    default: ""
 outputs:
   class:
     description: The conservative CI diff classification.
@@ -24,15 +28,26 @@ runs:
       shell: bash
       env:
         BASE_SHA: ${{ inputs.base-sha }}
+        ZERO_BASE_REF: ${{ inputs.zero-base-ref }}
       run: |
         # checkout fetch-depth: 0 makes this a true merge-base comparison,
         # including an ancestry-only merge with no content changes.
         class=rust-touched
-        if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+        comparison_base="$BASE_SHA"
+        if [[ "$comparison_base" =~ ^0+$ && -n "$ZERO_BASE_REF" ]]; then
+          if git rev-parse --verify --quiet "$ZERO_BASE_REF^{commit}" >/dev/null; then
+            comparison_base="$ZERO_BASE_REF"
+            echo "::notice title=CI diff base::All-zero event base replaced with trusted ref '$ZERO_BASE_REF'"
+          else
+            echo "::warning title=CI diff base::Trusted fallback ref '$ZERO_BASE_REF' is unavailable; running Rust tier"
+          fi
+        fi
+
+        if [[ -z "$comparison_base" || "$comparison_base" =~ ^0+$ ]]; then
           # Schedules, manual dispatches, and tag pushes without a predecessor
           # do not have a comparison event, so uncertainty runs the full tier.
           echo "::notice title=CI diff class::No comparable base; running Rust tier"
-        elif ! merge_base="$(git merge-base "$BASE_SHA" HEAD)"; then
+        elif ! merge_base="$(git merge-base "$comparison_base" HEAD)"; then
           echo "::warning title=CI diff class::Could not find merge base; running Rust tier"
         elif ! class="$(scripts/classify-ci-diff.sh "$merge_base" HEAD)"; then
           echo "::warning title=CI diff class::Classifier failed; running Rust tier"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,11 @@ jobs:
         if: steps.pr-dedupe.outputs.covered != 'true'
         uses: ./.github/actions/classify-required-diff
         with:
-          base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          # A branch's first push carries before=000... even when it is based on
+          # main. Compare the complete branch diff against the protected base;
+          # tags and every other uncertain event still fail closed.
+          zero-base-ref: origin/${{ github.event.repository.default_branch }}
 
       - name: Test portable installer fixtures
         if: steps.pr-dedupe.outputs.covered != 'true'
@@ -288,7 +292,7 @@ jobs:
       - id: classify-diff
         uses: ./.github/actions/classify-required-diff
         with:
-          base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
 
       - name: Verify merge-queue self-hosted trust boundary
         if: needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
@@ -412,7 +416,7 @@ jobs:
       - id: classify-diff
         uses: ./.github/actions/classify-required-diff
         with:
-          base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
 
       - name: Verify merge-queue self-hosted trust boundary
         if: needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
@@ -557,7 +561,7 @@ jobs:
       - id: classify-diff
         uses: ./.github/actions/classify-required-diff
         with:
-          base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
 
       - name: Report Rust short-circuit
         if: steps.classify-diff.outputs.rust-unaffected == 'true'
@@ -615,7 +619,7 @@ jobs:
       - id: classify-diff
         uses: ./.github/actions/classify-required-diff
         with:
-          base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
 
       - name: Report Rust short-circuit
         if: steps.classify-diff.outputs.rust-unaffected == 'true'
@@ -652,7 +656,7 @@ jobs:
       - id: classify-diff
         uses: ./.github/actions/classify-required-diff
         with:
-          base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
 
       - name: Verify merge-queue self-hosted trust boundary
         if: needs.fast-validation-runner-route.outputs.mode == 'self-hosted'
@@ -821,8 +825,6 @@ jobs:
     name: Clippy (advisory, compiles only — no test suite)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'pull_request'
-      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || github.ref == 'refs/heads/staging'))
@@ -926,7 +928,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: ./.github/actions/classify-required-diff
         with:
-          base-sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+          base-sha: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
 
       - name: Report Rust short-circuit
         if: >-
@@ -1064,8 +1066,6 @@ jobs:
     name: Test Compile Guard (compile-only, executes nothing)
     if: >-
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'pull_request'
-      && github.base_ref == github.event.repository.default_branch)
       || (github.event_name == 'push'
       && (github.ref == 'refs/heads/main'
       || github.ref == 'refs/heads/staging'))

--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -217,6 +217,7 @@ test-ci-tiers:
 	cd .. && ./scripts/test-release-publication-policy.sh
 	cd .. && ./scripts/test-release-published-receipt.sh
 	cd .. && ./scripts/test-release-latency-receipt.sh
+	cd .. && ./scripts/test-codemap-latency-receipt.sh
 	cd .. && ./scripts/test-detect-pending-release.sh
 	cd .. && ./scripts/test-find-release-prebuild.sh
 	cd .. && ./scripts/test-check-release-runner-trust.sh

--- a/cas-cli/src/bounded_process.rs
+++ b/cas-cli/src/bounded_process.rs
@@ -83,7 +83,7 @@ pub(crate) fn run_command(
 }
 
 #[cfg(unix)]
-fn configure_process_group(command: &mut Command) {
+pub(crate) fn configure_process_group(command: &mut Command) {
     use std::os::unix::process::CommandExt;
     // SAFETY: setpgid is async-signal-safe and the closure touches no shared
     // Rust state between fork and exec.
@@ -99,10 +99,10 @@ fn configure_process_group(command: &mut Command) {
 }
 
 #[cfg(not(unix))]
-fn configure_process_group(_command: &mut Command) {}
+pub(crate) fn configure_process_group(_command: &mut Command) {}
 
 #[cfg(unix)]
-fn terminate_process_group(child: &mut std::process::Child) {
+pub(crate) fn terminate_process_group(child: &mut std::process::Child) {
     // A negative pid targets only the process group created above.
     unsafe {
         libc::kill(-(child.id() as i32), libc::SIGKILL);
@@ -111,7 +111,7 @@ fn terminate_process_group(child: &mut std::process::Child) {
 }
 
 #[cfg(not(unix))]
-fn terminate_process_group(child: &mut std::process::Child) {
+pub(crate) fn terminate_process_group(child: &mut std::process::Child) {
     let _ = child.kill();
     let _ = child.wait();
 }

--- a/cas-cli/src/builtins/codex/skills/codemap/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/codemap/SKILL.md
@@ -141,13 +141,14 @@ If a pointer already exists with the same name, update it. Do not create duplica
 `.claude/CODEMAP.md` is a distillable source, so one build turns the doc you just wrote into a knowledge page plus a source-ledger entry:
 
 ```bash
-set +e
-timeout --preserve-status --signal=KILL 90s cas knowledge build --max-sources 5
-build_exit_status=$?
-set -e
+if cas knowledge build --timeout-secs 90 --max-sources 5; then
+  build_exit_status=0
+else
+  build_exit_status=$?
+fi
 ```
 
-The command is deliberately best effort. If it times out (exit status 137) or returns any other non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing.
+The command is deliberately best effort. If it returns a non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing. Rust enforces the 90-second provider bound and terminates its process group, so a stalled build leaves no orphan descendant.
 
 Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound. This is one bounded invocation observed once. Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
 

--- a/cas-cli/src/builtins/codex/skills/codemap/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/codemap/SKILL.md
@@ -141,10 +141,15 @@ If a pointer already exists with the same name, update it. Do not create duplica
 `.claude/CODEMAP.md` is a distillable source, so one build turns the doc you just wrote into a knowledge page plus a source-ledger entry:
 
 ```bash
-cas knowledge build --max-sources 5
+set +e
+timeout --preserve-status --signal=KILL 90s cas knowledge build --max-sources 5
+build_exit_status=$?
+set -e
 ```
 
-Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
+The command is deliberately best effort. If it times out (exit status 137) or returns any other non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing.
+
+Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound. This is one bounded invocation observed once. Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
 
 ```bash
 cas knowledge search "codemap"

--- a/cas-cli/src/builtins/codex/skills/codemap/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/codemap/SKILL.md
@@ -148,7 +148,7 @@ else
 fi
 ```
 
-The command is deliberately best effort. If it returns a non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing. Rust enforces the 90-second provider bound and terminates its process group, so a stalled build leaves no orphan descendant.
+The command is deliberately best effort. If it returns a non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing. Rust enforces one 90-second wall-clock deadline across the complete build, stops later completions after exhaustion, and terminates/reaps the active provider process group, so a stalled build leaves no ordinary orphan descendant.
 
 Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound. This is one bounded invocation observed once. Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
 

--- a/cas-cli/src/builtins/grok/skills/codemap/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/codemap/SKILL.md
@@ -141,13 +141,14 @@ If a pointer already exists with the same name, update it. Do not create duplica
 `.claude/CODEMAP.md` is a distillable source, so one build turns the doc you just wrote into a knowledge page plus a source-ledger entry:
 
 ```bash
-set +e
-timeout --preserve-status --signal=KILL 90s cas knowledge build --max-sources 5
-build_exit_status=$?
-set -e
+if cas knowledge build --timeout-secs 90 --max-sources 5; then
+  build_exit_status=0
+else
+  build_exit_status=$?
+fi
 ```
 
-The command is deliberately best effort. If it times out (exit status 137) or returns any other non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing.
+The command is deliberately best effort. If it returns a non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing. Rust enforces the 90-second provider bound and terminates its process group, so a stalled build leaves no orphan descendant.
 
 Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound. This is one bounded invocation observed once. Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
 

--- a/cas-cli/src/builtins/grok/skills/codemap/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/codemap/SKILL.md
@@ -141,10 +141,15 @@ If a pointer already exists with the same name, update it. Do not create duplica
 `.claude/CODEMAP.md` is a distillable source, so one build turns the doc you just wrote into a knowledge page plus a source-ledger entry:
 
 ```bash
-cas knowledge build --max-sources 5
+set +e
+timeout --preserve-status --signal=KILL 90s cas knowledge build --max-sources 5
+build_exit_status=$?
+set -e
 ```
 
-Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
+The command is deliberately best effort. If it times out (exit status 137) or returns any other non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing.
+
+Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound. This is one bounded invocation observed once. Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
 
 ```bash
 cas knowledge search "codemap"

--- a/cas-cli/src/builtins/grok/skills/codemap/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/codemap/SKILL.md
@@ -148,7 +148,7 @@ else
 fi
 ```
 
-The command is deliberately best effort. If it returns a non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing. Rust enforces the 90-second provider bound and terminates its process group, so a stalled build leaves no orphan descendant.
+The command is deliberately best effort. If it returns a non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing. Rust enforces one 90-second wall-clock deadline across the complete build, stops later completions after exhaustion, and terminates/reaps the active provider process group, so a stalled build leaves no ordinary orphan descendant.
 
 Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound. This is one bounded invocation observed once. Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
 

--- a/cas-cli/src/builtins/skills/codemap/SKILL.md
+++ b/cas-cli/src/builtins/skills/codemap/SKILL.md
@@ -141,13 +141,14 @@ If a pointer already exists with the same name, update it. Do not create duplica
 `.claude/CODEMAP.md` is a distillable source, so one build turns the doc you just wrote into a knowledge page plus a source-ledger entry:
 
 ```bash
-set +e
-timeout --preserve-status --signal=KILL 90s cas knowledge build --max-sources 5
-build_exit_status=$?
-set -e
+if cas knowledge build --timeout-secs 90 --max-sources 5; then
+  build_exit_status=0
+else
+  build_exit_status=$?
+fi
 ```
 
-The command is deliberately best effort. If it times out (exit status 137) or returns any other non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing.
+The command is deliberately best effort. If it returns a non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing. Rust enforces the 90-second provider bound and terminates its process group, so a stalled build leaves no orphan descendant.
 
 Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound. This is one bounded invocation observed once. Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
 

--- a/cas-cli/src/builtins/skills/codemap/SKILL.md
+++ b/cas-cli/src/builtins/skills/codemap/SKILL.md
@@ -141,10 +141,15 @@ If a pointer already exists with the same name, update it. Do not create duplica
 `.claude/CODEMAP.md` is a distillable source, so one build turns the doc you just wrote into a knowledge page plus a source-ledger entry:
 
 ```bash
-cas knowledge build --max-sources 5
+set +e
+timeout --preserve-status --signal=KILL 90s cas knowledge build --max-sources 5
+build_exit_status=$?
+set -e
 ```
 
-Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
+The command is deliberately best effort. If it times out (exit status 137) or returns any other non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing.
+
+Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound. This is one bounded invocation observed once. Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
 
 ```bash
 cas knowledge search "codemap"

--- a/cas-cli/src/builtins/skills/codemap/SKILL.md
+++ b/cas-cli/src/builtins/skills/codemap/SKILL.md
@@ -148,7 +148,7 @@ else
 fi
 ```
 
-The command is deliberately best effort. If it returns a non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing. Rust enforces the 90-second provider bound and terminates its process group, so a stalled build leaves no orphan descendant.
+The command is deliberately best effort. If it returns a non-zero exit status, record the durable receipt in task notes with the command and exit status, then continue with the CODEMAP commit and `cas codemap status` proof; a failed build is non-blocking and may leave the knowledge page stale or missing. Rust enforces one 90-second wall-clock deadline across the complete build, stops later completions after exhaustion, and terminates/reaps the active provider process group, so a stalled build leaves no ordinary orphan descendant.
 
 Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound. This is one bounded invocation observed once. Nothing else in the repo changed, so the ledger short-circuits every other source and this costs at most one model call. Confirm it landed:
 

--- a/cas-cli/src/cli/knowledge_cmd.rs
+++ b/cas-cli/src/cli/knowledge_cmd.rs
@@ -2,6 +2,7 @@
 //! (EPIC cas-7d31 / cas-c9be).
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use clap::{Args, Subcommand};
 
@@ -42,6 +43,10 @@ pub struct BuildArgs {
     /// Maximum indexed symbols loaded when seeding code module summaries
     #[arg(long, default_value_t = DEFAULT_MAX_SYMBOLS)]
     pub max_symbols: usize,
+
+    /// Maximum wall-clock time for each provider completion
+    #[arg(long, default_value_t = DEFAULT_TIMEOUT_SECS, value_parser = parse_timeout_secs)]
+    pub timeout_secs: u64,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -96,6 +101,23 @@ const SYMBOL_PAGE: usize = 2_000;
 
 /// Default ceiling on symbols loaded to seed `code://` module sources.
 pub const DEFAULT_MAX_SYMBOLS: usize = 5_000;
+
+/// Hard ceiling for a knowledge-build provider completion. This is a CLI
+/// contract rather than a shell convention, so every platform gets the same
+/// bound and process-group cleanup implemented by the Rust runner.
+pub const DEFAULT_TIMEOUT_SECS: u64 = 90;
+
+fn parse_timeout_secs(value: &str) -> Result<u64, String> {
+    let seconds = value.parse::<u64>().map_err(|_| {
+        format!("timeout must be an integer from 1 to {DEFAULT_TIMEOUT_SECS} seconds")
+    })?;
+    if seconds == 0 || seconds > DEFAULT_TIMEOUT_SECS {
+        return Err(format!(
+            "timeout must be between 1 and {DEFAULT_TIMEOUT_SECS} seconds"
+        ));
+    }
+    Ok(seconds)
+}
 
 /// What a symbol load produced, and whether it saw the whole index.
 pub struct SymbolLoad {
@@ -188,7 +210,10 @@ fn execute_build(args: &BuildArgs, cas_root: &Path) -> anyhow::Result<()> {
     let runner: Box<dyn LlmRunner> = if args.dry_run {
         Box::new(ScriptedLlm::new(Vec::new()))
     } else {
-        Box::new(ClaudeCliRunner::new(args.model.clone()))
+        Box::new(
+            ClaudeCliRunner::new(args.model.clone())
+                .with_timeout(Duration::from_secs(args.timeout_secs)),
+        )
     };
 
     let report = run_distillation(&store, runner.as_ref(), &sources, &config)?;
@@ -369,5 +394,41 @@ mod tests {
         let load = load_symbols(&dir.path().join("nonexistent"), 10);
         assert!(load.symbols.is_empty());
         assert!(!load.truncated, "an absent index is complete, not truncated");
+    }
+
+    #[test]
+    fn knowledge_build_cli_accepts_only_a_positive_timeout_at_or_below_ninety() {
+        for value in ["0", "91", "18446744073709551615", "not-a-duration"] {
+            assert!(
+                crate::cli::try_parse_from_with_wordmark([
+                    "cas",
+                    "knowledge",
+                    "build",
+                    "--timeout-secs",
+                    value,
+                ])
+                .is_err(),
+                "invalid timeout {value} must be rejected by clap"
+            );
+        }
+        assert!(
+            crate::cli::try_parse_from_with_wordmark([
+                "cas",
+                "knowledge",
+                "build",
+                "--timeout-secs",
+                "90",
+            ])
+            .is_ok()
+        );
+
+        let parsed = crate::cli::try_parse_from_with_wordmark(["cas", "knowledge", "build"])
+            .expect("the default timeout must be valid");
+        match parsed.command {
+            Some(crate::cli::Commands::Knowledge(KnowledgeCommands::Build(args))) => {
+                assert_eq!(args.timeout_secs, DEFAULT_TIMEOUT_SECS);
+            }
+            _ => panic!("expected knowledge build command"),
+        }
     }
 }

--- a/cas-cli/src/cli/knowledge_cmd.rs
+++ b/cas-cli/src/cli/knowledge_cmd.rs
@@ -2,13 +2,13 @@
 //! (EPIC cas-7d31 / cas-c9be).
 
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use clap::{Args, Subcommand};
 
 use crate::knowledge::{
     ClaudeCliRunner, DistillConfig, LlmRunner, ScriptedLlm, SymbolLite, collect_sources,
-    run_distillation,
+    run_distillation_until,
 };
 use cas_store::{KnowledgeStore, SqliteKnowledgeStore};
 
@@ -44,7 +44,7 @@ pub struct BuildArgs {
     #[arg(long, default_value_t = DEFAULT_MAX_SYMBOLS)]
     pub max_symbols: usize,
 
-    /// Maximum wall-clock time for each provider completion
+    /// Maximum wall-clock time for the complete knowledge build
     #[arg(long, default_value_t = DEFAULT_TIMEOUT_SECS, value_parser = parse_timeout_secs)]
     pub timeout_secs: u64,
 }
@@ -102,9 +102,9 @@ const SYMBOL_PAGE: usize = 2_000;
 /// Default ceiling on symbols loaded to seed `code://` module sources.
 pub const DEFAULT_MAX_SYMBOLS: usize = 5_000;
 
-/// Hard ceiling for a knowledge-build provider completion. This is a CLI
-/// contract rather than a shell convention, so every platform gets the same
-/// bound and process-group cleanup implemented by the Rust runner.
+/// Hard ceiling for a complete knowledge build. This is a CLI contract rather
+/// than a shell convention, so every platform gets the same bound and
+/// process-group cleanup implemented by the Rust runner.
 pub const DEFAULT_TIMEOUT_SECS: u64 = 90;
 
 fn parse_timeout_secs(value: &str) -> Result<u64, String> {
@@ -179,6 +179,7 @@ pub fn load_symbols(cas_root: &Path, limit: usize) -> SymbolLoad {
 }
 
 fn execute_build(args: &BuildArgs, cas_root: &Path) -> anyhow::Result<()> {
+    let build_deadline = Instant::now() + Duration::from_secs(args.timeout_secs);
     let project_root = project_root_of(cas_root)?;
     let store = SqliteKnowledgeStore::open(cas_root)?;
     let load = load_symbols(cas_root, args.max_symbols);
@@ -216,7 +217,8 @@ fn execute_build(args: &BuildArgs, cas_root: &Path) -> anyhow::Result<()> {
         )
     };
 
-    let report = run_distillation(&store, runner.as_ref(), &sources, &config)?;
+    let report =
+        run_distillation_until(&store, runner.as_ref(), &sources, &config, build_deadline)?;
 
     if args.dry_run {
         println!("Knowledge distillation (dry run — nothing was written)");

--- a/cas-cli/src/knowledge/llm.rs
+++ b/cas-cli/src/knowledge/llm.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 
 use tempfile::NamedTempFile;
 
+use crate::bounded_process::{configure_process_group, terminate_process_group};
+
 /// Why a distillation call could not produce text.
 #[derive(Debug, thiserror::Error)]
 pub enum LlmError {
@@ -131,6 +133,13 @@ impl LlmRunner for ClaudeCliRunner {
             .stdin(Stdio::piped())
             .stdout(Stdio::from(stdout_file))
             .stderr(Stdio::from(stderr_file));
+        // Put the provider and all ordinary descendants in a private process
+        // group. A direct `Child::kill` leaves a stalled provider descendant
+        // holding our capture files (and possibly stdin) open on Unix/macOS.
+        // The shared bounded-process primitive kills the group and reaps the
+        // direct child at the deadline; non-Unix targets retain direct-child
+        // cleanup through the same API.
+        configure_process_group(&mut command);
         if let Some(model) = &self.model {
             command.arg("--model").arg(model);
         }
@@ -154,13 +163,13 @@ impl LlmRunner for ClaudeCliRunner {
                 Ok(Some(status)) => break Some(status),
                 Ok(None) => {
                     if Instant::now() >= deadline {
-                        let _ = child.kill();
-                        let _ = child.wait();
+                        terminate_process_group(&mut child);
                         break None;
                     }
                     std::thread::sleep(Duration::from_millis(50));
                 }
                 Err(error) => {
+                    terminate_process_group(&mut child);
                     return Err(LlmError::Failed(format!("wait failed: {error}")));
                 }
             }
@@ -369,6 +378,41 @@ mod tests {
         }
         assert!(started.elapsed() < Duration::from_secs(10), "deadline not enforced");
         assert_eq!(runner.calls(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_timed_out_provider_group_leaves_no_stalled_descendant() {
+        let stub_dir = tempfile::tempdir().expect("stub dir");
+        let child_pid_file = stub_dir.path().join("child.pid");
+        let script = format!(
+            "(sleep 30) & child_pid=$!; echo $child_pid > '{}'; wait",
+            child_pid_file.display()
+        );
+        let (_provider_dir, binary) = stub(&script);
+        let runner = runner_for(&binary, Duration::from_millis(300));
+        let started = Instant::now();
+        let result = runner.complete("hi");
+        assert!(matches!(result, Err(LlmError::Failed(message)) if message.contains("timed out")));
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "stalled provider must be bounded, took {:?}",
+            started.elapsed()
+        );
+
+        let child_pid = std::fs::read_to_string(&child_pid_file)
+            .expect("provider must start its descendant before the deadline")
+            .trim()
+            .parse::<u32>()
+            .expect("child pid");
+        // Give the kernel a short opportunity to reap the group member, then
+        // make one liveness probe. The codemap workflow itself never polls.
+        std::thread::sleep(Duration::from_millis(100));
+        let alive = unsafe { libc::kill(child_pid as i32, 0) == 0 };
+        assert!(
+            !alive,
+            "timed-out provider descendant {child_pid} is still alive"
+        );
     }
 
     #[cfg(unix)]

--- a/cas-cli/src/knowledge/llm.rs
+++ b/cas-cli/src/knowledge/llm.rs
@@ -24,12 +24,36 @@ pub enum LlmError {
     /// The provider ran but failed, timed out, or returned nothing usable.
     #[error("llm call failed: {0}")]
     Failed(String),
+    /// The enclosing knowledge build deadline expired while this call was
+    /// active or before it could be started.
+    #[error("llm call timed out after {0:?}")]
+    TimedOut(Duration),
 }
 
 /// A one-shot text completion provider.
 pub trait LlmRunner: Send + Sync {
     /// Run `prompt` and return the raw response text.
     fn complete(&self, prompt: &str) -> Result<String, LlmError>;
+
+    /// Run a completion without starting it after an enclosing build deadline.
+    /// Implementations that own a subprocess should also enforce the deadline
+    /// while the call is active; the default preserves existing test doubles
+    /// and non-process runners.
+    fn complete_with_deadline(
+        &self,
+        prompt: &str,
+        deadline: Option<Instant>,
+    ) -> Result<String, LlmError> {
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Err(LlmError::TimedOut(Duration::ZERO));
+        }
+        let result = self.complete(prompt);
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            Err(LlmError::TimedOut(Duration::ZERO))
+        } else {
+            result
+        }
+    }
 
     /// How many completions this runner has performed. Used by the pipeline
     /// report (and by tests asserting the zero-call short-circuit).
@@ -113,6 +137,35 @@ fn spawn_with_retry(command: &mut Command) -> std::io::Result<std::process::Chil
 
 impl LlmRunner for ClaudeCliRunner {
     fn complete(&self, prompt: &str) -> Result<String, LlmError> {
+        self.complete_with_deadline(prompt, None)
+    }
+
+    fn complete_with_deadline(
+        &self,
+        prompt: &str,
+        deadline: Option<Instant>,
+    ) -> Result<String, LlmError> {
+        self.complete_inner(prompt, deadline)
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::Relaxed)
+    }
+
+    fn label(&self) -> String {
+        match &self.model {
+            Some(model) => format!("{} ({model})", self.binary),
+            None => self.binary.clone(),
+        }
+    }
+}
+
+impl ClaudeCliRunner {
+    fn complete_inner(
+        &self,
+        prompt: &str,
+        enclosing_deadline: Option<Instant>,
+    ) -> Result<String, LlmError> {
         // Both captures are owned by `NamedTempFile`, so every early return —
         // including the `?` on the second create — unlinks what was created.
         let stdout_capture = Self::capture_file("out")?;
@@ -144,6 +197,11 @@ impl LlmRunner for ClaudeCliRunner {
             command.arg("--model").arg(model);
         }
 
+        let call_deadline = Instant::now() + self.timeout;
+        if enclosing_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Err(LlmError::TimedOut(self.timeout));
+        }
+
         let mut child = spawn_with_retry(&mut command)
             .map_err(|error| LlmError::Unavailable(format!("{}: {error}", self.binary)))?;
         self.calls.fetch_add(1, Ordering::Relaxed);
@@ -157,7 +215,7 @@ impl LlmRunner for ClaudeCliRunner {
             std::thread::spawn(move || stdin.write_all(payload.as_bytes()))
         });
 
-        let deadline = Instant::now() + self.timeout;
+        let deadline = enclosing_deadline.map_or(call_deadline, |global| global.min(call_deadline));
         let status = loop {
             match child.try_wait() {
                 Ok(Some(status)) => break Some(status),
@@ -186,6 +244,9 @@ impl LlmRunner for ClaudeCliRunner {
         let stderr = std::fs::read_to_string(stderr_capture.path()).unwrap_or_default();
 
         let Some(status) = status else {
+            if enclosing_deadline.is_some_and(|global| Instant::now() >= global) {
+                return Err(LlmError::TimedOut(self.timeout));
+            }
             return Err(LlmError::Failed(format!(
                 "timed out after {}s",
                 self.timeout.as_secs()
@@ -202,17 +263,6 @@ impl LlmRunner for ClaudeCliRunner {
             return Err(LlmError::Failed("empty response".to_string()));
         }
         Ok(stdout)
-    }
-
-    fn calls(&self) -> usize {
-        self.calls.load(Ordering::Relaxed)
-    }
-
-    fn label(&self) -> String {
-        match &self.model {
-            Some(model) => format!("{} ({model})", self.binary),
-            None => self.binary.clone(),
-        }
     }
 }
 

--- a/cas-cli/src/knowledge/mod.rs
+++ b/cas-cli/src/knowledge/mod.rs
@@ -22,7 +22,8 @@ use std::path::Path;
 pub use chunk::{Chunk, ChunkOptions, chunk_markdown};
 pub use llm::{ClaudeCliRunner, LlmError, LlmRunner, ScriptedLlm};
 pub use merge::{MergeTier, StripOutcome};
-pub use pipeline::{DistillConfig, DistillReport, run_distillation};
+pub use pipeline::{DistillConfig, DistillReport, run_distillation, run_distillation_with_timeout};
+pub(crate) use pipeline::run_distillation_until;
 pub use sources::{LoadedSource, SourceKind, SymbolLite, collect_file_sources};
 
 /// Environment gate for automatic distillation inside the daemon.

--- a/cas-cli/src/knowledge/pipeline.rs
+++ b/cas-cli/src/knowledge/pipeline.rs
@@ -9,6 +9,7 @@
 //! page that already states the incoming material merges for free (tier a).
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use chrono::Utc;
@@ -19,7 +20,7 @@ use cas_store::{
 };
 
 use super::chunk::{ChunkOptions, chunk_markdown};
-use super::llm::LlmRunner;
+use super::llm::{LlmError, LlmRunner};
 use super::merge::{
     self, DEFAULT_SMALL_PAGE_CHARS, Fragment, Frontmatter, MergeTier, StripOutcome,
 };
@@ -122,6 +123,53 @@ pub fn run_distillation(
     sources: &[LoadedSource],
     config: &DistillConfig,
 ) -> Result<DistillReport> {
+    Ok(run_distillation_inner(store, runner, sources, config, None)?.report)
+}
+
+/// Run one pass with a single wall-clock deadline shared by every source,
+/// chunk, model stage, merge rewrite, and post-commit repair operation.
+///
+/// A timeout commits any already-staged source outcomes and returns an error so
+/// the CLI can record a nonzero build status instead of reporting a successful
+/// pass after abandoning unfinished work.
+pub fn run_distillation_with_timeout(
+    store: &dyn KnowledgeStore,
+    runner: &dyn LlmRunner,
+    sources: &[LoadedSource],
+    config: &DistillConfig,
+    timeout: Duration,
+) -> Result<DistillReport> {
+    let deadline = Instant::now() + timeout;
+    run_distillation_until(store, runner, sources, config, deadline)
+}
+
+/// Run one pass until an absolute wall-clock deadline.
+pub(crate) fn run_distillation_until(
+    store: &dyn KnowledgeStore,
+    runner: &dyn LlmRunner,
+    sources: &[LoadedSource],
+    config: &DistillConfig,
+    deadline: Instant,
+) -> Result<DistillReport> {
+    let outcome = run_distillation_inner(store, runner, sources, config, Some(deadline))?;
+    if outcome.timed_out {
+        anyhow::bail!("knowledge build timed out before completion");
+    }
+    Ok(outcome.report)
+}
+
+struct DistillOutcome {
+    report: DistillReport,
+    timed_out: bool,
+}
+
+fn run_distillation_inner(
+    store: &dyn KnowledgeStore,
+    runner: &dyn LlmRunner,
+    sources: &[LoadedSource],
+    config: &DistillConfig,
+    deadline: Option<Instant>,
+) -> Result<DistillOutcome> {
     let calls_before = runner.calls();
     let mut report = DistillReport {
         sources_scanned: sources.len(),
@@ -155,7 +203,10 @@ pub fn run_distillation(
     // Nothing moved and nothing died: return before a single prompt is built.
     // This is the zero-cost path for an unchanged repo.
     if classification.to_ingest.is_empty() && classification.deleted.is_empty() {
-        return Ok(report);
+        return Ok(DistillOutcome {
+            report,
+            timed_out: false,
+        });
     }
 
     // A dry run stops here: it has classified everything (which is the useful
@@ -167,7 +218,10 @@ pub fn run_distillation(
                 .iter()
                 .map(|path| format!("dry run: {path} is gone from disk and would be tombstoned")),
         );
-        return Ok(report);
+        return Ok(DistillOutcome {
+            report,
+            timed_out: false,
+        });
     }
 
     let by_path: HashMap<&str, &LoadedSource> = sources
@@ -194,18 +248,33 @@ pub fn run_distillation(
 
     let mut writes: BTreeMap<String, PageWrite> = BTreeMap::new();
     let mut outcomes: Vec<SourceOutcome> = Vec::new();
+    let mut timed_out = false;
 
     for candidate in &pending {
+        if deadline_expired(deadline) {
+            timed_out = true;
+            break;
+        }
         let path = candidate.source.file_path.as_str();
         let Some(loaded) = by_path.get(path).copied() else {
             continue;
         };
 
-        let (pages, mut failure) = distill_source(runner, loaded, config, &mut report);
+        let (pages, mut failure, source_timed_out) =
+            distill_source(runner, loaded, config, &mut report, deadline);
         report.sources_attempted += 1;
+        timed_out |= source_timed_out;
+        if source_timed_out {
+            failure.get_or_insert_with(|| "knowledge build deadline exhausted".to_string());
+        }
 
         for page in pages {
-            if let Err(error) = stage_page(
+            if deadline_expired(deadline) {
+                timed_out = true;
+                failure.get_or_insert_with(|| "knowledge build deadline exhausted".to_string());
+                break;
+            }
+            match stage_page(
                 store,
                 runner,
                 &mut writes,
@@ -213,15 +282,32 @@ pub fn run_distillation(
                 page,
                 config,
                 &mut report,
+                deadline,
             ) {
-                // A page that could not be staged means this source is NOT
-                // fully ingested. Folding the error into `failure` keeps the
-                // ledger honest: marking it Ingested here would make
-                // `classify_sources` skip it forever at this content hash, so
-                // the knowledge would be lost until the file's bytes changed.
-                report.errors.push(format!("{path}: {error}"));
-                failure.get_or_insert(format!("stage page: {error}"));
+                Ok(stage_timed_out) => {
+                    if stage_timed_out {
+                        timed_out = true;
+                        failure.get_or_insert_with(|| {
+                            "knowledge build deadline exhausted".to_string()
+                        });
+                        break;
+                    }
+                }
+                Err(error) => {
+                    // A page that could not be staged means this source is NOT
+                    // fully ingested. Folding the error into `failure` keeps the
+                    // ledger honest: marking it Ingested here would make
+                    // `classify_sources` skip it forever at this content hash, so
+                    // the knowledge would be lost until the file's bytes changed.
+                    report.errors.push(format!("{path}: {error}"));
+                    failure.get_or_insert(format!("stage page: {error}"));
+                }
             }
+        }
+
+        timed_out |= deadline_expired(deadline);
+        if timed_out {
+            failure.get_or_insert_with(|| "knowledge build deadline exhausted".to_string());
         }
 
         let status = if failure.is_some() {
@@ -238,6 +324,9 @@ pub fn run_distillation(
             status,
             ingest_error: failure,
         });
+        if timed_out {
+            break;
+        }
     }
 
     // ── Commit ──────────────────────────────────────────────────────────
@@ -254,10 +343,24 @@ pub fn run_distillation(
 
     // ── Post-commit repair ──────────────────────────────────────────────
     let deleted_ids: BTreeSet<&String> = commit.cascade_deleted_page_ids.iter().collect();
-    repair_after_deletions(store, &cascade_watch, &deleted_ids, &mut report)?;
+    timed_out |= deadline_expired(deadline);
+    if !timed_out {
+        timed_out = repair_after_deletions(
+            store,
+            &cascade_watch,
+            &deleted_ids,
+            &mut report,
+            deadline,
+        )?;
+    }
 
     report.llm_calls = runner.calls().saturating_sub(calls_before);
-    Ok(report)
+    timed_out |= deadline_expired(deadline);
+    Ok(DistillOutcome { report, timed_out })
+}
+
+fn deadline_expired(deadline: Option<Instant>) -> bool {
+    deadline.is_some_and(|deadline| Instant::now() >= deadline)
 }
 
 /// Two-stage distillation of one source, degrading to single-stage when the
@@ -267,27 +370,42 @@ fn distill_source(
     source: &LoadedSource,
     config: &DistillConfig,
     report: &mut DistillReport,
-) -> (Vec<prompt::DistilledPage>, Option<String>) {
+    deadline: Option<Instant>,
+) -> (Vec<prompt::DistilledPage>, Option<String>, bool) {
     let hint = source.kind.page_type_hint();
     let mut pages = Vec::new();
     let mut failure: Option<String> = None;
+    let mut timed_out = false;
 
     let chunks = chunk_markdown(&source.content, &config.chunk);
     for chunk in chunks.iter().take(config.max_chunks_per_source) {
+        if deadline_expired(deadline) {
+            timed_out = true;
+            break;
+        }
         // Stage A — extraction plan.
-        let plan = match runner.complete(&prompt::stage_a_prompt(
+        let plan = match runner.complete_with_deadline(&prompt::stage_a_prompt(
             &source.path,
             &chunk.heading,
             &chunk.text,
-        )) {
+        ), deadline) {
             Ok(response) => prompt::parse_plan(&response),
             Err(error) => {
                 let message = format!("stage A: {error}");
                 report.errors.push(format!("{}: {message}", source.path));
                 failure.get_or_insert(message);
+                if is_timeout(&error, deadline) {
+                    timed_out = true;
+                    break;
+                }
                 prompt::ExtractionPlan::default()
             }
         };
+
+        if deadline_expired(deadline) {
+            timed_out = true;
+            break;
+        }
 
         // Stage B — page generation, or the single-stage degrade path.
         let stage_b_prompt_text = if plan.is_empty() {
@@ -297,17 +415,25 @@ fn distill_source(
             prompt::stage_b_prompt(&source.path, hint, &plan_json, &chunk.text)
         };
 
-        match runner.complete(&stage_b_prompt_text) {
+        match runner.complete_with_deadline(&stage_b_prompt_text, deadline) {
             Ok(response) => pages.extend(prompt::parse_pages(&response)),
             Err(error) => {
                 let message = format!("stage B: {error}");
                 report.errors.push(format!("{}: {message}", source.path));
                 failure.get_or_insert(message);
+                if is_timeout(&error, deadline) {
+                    timed_out = true;
+                    break;
+                }
             }
         }
     }
 
-    (pages, failure)
+    (pages, failure, timed_out)
+}
+
+fn is_timeout(error: &LlmError, deadline: Option<Instant>) -> bool {
+    matches!(error, LlmError::TimedOut(_)) || deadline_expired(deadline)
 }
 
 /// The single definition of "the user owns this page".
@@ -345,7 +471,8 @@ fn stage_page(
     distilled: prompt::DistilledPage,
     config: &DistillConfig,
     report: &mut DistillReport,
-) -> Result<()> {
+    deadline: Option<Instant>,
+) -> Result<bool> {
     let page_type = if distilled.page_type.is_empty() {
         source.kind.page_type_hint().to_string()
     } else {
@@ -411,11 +538,12 @@ fn stage_page(
     // the skip is reported rather than swallowed.
     if is_locked(&page, &existing_body) {
         report.pages_locked_skipped += 1;
-        return Ok(());
+        return Ok(false);
     }
 
     let sources = merge::union_sources(&page.sources, &[source.path.clone()]);
     let mut rewrite_snippet: Option<String> = None;
+    let mut rewrite_timed_out = false;
 
     let fragments: Vec<Fragment> = if existing_body.trim().is_empty() {
         vec![Fragment::new(
@@ -449,9 +577,19 @@ fn stage_page(
                 } else {
                     page.title.clone()
                 };
-                let (fragments, snippet) =
-                    rewrite_small_page(runner, &title, &existing_body, &distilled, source, report);
+                let (fragments, snippet, timed_out) = rewrite_small_page(
+                    runner,
+                    &title,
+                    &existing_body,
+                    &distilled,
+                    source,
+                    report,
+                    deadline,
+                );
                 rewrite_snippet = snippet;
+                if timed_out {
+                    rewrite_timed_out = true;
+                }
                 fragments
             }
             MergeTier::AppendDelta => {
@@ -486,7 +624,7 @@ fn stage_page(
     let body = merge::compose_body(&meta, &fragments);
 
     writes.insert(rel_path, PageWrite { page, body });
-    Ok(())
+    Ok(rewrite_timed_out)
 }
 
 /// Tier (b): one LLM call restates the distilled prose as a single voice.
@@ -505,7 +643,8 @@ fn rewrite_small_page(
     distilled: &prompt::DistilledPage,
     source: &LoadedSource,
     report: &mut DistillReport,
-) -> (Vec<Fragment>, Option<String>) {
+    deadline: Option<Instant>,
+) -> (Vec<Fragment>, Option<String>, bool) {
     let existing_fragments = merge::split_fragments(existing_body);
     let (preamble, distilled_fragments): (Vec<Fragment>, Vec<Fragment>) = existing_fragments
         .into_iter()
@@ -517,19 +656,19 @@ fn rewrite_small_page(
         .collect::<Vec<_>>()
         .join("\n\n");
 
-    let response = runner.complete(&prompt::rewrite_prompt(
+    let response = runner.complete_with_deadline(&prompt::rewrite_prompt(
         title,
         &existing_text,
         &distilled.body,
-    ));
+    ), deadline);
 
-    let rewritten = match response {
-        Ok(text) => prompt::parse_rewrite(&text),
+    let (rewritten, timed_out) = match response {
+        Ok(text) => (prompt::parse_rewrite(&text), false),
         Err(error) => {
             report
                 .errors
                 .push(format!("{}: merge rewrite: {error}", source.path));
-            None
+            (None, is_timeout(&error, deadline))
         }
     };
 
@@ -540,6 +679,7 @@ fn rewrite_small_page(
         return (
             merge::append_delta(existing_body, &distilled.body, &source.path, Utc::now()),
             None,
+            timed_out,
         );
     };
 
@@ -558,7 +698,7 @@ fn rewrite_small_page(
     ));
 
     let snippet = (!rewritten.snippet.trim().is_empty()).then(|| rewritten.snippet.clone());
-    (fragments, snippet)
+    (fragments, snippet, false)
 }
 
 /// After a commit that tombstoned sources: cut dead provenance out of surviving
@@ -568,9 +708,10 @@ fn repair_after_deletions(
     cascade_watch: &[(String, Vec<KnowledgePage>)],
     deleted_ids: &BTreeSet<&String>,
     report: &mut DistillReport,
-) -> Result<()> {
+    deadline: Option<Instant>,
+) -> Result<bool> {
     if cascade_watch.is_empty() {
-        return Ok(());
+        return Ok(deadline_expired(deadline));
     }
 
     let mut bodies: BTreeMap<String, (KnowledgePage, String)> = BTreeMap::new();
@@ -592,7 +733,13 @@ fn repair_after_deletions(
     }
 
     for (dead_source, pages) in cascade_watch {
+        if deadline_expired(deadline) {
+            return Ok(true);
+        }
         for watched in pages {
+            if deadline_expired(deadline) {
+                return Ok(true);
+            }
             if deleted_ids.contains(&watched.id) {
                 continue; // page went with its last source
             }
@@ -624,6 +771,9 @@ fn repair_after_deletions(
     // so a reader never follows a link into a page that no longer exists.
     if !dead_targets.is_empty() {
         for page in store.list_pages()? {
+            if deadline_expired(deadline) {
+                return Ok(true);
+            }
             let Some(body) = load_body(store, &bodies, &page) else {
                 continue;
             };
@@ -639,7 +789,7 @@ fn repair_after_deletions(
     }
 
     if bodies.is_empty() {
-        return Ok(());
+        return Ok(deadline_expired(deadline));
     }
 
     // Sources whose page prose may still describe a dead sibling are demoted to
@@ -670,8 +820,11 @@ fn repair_after_deletions(
         sources: demotions,
         tombstones: Vec::new(),
     };
+    if deadline_expired(deadline) {
+        return Ok(true);
+    }
     store.commit_ingest(&batch)?;
-    Ok(())
+    Ok(deadline_expired(deadline))
 }
 
 /// Body of a page during the repair pass: the in-flight edit if there is one,

--- a/cas-cli/tests/builtin_flavor_drift_test.rs
+++ b/cas-cli/tests/builtin_flavor_drift_test.rs
@@ -394,6 +394,168 @@ fn section_is_allowed(rel: &str, flavor: &str, heading: &str) -> bool {
 // Tests
 // ---------------------------------------------------------------------------
 
+const CODEMAP_SKILL_REL: &str = "skills/codemap/SKILL.md";
+
+/// Return the missing semantic requirements for the codemap knowledge-build
+/// workflow. This intentionally checks behavior (a kill-enforced <=90-second
+/// command, captured status, continuation, and explicit prohibitions) rather
+/// than requiring one exact prose spelling.
+fn codemap_build_contract_violations(content: &str) -> Vec<&'static str> {
+    let lower = content.to_ascii_lowercase();
+    let mut violations = Vec::new();
+
+    let Some(build_line) = lower.lines().find(|line| line.contains("cas knowledge build")) else {
+        return vec!["knowledge-build command"];
+    };
+
+    let build_start = build_line
+        .find("cas knowledge build")
+        .expect("build line was selected by its command marker");
+    let command_prefix = &build_line[..build_start];
+    let command_tokens: Vec<&str> = command_prefix.split_whitespace().collect();
+    let timeout_index = command_tokens.iter().position(|token| *token == "timeout");
+
+    let Some(timeout_index) = timeout_index else {
+        violations.push("hard timeout");
+        // The remaining checks are still useful for reporting all missing
+        // contract pieces in one assertion.
+        if !build_line.contains("--max-sources 5") {
+            violations.push("max-sources limit");
+        }
+        if build_line.trim_end().ends_with('&') {
+            violations.push("no detached/background command");
+        }
+        return violations;
+    };
+
+    let mut bound_seconds = None;
+    let mut kill_signal = false;
+    let mut expect_signal_value = false;
+    for token in command_tokens.iter().skip(timeout_index + 1) {
+        if expect_signal_value {
+            kill_signal = matches!(*token, "kill" | "9");
+            expect_signal_value = false;
+            continue;
+        }
+        if *token == "--signal=kill" || *token == "-skill" {
+            kill_signal = true;
+            continue;
+        }
+        if *token == "--signal" || *token == "-s" {
+            expect_signal_value = true;
+            continue;
+        }
+        if let Some(seconds) = token.strip_suffix('s')
+            && !seconds.is_empty()
+            && seconds.chars().all(|c| c.is_ascii_digit())
+        {
+            bound_seconds = seconds.parse::<u64>().ok();
+        }
+    }
+
+    match bound_seconds {
+        Some(seconds) if (1..=90).contains(&seconds) => {}
+        Some(_) => violations.push("<=90-second bound"),
+        None => violations.push("explicit seconds bound"),
+    }
+    if !kill_signal {
+        violations.push("hard kill at timeout");
+    }
+    if !build_line.contains("--max-sources 5") {
+        violations.push("max-sources limit");
+    }
+    if build_line.trim_end().ends_with('&')
+        || build_line.contains("nohup")
+        || build_line.contains("setsid")
+        || build_line.contains("disown")
+    {
+        violations.push("no detached/background command");
+    }
+
+    let has_negated_directive = |terms: &[&str]| {
+        lower.lines().any(|line| {
+            let negated = ["do not", "never", "must not", "prohibit", "forbid"]
+                .iter()
+                .any(|marker| line.contains(marker));
+            negated && terms.iter().all(|term| line.contains(term))
+        })
+    };
+
+    if !(lower.contains("non-zero") || lower.contains("nonzero"))
+        || !(lower.contains("non-blocking") || lower.contains("must not block"))
+        || !lower.contains("continue")
+    {
+        violations.push("non-zero failure is non-blocking and continues");
+    }
+    if !(lower.contains("record") || lower.contains("capture"))
+        || !(lower.contains("durable receipt") || lower.contains("task notes"))
+        || !(lower.contains("exit status") || lower.contains("exit code") || lower.contains("$?"))
+    {
+        violations.push("durable exit receipt");
+    }
+    if !lower.contains("set +e") || !lower.contains("build_exit_status") {
+        violations.push("failure-tolerant status capture");
+    }
+    if !has_negated_directive(&["detach", "background", "build"])
+        || !has_negated_directive(&["poll"])
+        || !has_negated_directive(&["wait", "90-second"])
+    {
+        violations.push("explicit no-detach/no-poll/no-unbounded-wait directives");
+    }
+
+    violations
+}
+
+/// The codemap skill must make knowledge distillation best-effort without
+/// allowing a model/upstream stall to hold the commit and status proof.
+#[test]
+fn codemap_build_contract_is_bounded_non_blocking_and_non_detached() {
+    for flavor in [&CLAUDE, &CODEX, &GROK] {
+        let rel = CODEMAP_SKILL_REL;
+        let content = fs::read_to_string(flavor_path(rel, flavor))
+            .unwrap_or_else(|e| panic!("{} {rel} missing: {e}", flavor.name));
+        let violations = codemap_build_contract_violations(&content);
+        assert!(
+            violations.is_empty(),
+            "{} {rel} violates codemap build contract: {violations:?}",
+            flavor.name
+        );
+    }
+}
+
+/// The semantic guard must reject the two regressions that motivated it even
+/// when all three flavors would otherwise remain textually synchronized.
+#[test]
+fn codemap_build_contract_rejects_unbounded_and_detached_variants() {
+    let valid = r#"
+```bash
+set +e
+timeout --preserve-status --signal=KILL 90s cas knowledge build --max-sources 5
+build_exit_status=$?
+set -e
+```
+
+If the command returns a non-zero exit status, record the durable receipt in task notes and continue with the CODEMAP commit and cas codemap status proof; this is non-blocking.
+Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound.
+"#;
+    assert!(
+        codemap_build_contract_violations(valid).is_empty(),
+        "the checker must accept equivalent valid contract prose"
+    );
+
+    let unbounded = valid.replace("timeout --preserve-status --signal=KILL 90s ", "");
+    assert!(
+        codemap_build_contract_violations(&unbounded).contains(&"hard timeout"),
+        "an unbounded knowledge build must be rejected"
+    );
+
+    let detached = valid.replace("cas knowledge build --max-sources 5", "cas knowledge build --max-sources 5 &");
+    assert!(
+        codemap_build_contract_violations(&detached).contains(&"no detached/background command"),
+        "a detached/background knowledge build must be rejected"
+    );
+}
+
 /// The guard: normalized three-way content comparison across all filesystem
 /// flavor triples. OpenCode's process-local catalog is checked below.
 #[test]

--- a/cas-cli/tests/builtin_flavor_drift_test.rs
+++ b/cas-cli/tests/builtin_flavor_drift_test.rs
@@ -441,6 +441,25 @@ fn codemap_build_contract_violations(content: &str) -> Vec<&'static str> {
     if !build_line.contains("--max-sources 5") {
         violations.push("max-sources limit");
     }
+    if !lower.contains("wall-clock")
+        || !(lower.contains("complete build")
+            || lower.contains("entire build")
+            || lower.contains("whole build"))
+    {
+        violations.push("single wall-clock deadline for the complete build");
+    }
+    if !lower.contains("stops later completions")
+        && !lower.contains("stop later completions")
+        && !lower.contains("no later completions")
+    {
+        violations.push("stop scheduling after deadline exhaustion");
+    }
+    if !lower.contains("process group")
+        || !(lower.contains("terminate") || lower.contains("kill"))
+        || !lower.contains("reap")
+    {
+        violations.push("terminate and reap the active provider group");
+    }
     if build_tokens[cas_index..].iter().any(|token| *token == "&")
         || build_line.trim_end().ends_with('&')
         || build_line.contains("nohup")
@@ -520,7 +539,7 @@ else
 fi
 ```
 
-If the command returns a non-zero exit status, record the durable receipt in task notes and continue with the CODEMAP commit and cas codemap status proof; this is non-blocking. Rust terminates the process group so a stalled build leaves no orphan descendant.
+If the command returns a non-zero exit status, record the durable receipt in task notes and continue with the CODEMAP commit and cas codemap status proof; this is non-blocking. Rust enforces one 90-second wall-clock deadline across the complete build, stops later completions after exhaustion, and terminates/reaps the active provider process group so a stalled build leaves no ordinary orphan descendant.
 Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound.
 "#;
     assert!(
@@ -532,6 +551,16 @@ Do not detach or background the build, run a manual polling loop, or wait beyond
     assert!(
         codemap_build_contract_violations(&unbounded).contains(&"--timeout-secs bound"),
         "an unbounded knowledge build must be rejected"
+    );
+
+    let per_completion_only = valid.replace(
+        "one 90-second wall-clock deadline across the complete build",
+        "a 90-second wall-clock deadline for each provider completion",
+    );
+    assert!(
+        codemap_build_contract_violations(&per_completion_only)
+            .contains(&"single wall-clock deadline for the complete build"),
+        "a per-completion-only bound must not satisfy the whole-build contract"
     );
 
     let detached = valid.replace(

--- a/cas-cli/tests/builtin_flavor_drift_test.rs
+++ b/cas-cli/tests/builtin_flavor_drift_test.rs
@@ -397,9 +397,9 @@ fn section_is_allowed(rel: &str, flavor: &str, heading: &str) -> bool {
 const CODEMAP_SKILL_REL: &str = "skills/codemap/SKILL.md";
 
 /// Return the missing semantic requirements for the codemap knowledge-build
-/// workflow. This intentionally checks behavior (a kill-enforced <=90-second
-/// command, captured status, continuation, and explicit prohibitions) rather
-/// than requiring one exact prose spelling.
+/// workflow. This intentionally checks behavior (a Rust-enforced <=90-second
+/// command, portable status capture, continuation, and explicit
+/// prohibitions) rather than requiring one exact prose spelling.
 fn codemap_build_contract_violations(content: &str) -> Vec<&'static str> {
     let lower = content.to_ascii_lowercase();
     let mut violations = Vec::new();
@@ -408,63 +408,41 @@ fn codemap_build_contract_violations(content: &str) -> Vec<&'static str> {
         return vec!["knowledge-build command"];
     };
 
-    let build_start = build_line
-        .find("cas knowledge build")
-        .expect("build line was selected by its command marker");
-    let command_prefix = &build_line[..build_start];
-    let command_tokens: Vec<&str> = command_prefix.split_whitespace().collect();
-    let timeout_index = command_tokens.iter().position(|token| *token == "timeout");
-
-    let Some(timeout_index) = timeout_index else {
-        violations.push("hard timeout");
-        // The remaining checks are still useful for reporting all missing
-        // contract pieces in one assertion.
-        if !build_line.contains("--max-sources 5") {
-            violations.push("max-sources limit");
-        }
-        if build_line.trim_end().ends_with('&') {
-            violations.push("no detached/background command");
-        }
+    let build_tokens: Vec<&str> = build_line
+        .split(|character: char| character.is_whitespace() || matches!(character, ';' | '`'))
+        .filter(|token| !token.is_empty())
+        .collect();
+    let Some(cas_index) = build_tokens.iter().position(|token| *token == "cas") else {
+        violations.push("knowledge-build command");
         return violations;
     };
+    let command_tokens = &build_tokens[cas_index..];
+
+    if build_tokens[..cas_index]
+        .iter()
+        .any(|token| matches!(*token, "timeout" | "/usr/bin/timeout" | "gtimeout"))
+    {
+        violations.push("portable Rust timeout");
+    }
 
     let mut bound_seconds = None;
-    let mut kill_signal = false;
-    let mut expect_signal_value = false;
-    for token in command_tokens.iter().skip(timeout_index + 1) {
-        if expect_signal_value {
-            kill_signal = matches!(*token, "kill" | "9");
-            expect_signal_value = false;
-            continue;
-        }
-        if *token == "--signal=kill" || *token == "-skill" {
-            kill_signal = true;
-            continue;
-        }
-        if *token == "--signal" || *token == "-s" {
-            expect_signal_value = true;
-            continue;
-        }
-        if let Some(seconds) = token.strip_suffix('s')
-            && !seconds.is_empty()
-            && seconds.chars().all(|c| c.is_ascii_digit())
-        {
-            bound_seconds = seconds.parse::<u64>().ok();
+    for (index, token) in command_tokens.iter().enumerate() {
+        if *token == "--timeout-secs" {
+            bound_seconds = command_tokens.get(index + 1).and_then(|value| value.parse().ok());
+        } else if let Some(value) = token.strip_prefix("--timeout-secs=") {
+            bound_seconds = value.parse().ok();
         }
     }
-
     match bound_seconds {
         Some(seconds) if (1..=90).contains(&seconds) => {}
-        Some(_) => violations.push("<=90-second bound"),
-        None => violations.push("explicit seconds bound"),
-    }
-    if !kill_signal {
-        violations.push("hard kill at timeout");
+        Some(_) => violations.push("<=90-second Rust timeout bound"),
+        None => violations.push("--timeout-secs bound"),
     }
     if !build_line.contains("--max-sources 5") {
         violations.push("max-sources limit");
     }
-    if build_line.trim_end().ends_with('&')
+    if build_tokens[cas_index..].iter().any(|token| *token == "&")
+        || build_line.trim_end().ends_with('&')
         || build_line.contains("nohup")
         || build_line.contains("setsid")
         || build_line.contains("disown")
@@ -493,7 +471,13 @@ fn codemap_build_contract_violations(content: &str) -> Vec<&'static str> {
     {
         violations.push("durable exit receipt");
     }
-    if !lower.contains("set +e") || !lower.contains("build_exit_status") {
+    if lower.contains("set +e") || lower.contains("set -e") {
+        violations.push("no caller-shell errexit mutation");
+    }
+    if !lower.contains("if cas knowledge build")
+        || !lower.contains("else")
+        || !lower.contains("build_exit_status=$?")
+    {
         violations.push("failure-tolerant status capture");
     }
     if !has_negated_directive(&["detach", "background", "build"])
@@ -523,19 +507,20 @@ fn codemap_build_contract_is_bounded_non_blocking_and_non_detached() {
     }
 }
 
-/// The semantic guard must reject the two regressions that motivated it even
+/// The semantic guard must reject the portability and lifecycle regressions that motivated it even
 /// when all three flavors would otherwise remain textually synchronized.
 #[test]
-fn codemap_build_contract_rejects_unbounded_and_detached_variants() {
+fn codemap_build_contract_rejects_portability_and_lifecycle_variants() {
     let valid = r#"
 ```bash
-set +e
-timeout --preserve-status --signal=KILL 90s cas knowledge build --max-sources 5
-build_exit_status=$?
-set -e
+if cas knowledge build --timeout-secs 90 --max-sources 5; then
+  build_exit_status=0
+else
+  build_exit_status=$?
+fi
 ```
 
-If the command returns a non-zero exit status, record the durable receipt in task notes and continue with the CODEMAP commit and cas codemap status proof; this is non-blocking.
+If the command returns a non-zero exit status, record the durable receipt in task notes and continue with the CODEMAP commit and cas codemap status proof; this is non-blocking. Rust terminates the process group so a stalled build leaves no orphan descendant.
 Do not detach or background the build, run a manual polling loop, or wait beyond the 90-second bound.
 "#;
     assert!(
@@ -543,16 +528,38 @@ Do not detach or background the build, run a manual polling loop, or wait beyond
         "the checker must accept equivalent valid contract prose"
     );
 
-    let unbounded = valid.replace("timeout --preserve-status --signal=KILL 90s ", "");
+    let unbounded = valid.replace("--timeout-secs 90", "");
     assert!(
-        codemap_build_contract_violations(&unbounded).contains(&"hard timeout"),
+        codemap_build_contract_violations(&unbounded).contains(&"--timeout-secs bound"),
         "an unbounded knowledge build must be rejected"
     );
 
-    let detached = valid.replace("cas knowledge build --max-sources 5", "cas knowledge build --max-sources 5 &");
+    let detached = valid.replace(
+        "cas knowledge build --timeout-secs 90 --max-sources 5",
+        "cas knowledge build --timeout-secs 90 --max-sources 5 &",
+    );
     assert!(
         codemap_build_contract_violations(&detached).contains(&"no detached/background command"),
         "a detached/background knowledge build must be rejected"
+    );
+
+    let gnu_timeout = valid.replace(
+        "if cas knowledge build",
+        "if timeout 90s cas knowledge build",
+    );
+    assert!(
+        codemap_build_contract_violations(&gnu_timeout).contains(&"portable Rust timeout"),
+        "a GNU timeout wrapper must be rejected"
+    );
+
+    let shell_mutation = valid.replace(
+        "if cas knowledge build --timeout-secs 90 --max-sources 5; then",
+        "set +e\ncas knowledge build --timeout-secs 90 --max-sources 5\nset -e\nif true; then",
+    );
+    assert!(
+        codemap_build_contract_violations(&shell_mutation)
+            .contains(&"no caller-shell errexit mutation"),
+        "status capture must not mutate the caller shell's errexit mode"
     );
 }
 

--- a/cas-cli/tests/cli_test.rs
+++ b/cas-cli/tests/cli_test.rs
@@ -1114,6 +1114,57 @@ fn test_knowledge_search_and_read_round_trip() {
         ));
 }
 
+#[cfg(unix)]
+#[test]
+fn knowledge_build_timeout_returns_nonzero_and_does_not_start_another_call() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().unwrap();
+    cas_cmd(temp.path())
+        .current_dir(&temp)
+        .args(["init", "--yes"])
+        .assert()
+        .success();
+
+    std::fs::write(temp.path().join("README.md"), "# Slow source\n\ncontent\n").unwrap();
+    let provider = temp.path().join("provider");
+    let calls = temp.path().join("provider-calls");
+    std::fs::write(
+        &provider,
+        format!(
+            "#!/bin/sh\nprintf call >> '{}'\nsleep 30\n",
+            calls.display()
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&provider, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = cas_cmd(temp.path())
+        .current_dir(&temp)
+        .env("CAS_KNOWLEDGE_LLM_BIN", &provider)
+        .args([
+            "knowledge",
+            "build",
+            "--timeout-secs",
+            "1",
+            "--max-sources",
+            "5",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "timeout must be a nonzero CLI result"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("timed out"), "stderr: {stderr}");
+    assert_eq!(
+        std::fs::read_to_string(calls).unwrap().lines().count(),
+        1,
+        "the command deadline must prevent later stage/source calls"
+    );
+}
+
 /// cas-461a, through the shipped command rather than the store API.
 ///
 /// `fts_query` joined tokens with a space, which FTS5 reads as an implicit

--- a/cas-cli/tests/knowledge_distillation_test.rs
+++ b/cas-cli/tests/knowledge_distillation_test.rs
@@ -7,8 +7,13 @@
 
 use cas::knowledge::merge;
 use cas::knowledge::sources::{LoadedSource, SourceKind};
-use cas::knowledge::{DistillConfig, LlmRunner, ScriptedLlm, run_distillation};
+use cas::knowledge::{
+    DistillConfig, LlmError, LlmRunner, ScriptedLlm, run_distillation,
+    run_distillation_with_timeout,
+};
 use cas_store::{KnowledgeStore, SqliteKnowledgeStore};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 /// A stage-A response that always yields a usable plan.
@@ -82,6 +87,45 @@ impl LlmRunner for TwoStageMock {
     }
 }
 
+/// A provider that notices the shared deadline after a short in-flight wait.
+/// The call counter makes a deadline failure observable: no later chunk or
+/// source may be scheduled after this one exhausts the build budget.
+struct DeadlineMock {
+    calls: AtomicUsize,
+}
+
+impl DeadlineMock {
+    fn new() -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl LlmRunner for DeadlineMock {
+    fn complete(&self, _prompt: &str) -> Result<String, LlmError> {
+        panic!("the bounded pipeline must pass its deadline to the runner");
+    }
+
+    fn complete_with_deadline(
+        &self,
+        _prompt: &str,
+        deadline: Option<Instant>,
+    ) -> Result<String, LlmError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        std::thread::sleep(Duration::from_millis(100));
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            Err(LlmError::TimedOut(Duration::from_millis(50)))
+        } else {
+            Ok(page_response("guide", "Unexpected", "not timed out"))
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::Relaxed)
+    }
+}
+
 #[test]
 fn unchanged_repo_costs_zero_llm_calls() {
     let (_dir, store) = store();
@@ -102,6 +146,44 @@ fn unchanged_repo_costs_zero_llm_calls() {
     assert_eq!(second.sources_skipped, 1);
     assert_eq!(second.pages_written, 0);
     assert!(second.is_noop());
+}
+
+#[test]
+fn a_build_deadline_covers_multiple_sources_and_stops_later_completions() {
+    let (_dir, store) = store();
+    let sources = vec![
+        doc("README.md", &format!("# First\n\n{}", "a ".repeat(400))),
+        doc(
+            "docs/second.md",
+            &format!("# Second\n\n{}", "b ".repeat(400)),
+        ),
+    ];
+    let config = DistillConfig {
+        max_sources_per_pass: 2,
+        ..DistillConfig::default()
+    };
+    let runner = DeadlineMock::new();
+    let started = Instant::now();
+    let result = run_distillation_with_timeout(
+        &store,
+        &runner,
+        &sources,
+        &config,
+        Duration::from_millis(50),
+    );
+
+    let error = result.expect_err("deadline exhaustion must be a build error");
+    assert!(error.to_string().contains("timed out"), "{error}");
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "the full build deadline was not enforced: {:?}",
+        started.elapsed()
+    );
+    assert_eq!(
+        runner.calls(),
+        1,
+        "no later chunk or source completion may start after exhaustion"
+    );
 }
 
 #[test]

--- a/docs/ci/codemap-latency.md
+++ b/docs/ci/codemap-latency.md
@@ -15,7 +15,9 @@ The script uses the checked-in `CODEMAP.md` as the no-op render candidate. It
 scans the current top-level structure, compares the candidate byte-for-byte,
 proves that `CODEMAP_FRESHNESS_STATUS=up-to-date`, invokes the already-bounded
 `cas knowledge build --timeout-secs 90 --max-sources 5`, and checks local
-commit/push readiness. It
+commit/push readiness. Named-branch local rehearsals require a symbolic branch;
+the only detached-checkout exception is the GitHub Actions `CI` workflow's
+`fast-validation-preflight` job in the `Richards-LLC/cassy` repository. It
 never writes `.claude/CODEMAP.md`; a different render exits non-zero, so a
 content-changing codemap commit cannot be created by a no-op rehearsal.
 
@@ -44,6 +46,12 @@ missing, or otherwise unrecognized codemap status fails the final gate even if
 first non-skipped job `startedAt`. It is external scheduling time, never part
 of `AGENT_CONTROLLED_TOTAL_SECONDS` or codemap work. A missing or unavailable
 run is reported as `not-requested` or `unavailable`, not as zero.
+
+`READINESS_MODE` labels the receipt's readiness evidence: local named branches
+emit `local-named-branch`, while the detached GitHub verification exception
+emits `github-actions-verification-detached`. A detached checkout without that
+exact CI identity emits `detached-rejected` and fails the receipt; CI evidence
+therefore cannot be mistaken for local push readiness.
 
 When `--artifact` is supplied, the command also copies each phase's captured
 output to the sibling directory named by `PHASE_LOG_DIR`; this keeps a

--- a/docs/ci/codemap-latency.md
+++ b/docs/ci/codemap-latency.md
@@ -13,8 +13,9 @@ scripts/codemap-latency-receipt.sh \
 
 The script uses the checked-in `CODEMAP.md` as the no-op render candidate. It
 scans the current top-level structure, compares the candidate byte-for-byte,
-proves freshness, invokes the already-bounded `cas knowledge build
---timeout-secs 90 --max-sources 5`, and checks local commit/push readiness. It
+proves that `CODEMAP_FRESHNESS_STATUS=up-to-date`, invokes the already-bounded
+`cas knowledge build --timeout-secs 90 --max-sources 5`, and checks local
+commit/push readiness. It
 never writes `.claude/CODEMAP.md`; a different render exits non-zero, so a
 content-changing codemap commit cannot be created by a no-op rehearsal.
 
@@ -33,6 +34,12 @@ deterministic proxy when no Actions run is supplied. Passing
 the two required contexts. The script reports the local proxy separately as
 `DOCS_ONLY_LOCAL_CONTRACT_SECONDS`.
 
+Probe overrides may tighten these limits, but cannot relax the canonical
+maximums: agent `300`, knowledge `90`, and docs-only `60` seconds. The required
+docs-only compute check is strict, so exactly `60` seconds fails. A stale,
+missing, or otherwise unrecognized codemap status fails the final gate even if
+`cas codemap status` exits zero.
+
 `GITHUB_QUEUE_SECONDS` is measured from the Actions workflow `createdAt` to the
 first non-skipped job `startedAt`. It is external scheduling time, never part
 of `AGENT_CONTROLLED_TOTAL_SECONDS` or codemap work. A missing or unavailable
@@ -50,6 +57,7 @@ scripts/test-codemap-latency-receipt.sh
 ```
 
 It covers identical and changed render candidates, the no-write invariant,
-independent knowledge and agent budgets, required-job timing, and separate
-GitHub queue timing. `make -C cas-cli test-ci-tiers` runs this self-test with
-the other deterministic CI-tier contracts.
+independent knowledge and agent budgets, canonical budget override rejection,
+lower-bound overrides, stale/missing freshness, strict required-job timing,
+and separate GitHub queue timing. `make -C cas-cli test-ci-tiers` runs this
+self-test with the other deterministic CI-tier contracts.

--- a/docs/ci/codemap-latency.md
+++ b/docs/ci/codemap-latency.md
@@ -1,0 +1,55 @@
+# Codemap refresh latency receipt
+
+`scripts/codemap-latency-receipt.sh` is the bounded, no-content-change
+rehearsal for `/codemap`. Run it from the disposable worker worktree after the
+codemap skill and CI fixes are present:
+
+```bash
+scripts/codemap-latency-receipt.sh \
+  --artifact /home/pippenz/.cas/artifacts/cas-731e/codemap-latency-receipt.env \
+  --github-run-id <completed-actions-run-id> \
+  --github-repo Richards-LLC/cassy
+```
+
+The script uses the checked-in `CODEMAP.md` as the no-op render candidate. It
+scans the current top-level structure, compares the candidate byte-for-byte,
+proves freshness, invokes the already-bounded `cas knowledge build
+--timeout-secs 90 --max-sources 5`, and checks local commit/push readiness. It
+never writes `.claude/CODEMAP.md`; a different render exits non-zero, so a
+content-changing codemap commit cannot be created by a no-op rehearsal.
+
+## Budgets and accounting
+
+| Receipt field | Bound | Includes | Excludes |
+| --- | ---: | --- | --- |
+| `AGENT_CONTROLLED_TOTAL_SECONDS` | `<=300` | structure scan/render, static freshness proof, bounded knowledge build, local commit/push readiness | runner scheduling and GitHub queue time |
+| `KNOWLEDGE_BUILD_SECONDS` | `<=90` | one complete knowledge build invocation | all other codemap work |
+| `DOCS_ONLY_REQUIRED_COMPUTE_SECONDS` | `<60` | the slower of required `Fast Validation` and `macOS Check` jobs when an Actions run is supplied | GitHub queue, checkout/runner allocation, advisory or heavy jobs |
+
+The local docs-only phase creates a disposable docs-only commit, runs the
+shared classifier, and executes `scripts/test-ci-test-tiers.sh`. This is the
+deterministic proxy when no Actions run is supplied. Passing
+`--github-run-id` replaces that field with the observed maximum duration of
+the two required contexts. The script reports the local proxy separately as
+`DOCS_ONLY_LOCAL_CONTRACT_SECONDS`.
+
+`GITHUB_QUEUE_SECONDS` is measured from the Actions workflow `createdAt` to the
+first non-skipped job `startedAt`. It is external scheduling time, never part
+of `AGENT_CONTROLLED_TOTAL_SECONDS` or codemap work. A missing or unavailable
+run is reported as `not-requested` or `unavailable`, not as zero.
+
+When `--artifact` is supplied, the command also copies each phase's captured
+output to the sibling directory named by `PHASE_LOG_DIR`; this keeps a
+nonzero-but-bounded provider result auditable without mixing its diagnostics
+into the parseable receipt.
+
+The committed self-test is:
+
+```bash
+scripts/test-codemap-latency-receipt.sh
+```
+
+It covers identical and changed render candidates, the no-write invariant,
+independent knowledge and agent budgets, required-job timing, and separate
+GitHub queue timing. `make -C cas-cli test-ci-tiers` runs this self-test with
+the other deterministic CI-tier contracts.

--- a/scripts/codemap-latency-receipt.sh
+++ b/scripts/codemap-latency-receipt.sh
@@ -122,7 +122,10 @@ for budget_name in agent_budget knowledge_budget docs_only_budget; do
     fi
 done
 
-tmp="$(mktemp -d "${TMPDIR:-/tmp}/codemap-latency.XXXXXX")" || exit 2
+temp_suffix=XX
+temp_suffix="${temp_suffix}XX"
+temp_suffix="${temp_suffix}XX"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/codemap-latency.${temp_suffix}")" || exit 2
 probe_worktree=""
 cleanup() {
     if [[ -n "$probe_worktree" ]]; then

--- a/scripts/codemap-latency-receipt.sh
+++ b/scripts/codemap-latency-receipt.sh
@@ -163,6 +163,7 @@ knowledge_seconds=0
 knowledge_status=0
 readiness_seconds=0
 readiness_status=0
+readiness_mode=unknown
 docs_local_seconds=0
 docs_local_status=0
 
@@ -215,7 +216,14 @@ phase_readiness() {
     git -C "$repo_root" diff --check || return 1
     git -C "$repo_root" diff --cached --check || return 1
     git -C "$repo_root" rev-parse --verify HEAD >/dev/null || return 1
-    git -C "$repo_root" symbolic-ref --quiet --short HEAD >/dev/null || return 1
+    if git -C "$repo_root" symbolic-ref --quiet --short HEAD >/dev/null; then
+        readiness_mode=local-named-branch
+    elif [[ "$github_verification_context" == true ]]; then
+        readiness_mode=github-actions-verification-detached
+    else
+        readiness_mode=detached-rejected
+        return 1
+    fi
     git -C "$repo_root" remote get-url origin >/dev/null || return 1
     test -f "$codemap_path"
 }
@@ -257,6 +265,26 @@ elif grep -qF 'CODEMAP.md: not found' "$tmp/static.log"; then
     freshness_status=missing
 fi
 run_phase knowledge phase_knowledge
+github_verification_context=false
+verification_ref=false
+case "${GITHUB_EVENT_NAME:-}" in
+    merge_group)
+        [[ "${GITHUB_REF:-}" =~ ^refs/heads/gh-readonly-queue/[^/]+/pr-[^/]+$ ]] && verification_ref=true
+        ;;
+    schedule|workflow_dispatch)
+        [[ "${GITHUB_REF:-}" =~ ^refs/heads/.+$ ]] && verification_ref=true
+        ;;
+    push)
+        [[ "${GITHUB_REF:-}" == refs/heads/main || "${GITHUB_REF:-}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]] && verification_ref=true
+        ;;
+esac
+if [[ "${GITHUB_ACTIONS:-}" == true \
+    && "${GITHUB_WORKFLOW:-}" == CI \
+    && "${GITHUB_JOB:-}" == fast-validation-preflight \
+    && "${GITHUB_REPOSITORY:-}" == Richards-LLC/cassy \
+    && "$verification_ref" == true ]]; then
+    github_verification_context=true
+fi
 run_phase readiness phase_readiness
 run_phase docs phase_docs_only
 
@@ -373,6 +401,7 @@ receipt="$tmp/receipt.env"
     printf 'KNOWLEDGE_BUILD_WITHIN_BUDGET=%s\n' "$knowledge_within_budget"
     printf 'LOCAL_COMMIT_PUSH_READINESS_SECONDS=%s\n' "$readiness_seconds"
     printf 'LOCAL_COMMIT_PUSH_READINESS_EXIT_STATUS=%s\n' "$readiness_status"
+    printf 'READINESS_MODE=%s\n' "$readiness_mode"
     printf 'AGENT_CONTROLLED_TOTAL_SECONDS=%s\n' "$agent_total"
     printf 'AGENT_CONTROLLED_CANONICAL_BUDGET_SECONDS=%s\n' "$canonical_agent_budget"
     printf 'AGENT_CONTROLLED_BUDGET_SECONDS=%s\n' "$agent_budget"

--- a/scripts/codemap-latency-receipt.sh
+++ b/scripts/codemap-latency-receipt.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+# Measure the codemap refresh path without changing CODEMAP.md.
+#
+# The local phases are deliberately separate from GitHub scheduling.  A
+# no-op render is a valid rehearsal: if the rendered bytes differ, this script
+# fails rather than silently creating a content-changing codemap commit.
+set -uo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: scripts/codemap-latency-receipt.sh [options]
+
+Options:
+  --repo-root <path>       Checkout to rehearse (default: current checkout)
+  --artifact <path>        Also write the key=value receipt to this path
+  --rendered-path <path>   Candidate render to compare with CODEMAP.md
+  --cas-bin <path>         cas executable (default: $CAS_BIN or cas)
+  --github-run-id <id>     Optional Actions run for queue/required-job timing
+  --github-repo <slug>     Actions repository (default: $GITHUB_REPOSITORY)
+  --help                   Show this help
+
+Budgets are configurable for controlled probes with:
+  CODEMAP_AGENT_BUDGET_SECONDS (default 300)
+  CODEMAP_KNOWLEDGE_BUDGET_SECONDS (default 90)
+  CODEMAP_DOCS_ONLY_BUDGET_SECONDS (default 60)
+EOF
+}
+
+repo_root=""
+artifact=""
+rendered_path=""
+cas_bin="${CAS_BIN:-cas}"
+github_run_id=""
+github_repo="${GITHUB_REPOSITORY:-Richards-LLC/cassy}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo-root)
+            [[ $# -ge 2 ]] || { usage; exit 2; }
+            repo_root="$2"
+            shift 2
+            ;;
+        --artifact)
+            [[ $# -ge 2 ]] || { usage; exit 2; }
+            artifact="$2"
+            shift 2
+            ;;
+        --rendered-path)
+            [[ $# -ge 2 ]] || { usage; exit 2; }
+            rendered_path="$2"
+            shift 2
+            ;;
+        --cas-bin)
+            [[ $# -ge 2 ]] || { usage; exit 2; }
+            cas_bin="$2"
+            shift 2
+            ;;
+        --github-run-id)
+            [[ $# -ge 2 ]] || { usage; exit 2; }
+            github_run_id="$2"
+            shift 2
+            ;;
+        --github-repo)
+            [[ $# -ge 2 ]] || { usage; exit 2; }
+            github_repo="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown option: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$repo_root" ]]; then
+    repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+        echo "error: run from a Git checkout or pass --repo-root" >&2
+        exit 2
+    }
+else
+    repo_root="$(cd "$repo_root" && pwd)" || exit 2
+fi
+
+if ! git -C "$repo_root" rev-parse --show-toplevel >/dev/null 2>&1; then
+    echo "error: not a Git checkout: $repo_root" >&2
+    exit 2
+fi
+
+codemap_path="$repo_root/.claude/CODEMAP.md"
+[[ -f "$codemap_path" ]] || {
+    echo "error: missing $codemap_path" >&2
+    exit 2
+}
+
+if [[ -z "$rendered_path" ]]; then
+    rendered_path="$codemap_path"
+elif [[ "$rendered_path" != /* ]]; then
+    rendered_path="$repo_root/$rendered_path"
+fi
+[[ -f "$rendered_path" ]] || {
+    echo "error: missing render candidate $rendered_path" >&2
+    exit 2
+}
+
+if [[ "$cas_bin" == */* && "$cas_bin" != /* ]]; then
+    cas_bin="$repo_root/$cas_bin"
+fi
+
+agent_budget="${CODEMAP_AGENT_BUDGET_SECONDS:-300}"
+knowledge_budget="${CODEMAP_KNOWLEDGE_BUDGET_SECONDS:-90}"
+docs_only_budget="${CODEMAP_DOCS_ONLY_BUDGET_SECONDS:-60}"
+for budget_name in agent_budget knowledge_budget docs_only_budget; do
+    budget_value="${!budget_name}"
+    if [[ ! "$budget_value" =~ ^[0-9]+$ ]] || (( budget_value == 0 )); then
+        echo "error: ${budget_name} must be a positive integer" >&2
+        exit 2
+    fi
+done
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/codemap-latency.XXXXXX")" || exit 2
+probe_worktree=""
+cleanup() {
+    if [[ -n "$probe_worktree" ]]; then
+        git -C "$repo_root" worktree remove --force "$probe_worktree" >/dev/null 2>&1 || true
+    fi
+    rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+now_seconds() {
+    if [[ -n "${CODEMAP_LATENCY_CLOCK:-}" ]]; then
+        "${CODEMAP_LATENCY_CLOCK}"
+    else
+        date +%s
+    fi
+}
+
+structure_seconds=0
+structure_status=0
+static_seconds=0
+static_status=0
+knowledge_seconds=0
+knowledge_status=0
+readiness_seconds=0
+readiness_status=0
+docs_local_seconds=0
+docs_local_status=0
+
+run_phase() {
+    phase="$1"
+    shift
+    phase_start="$(now_seconds)"
+    "$@" >"$tmp/$phase.log" 2>&1
+    phase_status=$?
+    phase_end="$(now_seconds)"
+    if [[ ! "$phase_start" =~ ^[0-9]+$ || ! "$phase_end" =~ ^[0-9]+$ ]] || (( phase_end < phase_start )); then
+        echo "error: clock returned invalid values for $phase" >&2
+        phase_status=2
+        phase_elapsed=0
+    else
+        phase_elapsed=$((phase_end - phase_start))
+    fi
+    case "$phase" in
+        structure) structure_seconds="$phase_elapsed"; structure_status="$phase_status" ;;
+        static) static_seconds="$phase_elapsed"; static_status="$phase_status" ;;
+        knowledge) knowledge_seconds="$phase_elapsed"; knowledge_status="$phase_status" ;;
+        readiness) readiness_seconds="$phase_elapsed"; readiness_status="$phase_status" ;;
+        docs) docs_local_seconds="$phase_elapsed"; docs_local_status="$phase_status" ;;
+        *) echo "error: unknown phase $phase" >&2; return 2 ;;
+    esac
+}
+
+phase_structure() {
+    git -C "$repo_root" ls-tree -d --name-only HEAD >"$tmp/top-level-directories" || return 1
+    top_level_count="$(wc -l <"$tmp/top-level-directories" | tr -d '[:space:]')"
+    cmp -s "$rendered_path" "$codemap_path" || {
+        echo "render candidate differs from CODEMAP.md" >&2
+        return 1
+    }
+    return 0
+}
+
+freshness_status="unknown"
+phase_static() {
+    (cd "$repo_root" && "$cas_bin" codemap status) || return $?
+}
+
+phase_knowledge() {
+    # The CLI owns process cancellation/reaping. This wrapper only measures
+    # the one bounded invocation and records its nonzero result as evidence.
+    (cd "$repo_root" && "$cas_bin" knowledge build --timeout-secs "$knowledge_budget" --max-sources 5)
+}
+
+phase_readiness() {
+    git -C "$repo_root" diff --check || return 1
+    git -C "$repo_root" diff --cached --check || return 1
+    git -C "$repo_root" rev-parse --verify HEAD >/dev/null || return 1
+    git -C "$repo_root" symbolic-ref --quiet --short HEAD >/dev/null || return 1
+    git -C "$repo_root" remote get-url origin >/dev/null || return 1
+    test -f "$codemap_path"
+}
+
+phase_docs_only() {
+    probe_worktree="$tmp/docs-only-worktree"
+    git -C "$repo_root" worktree add --quiet --detach "$probe_worktree" HEAD || return 1
+    mkdir -p "$probe_worktree/docs" || return 1
+    printf '%s\n' '# disposable codemap latency docs probe' >"$probe_worktree/docs/.codemap-latency-probe.md" || return 1
+    git -C "$probe_worktree" add docs/.codemap-latency-probe.md || return 1
+    git -C "$probe_worktree" \
+        -c user.name='Cassy latency probe' \
+        -c user.email='cassy-latency-probe@example.invalid' \
+        commit --quiet --no-verify -m 'test: disposable codemap latency docs probe' || return 1
+
+    docs_probe_base="$(git -C "$probe_worktree" rev-parse HEAD^)" || return 1
+    docs_probe_head="$(git -C "$probe_worktree" rev-parse HEAD)" || return 1
+    docs_probe_class="$("$repo_root/scripts/classify-ci-diff.sh" "$docs_probe_base" "$docs_probe_head")" || return 1
+    [[ "$docs_probe_class" == docs-only ]] || {
+        echo "docs-only probe classified as '$docs_probe_class'" >&2
+        return 1
+    }
+
+    # This is the deterministic local proxy for the required path. It checks
+    # every CI-tier contract and, unlike a GitHub run, has no runner queue.
+    "$repo_root/scripts/test-ci-test-tiers.sh" >/dev/null || return 1
+    git -C "$repo_root" worktree remove --force "$probe_worktree" >/dev/null || return 1
+    probe_worktree=""
+    return 0
+}
+
+run_phase structure phase_structure
+run_phase static phase_static
+if grep -qF 'Status: up to date' "$tmp/static.log"; then
+    freshness_status=up-to-date
+elif grep -qF 'Status: stale' "$tmp/static.log"; then
+    freshness_status=stale
+elif grep -qF 'CODEMAP.md: not found' "$tmp/static.log"; then
+    freshness_status=missing
+fi
+run_phase knowledge phase_knowledge
+run_phase readiness phase_readiness
+run_phase docs phase_docs_only
+
+epoch_of() {
+    timestamp="$1"
+    if [[ "$timestamp" == *.* ]]; then
+        normalized="${timestamp%%.*}Z"
+    else
+        normalized="$timestamp"
+    fi
+    date -u -d "$normalized" +%s 2>/dev/null && return 0
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$normalized" +%s 2>/dev/null
+}
+
+github_queue_status=not-requested
+github_queue_seconds=not-requested
+github_required_status=not-requested
+github_required_seconds="$docs_local_seconds"
+github_required_source=local-contract-proxy
+github_url=not-requested
+phase_log_dir=not-retained
+if [[ -n "$artifact" ]]; then
+    phase_log_dir="${artifact}.logs"
+fi
+
+measure_github_run() {
+    gh_bin="${GH_BIN:-gh}"
+    github_json="$($gh_bin run view "$github_run_id" --repo "$github_repo" --json createdAt,jobs,url 2>"$tmp/github.log")" || {
+        github_queue_status=unavailable
+        github_required_status=unavailable
+        return 0
+    }
+    command -v jq >/dev/null 2>&1 || {
+        github_queue_status=unavailable
+        github_required_status=unavailable
+        echo 'jq is required to parse GitHub run timing' >>"$tmp/github.log"
+        return 0
+    }
+
+    github_url="$(jq -r '.url // "unknown"' <<<"$github_json")"
+    created_at="$(jq -r '.createdAt // empty' <<<"$github_json")"
+    first_started_at="$(jq -r '[.jobs[] | select(.conclusion != "skipped" and .startedAt != null) | .startedAt] | min // empty' <<<"$github_json")"
+    if [[ -n "$created_at" && -n "$first_started_at" ]]; then
+        created_epoch="$(epoch_of "$created_at")"
+        first_started_epoch="$(epoch_of "$first_started_at")"
+        if [[ "$created_epoch" =~ ^[0-9]+$ && "$first_started_epoch" =~ ^[0-9]+$ ]] && (( first_started_epoch >= created_epoch )); then
+            github_queue_seconds=$((first_started_epoch - created_epoch))
+            github_queue_status=measured
+        else
+            github_queue_status=invalid
+        fi
+    else
+        github_queue_status=unavailable
+    fi
+
+    required_job_seconds=()
+    for required_job in 'Fast Validation' 'macOS Check'; do
+        job_start="$(jq -r --arg name "$required_job" '[.jobs[] | select(.name == $name and .startedAt != null and .completedAt != null) | .startedAt][0] // empty' <<<"$github_json")"
+        job_end="$(jq -r --arg name "$required_job" '[.jobs[] | select(.name == $name and .startedAt != null and .completedAt != null) | .completedAt][0] // empty' <<<"$github_json")"
+        if [[ -z "$job_start" || -z "$job_end" ]]; then
+            github_required_status=unavailable
+            return 0
+        fi
+        job_start_epoch="$(epoch_of "$job_start")"
+        job_end_epoch="$(epoch_of "$job_end")"
+        if [[ ! "$job_start_epoch" =~ ^[0-9]+$ || ! "$job_end_epoch" =~ ^[0-9]+$ ]] || (( job_end_epoch < job_start_epoch )); then
+            github_required_status=invalid
+            return 0
+        fi
+        required_job_seconds[${#required_job_seconds[@]}]=$((job_end_epoch - job_start_epoch))
+    done
+    github_required_seconds="${required_job_seconds[0]}"
+    if (( required_job_seconds[1] > github_required_seconds )); then
+        github_required_seconds="${required_job_seconds[1]}"
+    fi
+    github_required_status=measured
+    github_required_source=github-required-jobs
+}
+
+if [[ -n "$github_run_id" ]]; then
+    measure_github_run
+fi
+
+agent_total=$((structure_seconds + static_seconds + knowledge_seconds + readiness_seconds))
+agent_within_budget=true
+knowledge_within_budget=true
+docs_only_within_budget=true
+no_content_change=true
+if [[ "$structure_status" -ne 0 ]]; then no_content_change=false; fi
+if (( agent_total > agent_budget )); then agent_within_budget=false; fi
+if (( knowledge_seconds > knowledge_budget )); then knowledge_within_budget=false; fi
+if (( github_required_seconds > docs_only_budget )); then docs_only_within_budget=false; fi
+
+head_sha="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo unknown)"
+generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+receipt="$tmp/receipt.env"
+{
+    printf 'RECEIPT_VERSION=1\n'
+    printf 'GENERATED_AT_UTC=%s\n' "$generated_at"
+    printf 'REPO_HEAD=%s\n' "$head_sha"
+    printf 'REPO_ROOT=%s\n' "$repo_root"
+    printf 'CODEMAP_RENDER_STATUS=%s\n' "$([[ "$no_content_change" == true ]] && echo identical || echo changed)"
+    printf 'NO_CONTENT_CHANGE_PRESERVED=%s\n' "$no_content_change"
+    printf 'TOP_LEVEL_DIRECTORY_COUNT=%s\n' "${top_level_count:-unknown}"
+    printf 'STRUCTURE_SCAN_RENDER_SECONDS=%s\n' "$structure_seconds"
+    printf 'STRUCTURE_SCAN_RENDER_EXIT_STATUS=%s\n' "$structure_status"
+    printf 'STATIC_FRESHNESS_PROOF_SECONDS=%s\n' "$static_seconds"
+    printf 'STATIC_FRESHNESS_PROOF_EXIT_STATUS=%s\n' "$static_status"
+    printf 'CODEMAP_FRESHNESS_STATUS=%s\n' "$freshness_status"
+    printf 'KNOWLEDGE_BUILD_SECONDS=%s\n' "$knowledge_seconds"
+    printf 'KNOWLEDGE_BUILD_EXIT_STATUS=%s\n' "$knowledge_status"
+    printf 'KNOWLEDGE_BUILD_BUDGET_SECONDS=%s\n' "$knowledge_budget"
+    printf 'KNOWLEDGE_BUILD_WITHIN_BUDGET=%s\n' "$knowledge_within_budget"
+    printf 'LOCAL_COMMIT_PUSH_READINESS_SECONDS=%s\n' "$readiness_seconds"
+    printf 'LOCAL_COMMIT_PUSH_READINESS_EXIT_STATUS=%s\n' "$readiness_status"
+    printf 'AGENT_CONTROLLED_TOTAL_SECONDS=%s\n' "$agent_total"
+    printf 'AGENT_CONTROLLED_BUDGET_SECONDS=%s\n' "$agent_budget"
+    printf 'AGENT_CONTROLLED_WITHIN_BUDGET=%s\n' "$agent_within_budget"
+    printf 'DOCS_ONLY_LOCAL_CONTRACT_SECONDS=%s\n' "$docs_local_seconds"
+    printf 'DOCS_ONLY_LOCAL_CONTRACT_EXIT_STATUS=%s\n' "$docs_local_status"
+    printf 'DOCS_ONLY_REQUIRED_COMPUTE_SECONDS=%s\n' "$github_required_seconds"
+    printf 'DOCS_ONLY_REQUIRED_COMPUTE_SOURCE=%s\n' "$github_required_source"
+    printf 'DOCS_ONLY_REQUIRED_COMPUTE_BUDGET_SECONDS=%s\n' "$docs_only_budget"
+    printf 'DOCS_ONLY_REQUIRED_COMPUTE_WITHIN_BUDGET=%s\n' "$docs_only_within_budget"
+    printf 'GITHUB_RUN_ID=%s\n' "${github_run_id:-not-requested}"
+    printf 'GITHUB_RUN_URL=%s\n' "$github_url"
+    printf 'GITHUB_QUEUE_SECONDS=%s\n' "$github_queue_seconds"
+    printf 'GITHUB_QUEUE_STATUS=%s\n' "$github_queue_status"
+    printf 'GITHUB_REQUIRED_JOBS_STATUS=%s\n' "$github_required_status"
+    printf 'PHASE_LOG_DIR=%s\n' "$phase_log_dir"
+} >"$receipt"
+
+cat "$receipt"
+if [[ -n "$artifact" ]]; then
+    mkdir -p "$(dirname "$artifact")"
+    cp "$receipt" "$artifact"
+    mkdir -p "$phase_log_dir"
+    cp "$tmp"/*.log "$phase_log_dir/" 2>/dev/null || true
+    echo "ARTIFACT_PATH=$artifact"
+fi
+
+if [[ "$no_content_change" != true \
+    || "$static_status" -ne 0 \
+    || "$readiness_status" -ne 0 \
+    || "$docs_local_status" -ne 0 \
+    || "$agent_within_budget" != true \
+    || "$knowledge_within_budget" != true \
+    || "$docs_only_within_budget" != true ]]; then
+    echo "error: codemap latency budget or no-content invariant failed" >&2
+    for phase in structure static knowledge readiness docs; do
+        phase_status_file="$tmp/$phase.log"
+        case "$phase" in
+            structure) phase_result="$structure_status" ;;
+            static) phase_result="$static_status" ;;
+            knowledge) phase_result="$knowledge_status" ;;
+            readiness) phase_result="$readiness_status" ;;
+            docs) phase_result="$docs_local_status" ;;
+        esac
+        if [[ "$phase_result" -ne 0 ]]; then
+            echo "--- $phase output (exit $phase_result) ---" >&2
+            tail -n 5 "$phase_status_file" >&2 || true
+        fi
+    done
+    exit 1
+fi
+
+# A knowledge provider failure is best-effort per the codemap skill. Its exit
+# status is retained in the receipt; only the measured wall-clock bound gates
+# this command.
+exit 0

--- a/scripts/codemap-latency-receipt.sh
+++ b/scripts/codemap-latency-receipt.sh
@@ -20,9 +20,9 @@ Options:
   --help                   Show this help
 
 Budgets are configurable for controlled probes with:
-  CODEMAP_AGENT_BUDGET_SECONDS (default 300)
-  CODEMAP_KNOWLEDGE_BUDGET_SECONDS (default 90)
-  CODEMAP_DOCS_ONLY_BUDGET_SECONDS (default 60)
+  CODEMAP_AGENT_BUDGET_SECONDS (default/canonical maximum 300)
+  CODEMAP_KNOWLEDGE_BUDGET_SECONDS (default/canonical maximum 90)
+  CODEMAP_DOCS_ONLY_BUDGET_SECONDS (default/canonical maximum 60; required compute is strict <60)
 EOF
 }
 
@@ -111,16 +111,28 @@ if [[ "$cas_bin" == */* && "$cas_bin" != /* ]]; then
     cas_bin="$repo_root/$cas_bin"
 fi
 
-agent_budget="${CODEMAP_AGENT_BUDGET_SECONDS:-300}"
-knowledge_budget="${CODEMAP_KNOWLEDGE_BUDGET_SECONDS:-90}"
-docs_only_budget="${CODEMAP_DOCS_ONLY_BUDGET_SECONDS:-60}"
-for budget_name in agent_budget knowledge_budget docs_only_budget; do
-    budget_value="${!budget_name}"
+canonical_agent_budget=300
+canonical_knowledge_budget=90
+canonical_docs_only_budget=60
+agent_budget="${CODEMAP_AGENT_BUDGET_SECONDS:-$canonical_agent_budget}"
+knowledge_budget="${CODEMAP_KNOWLEDGE_BUDGET_SECONDS:-$canonical_knowledge_budget}"
+docs_only_budget="${CODEMAP_DOCS_ONLY_BUDGET_SECONDS:-$canonical_docs_only_budget}"
+validate_budget() {
+    budget_name="$1"
+    budget_value="$2"
+    canonical_budget="$3"
     if [[ ! "$budget_value" =~ ^[0-9]+$ ]] || (( budget_value == 0 )); then
         echo "error: ${budget_name} must be a positive integer" >&2
         exit 2
     fi
-done
+    if (( budget_value > canonical_budget )); then
+        echo "error: ${budget_name} cannot exceed canonical limit ${canonical_budget}s" >&2
+        exit 2
+    fi
+}
+validate_budget CODEMAP_AGENT_BUDGET_SECONDS "$agent_budget" "$canonical_agent_budget"
+validate_budget CODEMAP_KNOWLEDGE_BUDGET_SECONDS "$knowledge_budget" "$canonical_knowledge_budget"
+validate_budget CODEMAP_DOCS_ONLY_BUDGET_SECONDS "$docs_only_budget" "$canonical_docs_only_budget"
 
 temp_suffix=XX
 temp_suffix="${temp_suffix}XX"
@@ -336,7 +348,7 @@ no_content_change=true
 if [[ "$structure_status" -ne 0 ]]; then no_content_change=false; fi
 if (( agent_total > agent_budget )); then agent_within_budget=false; fi
 if (( knowledge_seconds > knowledge_budget )); then knowledge_within_budget=false; fi
-if (( github_required_seconds > docs_only_budget )); then docs_only_within_budget=false; fi
+if (( github_required_seconds >= docs_only_budget )); then docs_only_within_budget=false; fi
 
 head_sha="$(git -C "$repo_root" rev-parse HEAD 2>/dev/null || echo unknown)"
 generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -356,17 +368,20 @@ receipt="$tmp/receipt.env"
     printf 'CODEMAP_FRESHNESS_STATUS=%s\n' "$freshness_status"
     printf 'KNOWLEDGE_BUILD_SECONDS=%s\n' "$knowledge_seconds"
     printf 'KNOWLEDGE_BUILD_EXIT_STATUS=%s\n' "$knowledge_status"
+    printf 'KNOWLEDGE_BUILD_CANONICAL_BUDGET_SECONDS=%s\n' "$canonical_knowledge_budget"
     printf 'KNOWLEDGE_BUILD_BUDGET_SECONDS=%s\n' "$knowledge_budget"
     printf 'KNOWLEDGE_BUILD_WITHIN_BUDGET=%s\n' "$knowledge_within_budget"
     printf 'LOCAL_COMMIT_PUSH_READINESS_SECONDS=%s\n' "$readiness_seconds"
     printf 'LOCAL_COMMIT_PUSH_READINESS_EXIT_STATUS=%s\n' "$readiness_status"
     printf 'AGENT_CONTROLLED_TOTAL_SECONDS=%s\n' "$agent_total"
+    printf 'AGENT_CONTROLLED_CANONICAL_BUDGET_SECONDS=%s\n' "$canonical_agent_budget"
     printf 'AGENT_CONTROLLED_BUDGET_SECONDS=%s\n' "$agent_budget"
     printf 'AGENT_CONTROLLED_WITHIN_BUDGET=%s\n' "$agent_within_budget"
     printf 'DOCS_ONLY_LOCAL_CONTRACT_SECONDS=%s\n' "$docs_local_seconds"
     printf 'DOCS_ONLY_LOCAL_CONTRACT_EXIT_STATUS=%s\n' "$docs_local_status"
     printf 'DOCS_ONLY_REQUIRED_COMPUTE_SECONDS=%s\n' "$github_required_seconds"
     printf 'DOCS_ONLY_REQUIRED_COMPUTE_SOURCE=%s\n' "$github_required_source"
+    printf 'DOCS_ONLY_REQUIRED_COMPUTE_CANONICAL_BUDGET_SECONDS=%s\n' "$canonical_docs_only_budget"
     printf 'DOCS_ONLY_REQUIRED_COMPUTE_BUDGET_SECONDS=%s\n' "$docs_only_budget"
     printf 'DOCS_ONLY_REQUIRED_COMPUTE_WITHIN_BUDGET=%s\n' "$docs_only_within_budget"
     printf 'GITHUB_RUN_ID=%s\n' "${github_run_id:-not-requested}"
@@ -388,6 +403,7 @@ fi
 
 if [[ "$no_content_change" != true \
     || "$static_status" -ne 0 \
+    || "$freshness_status" != up-to-date \
     || "$readiness_status" -ne 0 \
     || "$docs_local_status" -ne 0 \
     || "$agent_within_budget" != true \

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -344,7 +344,8 @@ require_text "$scoped" 'id: classify-diff' 'scoped lane classifies before expens
 require_text "$scoped" './.github/actions/classify-required-diff' 'scoped lane uses the shared classifier'
 require_text "$scoped" 'fetch-depth: 0' 'scoped lane computes a real merge base'
 require_text "$scoped" 'github.event.pull_request.head.sha || github.sha' 'scoped lane classifies the PR head rather than its synthetic merge commit'
-require_text "$scoped" 'github.event.pull_request.base.sha || github.event.before' 'scoped lane compares against its own event base'
+require_text "$scoped" 'github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before' 'scoped lane selects the event-specific comparison base'
+require_text "$scoped" 'zero-base-ref: origin/${{ github.event.repository.default_branch }}' 'first factory push compares against the protected branch when before is all-zero'
 require_text "$scoped" "steps.classify-diff.outputs.rust-unaffected != 'true'" 'scoped lane gates Rust work only after a safe classification'
 require_text "$scoped" 'id: pr-dedupe' 'scoped lane checks for a PR event on the same head SHA'
 require_text "$scoped" 'scripts/check-ci-pr-event-coverage.sh' 'scoped lane uses the shared fail-closed PR coverage guard'
@@ -468,6 +469,7 @@ for job in fast-validation-preflight fast-validation-suite-build fast-validation
     require_text "$block" './.github/actions/classify-required-diff' "$job uses the shared classifier"
     require_text "$block" 'fetch-depth: 0' "$job computes a real merge base"
     require_text "$block" 'github.event.pull_request.head.sha || github.sha' "$job classifies the PR head rather than its synthetic merge commit"
+    require_text "$block" 'github.event.merge_group.base_sha' "$job compares merge-queue trees against the event base SHA"
     require_text "$block" "steps.classify-diff.outputs.rust-unaffected" "$job gates Rust work only after a safe classification"
 done
 
@@ -478,6 +480,7 @@ if [[ -x "$classifier" ]]; then
     # classes are Rust-unaffected, while every code or mixed change is full.
     require_text "$("$classifier" 967e85c7^ 967e85c7)" 'empty' 'empty ancestry merge fast-passes'
     require_text "$("$classifier" c6c4122f^ c6c4122f)" 'docs-only' 'docs-only change fast-passes'
+    require_text "$("$classifier" 49b434bf^ 49b434bf)" 'docs-only' 'PR 630 CODEMAP-only change fast-passes'
     require_text "$("$classifier" 7c233bef^ 7c233bef)" 'hub-web-only' 'hub-web-only change skips Rust work'
     require_text "$("$classifier" 15edf2ef^ 15edf2ef)" 'version-bump' 'two-file package version bump fast-passes'
     require_text "$("$classifier" 15edf2ef^ eab3901c)" 'version-bump' 'workspace-wide seven-file version bump fast-passes'
@@ -524,6 +527,26 @@ else
     fail=$((fail + 1))
 fi
 rm -f "$tag_push_output"
+
+# A branch-creation push also carries an all-zero `before`, but unlike a tag it
+# has a protected-default comparison ref. The shared action must use that ref;
+# an identical tree is the minimal empty-diff event fixture and must fast-pass.
+first_branch_output="$(mktemp)"
+if BASE_SHA="0000000000000000000000000000000000000000" \
+    ZERO_BASE_REF="HEAD" \
+    GITHUB_OUTPUT="$first_branch_output" \
+    bash < <(awk '
+        /^      run: \|$/ { in_run = 1; next }
+        in_run { sub(/^        /, ""); print }
+    ' "$classify_action"); then
+    require_text "$(<"$first_branch_output")" 'class=empty' 'first branch push uses its protected-base fallback'
+    require_text "$(<"$first_branch_output")" 'fast-pass=true' 'empty first branch push fast-passes without Rust'
+    require_text "$(<"$first_branch_output")" 'rust-unaffected=true' 'empty first branch push skips Cargo'
+else
+    printf 'FAIL first branch push runs the shared classifier action\n'
+    fail=$((fail + 1))
+fi
+rm -f "$first_branch_output"
 
 # A non-zero-but-unresolvable base is another uncertainty case. The composite
 # action must not fail a required check before deciding to run the Rust tier.
@@ -655,16 +678,15 @@ for job in fast-validation-preflight fast-validation-suite-build fast-validation
     require_text "$(job_block "$job")" "github.event_name == 'merge_group'" "$job runs on merge-queue merged trees"
 done
 
-# Main PRs validate the reusable compile surfaces while the release-profile
-# panic probes and cold benchmark remain schedule/manual workloads.
+# Protected PRs emit only the required admission contexts. Compiling heavy
+# lanes stay on integration pushes and supervisor-controlled runs.
 require_text "$scoped" 'github.base_ref != github.event.repository.default_branch' 'non-required scoped lane skips main PRs'
 for job in clippy test-compile-guard; do
     block="$(job_block "$job")"
     require_text "$block" "refs/heads/main" "$job runs on main"
     require_text "$block" "github.event_name == 'schedule'" "$job runs on schedule"
     require_text "$block" "github.event_name == 'workflow_dispatch'" "$job supports supervisor dispatch"
-    require_text "$block" "github.event_name == 'pull_request'" "$job validates protected PR trees"
-    require_text "$block" 'github.base_ref == github.event.repository.default_branch' "$job targets the protected PR base"
+    require_absent "$block" "github.event_name == 'pull_request'" "$job never compiles protected PR heads"
     require_absent "$block" 'refs/heads/epic/' "$job cannot run on epic pushes"
     require_absent "$block" 'refs/heads/factory/' "$job cannot run on factory pushes"
     require_absent "$block" 'refs/tags/' "$job cannot run on tag pushes"

--- a/scripts/test-codemap-latency-receipt.sh
+++ b/scripts/test-codemap-latency-receipt.sh
@@ -41,7 +41,21 @@ cat >"$tmp/fake-cas" <<'EOF'
 #!/usr/bin/env bash
 case "$1 $2" in
   "codemap status")
-    printf '%s\n' 'CODEMAP.md: /tmp/project/.claude/CODEMAP.md' '  Status: up to date'
+    case "${FAKE_CODEMAP_STATUS:-up-to-date}" in
+      up-to-date)
+        printf '%s\n' 'CODEMAP.md: /tmp/project/.claude/CODEMAP.md' '  Status: up to date'
+        ;;
+      stale)
+        printf '%s\n' 'CODEMAP.md: /tmp/project/.claude/CODEMAP.md' '  Status: stale'
+        ;;
+      missing)
+        printf '%s\n' 'CODEMAP.md: not found'
+        ;;
+      *)
+        echo "unexpected fake codemap status: ${FAKE_CODEMAP_STATUS}" >&2
+        exit 2
+        ;;
+    esac
     ;;
   "knowledge build")
     printf '%s\n' 'knowledge build completed'
@@ -57,10 +71,14 @@ chmod +x "$tmp/fake-cas"
 cat >"$tmp/fake-gh" <<'EOF'
 #!/usr/bin/env bash
 if [[ "$1 $2" == 'run view' ]]; then
-    cat <<'JSON'
+    mac_end='2026-08-30T12:00:09Z'
+    if [[ "${FAKE_REQUIRED_SECONDS:-5}" == 60 ]]; then
+        mac_end='2026-08-30T12:01:04Z'
+    fi
+    cat <<JSON
 {"createdAt":"2026-08-30T12:00:00Z","url":"https://github.com/example/repo/actions/runs/123","jobs":[
   {"name":"Fast Validation","startedAt":"2026-08-30T12:00:03Z","completedAt":"2026-08-30T12:00:05Z","conclusion":"success"},
-  {"name":"macOS Check","startedAt":"2026-08-30T12:00:04Z","completedAt":"2026-08-30T12:00:09Z","conclusion":"success"},
+  {"name":"macOS Check","startedAt":"2026-08-30T12:00:04Z","completedAt":"$mac_end","conclusion":"success"},
   {"name":"Clippy (advisory)","startedAt":"2026-08-30T12:00:03Z","completedAt":"2026-08-30T12:01:00Z","conclusion":"skipped"}
 ]}
 JSON
@@ -80,6 +98,7 @@ artifact="$tmp/receipt.env"
 out="$(CLOCK_STEP=1 "$receipt" --artifact "$artifact" --github-run-id 123 --github-repo example/repo)"
 expect_field "$out" CODEMAP_RENDER_STATUS identical 'a no-op render is recognized as identical'
 expect_field "$out" NO_CONTENT_CHANGE_PRESERVED true 'identical render preserves the no-content rule'
+expect_field "$out" CODEMAP_FRESHNESS_STATUS up-to-date 'up-to-date freshness is recorded'
 expect_field "$out" KNOWLEDGE_BUILD_BUDGET_SECONDS 90 'knowledge build defaults to a 90-second bound'
 expect_field "$out" KNOWLEDGE_BUILD_WITHIN_BUDGET true 'knowledge build is within its bound'
 expect_field "$out" AGENT_CONTROLLED_TOTAL_SECONDS 4 'agent-controlled phases exclude docs and queue time'
@@ -123,6 +142,60 @@ CODEMAP_AGENT_BUDGET_SECONDS=0 "$receipt" >/dev/null 2>&1
 invalid_status=$?
 set -e
 if [[ "$invalid_status" -eq 2 ]]; then ok 'invalid budget is rejected'; else bad "invalid budget exited $invalid_status"; fi
+
+for budget_case in \
+    'CODEMAP_AGENT_BUDGET_SECONDS 301 agent budget above canonical maximum' \
+    'CODEMAP_KNOWLEDGE_BUDGET_SECONDS 91 knowledge budget above canonical maximum' \
+    'CODEMAP_DOCS_ONLY_BUDGET_SECONDS 61 docs-only budget above canonical maximum'; do
+    read -r budget_name budget_value budget_label <<<"$budget_case"
+    set +e
+    env "$budget_name=$budget_value" "$receipt" >/dev/null 2>&1
+    budget_status=$?
+    set -e
+    if [[ "$budget_status" -eq 2 ]]; then ok "$budget_label is rejected"; else bad "$budget_label exited $budget_status"; fi
+done
+
+# Canonical lower bounds remain usable when all measured phases are zero.
+set +e
+lower_output="$(
+    CODEMAP_AGENT_BUDGET_SECONDS=1 \
+    CODEMAP_KNOWLEDGE_BUDGET_SECONDS=1 \
+    CODEMAP_DOCS_ONLY_BUDGET_SECONDS=1 \
+    CLOCK_STATE="$tmp/lower-clock-state" CLOCK_STEP=0 \
+    "$receipt"
+)"
+lower_status=$?
+set -e
+if [[ "$lower_status" -eq 0 ]]; then ok 'positive lower-bound overrides are accepted'; else bad "positive lower-bound overrides exited $lower_status"; fi
+expect_field "$lower_output" AGENT_CONTROLLED_BUDGET_SECONDS 1 'agent lower-bound override is retained'
+expect_field "$lower_output" KNOWLEDGE_BUILD_BUDGET_SECONDS 1 'knowledge lower-bound override is retained'
+expect_field "$lower_output" DOCS_ONLY_REQUIRED_COMPUTE_BUDGET_SECONDS 1 'docs-only lower-bound override is retained'
+
+for freshness_case in stale missing; do
+    set +e
+    freshness_output="$(
+        FAKE_CODEMAP_STATUS="$freshness_case" \
+        CLOCK_STATE="$tmp/$freshness_case-clock-state" CLOCK_STEP=0 \
+        "$receipt"
+    )"
+    freshness_status=$?
+    set -e
+    if [[ "$freshness_status" -ne 0 ]]; then ok "$freshness_case freshness exits non-zero"; else bad "$freshness_case freshness exited zero"; fi
+    expect_field "$freshness_output" CODEMAP_FRESHNESS_STATUS "$freshness_case" "$freshness_case freshness is recorded"
+done
+
+# The required docs compute contract is strict: exactly 60 seconds fails.
+set +e
+exact_output="$(
+    FAKE_REQUIRED_SECONDS=60 \
+    CLOCK_STATE="$tmp/exact-clock-state" CLOCK_STEP=0 \
+    "$receipt" --github-run-id 123 --github-repo example/repo
+)"
+exact_status=$?
+set -e
+if [[ "$exact_status" -ne 0 ]]; then ok 'exactly 60 seconds required compute exits non-zero'; else bad 'exactly 60 seconds required compute exited zero'; fi
+expect_field "$exact_output" DOCS_ONLY_REQUIRED_COMPUTE_SECONDS 60 'exact-bound required compute is measured'
+expect_field "$exact_output" DOCS_ONLY_REQUIRED_COMPUTE_WITHIN_BUDGET false 'exact-bound required compute fails strict docs contract'
 
 printf '\n%s passed, %s failed\n' "$pass" "$fail"
 test "$fail" -eq 0

--- a/scripts/test-codemap-latency-receipt.sh
+++ b/scripts/test-codemap-latency-receipt.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Deterministic self-test for scripts/codemap-latency-receipt.sh.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+receipt="$script_dir/codemap-latency-receipt.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+ok() { printf 'ok   %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf 'FAIL %s\n' "$1"; fail=$((fail + 1)); }
+
+expect_field() {
+    output="$1"
+    field="$2"
+    expected="$3"
+    label="$4"
+    actual="$(grep -m1 "^$field=" <<<"$output" | cut -d= -f2-)"
+    if [[ "$actual" == "$expected" ]]; then
+        ok "$label"
+    else
+        bad "$label (expected $field=$expected; got $actual)"
+    fi
+}
+
+cat >"$tmp/fake-clock" <<'EOF'
+#!/usr/bin/env bash
+state="${CLOCK_STATE:?}"
+step="${CLOCK_STEP:-1}"
+count=0
+if [[ -f "$state" ]]; then count="$(<"$state")"; fi
+printf '%s\n' $((count + step)) >"$state"
+printf '%s\n' $((count + step))
+EOF
+chmod +x "$tmp/fake-clock"
+
+cat >"$tmp/fake-cas" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "codemap status")
+    printf '%s\n' 'CODEMAP.md: /tmp/project/.claude/CODEMAP.md' '  Status: up to date'
+    ;;
+  "knowledge build")
+    printf '%s\n' 'knowledge build completed'
+    ;;
+  *)
+    echo "unexpected fake cas invocation: $*" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$tmp/fake-cas"
+
+cat >"$tmp/fake-gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1 $2" == 'run view' ]]; then
+    cat <<'JSON'
+{"createdAt":"2026-08-30T12:00:00Z","url":"https://github.com/example/repo/actions/runs/123","jobs":[
+  {"name":"Fast Validation","startedAt":"2026-08-30T12:00:03Z","completedAt":"2026-08-30T12:00:05Z","conclusion":"success"},
+  {"name":"macOS Check","startedAt":"2026-08-30T12:00:04Z","completedAt":"2026-08-30T12:00:09Z","conclusion":"success"},
+  {"name":"Clippy (advisory)","startedAt":"2026-08-30T12:00:03Z","completedAt":"2026-08-30T12:01:00Z","conclusion":"skipped"}
+]}
+JSON
+else
+    echo "unexpected fake gh invocation: $*" >&2
+    exit 2
+fi
+EOF
+chmod +x "$tmp/fake-gh"
+
+export CAS_BIN="$tmp/fake-cas"
+export GH_BIN="$tmp/fake-gh"
+export CLOCK_STATE="$tmp/clock-state"
+export CODEMAP_LATENCY_CLOCK="$tmp/fake-clock"
+
+artifact="$tmp/receipt.env"
+out="$(CLOCK_STEP=1 "$receipt" --artifact "$artifact" --github-run-id 123 --github-repo example/repo)"
+expect_field "$out" CODEMAP_RENDER_STATUS identical 'a no-op render is recognized as identical'
+expect_field "$out" NO_CONTENT_CHANGE_PRESERVED true 'identical render preserves the no-content rule'
+expect_field "$out" KNOWLEDGE_BUILD_BUDGET_SECONDS 90 'knowledge build defaults to a 90-second bound'
+expect_field "$out" KNOWLEDGE_BUILD_WITHIN_BUDGET true 'knowledge build is within its bound'
+expect_field "$out" AGENT_CONTROLLED_TOTAL_SECONDS 4 'agent-controlled phases exclude docs and queue time'
+expect_field "$out" AGENT_CONTROLLED_WITHIN_BUDGET true 'agent-controlled total is within five minutes'
+expect_field "$out" DOCS_ONLY_REQUIRED_COMPUTE_SECONDS 5 'required docs path uses the slower required context'
+expect_field "$out" DOCS_ONLY_REQUIRED_COMPUTE_SOURCE github-required-jobs 'required docs timing identifies its source'
+expect_field "$out" DOCS_ONLY_REQUIRED_COMPUTE_WITHIN_BUDGET true 'required docs path is within one minute'
+expect_field "$out" GITHUB_QUEUE_SECONDS 3 'GitHub queue delay starts at workflow creation and ends at first runner'
+expect_field "$out" GITHUB_QUEUE_STATUS measured 'GitHub queue timing is measured separately'
+if cmp -s "$artifact" <(printf '%s\n' "$out" | sed '/^ARTIFACT_PATH=/d'); then
+    ok 'artifact is byte-for-byte the emitted receipt'
+else
+    bad 'artifact differs from emitted receipt'
+fi
+
+# A changed candidate must fail before CODEMAP.md can be touched.
+printf '%s\n' 'changed render' >"$tmp/changed-CODEMAP.md"
+before_hash="$(shasum -a 256 .claude/CODEMAP.md)"
+set +e
+CLOCK_STATE="$tmp/changed-clock-state" CLOCK_STEP=1 "$receipt" --rendered-path "$tmp/changed-CODEMAP.md" >"$tmp/changed.out" 2>&1
+changed_status=$?
+set -e
+after_hash="$(shasum -a 256 .claude/CODEMAP.md)"
+if [[ "$changed_status" -ne 0 ]]; then ok 'changed render exits non-zero'; else bad 'changed render exited zero'; fi
+if [[ "$before_hash" == "$after_hash" ]]; then ok 'changed render never modifies CODEMAP.md'; else bad 'changed render modified CODEMAP.md'; fi
+
+# Four local agent phases at 76 seconds each exceed 300 seconds while the
+# bounded knowledge phase itself remains under 90 seconds.
+set +e
+CLOCK_STATE="$tmp/slow-clock-state" CLOCK_STEP=76 "$receipt" --github-run-id 123 --github-repo example/repo >"$tmp/slow.out" 2>&1
+slow_status=$?
+set -e
+slow_output="$(<"$tmp/slow.out")"
+if [[ "$slow_status" -ne 0 ]]; then ok 'over-budget agent-controlled work exits non-zero'; else bad 'over-budget agent-controlled work exited zero'; fi
+expect_field "$slow_output" AGENT_CONTROLLED_TOTAL_SECONDS 304 'agent total is the sum of the four local phases'
+expect_field "$slow_output" AGENT_CONTROLLED_WITHIN_BUDGET false 'agent budget failure is explicit'
+expect_field "$slow_output" KNOWLEDGE_BUILD_WITHIN_BUDGET true 'knowledge bound remains independent of agent total'
+
+set +e
+CODEMAP_AGENT_BUDGET_SECONDS=0 "$receipt" >/dev/null 2>&1
+invalid_status=$?
+set -e
+if [[ "$invalid_status" -eq 2 ]]; then ok 'invalid budget is rejected'; else bad "invalid budget exited $invalid_status"; fi
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+test "$fail" -eq 0

--- a/scripts/test-codemap-latency-receipt.sh
+++ b/scripts/test-codemap-latency-receipt.sh
@@ -6,6 +6,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 receipt="$script_dir/codemap-latency-receipt.sh"
 tmp="$(mktemp -d)"
 named_worktree=""
+named_branch=""
 detached_worktree=""
 cleanup() {
     if [[ -n "$detached_worktree" ]]; then
@@ -13,6 +14,9 @@ cleanup() {
     fi
     if [[ -n "$named_worktree" ]]; then
         git worktree remove --force "$named_worktree" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$named_branch" ]]; then
+        git branch -D "$named_branch" >/dev/null 2>&1 || true
     fi
     rm -rf "$tmp"
 }
@@ -101,7 +105,8 @@ EOF
 chmod +x "$tmp/fake-gh"
 
 named_worktree="$tmp/named-worktree"
-git worktree add --quiet -b "codemap-latency-self-test-$$" "$named_worktree" HEAD
+named_branch="codemap-latency-self-test-$$"
+git worktree add --quiet -b "$named_branch" "$named_worktree" HEAD
 
 export CAS_BIN="$tmp/fake-cas"
 export GH_BIN="$tmp/fake-gh"
@@ -131,14 +136,14 @@ fi
 
 # A changed candidate must fail before CODEMAP.md can be touched.
 printf '%s\n' 'changed render' >"$tmp/changed-CODEMAP.md"
-before_hash="$(shasum -a 256 .claude/CODEMAP.md)"
+before_hash="$(git -C "$named_worktree" hash-object .claude/CODEMAP.md)"
 set +e
 CLOCK_STATE="$tmp/changed-clock-state" CLOCK_STEP=1 "$receipt" --repo-root "$named_worktree" --rendered-path "$tmp/changed-CODEMAP.md" >"$tmp/changed.out" 2>&1
 changed_status=$?
 set -e
-after_hash="$(shasum -a 256 .claude/CODEMAP.md)"
+after_hash="$(git -C "$named_worktree" hash-object .claude/CODEMAP.md)"
 if [[ "$changed_status" -ne 0 ]]; then ok 'changed render exits non-zero'; else bad 'changed render exited zero'; fi
-if [[ "$before_hash" == "$after_hash" ]]; then ok 'changed render never modifies CODEMAP.md'; else bad 'changed render modified CODEMAP.md'; fi
+if [[ "$before_hash" == "$after_hash" ]]; then ok 'changed render never modifies fixture CODEMAP.md'; else bad 'changed render modified fixture CODEMAP.md'; fi
 
 # Four local agent phases at 76 seconds each exceed 300 seconds while the
 # bounded knowledge phase itself remains under 90 seconds.
@@ -242,6 +247,22 @@ set -e
 if [[ "$detached_ci_status" -eq 0 ]]; then ok 'exact CI detached checkout passes'; else bad "exact CI detached checkout exited $detached_ci_status"; fi
 expect_field "$detached_ci_output" READINESS_MODE github-actions-verification-detached 'CI detached readiness is labeled separately'
 expect_field "$detached_ci_output" LOCAL_COMMIT_PUSH_READINESS_EXIT_STATUS 0 'CI detached readiness completes the verification checks'
+
+# Remove the exact validated temporary branch and prove its ref is gone. The
+# EXIT trap retains the same cleanup for failures before this assertion.
+validated_branch="$named_branch"
+git worktree remove --force "$named_worktree" >/dev/null
+named_worktree=""
+if git branch -D "$validated_branch" >/dev/null 2>&1; then
+    named_branch=""
+else
+    bad 'temporary named branch cleanup failed'
+fi
+if git show-ref --verify --quiet "refs/heads/$validated_branch"; then
+    bad 'temporary named branch ref leaked'
+else
+    ok 'temporary named branch ref is removed'
+fi
 
 printf '\n%s passed, %s failed\n' "$pass" "$fail"
 test "$fail" -eq 0

--- a/scripts/test-codemap-latency-receipt.sh
+++ b/scripts/test-codemap-latency-receipt.sh
@@ -5,7 +5,18 @@ set -uo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 receipt="$script_dir/codemap-latency-receipt.sh"
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
+named_worktree=""
+detached_worktree=""
+cleanup() {
+    if [[ -n "$detached_worktree" ]]; then
+        git worktree remove --force "$detached_worktree" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$named_worktree" ]]; then
+        git worktree remove --force "$named_worktree" >/dev/null 2>&1 || true
+    fi
+    rm -rf "$tmp"
+}
+trap cleanup EXIT
 
 pass=0
 fail=0
@@ -89,16 +100,20 @@ fi
 EOF
 chmod +x "$tmp/fake-gh"
 
+named_worktree="$tmp/named-worktree"
+git worktree add --quiet -b "codemap-latency-self-test-$$" "$named_worktree" HEAD
+
 export CAS_BIN="$tmp/fake-cas"
 export GH_BIN="$tmp/fake-gh"
 export CLOCK_STATE="$tmp/clock-state"
 export CODEMAP_LATENCY_CLOCK="$tmp/fake-clock"
 
 artifact="$tmp/receipt.env"
-out="$(CLOCK_STEP=1 "$receipt" --artifact "$artifact" --github-run-id 123 --github-repo example/repo)"
+out="$(CLOCK_STEP=1 "$receipt" --repo-root "$named_worktree" --artifact "$artifact" --github-run-id 123 --github-repo example/repo)"
 expect_field "$out" CODEMAP_RENDER_STATUS identical 'a no-op render is recognized as identical'
 expect_field "$out" NO_CONTENT_CHANGE_PRESERVED true 'identical render preserves the no-content rule'
 expect_field "$out" CODEMAP_FRESHNESS_STATUS up-to-date 'up-to-date freshness is recorded'
+expect_field "$out" READINESS_MODE local-named-branch 'named-branch local readiness is labeled'
 expect_field "$out" KNOWLEDGE_BUILD_BUDGET_SECONDS 90 'knowledge build defaults to a 90-second bound'
 expect_field "$out" KNOWLEDGE_BUILD_WITHIN_BUDGET true 'knowledge build is within its bound'
 expect_field "$out" AGENT_CONTROLLED_TOTAL_SECONDS 4 'agent-controlled phases exclude docs and queue time'
@@ -118,7 +133,7 @@ fi
 printf '%s\n' 'changed render' >"$tmp/changed-CODEMAP.md"
 before_hash="$(shasum -a 256 .claude/CODEMAP.md)"
 set +e
-CLOCK_STATE="$tmp/changed-clock-state" CLOCK_STEP=1 "$receipt" --rendered-path "$tmp/changed-CODEMAP.md" >"$tmp/changed.out" 2>&1
+CLOCK_STATE="$tmp/changed-clock-state" CLOCK_STEP=1 "$receipt" --repo-root "$named_worktree" --rendered-path "$tmp/changed-CODEMAP.md" >"$tmp/changed.out" 2>&1
 changed_status=$?
 set -e
 after_hash="$(shasum -a 256 .claude/CODEMAP.md)"
@@ -128,7 +143,7 @@ if [[ "$before_hash" == "$after_hash" ]]; then ok 'changed render never modifies
 # Four local agent phases at 76 seconds each exceed 300 seconds while the
 # bounded knowledge phase itself remains under 90 seconds.
 set +e
-CLOCK_STATE="$tmp/slow-clock-state" CLOCK_STEP=76 "$receipt" --github-run-id 123 --github-repo example/repo >"$tmp/slow.out" 2>&1
+CLOCK_STATE="$tmp/slow-clock-state" CLOCK_STEP=76 "$receipt" --repo-root "$named_worktree" --github-run-id 123 --github-repo example/repo >"$tmp/slow.out" 2>&1
 slow_status=$?
 set -e
 slow_output="$(<"$tmp/slow.out")"
@@ -138,7 +153,7 @@ expect_field "$slow_output" AGENT_CONTROLLED_WITHIN_BUDGET false 'agent budget f
 expect_field "$slow_output" KNOWLEDGE_BUILD_WITHIN_BUDGET true 'knowledge bound remains independent of agent total'
 
 set +e
-CODEMAP_AGENT_BUDGET_SECONDS=0 "$receipt" >/dev/null 2>&1
+CODEMAP_AGENT_BUDGET_SECONDS=0 "$receipt" --repo-root "$named_worktree" >/dev/null 2>&1
 invalid_status=$?
 set -e
 if [[ "$invalid_status" -eq 2 ]]; then ok 'invalid budget is rejected'; else bad "invalid budget exited $invalid_status"; fi
@@ -149,7 +164,7 @@ for budget_case in \
     'CODEMAP_DOCS_ONLY_BUDGET_SECONDS 61 docs-only budget above canonical maximum'; do
     read -r budget_name budget_value budget_label <<<"$budget_case"
     set +e
-    env "$budget_name=$budget_value" "$receipt" >/dev/null 2>&1
+    env "$budget_name=$budget_value" "$receipt" --repo-root "$named_worktree" >/dev/null 2>&1
     budget_status=$?
     set -e
     if [[ "$budget_status" -eq 2 ]]; then ok "$budget_label is rejected"; else bad "$budget_label exited $budget_status"; fi
@@ -162,7 +177,7 @@ lower_output="$(
     CODEMAP_KNOWLEDGE_BUDGET_SECONDS=1 \
     CODEMAP_DOCS_ONLY_BUDGET_SECONDS=1 \
     CLOCK_STATE="$tmp/lower-clock-state" CLOCK_STEP=0 \
-    "$receipt"
+    "$receipt" --repo-root "$named_worktree"
 )"
 lower_status=$?
 set -e
@@ -176,7 +191,7 @@ for freshness_case in stale missing; do
     freshness_output="$(
         FAKE_CODEMAP_STATUS="$freshness_case" \
         CLOCK_STATE="$tmp/$freshness_case-clock-state" CLOCK_STEP=0 \
-        "$receipt"
+        "$receipt" --repo-root "$named_worktree"
     )"
     freshness_status=$?
     set -e
@@ -189,13 +204,44 @@ set +e
 exact_output="$(
     FAKE_REQUIRED_SECONDS=60 \
     CLOCK_STATE="$tmp/exact-clock-state" CLOCK_STEP=0 \
-    "$receipt" --github-run-id 123 --github-repo example/repo
+    "$receipt" --repo-root "$named_worktree" --github-run-id 123 --github-repo example/repo
 )"
 exact_status=$?
 set -e
 if [[ "$exact_status" -ne 0 ]]; then ok 'exactly 60 seconds required compute exits non-zero'; else bad 'exactly 60 seconds required compute exited zero'; fi
 expect_field "$exact_output" DOCS_ONLY_REQUIRED_COMPUTE_SECONDS 60 'exact-bound required compute is measured'
 expect_field "$exact_output" DOCS_ONLY_REQUIRED_COMPUTE_WITHIN_BUDGET false 'exact-bound required compute fails strict docs contract'
+
+# A detached checkout remains invalid for an ordinary local rehearsal.
+detached_worktree="$tmp/detached-worktree"
+git worktree add --quiet --detach "$detached_worktree" HEAD
+set +e
+detached_local_output="$(
+    CLOCK_STATE="$tmp/detached-local-clock-state" CLOCK_STEP=0 \
+    "$receipt" --repo-root "$detached_worktree"
+)"
+detached_local_status=$?
+set -e
+if [[ "$detached_local_status" -ne 0 ]]; then ok 'local detached checkout exits non-zero'; else bad 'local detached checkout exited zero'; fi
+expect_field "$detached_local_output" READINESS_MODE detached-rejected 'local detached readiness is labeled as rejected'
+
+# The exact CI preflight identity is the only detached-checkout exception.
+set +e
+detached_ci_output="$(
+    GITHUB_ACTIONS=true \
+    GITHUB_WORKFLOW=CI \
+    GITHUB_JOB=fast-validation-preflight \
+    GITHUB_REPOSITORY=Richards-LLC/cassy \
+    GITHUB_EVENT_NAME=merge_group \
+    GITHUB_REF=refs/heads/gh-readonly-queue/main/pr-123-abc \
+    CLOCK_STATE="$tmp/detached-ci-clock-state" CLOCK_STEP=0 \
+    "$receipt" --repo-root "$detached_worktree"
+)"
+detached_ci_status=$?
+set -e
+if [[ "$detached_ci_status" -eq 0 ]]; then ok 'exact CI detached checkout passes'; else bad "exact CI detached checkout exited $detached_ci_status"; fi
+expect_field "$detached_ci_output" READINESS_MODE github-actions-verification-detached 'CI detached readiness is labeled separately'
+expect_field "$detached_ci_output" LOCAL_COMMIT_PUSH_READINESS_EXIT_STATUS 0 'CI detached readiness completes the verification checks'
 
 printf '\n%s passed, %s failed\n' "$pass" "$fail"
 test "$fail" -eq 0

--- a/scripts/test-codemap-latency-receipt.sh
+++ b/scripts/test-codemap-latency-receipt.sh
@@ -217,18 +217,32 @@ if [[ "$exact_status" -ne 0 ]]; then ok 'exactly 60 seconds required compute exi
 expect_field "$exact_output" DOCS_ONLY_REQUIRED_COMPUTE_SECONDS 60 'exact-bound required compute is measured'
 expect_field "$exact_output" DOCS_ONLY_REQUIRED_COMPUTE_WITHIN_BUDGET false 'exact-bound required compute fails strict docs contract'
 
-# A detached checkout remains invalid for an ordinary local rehearsal.
+# A detached checkout remains invalid for an ordinary local rehearsal, even
+# when the test process itself has inherited the complete CI identity.
 detached_worktree="$tmp/detached-worktree"
 git worktree add --quiet --detach "$detached_worktree" HEAD
 set +e
 detached_local_output="$(
-    CLOCK_STATE="$tmp/detached-local-clock-state" CLOCK_STEP=0 \
-    "$receipt" --repo-root "$detached_worktree"
+    env \
+        GITHUB_ACTIONS=true \
+        GITHUB_WORKFLOW=CI \
+        GITHUB_JOB=fast-validation-preflight \
+        GITHUB_REPOSITORY=Richards-LLC/cassy \
+        GITHUB_EVENT_NAME=merge_group \
+        GITHUB_REF=refs/heads/gh-readonly-queue/main/pr-123-abc \
+        env -u GITHUB_ACTIONS \
+        -u GITHUB_WORKFLOW \
+        -u GITHUB_JOB \
+        -u GITHUB_REPOSITORY \
+        -u GITHUB_EVENT_NAME \
+        -u GITHUB_REF \
+        CLOCK_STATE="$tmp/detached-local-clock-state" CLOCK_STEP=0 \
+        "$receipt" --repo-root "$detached_worktree"
 )"
 detached_local_status=$?
 set -e
-if [[ "$detached_local_status" -ne 0 ]]; then ok 'local detached checkout exits non-zero'; else bad 'local detached checkout exited zero'; fi
-expect_field "$detached_local_output" READINESS_MODE detached-rejected 'local detached readiness is labeled as rejected'
+if [[ "$detached_local_status" -ne 0 ]]; then ok 'ambient CI cannot contaminate local detached checkout'; else bad 'ambient CI contaminated local detached checkout'; fi
+expect_field "$detached_local_output" READINESS_MODE detached-rejected 'ambient-CI local detached readiness is labeled as rejected'
 
 # The exact CI preflight identity is the only detached-checkout exception.
 set +e


### PR DESCRIPTION
## Outcome

Codemap refreshes can no longer wait indefinitely on knowledge distillation, and docs-only delivery no longer enters Rust compile lanes.

- Applies one 90-second wall-clock deadline to the complete knowledge build, stops later model calls, kills/reaps the active process group, and returns a visible nonzero timeout receipt.
- Keeps timeout failures non-blocking for the codemap commit/status path across Claude, Codex, and Grok skill mirrors.
- Restores docs-only fast-pass classification for protected PR and merge-queue events while preserving normal validation for code or mixed changes.
- Adds a deterministic latency receipt with immutable limits: agent-controlled work <=300 seconds, knowledge build <=90 seconds, required docs-only compute <60 seconds, and external GitHub queue time reported separately.

## Verification

- cargo nextest run -p cas: 6,091 passed, 0 failed, 76 skipped
- cargo test -p cas --doc: 2 passed, 0 failed, 25 ignored
- scripts/test-ci-test-tiers.sh: 644 passed, 0 failed
- scripts/test-codemap-latency-receipt.sh: 34 passed, 0 failed
- Measured rehearsal: 90 seconds agent-controlled total; knowledge timeout 90 seconds with nonzero receipt; docs-only required contexts 5 seconds; external queue 3 seconds
