### PR TITLE
docs(release): record v3.7.3 publication receipts

### DIFF
--- a/docs/release-notes/2026-08-31-v3.7.3-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.3-slack.md
@@ -1,6 +1,8 @@
 # Release notes — Cassy v3.7.3 search-index repair
 
-**Channel:** `#cas-internal` · **Deploy:** Live on production · **Status:** Draft
+**Channel:** `#cas-internal` · **Deploy:** Live on production · **Status:** Posted 2026-08-31
+
+**Published assets:** Linux x86_64 archive SHA-256 `0357c92f4f351bda8d1e9b1137fd271651adebf49d4cba7f63f4a690835be5dd`; macOS ARM64 archive SHA-256 `142057bc32add0535e16ba719ead50ceffbff758785d0c5514f82a2fe7e61ea6`.
 
 ## User thread
 
@@ -24,4 +26,11 @@ Live on production — **Dev** — update refresh now repairs legacy Tantivy roo
 
 ## POSTED
 
-Not posted. Default Codex workers hand this draft to the supervisor for the canonical Slack transport.
+Channel: `#cas-internal` (`C0B44GUKDK2`) · Posted 2026-08-31 via the approved Claude profile route.
+
+| Message | Slack ts | Permalink |
+| --- | --- | --- |
+| User top-level | 1788185617.636989 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788185617636989 |
+| User reply (Was → Now) | 1788185622.140859 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788185622140859?thread_ts=1788185617.636989&cid=C0B44GUKDK2 |
+| Dev top-level | 1788185618.074809 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788185618074809 |
+| Dev reply (Was → Now) | 1788185622.800779 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788185622800779?thread_ts=1788185618.074809&cid=C0B44GUKDK2 |


### PR DESCRIPTION
## Summary

- Record the verified v3.7.3 published-asset digests.
- Record the approved Slack User and Dev thread receipts.

## Evidence

- Published Linux/macOS downloads matched GitHub SHA-256 metadata.
- Host update and tag-sourced clean install report `cas 3.7.3 (61a2724 2026-08-31)`.
- Slack draft has exactly two top-level posts and one threaded reply per post.
