### PR TITLE
docs(reports): salvage four 2026-08-25..30 supervisor reports

### DIFF
--- a/docs/reports/2026-08-25-harness-sweep-summary.html
+++ b/docs/reports/2026-08-25-harness-sweep-summary.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Harness Sweep 2026-08-25</title>
+<style>
+  :root {
+    --ink: #1a2333; --muted: #5b6577; --line: #d7dce5; --bg: #ffffff; --panel: #f4f6fa;
+    --ok: #1a7f37; --hold: #9a6700; --queue: #0969da; --accent: #174ea6;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; padding: 2rem 1.25rem 4rem; background: var(--bg); color: var(--ink);
+         font: 16px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif; }
+  main { max-width: 62rem; margin: 0 auto; }
+  h1 { font-size: 1.55rem; margin: 0 0 .4rem; }
+  h2 { font-size: 1.2rem; margin: 2.4rem 0 .7rem; border-bottom: 2px solid var(--line); padding-bottom: .3rem; }
+  h3 { font-size: 1.02rem; margin: 1.6rem 0 .5rem; }
+  .hero { background: var(--panel); border-left: 5px solid var(--accent); padding: 1rem 1.25rem;
+          margin: 1.2rem 0 1.6rem; font-size: 1.06rem; }
+  .hero strong { color: var(--accent); }
+  .meta { color: var(--muted); font-size: .85rem; margin-bottom: .2rem; }
+  table { border-collapse: collapse; width: 100%; margin: .8rem 0 1.4rem; font-size: .92rem; }
+  th, td { border: 1px solid var(--line); padding: .45rem .6rem; text-align: left; vertical-align: top; }
+  th { background: var(--panel); }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .pill { display: inline-block; border: 1.5px solid; border-radius: 999px; padding: 0 .55rem;
+          font-size: .8rem; font-weight: 600; white-space: nowrap; }
+  .pill.ok    { color: var(--ok);    border-color: var(--ok); }
+  .pill.hold  { color: var(--hold);  border-color: var(--hold); border-style: dashed; }
+  .pill.queue { color: var(--queue); border-color: var(--queue); border-style: dotted; }
+  .wasnow b { color: var(--accent); }
+  ul { margin: .4rem 0 1rem; padding-left: 1.3rem; }
+  li { margin: .28rem 0; }
+  code { background: var(--panel); border: 1px solid var(--line); border-radius: 4px;
+         padding: 0 .3rem; font-size: .87em; }
+  .decision { border: 2px solid var(--accent); border-radius: 8px; padding: 1rem 1.25rem; margin: 1.2rem 0; }
+  .decision h3 { margin-top: 0; }
+  .prov { color: var(--muted); font-size: .84rem; border-top: 2px solid var(--line);
+          margin-top: 2.5rem; padding-top: 1rem; }
+  .prov code { font-size: .95em; }
+  a { color: var(--queue); }
+  @media print {
+    body { padding: 0; } .hero { border-color: #000; }
+    .pill { border-color: #000 !important; color: #000 !important; }
+    a[href^="http"]::after { content: " (" attr(href) ")"; font-size: .8em; }
+  }
+</style>
+</head>
+<body>
+<main>
+  <p class="meta">Operator status report · 2026-08-25 · epic cas-abfc · prepared by the factory supervisor session</p>
+  <h1>Harness sweep: what changed, what Cassy changed, what's left</h1>
+
+  <div class="hero">
+    All three harness diaries are current; both movable validated pins advanced — <strong>Grok
+    0.2.114 → 1.0.5</strong> and <strong>Codex 0.146.0 → 0.149.1</strong> — on full live matrices
+    with typed receipts. The <strong>Luna-default model rubric</strong> shipped in the distributed
+    skill, and the <strong>OpenCode / Qwen3.8-Max assessment returned conditional GO</strong>.
+    Epic PR <a href="https://github.com/Richards-LLC/cassy/pull/585">#585</a> is in the merge
+    queue to main. Slack announcement embargoed until <strong>2026-08-31</strong>.
+  </div>
+
+  <h2>Overview</h2>
+  <table>
+    <thead><tr><th>Workstream</th><th>Status</th><th class="wasnow">Was → Now</th></tr></thead>
+    <tbody>
+      <tr><td>Claude Code diary</td><td><span class="pill ok">✔ merged</span></td>
+          <td class="wasnow">current through 2.1.231 → current through <b>2.1.245</b> (installed 2.1.245)</td></tr>
+      <tr><td>Codex diary + pin</td><td><span class="pill ok">✔ merged</span></td>
+          <td class="wasnow">diary 0.147.0 / pin 0.146.0 → diary <b>0.149.1</b> / pin <b>0.149.1</b> (live matrix + typed receipt)</td></tr>
+      <tr><td>Grok diary + pin</td><td><span class="pill ok">✔ merged</span></td>
+          <td class="wasnow">diary 1.0.3 / pin 0.2.114 → diary <b>1.0.5</b> / pin <b>1.0.5</b> (live matrix + typed receipt)</td></tr>
+      <tr><td>Model rubric</td><td><span class="pill ok">✔ merged</span></td>
+          <td class="wasnow">Terra default → <b>Luna xhigh-only default</b>; Terra suspended (operator-gated); light tier → Grok Composer/low</td></tr>
+      <tr><td>OpenCode assessment</td><td><span class="pill ok">✔ merged</span></td>
+          <td class="wasnow">no position → <b>conditional GO</b>: 3 blockers, 7 sized tasks (your decision)</td></tr>
+      <tr><td>Slack thread</td><td><span class="pill hold">⏸ embargoed</span></td>
+          <td class="wasnow">draft merged → posting held until <b>2026-08-31</b> (reminder #1088 set)</td></tr>
+      <tr><td>Epic PR #585</td><td><span class="pill ok">✔ merged to main</span></td>
+          <td class="wasnow">landed at <b>39a6c1d5</b> after one merge-queue rejection (six full-suite spawn tests still asserted Terra/high stock defaults — fixed under the rubric task)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>What changed upstream</h2>
+
+  <h3>Claude Code 2.1.232 → 2.1.245 (14 versions)</h3>
+  <ul>
+    <li>MCP reconnect/startup, cross-session delivery, hook matching, worktree and deleted-cwd
+        recovery, skill reload (incl. UTF-8 BOM files), and background/subagent lifecycle hardened.</li>
+    <li><b>No Cassy change required.</b> Standing watches: MCP startup behavior and Cassy-synced
+        skill-mirror precedence on upgrade.</li>
+    <li>Source gaps recorded honestly: 2.1.242 and 2.1.244 have no changelog sections;
+        2.1.240/2.1.241 are detail-free rollups. Nothing invented for them.</li>
+  </ul>
+
+  <h3>Codex CLI 0.148.0 → 0.149.1 (stables)</h3>
+  <ul>
+    <li>0.148.0: async/MCP hooks, MCP recovery and lazy start, skills-loader overhaul, fail-closed
+        sandboxing, resumed sessions restore cwd/approval policy.</li>
+    <li>0.149.0: <code>codex agents</code> dashboard, rmcp 3.1.2 + MCP tool hooks, SDK exact config
+        overrides and <b>new max/ultra reasoning-effort levels</b>, permission-profile restore
+        across resume/fork. 0.149.1: patch, no release-note body.</li>
+    <li><b>Cassy validated the whole range live:</b> full isolated <code>PtyConfig::codex</code>
+        matrix passed on installed 0.149.1 (<code>--yolo</code> fresh + resumed, xhigh accepted,
+        <code>developer_instructions</code> delivered, <code>mcp__cs__*</code> discovered before
+        lifecycle work). Pin 0.146.0 → 0.149.1.</li>
+    <li>Non-gating probe: <code>-c model_reasoning_effort=max</code> <b>is accepted</b> (exit 0).</li>
+  </ul>
+
+  <h3>Grok Build 1.0.4 → 1.0.5</h3>
+  <ul>
+    <li>1.0.4: <code>GROK_SESSION_ID</code> exported to tools/MCP, auto-permission grants honored,
+        headless MCP wait, subagent lifecycle correctness, transcript rebuild from disk.</li>
+    <li>1.0.5: <code>GROK_CONFIG</code>/<code>GROK_CONFIG_PATH</code> overrides, automatic safe
+        worktree reclaim, hook-block vs user-cancel distinction, session recap on /resume.</li>
+    <li><b>Cassy validated live:</b> full isolated <code>PtyConfig::grok</code> matrix on 1.0.5
+        (bypassPermissions; fresh <code>--session-id</code> = <code>CAS_SESSION_ID</code> =
+        transcript identity; <code>cas__*</code> discovery; <code>--rules</code> priming; worktree
+        containment). Pin 0.2.114 → 1.0.5. Local changelog ends at 1.0.3 — 1.0.4/1.0.5 attribution
+        from x.ai's official page.</li>
+  </ul>
+
+  <h2>What Cassy changed this session</h2>
+  <table>
+    <thead><tr><th>Change</th><th>Where</th><th>Receipt</th></tr></thead>
+    <tbody>
+      <tr><td>Three diaries brought current</td><td><code>docs/notes/*-changelog-diary.md</code></td>
+          <td>commits <code>cbe28fb3</code>, <code>fb09cfe1</code>, <code>c5b64e3f</code></td></tr>
+      <tr><td>Grok pin → 1.0.5</td><td><code>crates/cas-pty</code> conformance + pty.rs verification block</td>
+          <td>matrix 1/1 pass (22.2s); receipt <code>grok-build-1.0.5-2026-08-25</code>; branch CI green</td></tr>
+      <tr><td>Codex pin → 0.149.1</td><td><code>crates/cas-pty</code> conformance + diary version status</td>
+          <td>matrix 1/1 pass (61.3s re-run after conflict resolve); conformance 5/5; parity 2/2; branch CI green</td></tr>
+      <tr><td>Model rubric: Luna default</td><td>all three builtin <code>cas-supervisor</code> flavors + reference-history</td>
+          <td><code>cargo check</code> exit 0; builtins nextest 87/87</td></tr>
+      <tr><td>OpenCode assessment</td><td><code>docs/ideation/2026-08-25-opencode-harness-assessment.md</code></td>
+          <td>cited per-touchpoint verdicts + search manifest</td></tr>
+      <tr><td>Slack draft (embargoed)</td><td><code>docs/release-notes/2026-08-25-harness-diary-sweep-slack.md</code></td>
+          <td>rubric-conformant; posting held to 2026-08-31</td></tr>
+    </tbody>
+  </table>
+  <ul>
+    <li><b>Rubric detail (your directives, codified in the distributed skill):</b> default/standard/taste
+        worker is <code>cli=codex model=gpt-5.6-luna effort=xhigh</code>; Luna only ever at its maximum
+        effort (<code>max</code>/<code>ultra</code> documented as future-only); <b>Terra suspended at
+        every tier</b> (dated 2026-08-25, operator decision pending) with light work re-routed to
+        Grok Composer/low.</li>
+  </ul>
+
+  <h2>What Cassy still needs to change</h2>
+  <table>
+    <thead><tr><th>Item</th><th>Why</th><th>Size</th><th>Blocked on</th></tr></thead>
+    <tbody>
+      <tr><td>Extend effort vocabulary with <code>max</code> (poss. <code>ultra</code>)</td>
+          <td>Codex 0.149.1 accepts them (probe verified); you want Luna at literal max; <code>Effort</code> in <code>cas-mux/src/spec.rs</code> tops at xhigh</td>
+          <td class="num">S–M</td><td><b>Your go</b> — pin already validated</td></tr>
+      <tr><td>OpenCode implementation program (7 tasks)</td>
+          <td>Conditional GO; all primitives exist</td>
+          <td class="num">~15–24 worker-days</td><td><b>Your go/no-go</b> + <code>opencode</code> install</td></tr>
+      <tr><td>OpenCode blockers (inside the program)</td>
+          <td>(1) no caller-chosen session ID at spawn; (2) shared SQLite session store needs a liveness/blame adapter; (3) Qwen3.8-Max effort is only low/medium/xhigh — validate, never silently remap</td>
+          <td class="num">—</td><td>—</td></tr>
+      <tr><td>Post the #cas-internal diary thread</td><td>Mandatory publication duty</td>
+          <td class="num">XS</td><td>Embargo lifts 2026-08-31 (reminder #1088)</td></tr>
+      <tr><td>Close epic cas-abfc</td><td>cas-9cf9 stays open until the post lands</td>
+          <td class="num">—</td><td>Same embargo</td></tr>
+    </tbody>
+  </table>
+
+  <div class="decision">
+    <h3>OpenCode × Qwen 3.8 — decision brief</h3>
+    <p><b>Recommendation:</b> fund the 7-task adapter program when ready (~15–24 worker-days); do
+       <b>not</b> advertise <code>cli=opencode</code> before the final live-conformance receipt.</p>
+    <ul>
+      <li>Launch contract is real: <code>opencode &lt;dir&gt; --model alibaba/qwen3.8-max
+          --agent cassy-worker --prompt … --auto</code>; inline agent/MCP config via
+          <code>OPENCODE_CONFIG_CONTENT</code>; env inheritance carries the CAS identity set;
+          MCP tools surface as <code>cas_*</code>.</li>
+      <li>Qwen3.8-Max: provider <code>alibaba</code>, auth <code>DASHSCOPE_API_KEY</code>, 1M
+          context, tool calling; effort variants exactly low/medium/xhigh (xhigh default).</li>
+      <li>Chosen seam: existing <code>cas_mux::Backend</code> + one OpenCode plugin — no new
+          portability framework. Runner-up (minimum surface, no plugin) rejected: cannot satisfy
+          transcript/blame or prove requested effort.</li>
+    </ul>
+  </div>
+
+  <div class="prov">
+    <p><b>Provenance.</b> Epic branch
+       <code>epic/epic-2026-08-25-harness-diary-sweep-claude-codex-g-cas-abfc</code> @
+       <code>4bf0f6af</code> (base main @ <code>17891528</code>) ·
+       PR <a href="https://github.com/Richards-LLC/cassy/pull/585">#585</a> (merge queue) ·
+       tasks cas-e59d / cas-d8ce / cas-d21f (diaries), cas-444a / cas-b9a4 (matrices), cas-3465
+       (assessment), cas-e352 (rubric), cas-9cf9 (Slack, embargoed) under epic cas-abfc ·
+       worker-branch CI runs 32859071876 (Grok lane) and 32859003475 (Codex lane), both green.
+       Diary claims trace to the official Anthropic changelog, openai/codex GitHub releases, and
+       x.ai/build/changelog; OpenCode claims to opencode.ai docs, pinned source
+       <code>a7444bf9</code>, and the Models.dev catalog (full manifest in the assessment doc).
+       Markdown source of truth: <code>docs/reports/2026-08-25-harness-sweep-summary.md</code>.</p>
+  </div>
+</main>
+</body>
+</html>

--- a/docs/reports/2026-08-25-harness-sweep-summary.md
+++ b/docs/reports/2026-08-25-harness-sweep-summary.md
@@ -1,0 +1,113 @@
+# 2026-08-25 harness sweep — what changed, what Cassy changed, what's left
+
+**State in one line:** All three harness diaries are current, both movable validated pins advanced
+(Grok → 1.0.5, Codex → 0.149.1) with typed receipts, the Luna-default model rubric shipped, and the
+OpenCode/Qwen3.8-Max assessment returned **conditional GO** — the epic PR (#585) is in the merge
+queue to main; Slack announcement embargoed until 2026-08-31.
+
+Audience: operator (Daniel). Type: status/release summary with a nested decision brief (OpenCode).
+Source branch: `epic/epic-2026-08-25-harness-diary-sweep-claude-codex-g-cas-abfc` (epic cas-abfc),
+tip `4bf0f6af`, base `17891528` (main). Date: 2026-08-25.
+
+## Overview
+
+| Workstream | Status | Was → Now |
+| --- | --- | --- |
+| Claude Code diary | ✅ merged | Current through 2.1.231 → current through **2.1.245** (installed 2.1.245) |
+| Codex diary + pin | ✅ merged | Diary through 0.147.0, pin 0.146.0 → diary through **0.149.1**, pin **0.149.1** (live matrix + typed receipt) |
+| Grok diary + pin | ✅ merged | Diary through 1.0.3, pin 0.2.114 → diary through **1.0.5**, pin **1.0.5** (live matrix + typed receipt) |
+| Model rubric | ✅ merged | Terra default → **Luna `xhigh`-only default**; Terra suspended (operator-gated); light tier → Grok Composer/low |
+| OpenCode assessment | ✅ merged | No position → **conditional GO**, 3 blockers, 7 sized tasks (decision needed) |
+| Slack thread | ⏸ embargoed | Draft merged; posting held until 2026-08-31 (operator vacation), reminder #1088 set |
+| Epic PR #585 | ✅ merged to main | Landed at `39a6c1d5` after one merge-queue rejection (six full-suite spawn tests still asserted Terra/high stock defaults — fixed under the rubric task) |
+
+## What changed upstream (was → now)
+
+### Claude Code 2.1.232 → 2.1.245 (14 versions)
+
+- MCP reconnect/startup, cross-session delivery, hook matching, worktree/deleted-cwd recovery,
+  skill reload (incl. UTF-8 BOM files), and background/subagent lifecycle all hardened.
+- **No Cassy change required.** Verdicts are ✅/🟢 throughout; standing 👀 watches: MCP startup
+  behavior and Cassy-synced skill-mirror precedence on upgrade.
+- Source gaps recorded honestly: 2.1.242 and 2.1.244 have no sections in Anthropic's changelog;
+  2.1.240/2.1.241 are detail-free rollups. No behavior invented for them.
+
+### Codex CLI 0.148.0 → 0.149.1 (stables)
+
+- 0.148.0: async/MCP hooks, MCP recovery + lazy start, skills-loader overhaul (legacy loader
+  removed), fail-closed sandboxing, resumed sessions restore cwd/approval policy.
+- 0.149.0: `codex agents` dashboard, rmcp 3.1.2 + MCP tool hooks, SDK exact config overrides and
+  **new `max`/`ultra` reasoning-effort levels**, permission-profile restore across resume/fork.
+- 0.149.1: patch with no release-note body.
+- **Cassy response: validated the whole range live.** Full isolated `PtyConfig::codex` matrix passed
+  on installed 0.149.1 (`--yolo` fresh + resumed, `xhigh` accepted, `developer_instructions`
+  delivered, `mcp__cs__*` discovered before lifecycle work, mirrors visible). Pin advanced
+  0.146.0 → 0.149.1; receipt `crates/cas-pty/conformance/codex-cli-0.149.1-2026-08-25.json`.
+- Non-gating probe: `-c model_reasoning_effort=max` **is accepted** by 0.149.1 (exit 0).
+
+### Grok Build 1.0.4 → 1.0.5
+
+- 1.0.4: `GROK_SESSION_ID` exported to tools/MCP, auto-permission grants honored, headless MCP
+  wait, subagent lifecycle out-of-order correctness, transcript rebuild from disk.
+- 1.0.5: `GROK_CONFIG`/`GROK_CONFIG_PATH` overrides, automatic safe worktree reclaim under
+  `~/.grok/worktrees`, hook-block vs user-cancel distinction, session recap on `/resume`.
+- **Cassy response: validated live.** Full isolated `PtyConfig::grok` matrix passed on installed
+  1.0.5 (bypassPermissions, fresh `--session-id` = `CAS_SESSION_ID` = transcript identity, `cas__*`
+  discovery, `--rules` priming, env inheritance, worktree containment). Pin advanced
+  0.2.114 → 1.0.5; receipt `crates/cas-pty/conformance/grok-build-1.0.5-2026-08-25.json`.
+  Local changelog ends at 1.0.3; 1.0.4–1.0.5 attribution comes from x.ai's official page.
+
+## What Cassy changed this session
+
+| Change | Where | Receipt |
+| --- | --- | --- |
+| Three diaries brought current | `docs/notes/*-changelog-diary.md` | commits cbe28fb3, fb09cfe1, c5b64e3f |
+| Grok pin 0.2.114 → 1.0.5 | `crates/cas-pty` conformance + pty.rs verification block | matrix 1/1 pass (22.24s), receipt `grok-build-1.0.5-2026-08-25`, branch CI green |
+| Codex pin 0.146.0 → 0.149.1 | `crates/cas-pty` conformance + diary version status | matrix 1/1 pass (61.25s post-conflict re-run), conformance 5/5, parity 2/2, branch CI green |
+| Model rubric: Luna default | all three builtin `cas-supervisor` flavors + reference-history | `cargo check` exit 0; builtins nextest 87/87 |
+| OpenCode assessment | `docs/ideation/2026-08-25-opencode-harness-assessment.md` | cited per-touchpoint verdicts + search manifest |
+| Slack draft (embargoed) | `docs/release-notes/2026-08-25-harness-diary-sweep-slack.md` | rubric-conformant; posting held |
+
+Rubric detail (operator directives, both codified in the distributed skill, not just memory):
+
+- Default/standard/taste worker: `cli=codex model=gpt-5.6-luna effort=xhigh`. **Luna is only ever
+  run at its maximum effort**; `max`/`ultra` are documented as future-only until Cassy's effort
+  vocabulary is extended.
+- **Terra is suspended at every tier** (dated 2026-08-25, "operator decision pending") — slug kept
+  documented, no active route. Light tier re-routed to Grok Composer/low.
+
+## What Cassy still needs to change (decisions and follow-ups)
+
+| Item | Why | Size | Blocked on |
+| --- | --- | --- | --- |
+| Extend effort vocabulary with `max` (and possibly `ultra`) | Codex 0.149.1 accepts them (probe verified); operator wants Luna at literal max; `Effort` in `crates/cas-mux/src/spec.rs` tops at `xhigh` | S–M | Operator go — pin is already validated |
+| OpenCode implementation program (7 tasks) | Conditional GO; primitives all exist | ~15–24 worker-days | Operator go/no-go + `opencode` binary install |
+| OpenCode blockers to engineer around | (1) no caller-chosen session ID at spawn; (2) shared SQLite session store needs a liveness/blame adapter; (3) Qwen3.8-Max supports only low/medium/xhigh effort — validate, don't silently remap | inside the 7 tasks | — |
+| Post the #cas-internal diary thread | Mandatory publication duty | XS | Embargo lifts 2026-08-31 (reminder #1088) |
+| Epic close (cas-abfc) | cas-9cf9 stays open until the post lands | — | Same embargo |
+
+### OpenCode × Qwen 3.8 — nested decision brief
+
+**Recommendation:** proceed with the 7-task adapter program when you're ready to fund ~15–24
+worker-days; do **not** advertise `cli=opencode` before task 7's live conformance receipt.
+
+- Launch contract is real: `opencode <dir> --model alibaba/qwen3.8-max --agent cassy-worker
+  --prompt … --auto`, inline agent/MCP config via `OPENCODE_CONFIG_CONTENT`, env inheritance
+  carries the full CAS identity set; MCP tools surface as `cas_*`.
+- Qwen3.8-Max: provider `alibaba`, auth `DASHSCOPE_API_KEY`, 1M context, tool calling; effort
+  variants exactly low/medium/xhigh (xhigh default).
+- The recommended seam is the existing `cas_mux::Backend` + one OpenCode plugin — no new
+  portability framework (deletion test favors it).
+- Runner-up (minimum surface, no plugin) was rejected: it cannot satisfy transcript/blame or prove
+  requested effort.
+
+## Provenance
+
+- Epic branch `epic/epic-2026-08-25-harness-diary-sweep-claude-codex-g-cas-abfc` @ `4bf0f6af`
+  (base main @ `17891528`), PR https://github.com/Richards-LLC/cassy/pull/585 (merge queue).
+- Tasks: cas-e59d, cas-d8ce, cas-d21f (diaries) · cas-444a, cas-b9a4 (matrices) · cas-3465
+  (assessment) · cas-e352 (rubric) · cas-9cf9 (Slack, embargoed) — epic cas-abfc.
+- Worker branch CI: Grok lane run 32859071876, Codex lane run 32859003475 (both green).
+- All diary claims trace to the official Anthropic changelog, openai/codex GitHub releases, and
+  x.ai/build/changelog; OpenCode claims to opencode.ai docs + pinned source `a7444bf9` and the
+  Models.dev catalog (full manifest in the assessment doc).

--- a/docs/reports/2026-08-29-skillstate-vs-cas.html
+++ b/docs/reports/2026-08-29-skillstate-vs-cas.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SKILL.state vs CAS — evaluation, 2026-08-29</title>
+<style>
+  :root {
+    --ink: #1a2332; --muted: #5a6678; --line: #d8dee8; --bg: #ffffff; --panel: #f5f7fa;
+    --accent: #174ea6; --bad: #b3261e; --mixed: #9a6700; --good: #1a7f37;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink);
+    font: 16px/1.55 "Segoe UI", system-ui, -apple-system, sans-serif; }
+  main { max-width: 58rem; margin: 0 auto; padding: 2rem 1.25rem 4rem; }
+  h1 { font-size: 1.6rem; line-height: 1.25; margin: 0 0 .3rem; }
+  h2 { font-size: 1.2rem; margin: 2rem 0 .6rem; border-bottom: 2px solid var(--line); padding-bottom: .25rem; }
+  .meta { color: var(--muted); font-size: .85rem; margin-bottom: 1.4rem; }
+  .verdict { background: var(--panel); border-left: 4px solid var(--accent); padding: 1rem 1.2rem; margin: 1.2rem 0; }
+  .verdict p { margin: .3rem 0; }
+  table { border-collapse: collapse; width: 100%; margin: .8rem 0 1.2rem; font-size: .9rem; }
+  th, td { border: 1px solid var(--line); padding: .45rem .6rem; text-align: left; vertical-align: top; }
+  th { background: var(--panel); }
+  .wrap { overflow-x: auto; }
+  code { background: var(--panel); padding: .08rem .3rem; border-radius: 3px; font-size: .85em; }
+  .hit { color: var(--bad); font-weight: 600; }
+  .ok { color: var(--good); font-weight: 600; }
+  .na { color: var(--muted); font-weight: 600; }
+  .callout { background: #eef7f0; border-left: 4px solid var(--good); padding: .8rem 1.1rem; margin: 1rem 0; }
+  footer { margin-top: 3rem; padding-top: 1rem; border-top: 2px solid var(--line); font-size: .82rem; color: var(--muted); }
+  @media print { body { font-size: 11pt; } .wrap { overflow: visible; } }
+</style>
+</head>
+<body>
+<main>
+<h1>SKILL.state vs CAS: no runtime change, but it names our worker-notes problem</h1>
+<p class="meta">2026-08-29 · factory supervisor session · practitioner audience ·
+paper: Badhe, Tiwari, Chung, <em>SKILL.state: Scalable Long-Horizon Agent Skills</em>, Google LLC + Purdue,
+arXiv:2608.26263v1 (2026-08-26) · companion to the same-day WikiSkill evaluation</p>
+
+<div class="verdict">
+<p><strong>Verdict.</strong> SKILL.state is a <em>runtime architecture</em>: it replaces append-only conversational
+history with a structured, mutable execution state the model patches each step. CAS cannot adopt the runtime — our
+workers live inside conversational harnesses (Claude Code / Codex / Grok) whose history loop CAS does not own. But
+three findings land on real CAS surfaces, and the sharpest one names a problem we watch daily:
+<strong>worker task state is append-only prose notes, and workers burn context headroom exactly the way the paper
+predicts</strong> (95%→20% over a single task this session).</p>
+<p><strong>Confidence:</strong> high on the mechanism mapping; benchmarks are synthetic/procedural, so magnitudes
+will not transfer to open-ended coding work.</p>
+</div>
+
+<h2>The paper in one screen</h2>
+<p>Each step the model sees only <code>(P, Σ_t, O_t)</code> — immutable procedural spec, structured JSON execution
+state, latest observation. It emits reasoning (discarded after the step), a validated JSON state patch (dictionary
+merge, null = delete), and one action. Prompt footprint O(1), cumulative tokens O(T) vs O(T²). Schemas are authored
+once per domain, not per task; a malformed patch is rejected by the runtime and never corrupts state.</p>
+<div class="wrap"><table>
+<thead><tr><th>Result</th><th>Number</th></tr></thead>
+<tbody>
+<tr><td>Long horizon, T=200 (warehouse, Gemini-3-Flash)</td><td>0.94 vs 0.74 ReAct / 0.88 LangGraph-style; 122k tokens vs 2.6M–6.2M</td></tr>
+<tr><td>Token cut at T=100</td><td>16.2× vs stateful baseline</td></tr>
+<tr><td>Noise: 50 distractor events per turn</td><td>≥0.97 vs 0.53 ReAct — distractors filtered at patch time never re-enter context</td></tr>
+<tr><td>External state drift recovery</td><td>0 wasted turns vs 5–14 turns of hallucination lag for history runtimes</td></tr>
+<tr><td>Budget-matched controls (~1,800 tokens each)</td><td>truncation 0.18 · summary 0.52 · LLMLingua 0.22 · SKILL.state 0.94 — <strong>structure, not brevity, is the cause</strong></td></tr>
+<tr><td>InterCode CTF / τ-Bench</td><td>best pass rates at 40–65% fewer tokens</td></tr>
+<tr><td>Open-weight failure taxonomy</td><td>68% premature state overwrite · 20% schema confusion · 12% JSON slips → constrained decoding</td></tr>
+</tbody>
+</table></div>
+<p>Stated limitations: the state must be a <em>sufficient statistic</em> (fails when the schema can't be known up
+front, when an observation's relevance is recognized late, or <strong>when the trajectory itself is the deliverable —
+auditing, debugging, provenance</strong>); single-agent only (concurrent writes need deterministic merge semantics).</p>
+
+<h2>What it does and does not touch in CAS</h2>
+<div class="wrap"><table>
+<thead><tr><th>CAS surface</th><th>Impact</th></tr></thead>
+<tbody>
+<tr><td>Harness runtime (append-only chat history)</td>
+<td class="na">Not ours to change — Claude Code/Codex own the loop; CAS is hooks + MCP around it. No adoption path for the runtime itself.</td></tr>
+<tr><td>Factory orchestration state (<code>epic_status</code>, <code>worker_status</code>, task board)</td>
+<td class="ok">Already state-centric — structured current-state surfaces, not history replays. The paper validates the existing design.</td></tr>
+<tr><td>Task store as multi-agent merge operator</td>
+<td class="ok">CAS is ahead — the paper punts on concurrent writes; leases + status transitions are the deterministic merge semantics it says multi-agent needs.</td></tr>
+<tr><td>Worker task notes as the resume/continue surface</td>
+<td class="hit">The real hit — notes are append-only prose; resuming or context-cleared workers replay narrative history, and mid-task headroom drains 95%→20%. The fix maps onto <code>task action=start brief=true</code> growing a real schema (phase, receipts, files touched, next step); zero-recovery-step resume after <code>clear_context</code> is the paper's Table-3 result.</td></tr>
+<tr><td>SessionStart context injection (rules/memories)</td>
+<td class="ok">Supports current design — irrelevant context collapses ReAct 0.68→0.53; endorses budgeted, scored injection and argues against widening it casually.</td></tr>
+<tr><td>Verification / audit trail / provenance</td>
+<td class="na">Explicitly outside state-centric execution — the paper's own limitation: when the trajectory is the deliverable, history is the product. Verification audit rows stay history-shaped.</td></tr>
+</tbody>
+</table></div>
+
+<h2>How it composes with WikiSkill</h2>
+<div class="callout">
+<p>The two papers split the same raw material by consumer. SKILL.state: <strong>discard</strong> reasoning traces
+from the <em>execution</em> context — they poison long horizons. WikiSkill: <strong>retain</strong> traces durably
+for <em>learning</em> — the maintainer mines them. Division of labor, not contradiction:
+bounded structured execution state (SKILL.state) → immutable trace archive for mining (WikiSkill; already tasked
+as cas-62a6) → gated knowledge promotion (the cas-c845 epic in flight).</p>
+</div>
+
+<h2>Candidate follow-up — not tasked, awaiting operator call</h2>
+<p><strong>Structured task execution state:</strong> a schema'd, patchable state blob on tasks (phase / receipts /
+touched files / next action), updated by workers via small patches instead of only prose notes, and made the primary
+payload of <code>start brief=true</code> and post-<code>clear_context</code> re-briefs. Expected wins per the paper's
+mechanism: slower mid-task context burn, lossless resume, less narrative replay. Prose notes stay for humans and
+audit; the state blob becomes the machine resume surface. Moderate effort: task schema + MCP action + worker skill
+guidance.</p>
+
+<footer>
+<p><strong>Provenance.</strong> Paper: <code>~/Downloads/2608.26263v1.pdf</code>, read in full (16pp), 2026-08-29.
+CAS-side claims from the same-day WikiSkill code survey (working tree @ <code>f9692472</code>) and live factory-session
+observations. Source: <code>docs/reports/2026-08-29-skillstate-vs-cas.md</code> (markdown is authoritative).</p>
+</footer>
+</main>
+</body>
+</html>

--- a/docs/reports/2026-08-29-skillstate-vs-cas.md
+++ b/docs/reports/2026-08-29-skillstate-vs-cas.md
@@ -1,0 +1,74 @@
+# SKILL.state vs CAS: no runtime change, but it names our worker-notes problem
+
+**Date:** 2026-08-29 · **Author:** factory supervisor session · **Audience:** practitioner (Daniel)
+**Paper:** Badhe, Tiwari, Chung, *SKILL.state: Scalable Long-Horizon Agent Skills*, Google LLC + Purdue, arXiv:2608.26263v1 (2026-08-26) · Companion to the same-day WikiSkill evaluation (`2026-08-29-wikiskill-vs-cas.md`)
+
+## Verdict
+
+SKILL.state is a **runtime architecture** — it replaces append-only conversational history with a
+structured, mutable execution state the model patches each step. CAS cannot adopt it wholesale:
+our workers run inside conversational harnesses (Claude Code / Codex / Grok) whose append-only
+history CAS does not own. But the paper's results bear directly on three CAS surfaces, and its
+strongest lesson names a problem we live with daily: **worker task state is prose notes — an
+append-only history — and workers burn context headroom exactly the way the paper predicts.**
+Confidence: high on mechanism mapping; the benchmarks are synthetic/procedural, so magnitudes
+won't transfer to open-ended coding work.
+
+## The paper in one screen
+
+Each step the model sees only `(P, Σ_t, O_t)` — immutable procedural spec, structured execution
+state (JSON), latest observation. It emits reasoning (discarded after the step), a validated JSON
+state patch (dictionary merge, null = delete), and one action. Prompt footprint is O(1); cumulative
+tokens O(T) vs O(T²) for history runtimes. Schemas are authored once per domain, not per task.
+
+| Result | Number |
+| --- | --- |
+| Long horizon (T=200, warehouse, Gemini-3-Flash) | 0.94 accuracy vs 0.74 ReAct / 0.88 LangGraph-style; 122k tokens vs 2.6M–6.2M |
+| Token cut at T=100 | 16.2× vs stateful baseline |
+| Noise (50 distractor events/turn) | ≥0.97 vs 0.53 ReAct — distractors are filtered at patch time and never re-enter context |
+| External state drift recovery | 0 wasted turns vs 5–14 turns of "hallucination lag" for history runtimes |
+| Budget-matched controls (same ~1,800-token budget) | truncation 0.18, summary 0.52, LLMLingua 0.22, SKILL.state 0.94 — **structure, not brevity, is the cause** |
+| InterCode CTF / τ-Bench | best pass rates at 40–65% fewer tokens |
+| Open-weight failure taxonomy | 68% premature state overwrite, 20% schema confusion, 12% JSON slips → constrained decoding |
+
+Stated limitations: requires the state to be a *sufficient statistic* (fails when the schema can't be
+known in advance, when an observation's relevance is recognized late, or **when the trajectory itself
+is the target — auditing, debugging, provenance**); single-agent (concurrent writes need deterministic
+merge semantics); malformed patches are rejected by the runtime, never corrupting state.
+
+## What it does and does not touch in CAS
+
+| CAS surface | Impact |
+| --- | --- |
+| Harness runtime (append-only chat history) | **Not ours to change.** Claude Code/Codex own the loop; CAS is hooks + MCP around it. No adoption path for the runtime itself. |
+| Factory orchestration state (`epic_status`, `worker_status`, task board) | **Already state-centric.** These are structured, current-state surfaces, not history replays — the paper validates the design we have. |
+| Task store as multi-agent merge operator | **CAS is ahead.** The paper punts on concurrent writes; CAS's leases + status transitions are exactly the deterministic merge semantics it says multi-agent needs. |
+| **Worker task notes as the resume/continue surface** | **The real hit.** Notes are append-only prose; a resuming or context-cleared worker replays narrative history to reconstruct where it was, and mid-task workers report headroom dropping 95%→20% over one task. The paper's fix — a compact structured state patched as work proceeds, injected instead of history — maps exactly onto `task action=start brief=true` growing a real schema (phase, receipts collected, files touched, next step). Zero-recovery-step resume after `clear_context` is the paper's Table-3 result. |
+| SessionStart context injection (rules/memories) | **Supports current design.** The noise result (irrelevant context collapses ReAct 0.68→0.53) endorses CAS's budgeted, scored injection; argues against ever widening it casually. |
+| Verification / audit trail / provenance | **Explicitly out of scope for state-centric execution** — the paper's own limitation (3): when the trajectory is the deliverable (audits, provenance), history is the product. CAS's verification audit rows should stay history-shaped. |
+
+## How it composes with the WikiSkill report (same week, complementary)
+
+The two papers split the same raw material by consumer: SKILL.state says **discard** reasoning
+traces from the *execution* context (they poison long horizons); WikiSkill says **retain** traces
+durably for *learning* (the wiki maintainer mines them). Not a contradiction — a division of labor:
+
+- Execution context: bounded, structured, current-state (SKILL.state) →
+- Durable archive: immutable traces for later root-cause mining (WikiSkill; already tasked as cas-62a6) →
+- Knowledge loop: gated promotion from mined experience (the cas-c845 epic in flight).
+
+## Candidate follow-up (not tasked — awaiting operator call)
+
+**Structured task execution state**: add a schema'd, patchable state blob to tasks (phase /
+receipts / touched files / next action), updated by workers via small patches instead of only
+prose notes, and made the primary payload of `start brief=true` and post-`clear_context` re-briefs.
+Expected wins, per the paper's mechanism: slower context burn mid-task, lossless resume, and less
+narrative replay in worker turns. Prose notes stay for humans and audit; the state blob becomes
+the machine resume surface. Moderate effort (task schema + MCP action + worker skill guidance).
+
+## Provenance
+
+- Paper: `~/Downloads/2608.26263v1.pdf`, read in full (16pp), 2026-08-29.
+- CAS-side claims from the same-day WikiSkill survey (working tree @ `f9692472`) and live factory
+  session observations (worker headroom reports, task-notes flow).
+- This report: `docs/reports/2026-08-29-skillstate-vs-cas.md` (source) + `.html` (render).

--- a/docs/reports/2026-08-29-wikiskill-vs-cas.html
+++ b/docs/reports/2026-08-29-wikiskill-vs-cas.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WikiSkill vs CAS — evaluation, 2026-08-29</title>
+<style>
+  :root {
+    --ink: #1a2332; --muted: #5a6678; --line: #d8dee8; --bg: #ffffff; --panel: #f5f7fa;
+    --accent: #174ea6; --bad: #b3261e; --mixed: #9a6700; --good: #1a7f37;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink);
+    font: 16px/1.55 "Segoe UI", system-ui, -apple-system, sans-serif; }
+  main { max-width: 60rem; margin: 0 auto; padding: 2rem 1.25rem 4rem; }
+  h1 { font-size: 1.7rem; line-height: 1.25; margin: 0 0 .3rem; }
+  h2 { font-size: 1.25rem; margin: 2.2rem 0 .6rem; border-bottom: 2px solid var(--line); padding-bottom: .25rem; }
+  h3 { font-size: 1.05rem; margin: 1.4rem 0 .4rem; }
+  .meta { color: var(--muted); font-size: .85rem; margin-bottom: 1.4rem; }
+  .verdict { background: var(--panel); border-left: 4px solid var(--accent); padding: 1rem 1.2rem; margin: 1.2rem 0; }
+  .verdict p { margin: .3rem 0; }
+  table { border-collapse: collapse; width: 100%; margin: .8rem 0 1.2rem; font-size: .9rem; }
+  th, td { border: 1px solid var(--line); padding: .45rem .6rem; text-align: left; vertical-align: top; }
+  th { background: var(--panel); }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .wrap { overflow-x: auto; }
+  code { background: var(--panel); padding: .08rem .3rem; border-radius: 3px; font-size: .85em; }
+  .s-no { color: var(--bad); font-weight: 600; }
+  .s-mix { color: var(--mixed); font-weight: 600; }
+  .s-yes { color: var(--good); font-weight: 600; }
+  .findings li { margin-bottom: .8rem; }
+  .caveat { background: #fff8e6; border-left: 4px solid var(--mixed); padding: .8rem 1.1rem; margin: 1rem 0; }
+  figure.flow { max-width: 56rem; border: 1px solid var(--line); padding: .75rem; margin: 1rem 0; }
+  figure.flow svg { width: 100%; height: auto; }
+  .flow .node { fill: #eef4ff; stroke: var(--accent); stroke-width: 2; }
+  .flow .missing { fill: #fdecea; stroke: var(--bad); stroke-dasharray: 6 4; }
+  .flow text { font: 13px "Segoe UI", system-ui, sans-serif; fill: var(--ink); }
+  .flow .lbl { font-size: 11px; fill: var(--muted); }
+  figcaption { font-size: .85rem; color: var(--muted); margin-top: .5rem; }
+  footer { margin-top: 3rem; padding-top: 1rem; border-top: 2px solid var(--line);
+    font-size: .82rem; color: var(--muted); }
+  @media print {
+    body { font-size: 11pt; } .wrap { overflow: visible; }
+    figure.flow { break-inside: avoid; }
+    a[href^="http"]::after { content: " (" attr(href) ")"; font-size: .8em; }
+  }
+</style>
+</head>
+<body>
+<main>
+<h1>WikiSkill vs CAS: what the paper validates, and the three mechanisms it says we're missing</h1>
+<p class="meta">2026-08-29 · factory supervisor session · audience: practitioner ·
+paper: Tang et al., <em>WikiSkill: Compiling Agent Experience into Persistent Knowledge for Skill Evolution</em>,
+Google Research, arXiv:2608.27454v1 (2026-08-27) · CAS surveyed at <code>cas-src</code> working tree @ <code>f9692472</code></p>
+
+<div class="verdict">
+<p><strong>Verdict.</strong> WikiSkill independently validates the architecture CAS already has — raw experience → compounding
+knowledge → executable skills — and CAS is <em>ahead</em> of the paper on pruning and knowledge-page provenance.
+But the paper's measured results indict exactly the three mechanisms CAS lacks:</p>
+<p>① <strong>measured validation gating</strong> on skill/rule changes (CAS promotes Draft→Proven on a single self-reported tool call) —
+② <strong>immutable trace retention</strong> (CAS hard-deletes raw experience at 30 days) —
+③ <strong>experience→skill provenance</strong> (CAS's link is a free-text tag no code reads).</p>
+<p><strong>Confidence:</strong> high on the CAS side (code survey, file:line verified). The paper's numbers are benchmark
+results; transfer to open-world dev work is argued, not proven — see caveats.</p>
+</div>
+
+<h2>The paper in one screen</h2>
+<p>WikiSkill structures an agent workspace as three layers — an immutable <strong>raw layer</strong> of execution traces,
+a compounding <strong>wiki layer</strong> (pattern pages, an evolution log, a programmatically-maintained per-skill impact
+tracker) that is <em>never reset</em>, and an active <strong>skill layer</strong> where each skill carries a
+<code>PURPOSE.md</code> pointing at the wiki patterns that motivated it. Four components loop:
+Inference Agent (runs tasks, sees skills, <em>denied</em> wiki access), Wiki Maintainer (root-cause analysis over a
+stratified sample of ≤8 traces: ≤5 failing, ≤3 passing, 15k chars each), Skill Proposer (ReAct agent reading wiki
+index + impact history + outcomes; one atomic proposal per iteration), and Gating &amp; Rollback (accept only if the
+measured validation score improves; skills roll back, the wiki never does).</p>
+
+<div class="wrap"><table>
+<caption>Headline results (source: paper Tables 1–3, 5; Appendix D)</caption>
+<thead><tr><th>Result</th><th>Number</th><th>Where</th></tr></thead>
+<tbody>
+<tr><td>WikiSkill vs best competing skill-evolution method (avg, 5 benchmarks)</td><td class="num">+3.3 to +12.0 pts per model</td><td>Table 1</td></tr>
+<tr><td>Ablation: Skill Proposer given persistent-wiki access</td><td class="num">48.7% → 63.7% (<strong>+15.0</strong>)</td><td>Table 3</td></tr>
+<tr><td>Ablation: Inference Agent given wiki access during rollouts</td><td class="num">63.7% → 60.9% (<strong>−2.8</strong>, hurts)</td><td>Table 3</td></tr>
+<tr><td>Cross-model transfer (e.g. Qwen-27B skills on Gemma-31B LiveMath)</td><td class="num">33.9 → 73.7</td><td>Table 2</td></tr>
+<tr><td>Optimizer cost per iteration, full-batch</td><td class="num">O(1): 1 + T<sub>ReAct</sub> calls</td><td>App. D</td></tr>
+<tr><td>Accepted skill updates still landing in iterations 5–7</td><td class="num">4–28%</td><td>Table 5</td></tr>
+</tbody>
+</table></div>
+<p>Stated limitations: skill retrieval/triggering not evaluated (full injection), strict gating discards neutral
+proposals, <strong>no wiki pruning mechanism</strong>, no very-long-horizon tasks.</p>
+
+<h2>The loop, mapped onto CAS</h2>
+<figure class="flow" aria-describedby="flow-summary">
+<svg viewBox="0 0 760 260" role="img" aria-labelledby="flow-title flow-desc">
+<title id="flow-title">WikiSkill evolution loop with CAS equivalents</title>
+<desc id="flow-desc">Four boxes in a loop: Inference Agent, Wiki Maintainer, Skill Proposer, and Gating and Rollback.
+CAS has partial equivalents for the first three; the gating box is missing entirely in CAS.</desc>
+<defs><marker id="arr" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8z" fill="#174ea6"/></marker></defs>
+<rect class="node" x="15" y="30" width="165" height="62" rx="6"/>
+<text x="97" y="52" text-anchor="middle" font-weight="600">Inference Agent</text>
+<text x="97" y="70" text-anchor="middle" class="lbl">CAS: sessions + hooks ◐</text>
+<text x="97" y="84" text-anchor="middle" class="lbl">traces not retained ✗</text>
+<rect class="node" x="205" y="30" width="165" height="62" rx="6"/>
+<text x="287" y="52" text-anchor="middle" font-weight="600">Wiki Maintainer</text>
+<text x="287" y="70" text-anchor="middle" class="lbl">CAS: learning-reviewer ◐</text>
+<text x="287" y="84" text-anchor="middle" class="lbl">judges text, not traces</text>
+<rect class="node" x="395" y="30" width="165" height="62" rx="6"/>
+<text x="477" y="52" text-anchor="middle" font-weight="600">Skill Proposer</text>
+<text x="477" y="70" text-anchor="middle" class="lbl">CAS: prompt-table promotion ◐</text>
+<text x="477" y="84" text-anchor="middle" class="lbl">no impact history to read</text>
+<rect class="missing" x="585" y="30" width="160" height="62" rx="6"/>
+<text x="665" y="52" text-anchor="middle" font-weight="600">Gating &amp; Rollback</text>
+<text x="665" y="70" text-anchor="middle" class="lbl">CAS: absent ✗</text>
+<text x="665" y="84" text-anchor="middle" class="lbl">schema exists, never run</text>
+<path d="M180,61 H200 M370,61 H390 M560,61 H580" stroke="#174ea6" stroke-width="2" marker-end="url(#arr)"/>
+<path d="M665,92 V150 H97 V97" stroke="#174ea6" stroke-width="2" fill="none" marker-end="url(#arr)"/>
+<text x="380" y="167" text-anchor="middle" class="lbl">next iteration: accepted skills injected; wiki retained either way</text>
+<rect class="node" x="205" y="190" width="355" height="48" rx="6"/>
+<text x="382" y="210" text-anchor="middle" font-weight="600">Persistent wiki — never reset</text>
+<text x="382" y="227" text-anchor="middle" class="lbl">CAS: memories decay/consolidate (provenance destroyed); knowledge pages read files, not experience</text>
+</svg>
+<figcaption id="flow-summary">The WikiSkill loop with CAS's nearest equivalent under each box. ◐ = partial analogue,
+✗ = absent. The gating stage — the paper's +15pt ingredient together with the persistent wiki — has no CAS
+counterpart: skill and rule changes land unconditionally.</figcaption>
+</figure>
+
+<h2>Layer-by-layer status</h2>
+<div class="wrap"><table>
+<thead><tr><th>WikiSkill mechanism</th><th>CAS analogue</th><th>Status</th></tr></thead>
+<tbody>
+<tr><td>Raw layer: immutable write-once traces</td>
+<td><code>entries</code>/<code>events</code>/<code>recordings</code>; Claude Code transcripts parsed, never retained</td>
+<td class="s-no">✗ absent — mutable; hard-deleted at 30 days (<code>daemon/maintenance.rs:219-247</code>)</td></tr>
+<tr><td>Wiki pattern pages compounding from experience</td>
+<td>Memories/learnings + knowledge pages</td>
+<td class="s-mix">◐ partial — knowledge pages compound with real provenance but read <em>only the filesystem</em> (<code>knowledge/sources.rs:143-157</code>)</td></tr>
+<tr><td>Evolution log (<code>logs.md</code>)</td>
+<td>None — no history/versions tables; all rule/skill/memory updates are destructive in-place</td>
+<td class="s-no">✗ absent</td></tr>
+<tr><td>Per-skill impact tracker, programmatically maintained</td>
+<td><code>rules.surface_count</code> schema-only, never incremented; <code>helpful_count</code>/<code>usage_count</code> self-reported</td>
+<td class="s-no">✗ absent</td></tr>
+<tr><td>Skill→knowledge provenance (<code>PURPOSE.md</code>)</td>
+<td>Free-text tag <code>from_learning</code>; <code>Rule.source_ids</code> only populated by dead code; <code>Entry</code>/<code>Skill</code> have no provenance field</td>
+<td class="s-no">✗ absent</td></tr>
+<tr><td>Gating: accept only on measured validation improvement; rollback</td>
+<td><code>validation_script</code>/<code>preconditions</code>/<code>postconditions</code> shipped in schema (m073/m074), never executed</td>
+<td class="s-no">✗ absent</td></tr>
+<tr><td>Wiki Maintainer (root-cause over sampled traces)</td>
+<td><code>learning-reviewer</code>/<code>duplicate-detector</code>: prompt-only, threshold-triggered, judge learning <em>text</em></td>
+<td class="s-mix">◐ partial</td></tr>
+<tr><td>Skill Proposer reads impact history to avoid repeating rejects</td>
+<td>Prompt table maps phrasing → outcome; no impact history exists to consult</td>
+<td class="s-mix">◐ partial</td></tr>
+<tr><td>Wiki pruning</td>
+<td>Decay curves, tier demotion, consolidation, dedup (<code>daemon/decay.rs</code>)</td>
+<td class="s-yes">✓ CAS ahead — paper lists pruning as an open limitation</td></tr>
+</tbody>
+</table></div>
+
+<h2>The five sharpest findings</h2>
+<ol class="findings">
+<li><strong>One self-reported call promotes a rule to Proven.</strong> <code>cas_rule_helpful</code>
+(<code>cas-cli/src/mcp/tools/core/rules.rs:39-75</code>): a single <code>rule action=helpful</code> flips Draft→Proven and
+immediately syncs the rule to <code>.claude/rules/</code> for every future session. No threshold, no second party, no
+measurement. <code>harmful</code> increments a counter and <em>never demotes</em> (<code>rules.rs:191-216</code>). The paper's
+equivalent decision requires a measured validation improvement — worth +15pts in its ablation.</li>
+<li><strong>The skill validation schema is inert.</strong> <code>Skill.validation_script</code>, <code>preconditions</code>,
+<code>postconditions</code> (<code>crates/cas-types/src/skill.rs:204-218</code>) survive migration and round-tripping and are
+never executed or evaluated anywhere in the tree. WikiSkill's essential gate exists in CAS as three dormant columns.</li>
+<li><strong>The only true measurement loop is firewalled from every decision that matters.</strong>
+<code>retrieval_outcomes</code> (used/helpful/ignored/corrected/harmful; append-only; privacy-hashed) is well-engineered —
+and by explicit design (<code>crates/cas-store/src/retrieval_store.rs:1-6</code>) "never mutates entry/rule counters or global
+search weights." Its entire effect is a ±0.20-clamped nudge to ambient-recall ranking
+(<code>ambient_recall.rs:2178-2191</code>). Promotion, demotion, injection order, and learning review consume none of it.</li>
+<li><strong>No rollback exists for any knowledge artifact.</strong> Rules, skills, memories all update via destructive
+in-place <code>UPDATE</code>; the reviewer prompt says "archive" where the code does hard <code>DELETE</code>
+(<code>rules.rs:219-232</code> vs <code>.claude/agents/rule-reviewer.md:28</code>). WikiSkill's loop is safe to run autonomously
+<em>because</em> every skill change is reversible and every proposal outcome is logged.</li>
+<li><strong>Provenance is destroyed at every merge point.</strong> Consolidation (<code>daemon/decay.rs:129-166</code>)
+archives sources and writes a fresh merged entry with no link back; learnings derived from observations carry no source
+ids (<code>daemon/observation.rs:52-59</code>). The paper's case study shows the cost: its proposer avoided re-trying a
+rejected skill idea only because the audit trail recorded the rejection.</li>
+</ol>
+
+<h2>Where CAS is ahead</h2>
+<ul>
+<li><strong>Pruning and lifecycle</strong> — decay, tiering, consolidation, dedup: the paper's named open problem, solved in CAS.</li>
+<li><strong>Knowledge-page provenance engineering</strong> — per-fragment source markers with a forgery threat model
+(<code>knowledge/merge.rs:232-268</code>), cascade deletes, tombstones, locked pages. Stronger than anything in the paper —
+it just points at files, never at experience.</li>
+<li><strong>A real immutable gate exists — for task closure.</strong> The verification subsystem
+(<code>verification_store.rs</code>, external gates, audit rows) is precisely WikiSkill's gating discipline, aimed at
+delivery instead of knowledge artifacts.</li>
+<li><strong>Cross-harness skill distribution.</strong> Table 2's transfer results empirically support shipping identical
+skills to Claude/Codex/Grok — with the paper's caveat that model-specific workarounds can transfer negatively.</li>
+</ul>
+
+<h2>Caveats</h2>
+<div class="caveat">
+<p>WikiSkill runs on benchmarks with ground-truth scoring and train/val/test splits. CAS works open-world with no oracle:
+"measured validation" must be proxied (verification verdicts, test outcomes, <code>friction_score</code>, retrieval
+outcomes) and proxies inherit the self-report problem. Full skill injection is the paper's confound-avoidance choice, so
+its acceptance numbers don't transfer directly to CAS's budgeted injection. And the −2.8pt Inference-Agent result concerns
+skill-<em>development</em> trajectory quality — it is not an argument against ambient recall for immediate task success.</p>
+</div>
+
+<h2>Recommended changes, prioritized</h2>
+<div class="wrap"><table>
+<thead><tr><th>#</th><th>Change</th><th>Paper evidence</th><th>Anchor</th></tr></thead>
+<tbody>
+<tr><td class="num">1</td><td>Replace one-call Draft→Proven with an outcome-threshold fed by <code>retrieval_outcomes</code> + verification verdicts; add a demotion path from harmful/corrected</td><td>+15pt gating ablation</td><td><code>rules.rs:39-75</code>, <code>retrieval_store.rs:1-6</code></td></tr>
+<tr><td class="num">2</td><td>Version history for rules/skills + tombstone deletes (<code>RuleStatus::Retired</code> already exists, unused)</td><td>Rollback makes autonomous evolution safe</td><td><code>rules.rs:219-232</code></td></tr>
+<tr><td class="num">3</td><td>Execute <code>validation_script</code> as a create/update gate on skills</td><td>Gating &amp; Rollback §3.2.4</td><td><code>skill.rs:204-218</code></td></tr>
+<tr><td class="num">4</td><td>Populate provenance: <code>Entry.source_ids</code>, revive dead <code>Rule.source_ids</code> path, preserve links through consolidation</td><td>Case study: audit trail prevented repeated failures</td><td><code>decay.rs:129-166</code></td></tr>
+<tr><td class="num">5</td><td>Make <code>surface_count</code> real (increment at injection); correlate with session outcome — a skill-impact analogue</td><td>Proposer reads impact history</td><td><code>build_start.rs:436-505</code></td></tr>
+<tr><td class="num">6</td><td>Append-only archive for traces past 30 days instead of hard delete</td><td>Raw layer is write-once</td><td><code>maintenance.rs:219-247</code></td></tr>
+</tbody>
+</table></div>
+<p>Each row is a candidate factory task; none has been created — awaiting operator sign-off.</p>
+
+<footer>
+<p><strong>Provenance.</strong> Paper: <code>~/Downloads/2608.27454v1.pdf</code>, read in full (28pp), 2026-08-29.
+CAS evidence: read-only code survey of the <code>cas-src</code> working tree @ <code>f9692472</code>, 2026-08-29, ~90 tool
+calls; all file:line references verified at survey time. Source of this page:
+<code>docs/reports/2026-08-29-wikiskill-vs-cas.md</code> (markdown is authoritative).</p>
+</footer>
+</main>
+</body>
+</html>

--- a/docs/reports/2026-08-29-wikiskill-vs-cas.md
+++ b/docs/reports/2026-08-29-wikiskill-vs-cas.md
@@ -1,0 +1,139 @@
+# WikiSkill vs CAS: what the paper validates, and the three mechanisms it says we're missing
+
+**Date:** 2026-08-29 · **Author:** factory supervisor session · **Audience:** practitioner (Daniel)
+**Paper:** Tang et al., *WikiSkill: Compiling Agent Experience into Persistent Knowledge for Skill Evolution*, Google Research, arXiv:2608.27454v1 (2026-08-27) · **CAS surveyed at:** working tree of `cas-src` @ `f9692472` (main)
+
+## Thesis
+
+WikiSkill independently validates the architecture CAS already has — a three-layer pipeline from raw
+experience to compounding knowledge to executable skills — and CAS is *ahead* of the paper on pruning
+and knowledge-page provenance. But the paper's measured results indict exactly the three mechanisms
+CAS lacks: **measured validation gating** on skill/rule changes (CAS promotes on a single self-reported
+tool call), **immutable trace retention** (CAS hard-deletes raw experience at 30 days), and
+**experience→skill provenance** (CAS's link is a free-text tag no code reads). Confidence: high on the
+CAS side (code survey with file:line evidence); the paper's numbers are benchmark results whose
+transfer to open-world dev work is argued, not proven.
+
+## The paper in one section
+
+WikiSkill organizes an agent workspace into three layers and runs an evolutionary loop over them:
+
+- **Raw layer** (`raw/`) — immutable, write-once execution traces of every rollout.
+- **Wiki layer** (`wiki/`) — compounding structured knowledge: pattern pages, an evolution log
+  (`logs.md`), and a programmatically-maintained per-skill impact tracker (`skill-impact.md`).
+  **Never reset, never rolled back.**
+- **Skill layer** (`skills/`) — the active skills, each with a `PURPOSE.md` mapping it back to the
+  wiki patterns that motivated it.
+
+Four components per iteration: an **Inference Agent** (runs tasks; sees skills but is *denied* wiki
+access), a **Wiki Maintainer** (root-cause analysis over a stratified sample of ≤8 traces — ≤5
+failing, ≤3 passing, 15k chars each — producing patch-based pattern-page edits), a **Skill Proposer**
+(multi-turn ReAct agent reading the wiki index + skill-impact + task outcomes; one atomic skill
+proposal per iteration), and a **Gating & Rollback** mechanism (proposal accepted only if measured
+validation score improves; skills roll back, the wiki never does).
+
+Headline numbers:
+
+| Result | Number | Where |
+| --- | --- | --- |
+| WikiSkill vs best competing skill-evolution method (avg across 5 benchmarks) | +3.3 to +12.0 pts per model | Table 1 |
+| Ablation: giving the Skill Proposer wiki access (i.e. persistent knowledge) | 48.7% → 63.7% (**+15.0**) | Table 3 |
+| Ablation: giving the *Inference Agent* wiki access during rollouts | 63.7% → 60.9% (**−2.8**, hurts) | Table 3 |
+| Skills evolved by one model, run by another | frequently beats self-evolved; e.g. Qwen-27B skills lift Gemma-31B LiveMath 33.9→73.7 | Table 2 |
+| Optimizer cost per iteration (full-batch) | O(1): 1 + T_ReAct LLM calls | Appendix D |
+| Late-stage skill refinement (iterations 5–7) still accepted | 4–28% of accepted updates | Table 5 |
+
+Stated limitations: no skill retrieval/triggering evaluated (skills are fully injected), strict gating
+discards neutral proposals, **no wiki pruning mechanism**, benchmarks don't cover very long-horizon work.
+
+## Layer-by-layer mapping onto CAS
+
+| WikiSkill mechanism | CAS analogue | Status |
+| --- | --- | --- |
+| Raw layer: immutable write-once traces | `entries` (observations), `events`, `recordings`; Claude Code transcripts parsed but never retained | ✗ Mutable in place; `events`/`recordings` hard-deleted at 30 days (`cas-cli/src/daemon/maintenance.rs:219-247`) |
+| Wiki pattern pages compounding from experience | Memories/learnings (tiers, decay, consolidation) + knowledge pages | ◐ Knowledge pages genuinely compound with real provenance — but read **only the filesystem**, never experience (`cas-cli/src/knowledge/sources.rs:143-157`) |
+| Evolution log (`logs.md`) | None — no history/versions table for rules, skills, or memories; all updates destructive in-place | ✗ |
+| Per-skill impact tracker (`skill-impact.md`), programmatically maintained | `rules.surface_count` — schema-only, **never incremented anywhere**; `helpful_count`/`usage_count` are agent self-report | ✗ |
+| Skill→knowledge provenance (`PURPOSE.md`) | Free-text tag `from_learning`; `Rule.source_ids` populated only by dead code (`cas-cli/src/rules/mod.rs`, zero non-test callers); `Entry` and `Skill` have no provenance field at all | ✗ |
+| Gating: accept skill change only if measured validation score improves; rollback otherwise | `Skill.validation_script`/`preconditions`/`postconditions` exist in schema (m073/m074) and are **never executed**; `cas_skill_create` writes + syncs to disk in one shot | ✗ |
+| Wiki Maintainer (root-cause analysis over sampled traces) | `learning-reviewer`/`duplicate-detector` — prompt-only agents, threshold-triggered, judging the *text* of learnings, not traces | ◐ |
+| Skill Proposer (reads impact history to avoid repeating rejected proposals) | `learning-reviewer` prompt table maps phrasing → outcome ("Always X" → rule); no impact history exists to read | ◐ |
+| Wiki pruning | Decay/tiering (`daemon/decay.rs`), consolidation, dedup, archive | ✓ **CAS is ahead** — the paper lists this as an open limitation |
+
+## The five sharpest findings
+
+1. **One self-reported call promotes a rule to Proven.** `cas_rule_helpful`
+   (`cas-cli/src/mcp/tools/core/rules.rs:39-75`): a single `rule action=helpful` flips
+   Draft→Proven and immediately syncs the rule into `.claude/rules/` for injection into every
+   future session. No threshold, no second party, no measured effect. `harmful` increments a
+   counter and **never demotes** (`rules.rs:191-216`). WikiSkill's equivalent decision requires a
+   measured validation-score improvement, and its ablation puts +15pts on doing this right.
+
+2. **The skill validation schema is inert.** `Skill.validation_script`, `preconditions`,
+   `postconditions` (`crates/cas-types/src/skill.rs:204-218`) survive migration, storage, and
+   round-tripping — and are never executed or evaluated anywhere in the tree. The gate WikiSkill
+   says is essential exists in CAS as three dormant columns.
+
+3. **CAS's only true measurement loop is firewalled from every decision that matters.**
+   `retrieval_outcomes` (used/helpful/ignored/corrected/harmful, append-only, privacy-hashed) is
+   well-engineered — and by explicit design (`crates/cas-store/src/retrieval_store.rs:1-6`)
+   "never mutates entry/rule counters or global search weights." Its entire effect is a
+   ±0.20-clamped nudge to ambient-recall ranking (`cas-cli/src/ambient_recall.rs:2178-2191`).
+   Promotion, demotion, rule injection order, and learning review consume none of it.
+
+4. **No rollback exists for any knowledge artifact.** Rules, skills, and memories update via
+   destructive in-place `UPDATE`; rule "archive" in the reviewer prompt is a hard `DELETE` in code
+   (`rules.rs:219-232` vs `.claude/agents/rule-reviewer.md:28`). WikiSkill's loop is only safe to
+   run autonomously *because* every skill change is reversible and every proposal outcome is logged.
+
+5. **Provenance is destroyed at every merge point.** Consolidation (`cas-cli/src/daemon/decay.rs:129-166`)
+   archives source memories and writes a fresh merged entry with no link back. Learnings derived
+   from observations carry no source ids (`daemon/observation.rs:52-59`). The paper's case study
+   shows why this matters: the Skill Proposer avoided repeating a rejected proposal *because* the
+   audit trail said it had been tried.
+
+## Where CAS is ahead of the paper
+
+- **Pruning and lifecycle** — decay curves, tier demotion, consolidation, dedup: the paper names
+  wiki growth as an unsolved limitation; CAS has a working answer.
+- **Knowledge-page provenance engineering** — per-fragment source markers with a forgery threat
+  model (`cas-cli/src/knowledge/merge.rs:232-268`), cascade deletes, tombstones, locked pages.
+  Better than anything in the paper — it just points at files, not experience.
+- **A real, immutable gate exists — for task closure.** The verification subsystem
+  (`crates/cas-store/src/verification_store.rs`, external gates, audit rows) is exactly the
+  gating discipline WikiSkill wants; it's aimed at task delivery rather than knowledge artifacts.
+- **Cross-harness skill distribution.** The paper's cross-model transfer result (skills evolved by
+  one model helping another, Table 2) empirically supports CAS shipping identical skills to
+  Claude/Codex/Grok — with the caveat that model-specific workarounds can transfer negatively.
+
+## Caveats — the case against acting on this uncritically
+
+- WikiSkill runs on benchmarks with ground-truth scoring and train/val/test splits. CAS operates on
+  open-world dev tasks with no oracle; "measured validation" must be proxied (verification verdicts,
+  test outcomes, `friction_score`, retrieval outcomes), and proxies can be gamed by the same LLM
+  self-report problem CAS already has.
+- Full skill injection (no retrieval) is the paper's stated confound-avoidance choice; CAS's
+  injection is budgeted and scored, so their acceptance numbers don't transfer directly.
+- The −2.8pt result for Inference-Agent wiki access is about *skill-development* trajectory quality,
+  not about whether injecting memories helps the immediate task — it does not argue against ambient
+  recall as such.
+
+## Recommended changes, prioritized
+
+| # | Change | Paper evidence | Anchor |
+| --- | --- | --- | --- |
+| 1 | Replace one-call Draft→Proven with an outcome-threshold fed by `retrieval_outcomes` + verification verdicts; add a demotion path from `harmful`/`corrected` | +15pt gating ablation | `rules.rs:39-75`, `retrieval_store.rs:1-6` |
+| 2 | Add `rule_versions`/`skill_versions` history + make delete a tombstone (code already has `RuleStatus::Retired`, unused) | Rollback is what makes autonomous evolution safe | `rules.rs:219-232` |
+| 3 | Execute `validation_script` as a create/update gate on skills (schema already shipped) | Gating & Rollback §3.2.4 | `skill.rs:204-218` |
+| 4 | Populate provenance: `Entry.source_ids`, revive the dead `Rule.source_ids` path, preserve links through consolidation | Case study: audit trail prevented repeated failed proposals | `decay.rs:129-166`, `cas-cli/src/rules/mod.rs` |
+| 5 | Make `surface_count` real (increment at injection) and correlate with session outcome — a `skill-impact.md` analogue | Skill Proposer reads impact history | `build_start.rs:436-505` |
+| 6 | Append-only archive for traces past 30 days (compressed, or hash-chained summaries) instead of hard delete | Raw layer is write-once | `maintenance.rs:219-247` |
+
+Each row is a candidate factory task; none has been created — awaiting operator sign-off.
+
+## Provenance
+
+- Paper: `~/Downloads/2608.27454v1.pdf`, read in full (28pp), 2026-08-29.
+- CAS evidence: read-only code survey of `cas-src` working tree @ `f9692472`, 2026-08-29,
+  ~90 tool calls; all file:line references verified at survey time.
+- This report: `docs/reports/2026-08-29-wikiskill-vs-cas.md` (source) + `.html` (render).

--- a/docs/reports/2026-08-30-corrupted-task-rows.html
+++ b/docs/reports/2026-08-30-corrupted-task-rows.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Corrupted Cloud Task Rows — 2026-08-30</title>
+<style>
+  :root{--ink:#1a2233;--muted:#5b6577;--line:#dde3ec;--bg:#f7f9fc;--card:#ffffff;
+        --bad:#b42318;--bad-bg:#fef3f2;--warn:#b54708;--warn-bg:#fffaeb;--ok:#067647;--ok-bg:#ecfdf3;
+        --accent:#175cd3;--accent-bg:#eff8ff;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+  main{max-width:960px;margin:0 auto;padding:32px 24px 64px}
+  h1{font-size:26px;line-height:1.25;margin:0 0 4px}
+  h2{font-size:19px;margin:40px 0 12px;border-bottom:1px solid var(--line);padding-bottom:6px}
+  h3{font-size:16px;margin:24px 0 8px}
+  .meta{color:var(--muted);font-size:13px;margin-bottom:24px}
+  .verdict{background:var(--bad-bg);border:1px solid #f2c1bc;border-left:5px solid var(--bad);border-radius:8px;padding:16px 20px;margin:20px 0}
+  .verdict strong{color:var(--bad)}
+  .cards{display:flex;gap:14px;flex-wrap:wrap;margin:20px 0}
+  .card{flex:1 1 180px;background:var(--card);border:1px solid var(--line);border-radius:8px;padding:14px 16px}
+  .card .n{font-size:30px;font-weight:700;font-variant-numeric:tabular-nums}
+  .card .l{font-size:12.5px;color:var(--muted);margin-top:2px}
+  .card.bad .n{color:var(--bad)} .card.warn .n{color:var(--warn)} .card.ok .n{color:var(--ok)} .card.acc .n{color:var(--accent)}
+  table{border-collapse:collapse;width:100%;background:var(--card);border:1px solid var(--line);border-radius:8px;overflow:hidden;font-size:14px}
+  th{background:#eef2f8;text-align:left;padding:8px 12px;border-bottom:1px solid var(--line);font-size:13px}
+  td{padding:8px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  tr:last-child td{border-bottom:none}
+  td.num,th.num{text-align:right;font-variant-numeric:tabular-nums}
+  tr.total td{font-weight:700;background:#f2f5fa}
+  code{background:#eef1f6;border:1px solid var(--line);border-radius:4px;padding:1px 5px;font-size:13px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  pre{background:#101828;color:#e4e9f1;border-radius:8px;padding:14px 16px;overflow-x:auto;font-size:13px;line-height:1.5}
+  pre code{background:none;border:none;color:inherit;padding:0}
+  .idgrid{columns:5 150px;column-gap:18px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;background:var(--card);border:1px solid var(--line);border-radius:8px;padding:14px 18px;margin:8px 0}
+  .idgrid span{display:block;padding:1px 0}
+  .pill{display:inline-block;border-radius:99px;padding:1px 10px;font-size:12px;font-weight:600}
+  .pill.bad{background:var(--bad-bg);color:var(--bad)} .pill.ok{background:var(--ok-bg);color:var(--ok)}
+  .pill.warn{background:var(--warn-bg);color:var(--warn)} .pill.acc{background:var(--accent-bg);color:var(--accent)}
+  .note{background:var(--accent-bg);border:1px solid #b8daff;border-left:5px solid var(--accent);border-radius:8px;padding:12px 18px;margin:16px 0}
+  .flow{display:flex;gap:0;align-items:stretch;flex-wrap:wrap;margin:14px 0}
+  .flow .step{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:10px 14px;flex:1 1 200px;font-size:13.5px}
+  .flow .arr{align-self:center;padding:0 10px;color:var(--muted);font-size:20px}
+  footer{margin-top:48px;padding-top:14px;border-top:1px solid var(--line);color:var(--muted);font-size:12.5px}
+  @media print{ body{background:#fff} pre{white-space:pre-wrap} .idgrid{columns:4} a[href]:after{content:" (" attr(href) ")";font-size:11px} }
+</style>
+</head>
+<body>
+<main>
+<h1>Corrupted cloud task rows: 98 rows fail every team pull</h1>
+<p class="meta">2026-08-30 · factory supervisor session 9bc9520d · source: <code>cas_update_20280830.txt</code> + read-only queries on <code>cas-src/.cas/cas.db</code> · repair: EPIC cas-5697</p>
+
+<div class="verdict">
+<strong>Verdict:</strong> 98 task rows in the team cloud carry <code>deliverables</code> serialized as a JSON <em>string</em> where the sync contract expects the <code>TaskDeliverables</code> struct. Every team pull on every cloud-linked project rejects all 98 and applies partial results (8 projects × 98 = 784 error lines in one <code>cas update</code> run). Until repaired, these rows cannot reach any other machine. Client fix <strong>cas-6980</strong> and one-time cloud repair <strong>cas-9894</strong> are scheduled under EPIC cas-5697 with workers assigned.
+</div>
+
+<div class="cards">
+  <div class="card bad"><div class="n">98</div><div class="l">corrupted cloud rows (unique IDs)</div></div>
+  <div class="card warn"><div class="n">60</div><div class="l">live open cas-src tasks — cloud copy dead</div></div>
+  <div class="card acc"><div class="n">10</div><div class="l">closed cas-src archive rows — cloud copy dead</div></div>
+  <div class="card ok"><div class="n">28</div><div class="l">cloud-only tombstones of deleted contamination</div></div>
+</div>
+
+<h2>Error shape</h2>
+<pre><code>⚠ Team pull encountered 98 error(s); partial results applied
+  - task deserialize error (id=cas-XXXX): invalid type: string
+    "{\"files_changed\":[]}", expected struct TaskDeliverables</code></pre>
+<p>Identical on all 8 cloud-linked projects — log lines 40, 160, 305, 427, 547, 667, 787, 907. ID extraction: <code>grep -oP 'id=\Kcas-[0-9a-f]+' cas_update_20280830.txt | sort -u</code> → 98.</p>
+
+<h2>Breakdown and disposition</h2>
+<table>
+<thead><tr><th>Class</th><th class="num">Count</th><th>Disposition (cas-9894)</th></tr></thead>
+<tbody>
+<tr><td><span class="pill warn">live</span> Local <strong>open</strong> cas-src tasks — real work, cloud copy corrupted</td><td class="num">60</td><td>Re-push clean local canonical</td></tr>
+<tr><td><span class="pill acc">archive</span> Local <strong>closed</strong> cas-src tasks — cloud copy corrupted</td><td class="num">10</td><td>Re-push clean local canonical</td></tr>
+<tr><td><span class="pill ok">tombstone</span> Cloud-only remnants of contamination deleted 2026-08-30</td><td class="num">28</td><td>Delete cloud copy</td></tr>
+<tr class="total"><td>Total</td><td class="num">98</td><td></td></tr>
+</tbody>
+</table>
+
+<div class="note">
+<strong>Highest-impact row: cas-9cf9</strong> (P1 — publish the 2026-08-25 harness diary thread; sole remaining child of live EPIC cas-abfc). It is the only row whose stringified payload holds <em>real</em> data, not the trivial <code>{"files_changed":[]}</code>: a work_target (<code>project:cas-src</code> @ the cas-abfc epic branch), factory anchor <code>fdf43b20</code>, parked branch <code>factory/eager-heron-43</code>. Its cloud copy cannot sync anywhere — the diary publication task exists only on this host until repair. EPIC cas-abfc itself is also among the 60.
+</div>
+
+<h2>Root cause</h2>
+<div class="flow">
+  <div class="step"><strong>cas-02a7 relocation</strong> (2026-08-29) moves ~789 rows between project DBs</div>
+  <div class="arr">→</div>
+  <div class="step">Writer JSON-encodes an already-encoded <code>deliverables</code> value → string, not struct (<strong>cas-6980</strong>)</div>
+  <div class="arr">→</div>
+  <div class="step">That session pushes the stringified rows to the team cloud</div>
+  <div class="arr">→</div>
+  <div class="step">Every client pull rejects the 98 rows; partial results forever</div>
+</div>
+<p>The client's refusal is correct behavior; the gap is that the corruption reached the cloud at write time and pulls only report it as a per-run warning.</p>
+
+<h2>Blast radius — and what it is not</h2>
+<ul>
+<li><strong>No data loss on this host:</strong> all 70 local rows are intact; only their <em>cloud</em> copies are bad.</li>
+<li><strong>Cross-machine loss until repair:</strong> other machines pulling the team project receive none of the 98, including live P1 work (cas-9cf9, cas-abfc).</li>
+<li><strong>Silver lining:</strong> the 28 corrupted tombstones never resurrected the deleted contamination — pulls skip what they cannot decode.</li>
+</ul>
+
+<h2>The 98 IDs</h2>
+<h3>60 live open (P1: cas-7657, cas-9cf9, cas-abfc · P4: cas-0f22 · rest P2/P3)</h3>
+<div class="idgrid">
+<span>cas-7657</span><span>cas-9cf9</span><span>cas-abfc</span><span>cas-0101</span><span>cas-1b12</span><span>cas-2598</span><span>cas-3b29</span><span>cas-467a</span><span>cas-48e4</span><span>cas-4c89</span><span>cas-5bc14</span><span>cas-63b9</span><span>cas-6c28</span><span>cas-7265</span><span>cas-74e3</span><span>cas-844b</span><span>cas-9886</span><span>cas-9d8a</span><span>cas-b8b1</span><span>cas-c2b2</span><span>cas-c2f2</span><span>cas-c8a6</span><span>cas-ce30</span><span>cas-dae6</span><span>cas-dfa3</span><span>cas-046c</span><span>cas-0906</span><span>cas-1a95</span><span>cas-1c31</span><span>cas-236d</span><span>cas-24d0</span><span>cas-269ab</span><span>cas-2929</span><span>cas-326e</span><span>cas-3316</span><span>cas-3843</span><span>cas-4cec</span><span>cas-563a</span><span>cas-5eb9</span><span>cas-5f61</span><span>cas-6419</span><span>cas-7062</span><span>cas-7391</span><span>cas-746a</span><span>cas-74b9</span><span>cas-74c8</span><span>cas-8090</span><span>cas-84b3</span><span>cas-9040</span><span>cas-939a</span><span>cas-96ab</span><span>cas-9fe6</span><span>cas-a5c0</span><span>cas-b352</span><span>cas-d4a0</span><span>cas-d6b9</span><span>cas-de46</span><span>cas-ec70</span><span>cas-f163</span><span>cas-0f22</span>
+</div>
+<h3>10 closed archive</h3>
+<div class="idgrid">
+<span>cas-1833</span><span>cas-1ddf</span><span>cas-42a4</span><span>cas-8172</span><span>cas-9def</span><span>cas-a81f</span><span>cas-c40a</span><span>cas-cdcc</span><span>cas-d132</span><span>cas-eaf6</span>
+</div>
+<h3>28 cloud-only tombstones (delete)</h3>
+<div class="idgrid">
+<span>cas-082b</span><span>cas-0acb</span><span>cas-0b21</span><span>cas-1818</span><span>cas-29a6</span><span>cas-2cbb0</span><span>cas-3ac7</span><span>cas-43a1</span><span>cas-5548</span><span>cas-5f2e</span><span>cas-71b7</span><span>cas-8b21</span><span>cas-8e9d</span><span>cas-9841</span><span>cas-9c3a</span><span>cas-9f5e</span><span>cas-a1e0</span><span>cas-a2e6</span><span>cas-adb8</span><span>cas-b492</span><span>cas-bcfe</span><span>cas-c97a</span><span>cas-dbf9</span><span>cas-dcbc</span><span>cas-e42d</span><span>cas-e446</span><span>cas-ea8d</span><span>cas-f179</span>
+</div>
+
+<h2>Repair plan (scheduled)</h2>
+<table>
+<thead><tr><th>Task</th><th>What</th><th>State</th></tr></thead>
+<tbody>
+<tr><td><code>cas-6980</code></td><td>Client tolerates/repairs string-encoded deliverables on pull (double-decode); fix the writer that stringified</td><td><span class="pill acc">worker assigned</span></td></tr>
+<tr><td><code>cas-9894</code></td><td>Re-push 70 clean local canonicals · delete 28 tombstones · prove 0-error pulls from ≥2 projects with per-ID receipts</td><td><span class="pill warn">blocked by cas-6980</span></td></tr>
+</tbody>
+</table>
+
+<footer>
+Provenance: (a) <code>cas_update_20280830.txt</code>, cas-src repo root, unmodified, run 2026-08-30 10:48; (b) read-only SQLite on <code>/home/pippenz/Petrastella/cas-src/.cas/cas.db</code>, 2026-08-30 — 98-ID <code>IN</code> list, status grouping (open=60, closed=10), set difference (28). Markdown source of truth: <code>docs/reports/2026-08-30-corrupted-task-rows.md</code>.
+</footer>
+</main>
+</body>
+</html>

--- a/docs/reports/2026-08-30-corrupted-task-rows.md
+++ b/docs/reports/2026-08-30-corrupted-task-rows.md
@@ -1,0 +1,90 @@
+# Corrupted cloud task rows — 98 rows fail every team pull
+
+**Date:** 2026-08-30 · **Author:** factory supervisor session 9bc9520d · **Status:** repair scheduled (EPIC cas-5697)
+
+## Verdict
+
+98 task rows in the team cloud carry `deliverables` serialized as a JSON **string** instead of the
+`TaskDeliverables` struct. Every team pull on every cloud-linked project rejects all 98 and applies
+partial results — 8 projects × 98 = 784 error lines in a single `cas update` run. The rows are
+invisible to sync on every machine until repaired. Client fix is cas-6980; one-time cloud repair is
+cas-9894; both are children of EPIC cas-5697 with workers assigned.
+
+## Evidence
+
+- Source log: `cas_update_20280830.txt` (cas-src repo root, `cas update` run 2026-08-30 10:48 local).
+- Error shape: `task deserialize error (id=cas-XXXX): invalid type: string "{\"files_changed\":[]}", expected struct TaskDeliverables`.
+- Warning per project: `⚠ Team pull encountered 98 error(s); partial results applied` — identical for
+  all 8 cloud-linked projects (log lines 40, 160, 305, 427, 547, 667, 787, 907).
+- ID extraction: `grep -oP 'id=\Kcas-[0-9a-f]+' cas_update_20280830.txt | sort -u` → 98 unique IDs.
+- Local cross-reference: cas-src `.cas/cas.db` queried read-only 2026-08-30.
+
+## Breakdown of the 98
+
+| Class | Count | Disposition (cas-9894) |
+|---|---:|---|
+| Local **open** cas-src tasks — live work, cloud copy corrupted | 60 | Re-push clean local canonical |
+| Local **closed** cas-src tasks — archive, cloud copy corrupted | 10 | Re-push clean local canonical |
+| **Cloud-only tombstones** — contamination deleted locally 2026-08-30 (ozer cluster, cas-43a1, cas-b492, cas-e42d) | 28 | Delete cloud copy |
+
+### Highest-impact row
+
+`cas-9cf9` (P1, publish the 2026-08-25 harness diary thread — the sole remaining child of live EPIC
+cas-abfc) is the only row whose stringified payload carries **real data**, not the trivial
+`{"files_changed":[]}`: a `work_target` (repo_selector `project:cas-src`, target branch
+`epic/epic-2026-08-25-harness-diary-sweep-…-cas-abfc`), `factory_branch_anchor` `fdf43b20`, and
+`parked_branch` `factory/eager-heron-43`. Its cloud copy cannot sync to any machine, so the diary
+publication task exists only on this host until repair.
+
+Notable also in the 60 open: EPIC cas-abfc itself and cas-7657.
+
+### The 60 open rows (P1 → P4)
+
+cas-7657, cas-9cf9, cas-abfc (P1); cas-0101, cas-1b12, cas-2598, cas-3b29, cas-467a, cas-48e4,
+cas-4c89, cas-5bc14, cas-63b9, cas-6c28, cas-7265, cas-74e3, cas-844b, cas-9886, cas-9d8a, cas-b8b1,
+cas-c2b2, cas-c2f2, cas-c8a6, cas-ce30, cas-dae6, cas-dfa3 (P2); cas-046c, cas-0906, cas-1a95,
+cas-1c31, cas-236d, cas-24d0, cas-269ab, cas-2929, cas-326e, cas-3316, cas-3843, cas-4cec, cas-563a,
+cas-5eb9, cas-5f61, cas-6419, cas-7062, cas-7391, cas-746a, cas-74b9, cas-74c8, cas-8090, cas-84b3,
+cas-9040, cas-939a, cas-96ab, cas-9fe6, cas-a5c0, cas-b352, cas-d4a0, cas-d6b9, cas-de46, cas-ec70,
+cas-f163 (P3); cas-0f22 (P4).
+
+### The 10 closed rows
+
+cas-1833, cas-1ddf, cas-42a4, cas-8172, cas-9def, cas-a81f, cas-c40a, cas-cdcc, cas-d132, cas-eaf6.
+
+### The 28 cloud-only tombstones
+
+cas-082b, cas-0acb, cas-0b21, cas-1818, cas-29a6, cas-2cbb0, cas-3ac7, cas-43a1, cas-5548, cas-5f2e,
+cas-71b7, cas-8b21, cas-8e9d, cas-9841, cas-9c3a, cas-9f5e, cas-a1e0, cas-a2e6, cas-adb8, cas-b492,
+cas-bcfe, cas-c97a, cas-dbf9, cas-dcbc, cas-e42d, cas-e446, cas-ea8d, cas-f179.
+
+## Root cause
+
+The cas-02a7 cross-DB contamination cleanup (2026-08-29) relocated ~789 rows between project DBs.
+Its writer serialized the `deliverables` field by JSON-encoding an already-encoded value, producing a
+string where the sync contract expects a struct (tracked as **cas-6980**, filed before this run and
+now carrying this field evidence). The corrupted values reached the cloud through that session's
+pushes; the current client refuses them on pull, correctly, but with row-level silence about the
+consequence: partial pulls forever.
+
+## Blast radius and what it is not
+
+- **Not data loss on this host:** all 70 local rows are intact here; only their **cloud** copies are bad.
+- **Cross-machine loss until repair:** any other machine pulling the team project gets none of the 98 —
+  including live P1 work (cas-9cf9, cas-abfc).
+- **A silver lining:** the 28 corrupted tombstones never resurrected our deleted contamination —
+  they fail to deserialize, so pulls skip them.
+
+## Repair plan (scheduled)
+
+1. **cas-6980** (worker assigned): client tolerates/repairs string-encoded deliverables on pull
+   (double-decode), and the writer that stringified is fixed at the source.
+2. **cas-9894** (blocked by cas-6980): re-push the 70 clean local canonicals; delete the 28 cloud-only
+   tombstones; prove team pulls report 0 errors from at least 2 projects, with per-ID before/after receipts.
+
+## Provenance
+
+All counts derive from: (a) `cas_update_20280830.txt` as shipped in the cas-src repo root, unmodified;
+(b) read-only SQLite queries against `/home/pippenz/Petrastella/cas-src/.cas/cas.db` on 2026-08-30
+(98-ID `IN` list; status grouping `open=60, closed=10`; set difference for the 28). Reproduction
+commands are inline above.


### PR DESCRIPTION
Salvages four supervisor reports (md + html pairs) that were sitting untracked in the main checkout and existed on no branch:

- docs/reports/2026-08-25-harness-sweep-summary
- docs/reports/2026-08-29-skillstate-vs-cas
- docs/reports/2026-08-29-wikiskill-vs-cas
- docs/reports/2026-08-30-corrupted-task-rows

Docs-only; no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnQNXymumfZD2Wj5USRp2m
