### PR TITLE
chore(release): prepare v3.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.7.2] - 2026-08-31
+
+### Added
+- SessionStart memory injection is now telemetered with honest retrieval
+  outcomes: unresolved cards stay distinct from ignored cards, and reading an
+  injected memory counts as use. Ambient rule and skill surfaces are recorded
+  for the same impact accounting.
+- Added a labeled retrieval-evaluation harness with committed fixtures and
+  precision@5/recall@5 baseline gates so ranking changes are measured before
+  they ship.
+- `cas doctor` now detects memory entries stranded in a legacy daemon index;
+  `cas doctor --fix` recovers them into the active index with bounded,
+  resumable repair.
+
+### Changed
+- Helpful Memories now read from the live, curated, tier-aware corpus while
+  excluding raw context blobs, and `cas stats` reports the live corpus count.
+- `retrieval_metrics` supports session filtering and rejects unsupported
+  filters instead of silently widening the result set.
+- Rule review is enabled by default, and ambiently surfaced rules count toward
+  the promotion flywheel, so useful rules can progress instead of remaining
+  invisible drafts.
+- Team sync upserts auto-promoted entries without turning a successful pull
+  into an error; Claude worker lanes use canonical model identifiers and report
+  workers that die during boot as failed. Project-managed skills are ignored by
+  git so generated files no longer become repository noise.
+
+### Fixed
+- Background and legacy search indexing now share one repair path, making
+  daemon-written memories visible to search and giving busy legacy processes a
+  bounded doctor warning with a retry remedy.
+
 ## [3.7.1] - 2026-08-30
 
 ### Added
@@ -1525,7 +1557,8 @@ After upgrading, the new gates fire on `task.close` calls. If a worker hits the 
 ### Added
 - Initial stable release with core functionality.
 
-[Unreleased]: https://github.com/Richards-LLC/cassy/compare/v3.7.1...HEAD
+[Unreleased]: https://github.com/Richards-LLC/cassy/compare/v3.7.2...HEAD
+[3.7.2]: https://github.com/Richards-LLC/cassy/compare/v3.7.1...v3.7.2
 [3.7.1]: https://github.com/Richards-LLC/cassy/compare/v3.7.0...v3.7.1
 [3.7.0]: https://github.com/Richards-LLC/cassy/compare/v3.6.0...v3.7.0
 [2.13.0]: https://github.com/pippenz/cas/compare/v2.12.0...v2.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.7.1"
+version = "3.7.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.7.1"
+version = "3.7.2"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.7.1"
+version = "3.7.2"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.7.1"
+version = "3.7.2"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.7.1"
+version = "3.7.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.7.1"
+version = "3.7.2"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.7.1"
+version = "3.7.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.7.1"
+version = "3.7.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.7.1"
+version = "3.7.2"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.7.1"
+version = "3.7.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.7.1"
+version = "3.7.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.7.1"
+version = "3.7.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-31-v3.7.2-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.2-slack.md
@@ -1,0 +1,32 @@
+# Release notes — 2026-08-31 — CAS v3.7.2
+
+**Channel:** `#cas-internal` · **Deploy:** Live on production · **Status:** Draft, posting embargoed until the operator hold is lifted
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Cassy now learns from what you actually use, keeps its guidance trustworthy, and repairs memories that were hidden from search.
+
+**Reply:**
+- **Was** → Cassy could inject memories without showing whether they helped, leave useful rules stuck as drafts, and lose memories written by a background process from normal search. **Now** → every injected memory has an honest outcome, reading one counts as use, surfaced rules can progress, and `cas doctor --fix` finds and restores hidden memories.
+- **Was** → Helpful Memories could be drawn from stale or noisy context, and statistics did not clearly describe the live collection. **Now** → Helpful Memories use the live, curated collection with memory tiers respected and raw context excluded, while `cas stats` reports what is actually available.
+- **Was** → a sync could report an error after bringing in an auto-promoted entry, and a worker could disappear during startup without a clear result. **Now** → sync accepts those entries cleanly, canonical worker lanes are used, and a worker that dies at boot is reported as failed.
+- **Deploy guidance** → after updating, restart any long-running `cas serve` process first; then `cas update` repairs any stray search index in every project automatically.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — CAS v3.7.2 makes retrieval outcomes measurable, ranking changes gateable, and legacy index repair observable and bounded.
+
+**Reply:**
+- **Was** → SessionStart injection, ambient surfaces, and retrieval use were only partially observable, and unresolved cards could distort ranking feedback. **Now** → injection and ambient rule/skill surfacing are durable telemetry, unresolved is separate from ignored, exact memory reads count as used, and `retrieval_metrics` can scope by session while rejecting unsupported filters.
+- **Was** → ranking work had no committed labeled baseline, Helpful Memories could measure a fallback instead of production retrieval, and `cas stats` could describe historical tiers rather than the live corpus. **Now** → the labeled evaluation harness gates precision@5/recall@5 against committed fixtures, production Helpful-Memories retrieval is measured directly, and live tier-aware curated counts exclude raw context blobs.
+- **Was** → daemon writes to the legacy Tantivy root could leave entries invisible and repair could block behind an old process. **Now** → `cas doctor` reports the stray index and `cas doctor --fix` performs bounded, resumable recovery; busy processes produce a warning and retry command.
+- **Was** → team sync rejected auto-promoted entries, Claude lanes accepted non-canonical identifiers, and generated project skills appeared as tracked files. **Now** → sync upserts cleanly, worker lanes use canonical model IDs and classify dead-at-boot workers as failed, and project-managed skills are git-ignored.
+- **Deploy guidance** → after updating, `cas update` repairs any stray search index in every project automatically; restart any long-running `cas serve` first so it cannot keep writing to the legacy index root.
+
+<!--
+Fallback manual-step wording, pending the automatic repair landing:
+After updating, restart any running `cas serve`/daemon processes, then run
+`cas doctor --fix` once per project.
+-->


### PR DESCRIPTION
## Summary

- Bump all six release-train crates and Cargo.lock from 3.7.1 to 3.7.2.
- Add the 2026-08-31 changelog entry covering the memory effectiveness, retrieval evaluation, legacy-index repair, sync, lane, and project-skill changes.
- Save the embargoed two-thread runtime release draft with automatic `cas update` repair guidance primary and manual fallback wording in an HTML comment.

## Validation

- `cargo metadata --locked --format-version 1`
- `cargo check -p cas --locked`
- `scripts/check-release-migration-snapshots.sh` (13/13 passed)
- `git diff --check`

Tagging, release publication, and Slack posting remain operator-owned.
