### PR TITLE
chore(release): prepare v3.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.7.3] - 2026-08-31
+
+### Fixed
+- `cas update` now turns over stale `cas serve` processes before refreshing
+  each project and repairs legacy Tantivy search-index roots; busy locks warn
+  without failing the update.
+- The contributor `cas-update` helper turns over running processes before
+  refreshing project state.
+
 ## [3.7.2] - 2026-08-31
 
 ### Added
@@ -1557,7 +1566,8 @@ After upgrading, the new gates fire on `task.close` calls. If a worker hits the 
 ### Added
 - Initial stable release with core functionality.
 
-[Unreleased]: https://github.com/Richards-LLC/cassy/compare/v3.7.2...HEAD
+[Unreleased]: https://github.com/Richards-LLC/cassy/compare/v3.7.3...HEAD
+[3.7.3]: https://github.com/Richards-LLC/cassy/compare/v3.7.2...v3.7.3
 [3.7.2]: https://github.com/Richards-LLC/cassy/compare/v3.7.1...v3.7.2
 [3.7.1]: https://github.com/Richards-LLC/cassy/compare/v3.7.0...v3.7.1
 [3.7.0]: https://github.com/Richards-LLC/cassy/compare/v3.6.0...v3.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.7.2"
+version = "3.7.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.7.2"
+version = "3.7.3"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.7.2"
+version = "3.7.3"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.7.2"
+version = "3.7.3"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.7.2"
+version = "3.7.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.7.2"
+version = "3.7.3"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.7.2"
+version = "3.7.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.7.2"
+version = "3.7.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.7.2"
+version = "3.7.3"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.7.2"
+version = "3.7.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.7.2"
+version = "3.7.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.7.2"
+version = "3.7.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"


### PR DESCRIPTION
## Summary

- Bump the six release-train crates and lockfile to v3.7.3.
- Move the legacy search-index repair and runtime-turnover notes into the dated changelog section.

## Validation

- `cargo metadata --locked --format-version 1`
- `cargo check -p cas --locked`
- `scripts/check-release-migration-snapshots.sh`
- `git diff --check`
