### PR TITLE
fix(search): schema-versioned Tantivy path — open never deletes a mismatched index

### DIFF
--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -475,6 +475,9 @@ pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
 
     // Check 4: Search index
     checks.push(legacy_search_index_check(&cas_root));
+    if let Some(check) = legacy_versioned_search_index_check(&cas_root) {
+        checks.push(check);
+    }
     let index_dir = crate::hybrid_search::tantivy_index_dir(&cas_root);
     if index_dir.exists() {
         match SearchIndex::open(&index_dir) {
@@ -482,7 +485,7 @@ pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
                 checks.push(Check {
                     name: "search index".to_string(),
                     status: CheckStatus::Ok,
-                    message: "Tantivy index accessible".to_string(),
+                    message: format!("Tantivy index accessible at {}", index_dir.display()),
                 });
             }
             Err(e) => {
@@ -497,7 +500,10 @@ pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
         checks.push(Check {
             name: "search index".to_string(),
             status: CheckStatus::Warning,
-            message: "Index not found. Will be created on first search.".to_string(),
+            message: format!(
+                "Index not found at {}. Will be created on first search.",
+                index_dir.display()
+            ),
         });
     }
 
@@ -916,6 +922,26 @@ fn legacy_search_index_check(cas_root: &Path) -> Check {
             message: format!("cannot inspect stray Tantivy root: {error}"),
         },
     }
+}
+
+/// Report the pre-versioned canonical path separately from the older stray
+/// root handled by [`legacy_search_index_check`]. This check is read-only: the
+/// next explicit reindex performs the one-time migration or quarantine.
+fn legacy_versioned_search_index_check(cas_root: &Path) -> Option<Check> {
+    let legacy_dir = crate::hybrid_search::legacy_tantivy_index_dir(cas_root);
+    if !legacy_dir.join("meta.json").is_file() {
+        return None;
+    }
+
+    Some(Check {
+        name: "pre-versioned search index".to_string(),
+        status: CheckStatus::Warning,
+        message: format!(
+            "legacy Tantivy index at {}; current versioned path is {}; run the reindex maintenance action (`mcp__cas__system action=reindex bm25=true`) from an agent session to migrate it safely",
+            legacy_dir.display(),
+            crate::hybrid_search::tantivy_index_dir(cas_root).display()
+        ),
+    })
 }
 
 /// Turn a contamination scan into a single `cas doctor` row.

--- a/cas-cli/src/hybrid_search/background.rs
+++ b/cas-cli/src/hybrid_search/background.rs
@@ -4,6 +4,7 @@
 //! their last index. Runs as part of the daemon process every 30 seconds.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::error::Result;
 use crate::store::Store;
@@ -41,6 +42,8 @@ pub struct IndexingResult {
 /// Background indexer for incremental BM25 index updates
 pub struct BackgroundIndexer {
     index: SearchIndex,
+    rebuild_marker: Option<std::path::PathBuf>,
+    rebuild_required: AtomicBool,
 }
 
 impl BackgroundIndexer {
@@ -48,13 +51,23 @@ impl BackgroundIndexer {
     pub fn open(cas_dir: &Path) -> Result<Self> {
         let index_dir = crate::hybrid_search::tantivy_index_dir(cas_dir);
         let index = SearchIndex::open(&index_dir)?;
-        Ok(Self { index })
+        let rebuild_marker = crate::hybrid_search::tantivy_rebuild_marker(cas_dir);
+        let rebuild_required = rebuild_marker.is_file();
+        Ok(Self {
+            index,
+            rebuild_marker: Some(rebuild_marker),
+            rebuild_required: AtomicBool::new(rebuild_required),
+        })
     }
 
     /// Create an in-memory indexer (for testing)
     pub fn in_memory() -> Result<Self> {
         let index = SearchIndex::in_memory()?;
-        Ok(Self { index })
+        Ok(Self {
+            index,
+            rebuild_marker: None,
+            rebuild_required: AtomicBool::new(false),
+        })
     }
 
     /// Get a reference to the search index
@@ -72,6 +85,22 @@ impl BackgroundIndexer {
         config: &IndexingConfig,
     ) -> Result<IndexingResult> {
         let mut result = IndexingResult::default();
+
+        // A mismatched pre-versioned index was quarantined during open. Its
+        // indexed_at timestamps are no longer evidence that the new index is
+        // complete, so requeue all entry rows exactly once before draining the
+        // normal pending queue. The database update is durable even if the
+        // process exits before the marker is removed.
+        if self.rebuild_required.load(Ordering::Acquire) {
+            let entries = store.list()?;
+            let ids: Vec<&str> = entries.iter().map(|entry| entry.id.as_str()).collect();
+            store.mark_index_pending_batch(&ids)?;
+            if self.rebuild_required.swap(false, Ordering::AcqRel) {
+                if let Some(marker) = &self.rebuild_marker {
+                    let _ = std::fs::remove_file(marker);
+                }
+            }
+        }
 
         // Get pending entries
         let pending = store.list_pending_index(config.max_per_run)?;
@@ -155,6 +184,24 @@ mod tests {
     use crate::types::MemoryTier;
     use cas_core::hooks::{ContextQuery, ContextScorer};
     use std::time::Instant;
+
+    fn create_mismatched_legacy_index(path: &std::path::Path) {
+        use tantivy::schema::{Schema, STORED, TEXT};
+
+        std::fs::create_dir_all(path).expect("create legacy index directory");
+        let mut builder = Schema::builder();
+        builder.add_text_field("id", TEXT | STORED);
+        builder.add_text_field("content", TEXT);
+        let index = tantivy::Index::create_in_dir(path, builder.build()).expect("create legacy index");
+        let mut writer = index.writer(15_000_000).expect("legacy writer");
+        writer
+            .add_document(tantivy::doc!(
+                index.schema().get_field("id").expect("id field") => "legacy-entry",
+                index.schema().get_field("content").expect("content field") => "legacy content"
+            ))
+            .expect("write legacy document");
+        writer.commit().expect("commit legacy document");
+    }
 
     #[test]
     fn test_indexing_config_default() {
@@ -283,6 +330,140 @@ mod tests {
 
         assert!(canonical.join("meta.json").exists());
         assert!(!cas_root.join("index/meta.json").exists());
+    }
+
+    #[test]
+    fn compatible_pre_versioned_index_moves_once_and_remains_searchable() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cas_root = temp.path().join(".cas");
+        std::fs::create_dir_all(&cas_root).expect("create .cas");
+        let entry = Entry::new(
+            "compatible-legacy".to_string(),
+            "compatible legacy index survives migration".to_string(),
+        );
+        let legacy_dir = crate::hybrid_search::legacy_tantivy_index_dir(&cas_root);
+        let legacy = SearchIndex::open(&legacy_dir).expect("legacy index");
+        legacy.index_entry(&entry).expect("index legacy entry");
+        drop(legacy);
+
+        let current_dir = crate::hybrid_search::tantivy_index_dir(&cas_root);
+        let migrated = SearchIndex::open(&current_dir).expect("migrate index");
+        assert!(current_dir.join("meta.json").is_file());
+        assert!(!legacy_dir.exists(), "migration must retire the old path once");
+        let results = migrated
+            .search(
+                &SearchOptions {
+                    query: "survives migration".to_string(),
+                    ..Default::default()
+                },
+                std::slice::from_ref(&entry),
+            )
+            .expect("search migrated index");
+        assert_eq!(results.first().map(|result| result.id.as_str()), Some(entry.id.as_str()));
+
+        // A second open sees only the versioned path and must not repeat or
+        // recreate the legacy directory.
+        drop(migrated);
+        let _again = SearchIndex::open(&current_dir).expect("reopen migrated index");
+        assert!(!legacy_dir.exists());
+    }
+
+    #[test]
+    fn mismatched_pre_versioned_index_is_quarantined_and_rebuilt_once() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cas_root = temp.path().join(".cas");
+        std::fs::create_dir_all(&cas_root).expect("create .cas");
+        let store = open_store(&cas_root).expect("store");
+        let entry = Entry::new(
+            "mismatched-legacy".to_string(),
+            "mismatched legacy index is rebuilt safely".to_string(),
+        );
+        store.add(&entry).expect("add entry");
+        store.mark_indexed(&entry.id).expect("simulate old index state");
+
+        let legacy_dir = crate::hybrid_search::legacy_tantivy_index_dir(&cas_root);
+        create_mismatched_legacy_index(&legacy_dir);
+        let current_dir = crate::hybrid_search::tantivy_index_dir(&cas_root);
+        let marker = crate::hybrid_search::tantivy_rebuild_marker(&cas_root);
+
+        let indexer = BackgroundIndexer::open(&cas_root).expect("open versioned index");
+        assert!(current_dir.join("meta.json").is_file());
+        assert!(!legacy_dir.exists(), "mismatched path must be quarantined, not deleted");
+        assert!(marker.is_file(), "rebuild marker must survive the open");
+        assert!(cas_root.join("index/tantivy-legacy-v2").is_dir());
+
+        let first = indexer
+            .process_pending(store.as_ref(), &IndexingConfig::default())
+            .expect("rebuild pending entries");
+        assert_eq!(first.indexed, 1);
+        assert!(!marker.exists(), "background indexing consumes the marker once");
+
+        let second = BackgroundIndexer::open(&cas_root)
+            .expect("reopen rebuilt index")
+            .process_pending(store.as_ref(), &IndexingConfig::default())
+            .expect("drain second cycle");
+        assert_eq!(second.indexed, 0, "the migration must not requeue repeatedly");
+        let entries = store.list().expect("list entries");
+        let results = indexer
+            .index()
+            .search(
+                &SearchOptions {
+                    query: "rebuilt safely".to_string(),
+                    ..Default::default()
+                },
+                &entries,
+            )
+            .expect("search rebuilt index");
+        assert_eq!(results.first().map(|result| result.id.as_str()), Some(entry.id.as_str()));
+    }
+
+    #[test]
+    fn mismatched_versioned_open_preserves_the_existing_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cas_root = temp.path().join(".cas");
+        let current_dir = crate::hybrid_search::tantivy_index_dir(&cas_root);
+        create_mismatched_legacy_index(&current_dir);
+        let metadata = current_dir.join("meta.json");
+        let metadata_before = std::fs::read(&metadata).expect("read mismatched metadata");
+
+        let error = match SearchIndex::open(&current_dir) {
+            Ok(_) => panic!("mismatch must fail closed"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("schema mismatch"));
+        assert!(metadata.is_file(), "open must not delete a mismatched index");
+        assert_eq!(
+            std::fs::read(&metadata).expect("read preserved metadata"),
+            metadata_before,
+            "mismatch handling must leave the existing index byte-for-byte intact"
+        );
+    }
+
+    #[test]
+    fn explicit_rebuild_clears_documents_after_migration() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cas_root = temp.path().join(".cas");
+        std::fs::create_dir_all(&cas_root).expect("create .cas");
+        let entry = Entry::new(
+            "rebuild-clears".to_string(),
+            "stale document must not survive explicit rebuild".to_string(),
+        );
+        let current_dir = crate::hybrid_search::tantivy_index_dir(&cas_root);
+        let index = SearchIndex::open(&current_dir).expect("open index");
+        index.index_entry(&entry).expect("index entry");
+        drop(index);
+
+        let rebuilt = SearchIndex::rebuild(&current_dir).expect("rebuild index");
+        let results = rebuilt
+            .search(
+                &SearchOptions {
+                    query: "stale document".to_string(),
+                    ..Default::default()
+                },
+                std::slice::from_ref(&entry),
+            )
+            .expect("search rebuilt index");
+        assert!(results.is_empty(), "explicit rebuild must clear prior documents");
     }
 
     #[test]

--- a/cas-cli/src/hybrid_search/mod.rs
+++ b/cas-cli/src/hybrid_search/mod.rs
@@ -169,12 +169,51 @@ impl DocType {
 /// Default memory budget for BM25 index writer (50MB)
 pub const DEFAULT_WRITER_MEMORY: usize = 50_000_000;
 
+/// Expected number of fields in the current schema version.
+///
+/// The field count is part of the on-disk path so an older binary can never
+/// mistake the current index for its own and delete it while rebuilding.
+/// Bump this when adding new fields to trigger a one-time migration.
+pub(crate) const EXPECTED_FIELD_COUNT: usize = 15;
+
+const TANTIVY_INDEX_PREFIX: &str = "tantivy-v";
+const LEGACY_TANTIVY_INDEX_NAME: &str = "tantivy";
+
 /// Canonical location of the unified Tantivy index below a Cassy root.
 ///
 /// Every reader and writer must use this resolver. Keeping the path derivation
 /// here prevents the background daemon from silently creating a sibling index.
+/// The schema version in the directory name isolates mixed-version processes:
+/// an older binary still using `index/tantivy` cannot remove this directory.
 pub fn tantivy_index_dir(cas_dir: &Path) -> PathBuf {
-    cas_dir.join("index").join("tantivy")
+    cas_dir
+        .join("index")
+        .join(format!("{TANTIVY_INDEX_PREFIX}{EXPECTED_FIELD_COUNT}"))
+}
+
+/// Location used by releases before the versioned resolver was introduced.
+pub(crate) fn legacy_tantivy_index_dir(cas_dir: &Path) -> PathBuf {
+    cas_dir.join("index").join(LEGACY_TANTIVY_INDEX_NAME)
+}
+
+/// Durable marker set when a legacy index had to be rebuilt rather than moved.
+/// The background indexer consumes it by re-queueing all entry rows once.
+pub(crate) fn tantivy_rebuild_marker(cas_dir: &Path) -> PathBuf {
+    cas_dir
+        .join("index")
+        .join(format!(".{TANTIVY_INDEX_PREFIX}{EXPECTED_FIELD_COUNT}-rebuild"))
+}
+
+/// Resolve the rebuild marker from an already-resolved canonical index path.
+pub(crate) fn tantivy_rebuild_marker_for_index(index_dir: &Path) -> PathBuf {
+    index_dir
+        .parent()
+        .map(|index_parent| {
+            index_parent.join(format!(
+                ".{TANTIVY_INDEX_PREFIX}{EXPECTED_FIELD_COUNT}-rebuild"
+            ))
+        })
+        .unwrap_or_else(|| PathBuf::from(format!(".{TANTIVY_INDEX_PREFIX}{EXPECTED_FIELD_COUNT}-rebuild")))
 }
 
 /// Search index backed by Tantivy
@@ -289,10 +328,6 @@ pub struct SearchResult {
     /// Score after boosts applied
     pub boosted_score: f64,
 }
-
-/// Expected number of fields in the current schema version.
-/// Bump this when adding new fields to trigger automatic index rebuild.
-pub(crate) const EXPECTED_FIELD_COUNT: usize = 15;
 
 #[cfg(test)]
 mod tests {

--- a/cas-cli/src/hybrid_search/search_index_impl.rs
+++ b/cas-cli/src/hybrid_search/search_index_impl.rs
@@ -69,6 +69,7 @@ impl SearchIndex {
 
     /// Open or create a search index
     pub fn open(index_dir: &Path) -> Result<Self, MemError> {
+        prepare_versioned_index_dir(index_dir)?;
         let schema = Self::build_schema();
 
         let index = if index_dir.exists() && index_dir.join("meta.json").exists() {
@@ -77,16 +78,15 @@ impl SearchIndex {
             let existing_field_count = existing_index.schema().fields().count();
 
             if existing_field_count != EXPECTED_FIELD_COUNT {
-                // Schema mismatch - delete old index and recreate
-                tracing::info!(
-                    "Schema mismatch detected: existing index has {} fields, expected {}. Rebuilding index.",
-                    existing_field_count,
-                    EXPECTED_FIELD_COUNT
-                );
-                drop(existing_index); // Release file handles
-                std::fs::remove_dir_all(index_dir)?;
-                std::fs::create_dir_all(index_dir)?;
-                Index::create_in_dir(index_dir, schema.clone())?
+                // Never remove a directory merely because its schema is from
+                // another release. A still-running binary may be using the
+                // same path, and a caller can explicitly rebuild the
+                // versioned path through `rebuild` when it owns that action.
+                drop(existing_index);
+                return Err(MemError::Other(format!(
+                    "schema mismatch at {}: existing index has {existing_field_count} fields, expected {EXPECTED_FIELD_COUNT}; run the reindex maintenance action (`mcp__cas__system action=reindex bm25=true`) from an agent session",
+                    index_dir.display()
+                )));
             } else {
                 existing_index
             }
@@ -149,6 +149,22 @@ impl SearchIndex {
             cached_reader: std::sync::Mutex::new(None),
             cached_query_parser: std::sync::Mutex::new(None),
         })
+    }
+
+    /// Explicitly rebuild a versioned index directory.
+    ///
+    /// Automatic opens are read/create-only with respect to an existing
+    /// index. Rebuilding is reserved for an explicit reindex request, and is
+    /// confined to the caller's already-resolved schema-versioned path.
+    pub fn rebuild(index_dir: &Path) -> Result<Self, MemError> {
+        if index_dir.exists() {
+            std::fs::remove_dir_all(index_dir)?;
+        }
+        let index = Self::open(index_dir)?;
+        let mut writer = index.writer()?;
+        writer.delete_all_documents()?;
+        writer.commit()?;
+        Ok(index)
     }
 
     /// Open or create a search index with custom writer memory budget
@@ -827,4 +843,85 @@ impl SearchIndex {
         writer.commit()?;
         Ok(count)
     }
+}
+
+/// Move the pre-versioned canonical index out of the way once, before opening
+/// the current schema path. Same-schema indexes are retained by an atomic
+/// rename. Mismatched indexes are quarantined instead of deleted and leave a
+/// marker for the background indexer to requeue entry rows for a rebuild.
+fn prepare_versioned_index_dir(index_dir: &Path) -> Result<(), MemError> {
+    let Some(index_name) = index_dir.file_name().and_then(|name| name.to_str()) else {
+        return Ok(());
+    };
+    let expected_name = format!("tantivy-v{EXPECTED_FIELD_COUNT}");
+    if index_name != expected_name || index_dir.exists() {
+        return Ok(());
+    }
+
+    let Some(index_parent) = index_dir.parent() else {
+        return Ok(());
+    };
+    let legacy_dir = crate::hybrid_search::legacy_tantivy_index_dir(
+        index_parent.parent().unwrap_or(index_parent),
+    );
+    if !legacy_dir.join("meta.json").is_file() {
+        return Ok(());
+    }
+
+    let existing_index = Index::open_in_dir(&legacy_dir)?;
+    let existing_field_count = existing_index.schema().fields().count();
+    drop(existing_index);
+
+    std::fs::create_dir_all(index_parent)?;
+    if existing_field_count == EXPECTED_FIELD_COUNT {
+        match std::fs::rename(&legacy_dir, index_dir) {
+            Ok(()) => {
+                tracing::info!(
+                    from = %legacy_dir.display(),
+                    to = %index_dir.display(),
+                    "migrated Tantivy index to its schema-versioned path"
+                );
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error.into()),
+        }
+        return Ok(());
+    }
+
+    let marker = crate::hybrid_search::tantivy_rebuild_marker_for_index(index_dir);
+    std::fs::write(
+        &marker,
+        format!(
+            "legacy Tantivy index has {existing_field_count} fields; rebuild required for {EXPECTED_FIELD_COUNT}\n"
+        ),
+    )?;
+
+    // The suffix is deterministic for the normal one-time migration, while
+    // the loop preserves an old process that recreated `index/tantivy` after
+    // an earlier migration.
+    let mut quarantine = index_parent.join(format!(
+        "tantivy-legacy-v{existing_field_count}"
+    ));
+    let mut ordinal = 2;
+    while quarantine.exists() {
+        quarantine = index_parent.join(format!(
+            "tantivy-legacy-v{existing_field_count}-{ordinal}"
+        ));
+        ordinal += 1;
+    }
+    match std::fs::rename(&legacy_dir, &quarantine) {
+        Ok(()) => {
+            tracing::warn!(
+                from = %legacy_dir.display(),
+                to = %quarantine.display(),
+                existing_field_count,
+                expected_field_count = EXPECTED_FIELD_COUNT,
+                "quarantined a mismatched Tantivy index for one-time rebuild"
+            );
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    Ok(())
 }

--- a/cas-cli/src/mcp/tools/core/system.rs
+++ b/cas-cli/src/mcp/tools/core/system.rs
@@ -744,9 +744,10 @@ impl CasCore {
             let skills = skill_store.list(None).unwrap_or_default();
 
             let index_dir = crate::hybrid_search::tantivy_index_dir(&self.cas_root);
-            // Clear existing index first
-            let _ = std::fs::remove_dir_all(&index_dir);
-            match SearchIndex::open(&index_dir) {
+            // Rebuild only the current schema-versioned directory. Older
+            // binaries use the pre-versioned path and cannot be affected by
+            // this explicit rebuild.
+            match SearchIndex::rebuild(&index_dir) {
                 Ok(search) => {
                     let mut indexed = 0;
                     for entry in &entries {
@@ -785,6 +786,9 @@ impl CasCore {
                             tracing::warn!(error = %error, "artifact backfill indexing failed")
                         }
                     }
+                    let _ = std::fs::remove_file(
+                        crate::hybrid_search::tantivy_rebuild_marker(&self.cas_root),
+                    );
                     results.push(format!("BM25: Indexed {indexed} documents"));
                 }
                 Err(e) => results.push(format!("BM25: Failed - {e}")),

--- a/cas-cli/src/retrieval_eval.rs
+++ b/cas-cli/src/retrieval_eval.rs
@@ -397,7 +397,7 @@ impl ProductionScorerState {
 
 /// Live documents in the BM25 index `HybridSearch` actually reads.
 ///
-/// Read from the Tantivy `meta.json` at `<cas_dir>/index/tantivy` rather than
+/// Read from the Tantivy `meta.json` at the schema-versioned canonical path rather than
 /// through a search, because a search cannot distinguish "no lexical hits" from
 /// "no lexical index": the temporal channel returns results either way.
 /// Returns 0 when the index does not exist.
@@ -457,7 +457,7 @@ impl EvalCorpus {
     ///
     /// The index is written through `HybridSearch::open` + `index_entry` — the
     /// same production code the inline write sites use — so it lands in
-    /// `<cas_root>/index/tantivy`, exactly where
+    /// the schema-versioned canonical path, exactly where
     /// `HybridContextScorer::open_with_graph` reads from
     /// (hybrid_search/hybrid.rs:370). Deliberately NOT `BackgroundIndexer`,
     /// which writes to `<cas_root>/index` and is read by nothing.

--- a/cas-cli/src/retrieval_parity/mod.rs
+++ b/cas-cli/src/retrieval_parity/mod.rs
@@ -136,7 +136,8 @@ pub struct Baseline {
 /// Everything a capture or replay run needs to reach the stores.
 pub struct ParityContext {
     pub cas_dir: PathBuf,
-    /// Tantivy index directory; defaults to `<cas_dir>/index/tantivy`.
+    /// Tantivy index directory; defaults to the schema-versioned resolver
+    /// below `<cas_dir>/index/`.
     pub index_dir: PathBuf,
     /// Global memory store directory (the host's `~/.cas`, see
     /// [`crate::cli::retrieval_parity::resolve_global_cas_dir`]), when it holds

--- a/cas-cli/tests/mcp_tools_test/search_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/search_tools.rs
@@ -11,7 +11,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::ErrorCode;
 
 fn seed_projection_documents(cas_root: &std::path::Path) {
-    let index_dir = cas_root.join("index/tantivy");
+    let index_dir = cas::hybrid_search::tantivy_index_dir(cas_root);
     drop(cas::hybrid_search::SearchIndex::open(&index_dir).unwrap());
 
     let index = tantivy::Index::open_in_dir(index_dir).unwrap();

--- a/cas-cli/tests/mcp_tools_test/system_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/system_tools.rs
@@ -158,7 +158,9 @@ async fn task_focused_context_surfaces_preferences_and_task_content_matches() {
     // six-field index while HybridContextScorer expected cas-cli's 15-field
     // schema at the same path. Opening context then destructively rebuilt a
     // live index and could fail with ENOTEMPTY under suite concurrency.
-    let index = tantivy::Index::open_in_dir(temp.path().join(".cas/index/tantivy"))
+    let index = tantivy::Index::open_in_dir(cas::hybrid_search::tantivy_index_dir(
+        &temp.path().join(".cas"),
+    ))
         .expect("the production write path should create a readable search index");
     let field_names: Vec<String> = index
         .schema()
@@ -431,7 +433,9 @@ async fn doctor_flags_stale_search_index_after_store_growth() {
         .add(&indexed_task)
         .expect("indexed task should be stored");
 
-    let search = cas::hybrid_search::SearchIndex::open(&cas_dir.join("index/tantivy"))
+    let search = cas::hybrid_search::SearchIndex::open(
+        &cas::hybrid_search::tantivy_index_dir(&cas_dir),
+    )
         .expect("search index should open");
     search
         .index_task(&indexed_task)
@@ -465,7 +469,9 @@ async fn doctor_accepts_a_fresh_search_index() {
     let task = Task::new("task-fresh".to_string(), "Freshly indexed task".to_string());
     task_store.add(&task).expect("task should be stored");
 
-    let search = cas::hybrid_search::SearchIndex::open(&cas_dir.join("index/tantivy"))
+    let search = cas::hybrid_search::SearchIndex::open(
+        &cas::hybrid_search::tantivy_index_dir(&cas_dir),
+    )
         .expect("search index should open");
     search.index_task(&task).expect("task should be indexed");
 

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: cas-cli/tests/component_output_test.rs
-assertion_line: 200
 expression: redacted
 ---
 cas doctor
@@ -13,7 +12,7 @@ cas doctor
 [OK] tables: [N] tables, 787 columns, 208 rows total
 [OK] entry store: [N] entries accessible
 [OK] legacy search index: no stray Tantivy root below `.cas/index/`
-[WARN] search index: Index not found. Will be created on first search.
+[WARN] search index: Index not found at [CAS_PATH] Will be created on first search.
 [WARN] symbol index: nothing indexed for this project (0 symbol(s) in the store across all repositories); the code search index is missing. The daemon only indexes while idle — run `cas index code` to catch up now.
 [OK] embedding drain: no cloud embedding capability (not logged in); nothing is queued
 [WARN] code history index: cannot check code history index: not a git repository: [TEMP_PATH] ([GIT_NOT_REPOSITORY])

--- a/cas-cli/tests/update_all_projects_test.rs
+++ b/cas-cli/tests/update_all_projects_test.rs
@@ -139,7 +139,9 @@ fn all_projects_repairs_stray_search_roots_and_reports_clean_projects() {
 
     let store = cas::store::open_store(&stranded.join(".cas")).expect("reopen store");
     let entries = store.list().expect("list entries");
-    let hits = SearchIndex::open(&stranded.join(".cas/index/tantivy"))
+    let hits = SearchIndex::open(&cas::hybrid_search::tantivy_index_dir(
+        &stranded.join(".cas"),
+    ))
         .expect("open canonical index")
         .search(
             &SearchOptions {

--- a/docs/commander-fleet-runbook.md
+++ b/docs/commander-fleet-runbook.md
@@ -138,6 +138,16 @@ restart the installed service or run `cas hub restart` and repeat the full
 start/health/status sequence. Preserve `~/.cas/hub/`; it contains the stable
 machine identity and paired-device state. Never delete it as an upgrade step.
 
+### Search index schema upgrades
+
+After installing a release that changes the memory search schema, restart every
+running `cas serve` process before checking search health. Cassy stores the
+active Tantivy index under a schema-versioned path (for example,
+`.cas/index/tantivy-v15`), so an older process may continue using the retired
+`.cas/index/tantivy` path without deleting the new index. If `cas doctor` reports
+a pre-versioned index, run the reindex maintenance action (`mcp__cas__system action=reindex bm25=true`) from an agent session once; it migrates a compatible
+index or quarantines an incompatible one and rebuilds the versioned path.
+
 ## H5 proof record (2026-08-09)
 
 Executed in the H5 development environment:


### PR DESCRIPTION
## Summary

`SearchIndex::open` no longer deletes the canonical Tantivy directory on a schema field-count mismatch — a mixed-version fleet (old `cas serve` still running after an update) could wipe the live index.

- canonical path is now schema-versioned (`index/tantivy-v15`); an older binary on `index/tantivy` cannot touch it
- `open` fails closed on mismatch (byte-preservation regression test); destructive rebuild only via the explicit reindex maintenance action, confined to the versioned path
- compatible pre-versioned index migrates once by atomic rename; mismatched one is quarantined (never deleted) with a durable marker the background indexer consumes by re-queueing entries exactly once
- doctor reports a pre-versioned index; fleet runbook documents the upgrade step

Proofs: hybrid_search 128/128, mcp_tools_test 359/359, doctor 56/56, cargo check exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnQNXymumfZD2Wj5USRp2m
