### PR TITLE
chore(release): prepare v3.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.7.4] - 2026-08-31
+
+### Changed
+- Curated memories with importance at least 0.9 or positive helpful feedback
+  stay in the working tier during decay, and reading a cold or archived memory
+  brings it back to working; `[memory.decay]` settings and doctor counters make
+  the policy visible.
+- Legacy search-index inspection counts metadata without loading every stored
+  document, so doctor and daemon checks are fast even with stranded entries.
+- Tantivy indexes now use versioned paths; schema mismatches preserve the old
+  directory and explicit reindexing migrates or quarantines it safely.
+
 ## [3.7.3] - 2026-08-31
 
 ### Fixed
@@ -1566,7 +1578,8 @@ After upgrading, the new gates fire on `task.close` calls. If a worker hits the 
 ### Added
 - Initial stable release with core functionality.
 
-[Unreleased]: https://github.com/Richards-LLC/cassy/compare/v3.7.3...HEAD
+[Unreleased]: https://github.com/Richards-LLC/cassy/compare/v3.7.4...HEAD
+[3.7.4]: https://github.com/Richards-LLC/cassy/compare/v3.7.3...v3.7.4
 [3.7.3]: https://github.com/Richards-LLC/cassy/compare/v3.7.2...v3.7.3
 [3.7.2]: https://github.com/Richards-LLC/cassy/compare/v3.7.1...v3.7.2
 [3.7.1]: https://github.com/Richards-LLC/cassy/compare/v3.7.0...v3.7.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.7.3"
+version = "3.7.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.7.3"
+version = "3.7.4"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.7.3"
+version = "3.7.4"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.7.3"
+version = "3.7.4"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.7.3"
+version = "3.7.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.7.3"
+version = "3.7.4"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.7.3"
+version = "3.7.4"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.7.3"
+version = "3.7.4"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.7.3"
+version = "3.7.4"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.7.3"
+version = "3.7.4"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.7.3"
+version = "3.7.4"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.7.3"
+version = "3.7.4"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-31-v3.7.4-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.4-slack.md
@@ -1,0 +1,48 @@
+# Release notes — Cassy v3.7.4 curated memory and safer search maintenance
+
+**Channel:** `#cas-internal` · **Deploy:** Live on production · **Status:** Draft
+
+**Published assets:** Linux x86_64 archive SHA-256 `{{LINUX_SHA256}}`; macOS ARM64 archive SHA-256 `{{MACOS_SHA256}}`.
+
+## User thread
+
+**Top-level:**
+
+Live on production — **User** — Important memories now stay findable while search maintenance becomes safer and faster.
+
+**Reply (Was → Now):**
+
+- **Was** → memories you marked important could silently fall out of session recall after about two weeks. **Now** → highly important or helpful memories stay eligible, and reading a cold or archived memory brings it back to working memory.
+- **Was** → an older running process could wipe a rebuilt search index during an update. **Now** → search indexes live at versioned paths, and a schema mismatch preserves existing data for explicit migration.
+- **Was** → doctor loaded every stranded document just to count it. **Now** → doctor counts index metadata directly, so the check is fast even when many documents are stranded.
+- Install: use `cas update` for an existing installation, or download the v3.7.4 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64 (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+
+Live on production — **Dev** — Curated-memory decay and versioned Tantivy maintenance now preserve state across mixed-version processes.
+
+**Reply (Was → Now):**
+
+- **Was** → decay could demote curated entries below the working tier, and reads did not restore cold or archived memories. **Now** → the configurable `[memory.decay]` policy protects importance ≥ 0.9 or helpful entries, promotes accessed entries, and records counters for doctor.
+- **Was** → legacy-index inspection fetched stored fields for every document, and schema mismatch handling could remove the existing path. **Now** → inspection reads live segment metadata and `doc_type` terms only, while versioned Tantivy paths preserve mismatched indexes for explicit reindex migration or quarantine.
+- **Was** → legacy repair materialized the complete entry-ID set before requeueing. **Now** → repair fetches stored IDs only on the repair path and requeues bounded batches before retirement.
+- Validation and artifact: locked metadata, `cargo check -p cas --locked`, migration-snapshot checks, `component_output_test`, and `git diff --check`; the published archives are `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and macOS are both available from CI.
+
+## Posting sequence
+
+1. Replace the checksum placeholders after the tagged GitHub workflow publishes both assets.
+2. Post the User top-level and its only reply, then the Dev top-level and its only reply.
+3. Append the returned timestamps and permalinks below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |


### PR DESCRIPTION
## Summary

- bump the six release-train crates and `Cargo.lock` to v3.7.4
- document curated-memory tier protection, metadata-only legacy-index inspection, and versioned Tantivy paths
- add the v3.7.4 runtime Slack draft with User/Dev Was → Now threads

## Validation

- `cargo metadata --locked --format-version 1`
- `cargo check -p cas --locked`
- `scripts/check-release-migration-snapshots.sh`
- `scripts/run-scoped-tests.sh -p cas --test component_output_test` (13 passed)
- `git diff --check`

Task: cas-132e
