### PR TITLE
docs(release-notes): POSTED receipts for the 2026-08-31 #cas-internal announcements

### DIFF
--- a/docs/release-notes/2026-08-25-harness-diary-sweep-slack.md
+++ b/docs/release-notes/2026-08-25-harness-diary-sweep-slack.md
@@ -51,3 +51,14 @@ and `AGENTS.md` loading, `--yolo`, model/effort config, and resume/approval
 continuity. No Cassy code change is required from the notes alone. **Source
 gaps:** none for 0.148.0 and 0.149.0; 0.149.1 has no release-note body, so no
 item-level change is inferred.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`) · Posted 2026-08-31 via the approved Claude profile route (embargo lifted by the operator on 2026-08-31).
+
+| Message | Slack ts | Permalink |
+| --- | --- | --- |
+| Parent | 1788180395.467059 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180395467059 |
+| Grok reply | 1788180401.859449 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180401859449?thread_ts=1788180395.467059&cid=C0B44GUKDK2 |
+| Claude reply | 1788180408.002849 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180408002849?thread_ts=1788180395.467059&cid=C0B44GUKDK2 |
+| Codex reply | 1788180413.884179 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180413884179?thread_ts=1788180395.467059&cid=C0B44GUKDK2 |

--- a/docs/release-notes/2026-08-30-close-gate-regression-coverage-slack.md
+++ b/docs/release-notes/2026-08-30-close-gate-regression-coverage-slack.md
@@ -1,0 +1,34 @@
+# Close-gate regression coverage — Slack draft
+
+Target: `#cas-internal` (`C0B44GUKDK2`)
+
+Deploy target: `Live on production`
+
+Post in the numbered order below. Send only each body, excluding the separator headers.
+
+=== MESSAGE 1 — USER TOP-LEVEL ===
+
+Live on production — User: When a task is finished, Cassy now proves it can tell a file a reviewer asked to remove apart from work that quietly went missing.
+
+=== MESSAGE 2 — USER REPLY TO MESSAGE 1 ===
+
+Was → That safeguard already existed, but the exact sequence a reviewer actually follows — park the work, ask for a file to be removed, merge, finish — had no dedicated proof. Now → That sequence is proven end to end, and the safeguard still refuses to finish a task whose work has actually disappeared.
+
+=== MESSAGE 3 — DEV TOP-LEVEL ===
+
+Live on production — Dev: Close-gate regression tests now pin integrated descendant-tip proof without weakening fail-closed delivery checks.
+
+=== MESSAGE 4 — DEV REPLY TO MESSAGE 3 ===
+
+Was → The integrated-descendant selector and measured-fact rejection wording were already in the runtime, but the post-park deletion path lacked exact regression coverage. Now → PR #629 adds a real-Git fixture for park → delete-on-branch → merge → close, alongside the existing dropped-content rejection test.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`) · Posted 2026-08-31 via the approved Claude profile route (embargo lifted by the operator on 2026-08-31).
+
+| Message | Slack ts | Permalink |
+| --- | --- | --- |
+| User top-level | 1788180490.896659 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180490896659 |
+| User reply (Was → Now) | 1788180495.150219 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180495150219?thread_ts=1788180490.896659&cid=C0B44GUKDK2 |
+| Dev top-level | 1788180491.382409 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180491382409 |
+| Dev reply (Was → Now) | 1788180496.234599 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180496234599?thread_ts=1788180491.382409&cid=C0B44GUKDK2 |

--- a/docs/release-notes/2026-08-30-knowledge-loop-hardening-slack.md
+++ b/docs/release-notes/2026-08-30-knowledge-loop-hardening-slack.md
@@ -1,0 +1,48 @@
+# Release notes — knowledge-loop hardening + sync fixes (merged to main 2026-08-29/30)
+
+> Target: `#cas-internal` (`C0B44GUKDK2`) · Label: **Live on production**
+> Embargo lifted 2026-08-31; posted (see POSTED).
+> Covers PRs #615–#623.
+
+---
+
+## User thread
+
+**Top-level:**
+Live on production · **User** · Cassy now has to *prove* a rule works before it starts injecting it into your sessions — and every rule and skill keeps full version history you can roll back.
+
+**Threaded reply:**
+- **Rule promotion** — Was: a single "helpful" report promoted a rule straight into every future session. Now: promotion requires repeated, independent evidence across multiple sessions, and rules that keep getting corrected or flagged harmful are automatically demoted back out.
+- **Version history & undo** — Was: editing or deleting a rule or skill destroyed the old version permanently. Now: every change is recorded with who/when/why, deletes are reversible tombstones, and any prior version can be restored.
+- **Skill safety checks** — Was: a skill's validation script was stored but never run. Now: it runs in a network-isolated sandbox before the skill is accepted; a failing check blocks the change and keeps the previous version live.
+- **Where knowledge comes from** — Was: merged or promoted knowledge lost all links to its sources. Now: rules, skills, and learnings carry their ancestry end-to-end, visible in `show`.
+- **Usage tracking** — Was: "how often was this rule actually used?" had no real answer. Now: every injection is recorded and an impact report joins usage to session outcomes.
+- **Old activity data** — Was: events older than 30 days were deleted forever. Now: they age into a compressed, size-capped archive you can query.
+- **Sync reliability** — Was: some task deletions and moved tasks silently never reached the cloud (server said OK but skipped them). Now: deletions and moves carry full project identity, silent skips surface as errors, and the stuck backlog was flushed and verified.
+
+---
+
+## Dev thread
+
+**Top-level:**
+Live on production · **Dev** · Rule/skill lifecycle is now gated on measured `retrieval_outcomes` evidence with versioned, tombstoned mutations — plus wire-scope fixes that end the silent-skip/400 family on team and personal sync (PRs #615–#623).
+
+**Threaded reply:**
+- **Promotion gating (#622)** — Was: `rule helpful` flipped Draft→Proven in one call; `harmful` never demoted. Now: promotion needs a configurable multi-signal threshold (helpful floor ≥2 AND retrieval evidence from ≥2 distinct sessions, usefulness ≥0.5, zero corrections/harmful); threshold-floored demotion lands through `update_with_metadata` with a version-ledger change note. `RetrievalAggregate` gains a privacy-preserving `distinct_sessions` count.
+- **Version ledger (#617, m242)** — Was: rule/skill mutations were destructive in-place UPDATEs; "archive" was a hard DELETE. Now: every create/update/delete/restore writes a version row with a lifecycle `operation` column; deletes are `Retired` tombstones; restore is a supported action.
+- **Validation gate (#620)** — Was: `Skill.validation_script`/pre/postconditions were three dormant columns. Now: scripts execute pre-persist in a bubblewrap sandbox on Linux (`--unshare-net`, ro-binds, tmpfs, cleared env) with plain-sh fallback + explicit warning when bwrap is absent; `skill_validation.require_sandbox` enables fail-closed; rejected updates leave the prior version and its history untouched.
+- **Provenance (#623)** — Was: consolidation and promotion destroyed source links. Now: `merge_source_ids` unions ancestry (ordered, deduped) through consolidation; session-stop synthesis stamps `source_ids` onto learnings/rules; SKILL.md sync round-trips them; `show` surfaces the chain.
+- **Impact tracking (#619, m243)** — Was: `rules.surface_count` was schema-only. Now: injection increments it via a batched callback and records per-session `surfaced_artifacts` rows joined to session outcomes in a new impact report (ledger write ~9ms, sub-ms per artifact).
+- **Trace archive (#618)** — Was: daemon maintenance hard-deleted events/recordings at 30 days. Now: archive-before-delete into zstd JSONL under `.cas/archive/`, 1 GiB configurable cap with oldest-first eviction and logged evictions, range list/sample read APIs.
+- **Sync wire scope (#615, #616, #621)** — Was: team task upserts without explicit `scope` were silently skipped (HTTP 200, `skipped:N`); team/personal deletes without `project_id` got 400s and parked forever; a dangling-symlink `cloud.json` could route a test fixture write into a real project. Now: upserts stamp `scope=project`, both delete paths carry `project_id` (slash-encoded), all-skipped 200s surface client-side as failures, the symlink guard rejects symlink destinations, and the parked backlog was flushed with server-verified deletion and non-resurrection.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`) · Posted 2026-08-31 via the approved Claude profile route (embargo lifted by the operator on 2026-08-31).
+
+| Message | Slack ts | Permalink |
+| --- | --- | --- |
+| User top-level | 1788180456.703989 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180456703989 |
+| User reply (Was → Now) | 1788180464.279309 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180464279309?thread_ts=1788180456.703989&cid=C0B44GUKDK2 |
+| Dev top-level | 1788180457.431129 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180457431129 |
+| Dev reply (Was → Now) | 1788180470.446359 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180470446359?thread_ts=1788180457.431129&cid=C0B44GUKDK2 |

--- a/docs/release-notes/2026-08-30-v3.7.1-slack.md
+++ b/docs/release-notes/2026-08-30-v3.7.1-slack.md
@@ -1,0 +1,61 @@
+# Slack draft — Cassy v3.7.1 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Posted 2026-08-31 after the operator lifted the August 31 hold.
+The tagged GitHub workflow published both assets and
+`release-published-receipt.sh --write-draft` replaced both checksum
+placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — codemap refreshes now finish predictably while
+the release remains installable on both supported platforms.
+
+**Reply (Was → Now):**
+- Was: a codemap refresh could run without a clear time bound or freshness
+  proof. Now: the refresh has a bounded knowledge pass and receipts that prove
+  freshness without writing unchanged content.
+- Install: use `cas update` for an existing installation, or download the
+  v3.7.1 archive for Linux x86_64 (SHA-256 `9e8814229146b6e0880a15ba2bf27faac51febf3bfd8ddecd1e04ef2064c1e1c`) or macOS ARM64
+  (SHA-256 `0bd1fdc831c186c4cadacb9c4a37e12a8dfd99816e8cf448f387840421ce2fd0`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v3.7.1 bounds and measures the codemap path from
+source scan through provider cleanup and protected-PR validation.
+
+**Reply (Was → Now):**
+- Was: an unbounded provider or incomplete no-op rehearsal could leave the
+  release path uncertain. Now: one 90-second whole-build deadline, process-group
+  cleanup, no-write/freshness gates, and the successful tagged workflow make the
+  path observable. Validation and artifact: release workflow 33337197438 passed
+  at tagged main commit 47707f3; fresh-download receipt passed. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `9e8814229146b6e0880a15ba2bf27faac51febf3bfd8ddecd1e04ef2064c1e1c`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `0bd1fdc831c186c4cadacb9c4a37e12a8dfd99816e8cf448f387840421ce2fd0`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 1788180529.513689 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180529513689 |
+| User reply (Was → Now) | 1788180537.783869 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180537783869?thread_ts=1788180529.513689&cid=C0B44GUKDK2 |
+| Dev top-level | 1788180538.509299 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180538509299 |
+| Dev reply (Was → Now) | 1788180544.872709 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180544872709?thread_ts=1788180538.509299&cid=C0B44GUKDK2 |

--- a/docs/release-notes/2026-08-31-v3.7.2-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.2-slack.md
@@ -1,6 +1,6 @@
 # Release notes — 2026-08-31 — CAS v3.7.2
 
-**Channel:** `#cas-internal` · **Deploy:** Live on production · **Status:** Draft, posting embargoed until the operator hold is lifted
+**Channel:** `#cas-internal` · **Deploy:** Live on production · **Status:** Posted 2026-08-31 after the operator lifted the hold
 
 **Published assets:** Linux x86_64 archive SHA-256 `0529bfbb934a093b8567244ff818000dfa32e30c44ce3a0d368896be31c0ed15`; macOS ARM64 archive SHA-256 `6c32f867e3d61b60b3fa76b7b4c9328dbc9cdb40da9af0c000a8a8ea624fa19a`.
 
@@ -26,3 +26,14 @@ Live on production — **Dev** — CAS v3.7.2 makes retrieval outcomes measurabl
 - **Was** → daemon writes to the legacy Tantivy root could leave entries invisible and repair could block behind an old process. **Now** → `cas doctor` reports the stray index and `cas doctor --fix` performs bounded, resumable recovery; busy processes produce a warning and retry command.
 - **Was** → team sync rejected auto-promoted entries, Claude lanes accepted non-canonical identifiers, and generated project skills appeared as tracked files. **Now** → sync upserts cleanly, worker lanes use canonical model IDs and classify dead-at-boot workers as failed, and project-managed skills are git-ignored.
 - **Deploy guidance** → after updating, restart any running `cas serve`/daemon processes, then run `cas doctor --fix` once per project (the next release does this automatically during `cas update`).
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`) · Posted 2026-08-31 via the approved Claude profile route.
+
+| Message | Slack ts | Permalink |
+| --- | --- | --- |
+| User top-level | 1788180565.812719 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180565812719 |
+| User reply (Was → Now) | 1788180573.112469 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180573112469?thread_ts=1788180565.812719&cid=C0B44GUKDK2 |
+| Dev top-level | 1788180566.383389 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180566383389 |
+| Dev reply (Was → Now) | 1788180577.035889 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788180577035889?thread_ts=1788180566.383389&cid=C0B44GUKDK2 |


### PR DESCRIPTION
Records Slack ts + permalinks for the five announcement threads posted on 2026-08-31 after the embargo lift (harness diary 2026-08-25; knowledge-loop hardening; close-gate proof; v3.7.1; v3.7.2). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzWVWHGEGzc78f9ED7r4Tp