### PR TITLE
Release v3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.7.1] - 2026-08-30
+
+### Added
+- Refreshed the generated `.claude/CODEMAP.md` navigation map and added a
+  bounded codemap-latency receipt that proves no content change, freshness,
+  local commit/push readiness, and the required protected-PR compute budget.
+- Added `cas knowledge build --timeout-secs <seconds>` with a 90-second default
+  and a single deadline covering the complete build, including source
+  processing, model calls, merges, and post-commit repair.
+- Added process-group cleanup for knowledge providers so a timed-out provider
+  and its ordinary descendants are terminated and reaped, plus regression
+  tests for the timeout, receipt, freshness, and no-write contracts.
+
+### Changed
+- Protected pull requests now run only the required Fast Validation and macOS
+  Check paths; heavy compile lanes remain on main, scheduled, or explicitly
+  dispatched runs. First branch pushes use the protected default branch as a
+  trusted comparison base, while merge-queue jobs use their event base SHA.
+- Updated the Claude, Codex, and Grok codemap skills to invoke the bounded
+  knowledge build as best effort, record its exit status, and continue with
+  codemap status proof when knowledge distillation is unavailable or times out.
+
+### Fixed
+- Codemap latency validation now labels detached GitHub Actions readiness
+  separately from ordinary local readiness and rejects stale or missing
+  freshness proofs without touching `CODEMAP.md`.
+- Added regression coverage for review fixes that intentionally delete content
+  after a task parks, preserving the final-tree merge proof contract.
+
 ## [3.7.0] - 2026-08-30
 
 ### Added
@@ -1496,7 +1525,9 @@ After upgrading, the new gates fire on `task.close` calls. If a worker hits the 
 ### Added
 - Initial stable release with core functionality.
 
-[Unreleased]: https://github.com/pippenz/cas/compare/v2.12.0...HEAD
+[Unreleased]: https://github.com/Richards-LLC/cassy/compare/v3.7.1...HEAD
+[3.7.1]: https://github.com/Richards-LLC/cassy/compare/v3.7.0...v3.7.1
+[3.7.0]: https://github.com/Richards-LLC/cassy/compare/v3.6.0...v3.7.0
 [2.13.0]: https://github.com/pippenz/cas/compare/v2.12.0...v2.13.0
 [2.12.0]: https://github.com/pippenz/cas/compare/v2.11.0...v2.12.0
 [2.11.0]: https://github.com/pippenz/cas/compare/v2.10.1...v2.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.7.0"
+version = "3.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.7.0"
+version = "3.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.7.0"
+version = "3.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.7.0"
+version = "3.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.7.0"
+version = "3.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.7.0"
+version = "3.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"


### PR DESCRIPTION
Ships every commit merged since v3.7.0, including the refreshed codemap, bounded knowledge-build deadline and process cleanup, codemap latency/no-write/freshness gates, protected-PR fast path, and close-gate regression coverage.

Release-prep verification:
- cargo check --locked
- CI policy: 644/644
- codemap latency contract: 41/41
- nine release guard suites

After protected merge, the supervisor will push the annotated v3.7.1 tag, verify both published assets and a clean install/update, and preserve Slack publication under the explicit August 31 embargo.