### PR TITLE
docs(release): record v3.7.2 publication receipt

### DIFF
--- a/docs/release-notes/2026-08-31-v3.7.2-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.2-slack.md
@@ -2,6 +2,8 @@
 
 **Channel:** `#cas-internal` · **Deploy:** Live on production · **Status:** Draft, posting embargoed until the operator hold is lifted
 
+**Published assets:** Linux x86_64 archive SHA-256 `0529bfbb934a093b8567244ff818000dfa32e30c44ce3a0d368896be31c0ed15`; macOS ARM64 archive SHA-256 `6c32f867e3d61b60b3fa76b7b4c9328dbc9cdb40da9af0c000a8a8ea624fa19a`.
+
 ## User thread
 
 **Top-level:**
@@ -11,7 +13,7 @@ Live on production — **User** — Cassy now learns from what you actually use,
 - **Was** → Cassy could inject memories without showing whether they helped, leave useful rules stuck as drafts, and lose memories written by a background process from normal search. **Now** → every injected memory has an honest outcome, reading one counts as use, surfaced rules can progress, and `cas doctor --fix` finds and restores hidden memories.
 - **Was** → Helpful Memories could be drawn from stale or noisy context, and statistics did not clearly describe the live collection. **Now** → Helpful Memories use the live, curated collection with memory tiers respected and raw context excluded, while `cas stats` reports what is actually available.
 - **Was** → a sync could report an error after bringing in an auto-promoted entry, and a worker could disappear during startup without a clear result. **Now** → sync accepts those entries cleanly, canonical worker lanes are used, and a worker that dies at boot is reported as failed.
-- **Deploy guidance** → after updating, restart any long-running `cas serve` process first; then `cas update` repairs any stray search index in every project automatically.
+- **Deploy guidance** → after updating, restart any running `cas serve`/daemon processes, then run `cas doctor --fix` once per project (the next release does this automatically during `cas update`).
 
 ## Dev thread
 
@@ -23,10 +25,4 @@ Live on production — **Dev** — CAS v3.7.2 makes retrieval outcomes measurabl
 - **Was** → ranking work had no committed labeled baseline, Helpful Memories could measure a fallback instead of production retrieval, and `cas stats` could describe historical tiers rather than the live corpus. **Now** → the labeled evaluation harness gates precision@5/recall@5 against committed fixtures, production Helpful-Memories retrieval is measured directly, and live tier-aware curated counts exclude raw context blobs.
 - **Was** → daemon writes to the legacy Tantivy root could leave entries invisible and repair could block behind an old process. **Now** → `cas doctor` reports the stray index and `cas doctor --fix` performs bounded, resumable recovery; busy processes produce a warning and retry command.
 - **Was** → team sync rejected auto-promoted entries, Claude lanes accepted non-canonical identifiers, and generated project skills appeared as tracked files. **Now** → sync upserts cleanly, worker lanes use canonical model IDs and classify dead-at-boot workers as failed, and project-managed skills are git-ignored.
-- **Deploy guidance** → after updating, `cas update` repairs any stray search index in every project automatically; restart any long-running `cas serve` first so it cannot keep writing to the legacy index root.
-
-<!--
-Fallback manual-step wording, pending the automatic repair landing:
-After updating, restart any running `cas serve`/daemon processes, then run
-`cas doctor --fix` once per project.
--->
+- **Deploy guidance** → after updating, restart any running `cas serve`/daemon processes, then run `cas doctor --fix` once per project (the next release does this automatically during `cas update`).


### PR DESCRIPTION
## Summary

- Record the SHA-256 digests from the published v3.7.2 Linux and macOS assets.
- Correct the v3.7.2 deploy guidance to use `cas doctor --fix`; automatic repair arrives in the next release.
- Keep the runtime release draft embargoed and unposted.

## Receipts

- `release-published-receipt.sh v3.7.2 --write-draft` passed for both assets.
- `release-latency-receipt.sh v3.7.2` passed: 169 seconds within the 600-second budget.
- `cas update --version 3.7.2 --yes` and clean v3.7.2 install both report tagged hash `92d742d`.
