### PR TITLE
Repair legacy search indexes during cas update

### DIFF
--- a/cas-cli/src/cli/update.rs
+++ b/cas-cli/src/cli/update.rs
@@ -24,8 +24,9 @@ use crate::cli::hook::{
 use crate::cli::init::{generate_cas_skill, update_claude_md};
 use crate::cli::update::preview::{build_update_transaction, show_enhanced_dry_run};
 use crate::cloud::{CloudConfig, FetchTeamsOutcome, fetch_and_cache_teams, maybe_adopt_team_scope};
+use crate::hybrid_search::{LegacyRepairLimits, LegacyRepairOutcome, repair_legacy_index_bounded};
 use crate::migration::{check_migrations, run_migrations};
-use crate::store::{open_rule_store, open_skill_store};
+use crate::store::{open_rule_store, open_skill_store, open_store};
 use crate::sync::{SkillSyncer, Syncer};
 use crate::ui::components::Formatter;
 use crate::ui::theme::ActiveTheme;
@@ -135,6 +136,11 @@ const REPO_NAME: &str = "cas";
 /// Binary name in release assets
 const BIN_NAME: &str = "cas";
 
+/// An automatic update must not hang indefinitely behind a pre-update daemon.
+/// The repair primitive itself also bounds lock acquisition, but this outer
+/// deadline closes the reader-acquisition race described in legacy_index.rs.
+const UPDATE_REPAIR_BUDGET: Duration = Duration::from_secs(20);
+
 #[derive(Args)]
 pub struct UpdateArgs {
     /// Only check for updates without installing
@@ -174,7 +180,8 @@ pub struct UpdateArgs {
     /// Refresh every discovered local Cassy project after updating.
     ///
     /// Performs schema migration, generated-file/builtin sync, cloud team
-    /// membership refresh, and cloud sync for every cloud-linked project.
+    /// membership refresh, legacy search-index repair, and cloud sync for
+    /// every cloud-linked project.
     #[arg(long)]
     pub all_projects: bool,
 }
@@ -255,6 +262,7 @@ enum ProjectPhase {
     Ok(String),
     Skipped(String),
     Planned(String),
+    Warning(String),
     Failed(String),
 }
 
@@ -264,6 +272,7 @@ impl ProjectPhase {
             Self::Ok(detail) => format!("ok: {detail}"),
             Self::Skipped(detail) => format!("skipped: {detail}"),
             Self::Planned(detail) => format!("dry-run: {detail}"),
+            Self::Warning(detail) => format!("warning: {detail}"),
             Self::Failed(detail) => format!("FAILED: {detail}"),
         }
     }
@@ -276,6 +285,7 @@ impl ProjectPhase {
 struct ProjectRefreshReceipt {
     project: PathBuf,
     migration: ProjectPhase,
+    search_index: ProjectPhase,
     skills: ProjectPhase,
     membership: ProjectPhase,
     cloud: ProjectPhase,
@@ -320,6 +330,7 @@ fn refresh_all_projects(
         let migration = run_project_phase("migration", args.dry_run, || {
             run_schema_migrations(args, cli, Some(&cas_root))
         });
+        let search_index = repair_project_search_index(&cas_root, args.dry_run, cli);
         let skills = run_project_phase("skills", args.dry_run, || {
             sync_claude_files(cli, Some(&cas_root))
         });
@@ -329,6 +340,7 @@ fn refresh_all_projects(
         receipts.push(ProjectRefreshReceipt {
             project,
             migration,
+            search_index,
             skills,
             membership,
             cloud,
@@ -351,6 +363,95 @@ fn refresh_all_projects(
         );
     }
     Ok(())
+}
+
+/// Repair the pre-cas-bc42 Tantivy root as part of the native update walk.
+///
+/// Search repair is deliberately advisory: a held lock, malformed legacy
+/// index, or unavailable project store must be visible to the operator but
+/// must not prevent the remaining update phases or other projects from being
+/// refreshed. The cheap metadata check avoids opening a project store on the
+/// common no-stray-root path.
+fn repair_project_search_index(cas_root: &Path, dry_run: bool, cli: &Cli) -> ProjectPhase {
+    let legacy_dir = cas_root.join("index");
+    let has_legacy_root = legacy_dir.join("meta.json").is_file();
+    let has_resumable_sweep = legacy_dir.join(".managed.json").is_file();
+
+    let phase = if dry_run {
+        ProjectPhase::Planned("legacy-root repair".to_string())
+    } else if !has_legacy_root && !has_resumable_sweep {
+        ProjectPhase::Ok("no stray root".to_string())
+    } else {
+        match open_store(cas_root) {
+            Err(error) => {
+                ProjectPhase::Warning(format!("could not open project store for repair: {error}"))
+            }
+            Ok(store) => match repair_legacy_index_bounded(
+                cas_root,
+                store,
+                LegacyRepairLimits::default(),
+                UPDATE_REPAIR_BUDGET,
+            ) {
+                Ok(LegacyRepairOutcome::NoLegacyRoot) => {
+                    ProjectPhase::Ok("no stray root".to_string())
+                }
+                Ok(LegacyRepairOutcome::Busy { reason }) => ProjectPhase::Warning(format!(
+                    "busy, will retry in the daemon cycle ({reason})"
+                )),
+                Ok(LegacyRepairOutcome::Repaired(repair)) => {
+                    let mut detail = format!(
+                        "repaired {} stranded memories ({} re-queued)",
+                        repair.legacy_documents, repair.requeued_entries
+                    );
+                    if !repair.errors.is_empty() {
+                        detail.push_str(&format!(
+                            "; {} memory(s) remain queued for retry",
+                            repair.errors.len()
+                        ));
+                    }
+                    if !repair.unswept_files.is_empty() {
+                        detail.push_str(&format!(
+                            "; {} legacy file(s) remain for the next sweep",
+                            repair.unswept_files.len()
+                        ));
+                    }
+                    if !repair.retired_non_entry_documents.is_empty() {
+                        detail.push_str(&format!(
+                            "; retired non-memory documents: {}",
+                            repair
+                                .retired_non_entry_documents
+                                .iter()
+                                .map(|(kind, count)| format!("{count} {kind}"))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ));
+                    }
+                    if repair.errors.is_empty()
+                        && repair.unswept_files.is_empty()
+                        && repair.retired_non_entry_documents.is_empty()
+                    {
+                        ProjectPhase::Ok(detail)
+                    } else {
+                        ProjectPhase::Warning(detail)
+                    }
+                }
+                Err(error) => ProjectPhase::Warning(format!("repair failed: {error}")),
+            },
+        }
+    };
+
+    if !cli.json {
+        let (status, detail) = match &phase {
+            ProjectPhase::Ok(detail) => ("OK", detail),
+            ProjectPhase::Planned(detail) => ("DRY RUN", detail),
+            ProjectPhase::Warning(detail) => ("WARN", detail),
+            ProjectPhase::Skipped(detail) => ("SKIP", detail),
+            ProjectPhase::Failed(detail) => ("FAIL", detail),
+        };
+        println!("    [{status}] search index: {detail}");
+    }
+
+    phase
 }
 
 fn run_project_phase(
@@ -456,6 +557,7 @@ fn print_project_refresh_summary(
                 serde_json::json!({
                     "project": receipt.project,
                     "migration": receipt.migration.summary(),
+                    "search_index": receipt.search_index.summary(),
                     "skills": receipt.skills.summary(),
                     "membership": receipt.membership.summary(),
                     "cloud_sync": receipt.cloud.summary(),
@@ -473,6 +575,7 @@ fn print_project_refresh_summary(
     for receipt in receipts {
         println!("  {}", receipt.project.display());
         println!("    migration:  {}", receipt.migration.summary());
+        println!("    search index: {}", receipt.search_index.summary());
         println!("    skills:     {}", receipt.skills.summary());
         println!("    membership: {}", receipt.membership.summary());
         println!("    cloud sync: {}", receipt.cloud.summary());

--- a/cas-cli/tests/update_all_projects_test.rs
+++ b/cas-cli/tests/update_all_projects_test.rs
@@ -2,7 +2,6 @@
 
 use assert_cmd::Command;
 use cas::hybrid_search::{SearchIndex, SearchOptions};
-use cas::store::Store;
 use cas::types::Entry;
 use std::path::{Path, PathBuf};
 use tantivy::directory::{Directory, META_LOCK};

--- a/cas-cli/tests/update_all_projects_test.rs
+++ b/cas-cli/tests/update_all_projects_test.rs
@@ -1,7 +1,11 @@
 //! End-to-end coverage for the native multi-project update sweep (cas-4ee9).
 
 use assert_cmd::Command;
+use cas::hybrid_search::{SearchIndex, SearchOptions};
+use cas::store::Store;
+use cas::types::Entry;
 use std::path::{Path, PathBuf};
+use tantivy::directory::{Directory, META_LOCK};
 use tempfile::TempDir;
 
 fn cas_cmd(root: &Path) -> Command {
@@ -31,6 +35,24 @@ fn init_project(root: &Path, project: &Path) {
 
 fn worker_skill(project: &Path) -> PathBuf {
     project.join(".claude/skills/cas-worker/SKILL.md")
+}
+
+fn seed_stray_memory(project: &Path) -> String {
+    let cas_root = project.join(".cas");
+    let store = cas::store::open_store(&cas_root).expect("open project store");
+    let entry = Entry::new(
+        "legacy-update-memory".to_string(),
+        "legacy update repair makes this memory searchable".to_string(),
+    );
+    store.add(&entry).expect("add entry");
+    SearchIndex::open(&cas_root.join("index"))
+        .expect("open legacy index")
+        .index_entry(&entry)
+        .expect("seed legacy index");
+    store
+        .mark_indexed(&entry.id)
+        .expect("mark entry indexed in legacy root");
+    entry.id
 }
 
 #[test]
@@ -82,5 +104,86 @@ fn all_projects_dry_run_is_non_mutating_then_syncs_every_discovered_project() {
     assert!(
         missing.is_file(),
         "native sweep must restore the stale builtin"
+    );
+}
+
+#[test]
+fn all_projects_repairs_stray_search_roots_and_reports_clean_projects() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    let projects = root.join("projects");
+    let stranded = projects.join("stranded");
+    let clean = projects.join("clean");
+    init_project(root, &stranded);
+    init_project(root, &clean);
+    let entry_id = seed_stray_memory(&stranded);
+
+    let update = cas_cmd(root)
+        .current_dir(root)
+        .env("CAS_PROJECT_ROOTS", &projects)
+        .args(["update", "--all-projects"])
+        .assert()
+        .success();
+    let output = String::from_utf8_lossy(&update.get_output().stdout);
+    assert!(
+        output.contains("[OK] search index: repaired 1 stranded memories (1 re-queued)"),
+        "repair receipt missing from output:\n{output}"
+    );
+    assert!(
+        output.contains("[OK] search index: no stray root"),
+        "clean-project receipt missing from output:\n{output}"
+    );
+    assert!(
+        !stranded.join(".cas/index/meta.json").exists(),
+        "the legacy Tantivy root must be retired"
+    );
+
+    let store = cas::store::open_store(&stranded.join(".cas")).expect("reopen store");
+    let entries = store.list().expect("list entries");
+    let hits = SearchIndex::open(&stranded.join(".cas/index/tantivy"))
+        .expect("open canonical index")
+        .search(
+            &SearchOptions {
+                query: "legacy update repair".to_string(),
+                ..Default::default()
+            },
+            &entries,
+        )
+        .expect("search repaired index");
+    assert_eq!(
+        hits.first().map(|hit| hit.id.as_str()),
+        Some(entry_id.as_str()),
+        "the stranded memory must be searchable after update"
+    );
+}
+
+#[test]
+fn all_projects_warns_on_a_held_legacy_lock_but_still_succeeds() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    let projects = root.join("projects");
+    let project = projects.join("busy");
+    init_project(root, &project);
+    seed_stray_memory(&project);
+
+    let legacy = tantivy::Index::open_in_dir(project.join(".cas/index")).unwrap();
+    let _held = legacy
+        .directory()
+        .acquire_lock(&META_LOCK)
+        .expect("hold legacy metadata lock");
+    let update = cas_cmd(root)
+        .current_dir(root)
+        .env("CAS_PROJECT_ROOTS", &projects)
+        .args(["update", "--all-projects"])
+        .assert()
+        .success();
+    let output = String::from_utf8_lossy(&update.get_output().stdout);
+    assert!(
+        output.contains("[WARN] search index: busy"),
+        "busy repair receipt missing from output:\n{output}"
+    );
+    assert!(
+        output.contains("Total: 1 succeeded, 0 failed"),
+        "busy repair must not fail the project refresh:\n{output}"
     );
 }

--- a/contrib/shell-helpers/README.md
+++ b/contrib/shell-helpers/README.md
@@ -9,10 +9,11 @@ contrib/shell-helpers/install.sh
 
 That copies the helper to `~/.local/bin/cas-update` (override the destination
 with `CAS_UPDATE_INSTALL_DIR`). The helper builds the current source checkout,
-atomically installs `~/.local/bin/cas`, then delegates the complete local
+atomically installs `~/.local/bin/cas`, then turns over processes that still
+execute the exact pre-install binary bytes, and delegates the complete local
 project refresh to `cas update --all-projects` (schema, generated files and
-builtins, team membership refresh, and cloud sync for linked projects) before
-turning over processes that still execute the exact pre-install binary bytes.
+builtins, team membership refresh, cloud sync for linked projects, and legacy
+search-index repair).
 
 Plain `cas-update` performs the full workflow. `--no-restart` performs the
 build/install/native-project-refresh portion without signalling any runtime. Both

--- a/contrib/shell-helpers/cas-update
+++ b/contrib/shell-helpers/cas-update
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# cas-update — build CAS from source, install it, delegate the native
-# all-project refresh, then safely turn over processes still executing the
-# previous binary.
+# cas-update — build CAS from source, install it, safely turn over processes
+# still executing the previous binary, then delegate the native all-project
+# refresh.
 #
 # Canonical source: contrib/shell-helpers/cas-update
 # Install with:     contrib/shell-helpers/install.sh
@@ -484,6 +484,18 @@ verify_runtime_epoch() {
   RUNTIME_STATUS="verified: no process executes the previous installed hash"
 }
 
+report_stale_turnover_processes() {
+  [ -s "$TURNOVER_RESULTS_FILE" ] || return 0
+  local pid action kind session owner cmd restart
+  while IFS='|' read -r pid action kind session owner cmd restart; do
+    case "$action" in
+      *STALE*|not\ stopped*)
+        warn "PID $pid [$kind] is still running after runtime turnover; search-index repair will continue and may report busy"
+        ;;
+    esac
+  done <"$TURNOVER_RESULTS_FILE"
+}
+
 run_cmd() {
   if [ "$DRY_RUN" = "1" ]; then dim "  [dry-run] $*"; else "$@"; fi
 }
@@ -606,7 +618,7 @@ sync_projects() {
   step "Refresh every CAS project natively"
   local args=(update --all-projects)
   [ "$DRY_RUN" = "1" ] && args+=(--dry-run)
-  info "delegating migration, skills, team membership, and cloud sync to cas (${SCAN_ROOTS})"
+  info "delegating migration, skills, legacy search-index repair, team membership, and cloud sync to cas (${SCAN_ROOTS})"
   CAS_PROJECT_ROOTS="$SCAN_ROOTS" "$CAS_INSTALL" "${args[@]}"
 }
 
@@ -744,7 +756,7 @@ finish() {
 }
 
 main() {
-  local parse_rc=0
+  local parse_rc=0 runtime_turnover_failed=0
   parse_args "$@" || parse_rc=$?
   if [ "$parse_rc" -ne 0 ]; then
     if [ "$parse_rc" -eq 2 ]; then SUMMARY_PRINTED=1; return 0; fi
@@ -764,6 +776,13 @@ main() {
     NEW_INSTALLED_HASH="$(sha256_file "$CAS_INSTALL")"
   fi
 
+  # The native `cas update --all-projects` phase repairs legacy Tantivy roots.
+  # Turn over the old runtime epoch first so an old daemon cannot recreate the
+  # stray root while that repair is running. A stale survivor is retained as a
+  # failure for final verification, but it must not prevent the repair walk.
+  if ! turnover_old_processes; then runtime_turnover_failed=1; fi
+  report_stale_turnover_processes
+
   if [ "$DO_SYNC" = "1" ]; then
     migrate_host_db; MIGRATION_STATUS="$([ "$DRY_RUN" = 1 ] && printf planned || printf complete)"
     sync_projects; sync_user_builtins
@@ -772,13 +791,11 @@ main() {
     MIGRATION_STATUS="skipped (--build-only)"; SYNC_STATUS="skipped (--build-only)"
   fi
 
-  if [ "$DO_TURNOVER" = "1" ]; then
-    turnover_old_processes
-    verify_runtime_epoch
-  else
-    turnover_old_processes
+  if [ "$DO_TURNOVER" = "1" ] && ! verify_runtime_epoch; then
+    runtime_turnover_failed=1
   fi
   print_summary
+  return "$runtime_turnover_failed"
 }
 
 if [ "${CAS_UPDATE_SOURCE_ONLY:-0}" != "1" ]; then

--- a/contrib/shell-helpers/tests/cas-update-test.sh
+++ b/contrib/shell-helpers/tests/cas-update-test.sh
@@ -395,6 +395,62 @@ test_native_project_refresh_delegation() {
   rm -rf "$tmp"
 }
 
+test_turnover_precedes_native_project_refresh() {
+  local tmp out events
+  tmp="$(new_fixture)"; out="$tmp/out"; events="$tmp/events"
+  if (
+    export HOME="$tmp/home" CAS_INSTALL="$tmp/bin/cas" CAS_PROJECT_ROOTS="$tmp/home"
+    export CAS_UPDATE_PROC_ROOT="$tmp/proc" CAS_UPDATE_SOURCE_ONLY=1
+    export CAS_UPDATE_SESSIONS_DIR="$tmp/home/.cas/sessions"
+    export CAS_UPDATE_SERVER_REGISTRY_ROOTS="$tmp/registry"
+    export CAS_UPDATE_EVENT_LOG="$events"
+    source "$helper"
+    turnover_old_processes() { printf 'turnover\n' >>"$CAS_UPDATE_EVENT_LOG"; }
+    migrate_host_db() { printf 'host-migration\n' >>"$CAS_UPDATE_EVENT_LOG"; }
+    sync_projects() { printf 'project-refresh\n' >>"$CAS_UPDATE_EVENT_LOG"; }
+    sync_user_builtins() { printf 'user-refresh\n' >>"$CAS_UPDATE_EVENT_LOG"; }
+    print_summary() { :; }
+    cleanup() { :; }
+    main --sync-only --projects "$tmp/home"
+  ) >"$out" 2>&1 \
+    && [ "$(cat "$events")" = $'turnover\nhost-migration\nproject-refresh\nuser-refresh' ]; then
+    pass 'runtime turnover completes before the native project refresh begins'
+  else
+    fail 'runtime turnover completes before the native project refresh begins'
+  fi
+  rm -rf "$tmp"
+}
+
+test_stale_turnover_is_reported_before_project_refresh() {
+  local tmp out events
+  tmp="$(new_fixture)"; out="$tmp/out"; events="$tmp/events"
+  if (
+    export HOME="$tmp/home" CAS_INSTALL="$tmp/bin/cas" CAS_PROJECT_ROOTS="$tmp/home"
+    export CAS_UPDATE_PROC_ROOT="$tmp/proc" CAS_UPDATE_SOURCE_ONLY=1
+    export CAS_UPDATE_SESSIONS_DIR="$tmp/home/.cas/sessions"
+    export CAS_UPDATE_SERVER_REGISTRY_ROOTS="$tmp/registry"
+    export CAS_UPDATE_EVENT_LOG="$events"
+    source "$helper"
+    ensure_state_files; capture_installed_identity
+    printf '401|start|hash|cas serve|none|none|mcp-client-managed|restart\n' >"$OLD_PROCESS_FILE"
+    turnover_old_processes() {
+      record_turnover 401 'STALE SURVIVOR after SIGKILL' mcp-client-managed none none 'cas serve' restart
+      return 1
+    }
+    report_stale_turnover_processes
+    sync_projects() { printf 'project-refresh\n' >>"$CAS_UPDATE_EVENT_LOG"; }
+    sync_projects
+  ) >"$out" 2>&1 \
+    && assert_contains "$out" 'PID 401' \
+    && assert_contains "$out" 'search-index repair will continue' \
+    && assert_contains "$events" 'project-refresh'; then
+    pass 'a stale runtime is named while project search repair remains scheduled'
+  else
+    fail 'a stale runtime is named while project search repair remains scheduled'
+  fi
+  rm -rf "$tmp"
+}
+
 test_installer() {
   local tmp
   tmp="$(mktemp -d -t cas-update-install.XXXXXX)"
@@ -448,6 +504,8 @@ test_dry_run_and_opt_out
 test_stale_survivor_is_nonzero
 test_no_process_and_flag_semantics
 test_native_project_refresh_delegation
+test_turnover_precedes_native_project_refresh
+test_stale_turnover_is_reported_before_project_refresh
 test_installer
 test_updater_ancestry_is_protected
 test_main_exit_and_help

--- a/contrib/shell-helpers/tests/cas-update-test.sh
+++ b/contrib/shell-helpers/tests/cas-update-test.sh
@@ -389,7 +389,7 @@ test_native_project_refresh_delegation() {
     sync_projects
   ) >"$out" 2>&1 \
     && [ "$(cat "$args")" = 'update --all-projects' ] \
-    && assert_contains "$out" 'delegating migration, skills, team membership, and cloud sync'; then
+    && assert_contains "$out" 'delegating migration, skills, legacy search-index repair, team membership, and cloud sync'; then
     pass 'sync-only phase delegates the complete project refresh to native cas'
   else fail 'sync-only phase delegates the complete project refresh to native cas'; fi
   rm -rf "$tmp"
@@ -437,6 +437,7 @@ test_stale_turnover_is_reported_before_project_refresh() {
       record_turnover 401 'STALE SURVIVOR after SIGKILL' mcp-client-managed none none 'cas serve' restart
       return 1
     }
+    if ! turnover_old_processes; then :; fi
     report_stale_turnover_processes
     sync_projects() { printf 'project-refresh\n' >>"$CAS_UPDATE_EVENT_LOG"; }
     sync_projects

--- a/docs/release-notes/2026-08-31-v3.7.3-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.3-slack.md
@@ -1,0 +1,27 @@
+# Release notes — Cassy v3.7.3 search-index repair
+
+**Channel:** `#cas-internal` · **Deploy:** Live on production · **Status:** Draft
+
+## User thread
+
+**Top-level:**
+
+Live on production — **User** — `cas update` now repairs every project's search index automatically.
+
+**Reply (Was → Now):**
+
+**Was** → after updating, you had to run `cas doctor --fix` per project. **Now** → `cas update` repairs every project's search index automatically, after turning over old `cas serve` processes.
+
+## Dev thread
+
+**Top-level:**
+
+Live on production — **Dev** — update refresh now repairs legacy Tantivy roots after runtime turnover.
+
+**Reply (Was → Now):**
+
+**Was** → project refresh could leave memories in a legacy Tantivy root and an old `cas serve` process could recreate it during repair. **Now** → runtime turnover runs first, then each project receives bounded legacy-index repair; busy locks are reported without failing the update.
+
+## POSTED
+
+Not posted. Default Codex workers hand this draft to the supervisor for the canonical Slack transport.


### PR DESCRIPTION
## Summary
- repair legacy Tantivy roots during every native per-project update walk
- turn over stale CAS runtimes before refresh and warn on survivors without failing repair
- add v3.7.3 release-note draft; preserve the landed v3.7.2 draft unchanged

## Verification
- cargo check -p cas --lib --tests
- scripts/run-scoped-tests.sh -p cas --test update_all_projects_test (3/3)
- bash contrib/shell-helpers/tests/cas-update-test.sh (22/22)

No auto-merge enabled. macOS turnover remains out of scope.