### PR TITLE
fix(cloud): team pull upserts entries with LWW instead of insert (GH #633)

### DIFF
--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 
 use crate::cloud::syncer::{
@@ -41,6 +42,19 @@ fn deserialize_pulled_entity<T: DeserializeOwned>(
         .to_owned();
     serde_json::from_value(raw)
         .map_err(|error| format!("{entity_type} deserialize error (id={id}): {error}"))
+}
+
+/// Read the cloud mutation timestamp carried by a team-pull entry.
+///
+/// The local `Entry` model predates the wire-level `updated_at` field, so
+/// retain the timestamp as pull metadata instead of changing that public
+/// model. Older responses fall back to `last_accessed`/`created` below.
+fn pulled_entry_updated_at(raw: &serde_json::Value) -> Option<DateTime<Utc>> {
+    raw.get("updated_at")
+        .or_else(|| raw.get("updatedAt"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
 }
 
 const PROPOSAL_PROVENANCE_BEGIN: &str = "--- BEGIN SERVER-ATTESTED PROPOSAL PROVENANCE ---";
@@ -1027,41 +1041,84 @@ impl CloudSyncer {
         }
     }
 
-    /// Upsert entry with configurable conflict resolution for team sync
-    fn upsert_entry_with_strategy(
+    /// Upsert a team entry by id using timestamp last-writer-wins.
+    ///
+    /// Team pulls intentionally use LWW for entries even though the other
+    /// team entity kinds retain their configured conflict strategy. An entry
+    /// can legitimately exist in both personal and team scope under the same
+    /// id (GH #633); RemoteWins would overwrite a newer personal copy with an
+    /// older team snapshot and would rewrite equal snapshots on every pull.
+    fn upsert_entry_lww(
         &self,
         store: &dyn Store,
         entry: Entry,
-        strategy: ConflictResolution,
+        remote_updated_at: DateTime<Utc>,
     ) -> Result<UpsertResult, CasError> {
-        match store.get(&entry.id) {
-            Ok(local) => {
-                let local_time = local.last_accessed.unwrap_or(local.created);
-                let remote_time = entry.last_accessed.unwrap_or(entry.created);
+        let local = match store.get(&entry.id) {
+            Ok(local) => Some(local),
+            Err(cas_store::StoreError::EntryNotFound(_)) => match store.get_archived(&entry.id) {
+                Ok(local) => Some(local),
+                Err(cas_store::StoreError::EntryNotFound(_)) => None,
+                Err(error) => return Err(error.into()),
+            },
+            Err(error) => return Err(error.into()),
+        };
 
-                let action =
-                    self.resolve_conflict("entry", &entry.id, local_time, remote_time, strategy);
-
-                match action {
-                    ConflictAction::UseRemote => {
-                        self.journal_local_overwrite(
-                            EntityType::Entry,
-                            &entry.id,
-                            &local,
-                            "remote",
-                            strategy.as_str(),
-                        )?;
-                        store.update(&entry)?;
-                        Ok(UpsertResult::Updated)
-                    }
-                    ConflictAction::UseLocal | ConflictAction::Skip => Ok(UpsertResult::Skipped),
+        let Some(local) = local else {
+            return match store.add(&entry) {
+                Ok(()) => Ok(UpsertResult::Created),
+                // A concurrent local write can win the get→add race. Resolve
+                // that row through the same LWW path instead of surfacing a
+                // duplicate-key warning for an otherwise healthy pull.
+                Err(cas_store::StoreError::EntryExists(_)) => {
+                    let local = match store.get(&entry.id) {
+                        Ok(local) => local,
+                        Err(cas_store::StoreError::EntryNotFound(_)) => {
+                            match store.get_archived(&entry.id) {
+                                Ok(local) => local,
+                                Err(error) => return Err(error.into()),
+                            }
+                        }
+                        Err(error) => return Err(error.into()),
+                    };
+                    self.merge_entry_lww(store, local, entry, remote_updated_at)
                 }
+                Err(error) => Err(error.into()),
+            };
+        };
+
+        self.merge_entry_lww(store, local, entry, remote_updated_at)
+    }
+
+    fn merge_entry_lww(
+        &self,
+        store: &dyn Store,
+        local: Entry,
+        remote: Entry,
+        remote_updated_at: DateTime<Utc>,
+    ) -> Result<UpsertResult, CasError> {
+        let local_time = store.recent_timestamp(&local)?;
+        let action = self.resolve_conflict(
+            "entry",
+            &remote.id,
+            local_time,
+            remote_updated_at,
+            ConflictResolution::KeepRecent,
+        );
+
+        match action {
+            ConflictAction::UseRemote => {
+                self.journal_local_overwrite(
+                    EntityType::Entry,
+                    &remote.id,
+                    &local,
+                    "remote",
+                    ConflictResolution::KeepRecent.as_str(),
+                )?;
+                store.update(&remote)?;
+                Ok(UpsertResult::Updated)
             }
-            Err(cas_store::StoreError::EntryNotFound(_)) => {
-                store.add(&entry)?;
-                Ok(UpsertResult::Created)
-            }
-            Err(e) => Err(e.into()),
+            ConflictAction::UseLocal | ConflictAction::Skip => Ok(UpsertResult::Skipped),
         }
     }
 
@@ -1419,6 +1476,7 @@ impl CloudSyncer {
             if !entity_matches_project(&raw_entry, &current_project_id, "entry") {
                 continue;
             }
+            let remote_updated_at = pulled_entry_updated_at(&raw_entry);
             let remote_entry: Entry = match deserialize_pulled_entity(raw_entry, "entry") {
                 Ok(e) => e,
                 Err(e) => {
@@ -1426,7 +1484,9 @@ impl CloudSyncer {
                     continue;
                 }
             };
-            match self.upsert_entry_with_strategy(store, remote_entry, strategy) {
+            let remote_updated_at = remote_updated_at
+                .unwrap_or_else(|| remote_entry.last_accessed.unwrap_or(remote_entry.created));
+            match self.upsert_entry_lww(store, remote_entry, remote_updated_at) {
                 Ok(UpsertResult::Created) | Ok(UpsertResult::Updated) => {
                     result.pulled_entries += 1;
                 }

--- a/cas-cli/tests/team_pull_lww_test.rs
+++ b/cas-cli/tests/team_pull_lww_test.rs
@@ -3,13 +3,13 @@
 
 mod common;
 
-use common::TEST_TEAM;
 use cas::cloud::{CloudConfig, CloudSyncer, CloudSyncerConfig};
 use cas::store::{
     open_rule_store_local, open_skill_store_local, open_store_local, open_task_store_local,
 };
 use cas::types::{Entry, EntryType, Scope};
 use chrono::{DateTime, Utc};
+use common::TEST_TEAM;
 use std::sync::Arc;
 use tempfile::TempDir;
 use wiremock::matchers::{method, path};
@@ -34,42 +34,60 @@ fn with_project_id(entry: Entry, project_id: &str) -> serde_json::Value {
     value
 }
 
+fn with_updated_at(mut entry: serde_json::Value, updated_at: DateTime<Utc>) -> serde_json::Value {
+    entry["updated_at"] = serde_json::json!(updated_at.to_rfc3339());
+    entry
+}
+
 #[tokio::test]
 async fn team_pull_reconciles_same_id_entries_with_lww_and_skips_foreign_rows() {
     let server = MockServer::start().await;
     let project_id = "cas-633-project";
+    let now = Utc::now();
 
-    let remote_personal_newer = with_project_id(
-        entry(
-            "same-id-personal-newer",
-            "stale team copy",
-            "2026-08-10T00:00:00Z",
+    let remote_personal_newer = with_updated_at(
+        with_project_id(
+            entry(
+                "same-id-personal-newer",
+                "stale team copy",
+                &(now - chrono::Duration::hours(2)).to_rfc3339(),
+            ),
+            project_id,
         ),
-        project_id,
+        now - chrono::Duration::minutes(30),
     );
-    let remote_team_newer = with_project_id(
-        entry(
-            "same-id-team-newer",
-            "new team copy",
-            "2026-08-12T00:00:00Z",
+    let remote_team_newer = with_updated_at(
+        with_project_id(
+            entry(
+                "same-id-team-newer",
+                "new team copy",
+                &(now + chrono::Duration::hours(1)).to_rfc3339(),
+            ),
+            project_id,
         ),
-        project_id,
+        now + chrono::Duration::hours(1),
     );
-    let remote_unchanged = with_project_id(
-        entry(
-            "same-id-unchanged",
-            "unchanged copy",
-            "2026-08-11T00:00:00Z",
+    let remote_unchanged = with_updated_at(
+        with_project_id(
+            entry(
+                "same-id-unchanged",
+                "unchanged copy",
+                &(now - chrono::Duration::hours(1)).to_rfc3339(),
+            ),
+            project_id,
         ),
-        project_id,
+        now - chrono::Duration::hours(1),
     );
-    let foreign_same_id = with_project_id(
-        entry(
-            "same-id-cross-project",
-            "foreign project copy",
-            "2026-08-13T00:00:00Z",
+    let foreign_same_id = with_updated_at(
+        with_project_id(
+            entry(
+                "same-id-cross-project",
+                "foreign project copy",
+                &(now + chrono::Duration::hours(2)).to_rfc3339(),
+            ),
+            "other-project",
         ),
-        "other-project",
+        now + chrono::Duration::hours(2),
     );
 
     Mock::given(method("GET"))
@@ -104,21 +122,21 @@ async fn team_pull_reconciles_same_id_entries_with_lww_and_skips_foreign_rows() 
         .add(&entry(
             "same-id-personal-newer",
             "new personal copy",
-            "2026-08-13T00:00:00Z",
+            &(now - chrono::Duration::hours(1)).to_rfc3339(),
         ))
         .unwrap();
     store
         .add(&entry(
             "same-id-team-newer",
             "old personal copy",
-            "2026-08-11T00:00:00Z",
+            &(now - chrono::Duration::hours(3)).to_rfc3339(),
         ))
         .unwrap();
     store
         .add(&entry(
             "same-id-unchanged",
             "unchanged copy",
-            "2026-08-11T00:00:00Z",
+            &(now - chrono::Duration::hours(1)).to_rfc3339(),
         ))
         .unwrap();
 
@@ -142,9 +160,16 @@ async fn team_pull_reconciles_same_id_entries_with_lww_and_skips_foreign_rows() 
     .unwrap()
     .unwrap();
 
-    assert!(result.errors.is_empty(), "unexpected pull errors: {:?}", result.errors);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected pull errors: {:?}",
+        result.errors
+    );
     assert_eq!(result.pulled_entries, 1, "only the newer team copy applies");
-    assert_eq!(result.conflicts_resolved, 2, "older and equal rows are no-ops");
+    assert_eq!(
+        result.conflicts_resolved, 2,
+        "older and equal rows are no-ops"
+    );
 
     let store = open_store_local(tmp.path()).unwrap();
     assert_eq!(

--- a/cas-cli/tests/team_pull_lww_test.rs
+++ b/cas-cli/tests/team_pull_lww_test.rs
@@ -1,0 +1,166 @@
+//! Regression coverage for GH #633: team-pull entries share IDs with the
+//! author's personal rows and must reconcile by last-writer-wins.
+
+mod common;
+
+use common::TEST_TEAM;
+use cas::cloud::{CloudConfig, CloudSyncer, CloudSyncerConfig};
+use cas::store::{
+    open_rule_store_local, open_skill_store_local, open_store_local, open_task_store_local,
+};
+use cas::types::{Entry, EntryType, Scope};
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn entry(id: &str, content: &str, created: &str) -> Entry {
+    Entry {
+        id: id.to_string(),
+        scope: Scope::Project,
+        entry_type: EntryType::Context,
+        content: content.to_string(),
+        created: DateTime::parse_from_rfc3339(created)
+            .unwrap()
+            .with_timezone(&Utc),
+        ..Default::default()
+    }
+}
+
+fn with_project_id(entry: Entry, project_id: &str) -> serde_json::Value {
+    let mut value = serde_json::to_value(&entry).unwrap();
+    value["project_id"] = serde_json::json!(project_id);
+    value
+}
+
+#[tokio::test]
+async fn team_pull_reconciles_same_id_entries_with_lww_and_skips_foreign_rows() {
+    let server = MockServer::start().await;
+    let project_id = "cas-633-project";
+
+    let remote_personal_newer = with_project_id(
+        entry(
+            "same-id-personal-newer",
+            "stale team copy",
+            "2026-08-10T00:00:00Z",
+        ),
+        project_id,
+    );
+    let remote_team_newer = with_project_id(
+        entry(
+            "same-id-team-newer",
+            "new team copy",
+            "2026-08-12T00:00:00Z",
+        ),
+        project_id,
+    );
+    let remote_unchanged = with_project_id(
+        entry(
+            "same-id-unchanged",
+            "unchanged copy",
+            "2026-08-11T00:00:00Z",
+        ),
+        project_id,
+    );
+    let foreign_same_id = with_project_id(
+        entry(
+            "same-id-cross-project",
+            "foreign project copy",
+            "2026-08-13T00:00:00Z",
+        ),
+        "other-project",
+    );
+
+    Mock::given(method("GET"))
+        .and(path(format!("/api/teams/{TEST_TEAM}/sync/pull")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": [
+                remote_personal_newer,
+                remote_team_newer,
+                remote_unchanged,
+                foreign_same_id,
+            ],
+            "tasks": [],
+            "rules": [],
+            "skills": [],
+            "pulled_at": "2026-08-14T00:00:00Z",
+            "team_id": TEST_TEAM,
+            "status": "ok",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let queue = Arc::new(cas::cloud::SyncQueue::open(tmp.path()).unwrap());
+    queue.init().unwrap();
+    let store = open_store_local(tmp.path()).unwrap();
+    let task_store = open_task_store_local(tmp.path()).unwrap();
+    let rule_store = open_rule_store_local(tmp.path()).unwrap();
+    let skill_store = open_skill_store_local(tmp.path()).unwrap();
+
+    store
+        .add(&entry(
+            "same-id-personal-newer",
+            "new personal copy",
+            "2026-08-13T00:00:00Z",
+        ))
+        .unwrap();
+    store
+        .add(&entry(
+            "same-id-team-newer",
+            "old personal copy",
+            "2026-08-11T00:00:00Z",
+        ))
+        .unwrap();
+    store
+        .add(&entry(
+            "same-id-unchanged",
+            "unchanged copy",
+            "2026-08-11T00:00:00Z",
+        ))
+        .unwrap();
+
+    let mut config = CloudConfig::default();
+    config.endpoint = server.uri();
+    config.token = Some("test-token".to_string());
+    config.set_team(TEST_TEAM, "test-team");
+    let syncer = CloudSyncer::new(queue, config, CloudSyncerConfig::default());
+
+    let result = tokio::task::spawn_blocking(move || {
+        syncer.pull_team(
+            TEST_TEAM,
+            project_id,
+            store.as_ref(),
+            task_store.as_ref(),
+            rule_store.as_ref(),
+            skill_store.as_ref(),
+        )
+    })
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert!(result.errors.is_empty(), "unexpected pull errors: {:?}", result.errors);
+    assert_eq!(result.pulled_entries, 1, "only the newer team copy applies");
+    assert_eq!(result.conflicts_resolved, 2, "older and equal rows are no-ops");
+
+    let store = open_store_local(tmp.path()).unwrap();
+    assert_eq!(
+        store.get("same-id-personal-newer").unwrap().content,
+        "new personal copy"
+    );
+    assert_eq!(
+        store.get("same-id-team-newer").unwrap().content,
+        "new team copy"
+    );
+    assert_eq!(
+        store.get("same-id-unchanged").unwrap().content,
+        "unchanged copy"
+    );
+    assert!(
+        store.get("same-id-cross-project").is_err(),
+        "foreign project row must not be imported"
+    );
+}


### PR DESCRIPTION
Fixes #633.

**Was →** team pull applied pulled entry rows with an insert, so the team copy of an entry that was auto-promoted personal→team under the same id collided with the personal original: `Team pull encountered error(s); partial results applied — entry already exists: …` on every pull, and drifted pairs (426 measured on the cloud DB) never converged.

**Now →** team-pull entries are upserted by id with last-writer-wins: the wire `updated_at` (fallback `last_accessed`/`created`) is compared against the local row's `Store::recent_timestamp` (MAX(created, updated_at)); newer remote overwrites (journaled), older/equal remote is skipped, archived local rows are considered before `add`, and a get→add race resolves through the same LWW path instead of surfacing a duplicate-key warning. Other team entity kinds keep their configured conflict strategy. Real store errors still surface.

Tests: new `cas-cli/tests/team_pull_lww_test.rs` (same-id personal+team newer/older/equal, cross-project same-id filtered, unchanged no-op); `team_pull_wiring_test` 9/9; scoped lib surface 4,881 passed.

Supervisor-reviewed delivery from factory worker agile-lynx-37 (task cas-0fae).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzWVWHGEGzc78f9ED7r4Tp