### PR TITLE
docs(release): record v3.7.4 publication + POSTED receipts

### DIFF
--- a/docs/release-notes/2026-08-31-v3.7.4-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.4-slack.md
@@ -1,8 +1,8 @@
 # Release notes — Cassy v3.7.4 curated memory and safer search maintenance
 
-**Channel:** `#cas-internal` · **Deploy:** Live on production · **Status:** Draft
+**Channel:** `#cas-internal` · **Deploy:** Live on production · **Status:** Posted 2026-08-31
 
-**Published assets:** Linux x86_64 archive SHA-256 `{{LINUX_SHA256}}`; macOS ARM64 archive SHA-256 `{{MACOS_SHA256}}`.
+**Published assets:** Linux x86_64 archive SHA-256 `2b6b27e2452408c76978fc551e8964806799122e060d7bac041f2ef63e898eb4`; macOS ARM64 archive SHA-256 `48b0125979f0ba566ce626027fe9813860d2ac07f3728cbf4c654ded9e37c8fb`.
 
 ## User thread
 
@@ -15,7 +15,7 @@ Live on production — **User** — Important memories now stay findable while s
 - **Was** → memories you marked important could silently fall out of session recall after about two weeks. **Now** → highly important or helpful memories stay eligible, and reading a cold or archived memory brings it back to working memory.
 - **Was** → an older running process could wipe a rebuilt search index during an update. **Now** → search indexes live at versioned paths, and a schema mismatch preserves existing data for explicit migration.
 - **Was** → doctor loaded every stranded document just to count it. **Now** → doctor counts index metadata directly, so the check is fast even when many documents are stranded.
-- Install: use `cas update` for an existing installation, or download the v3.7.4 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64 (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+- Install: use `cas update` for an existing installation, or download the v3.7.4 archive for Linux x86_64 (SHA-256 `2b6b27e2452408c76978fc551e8964806799122e060d7bac041f2ef63e898eb4`) or macOS ARM64 (SHA-256 `48b0125979f0ba566ce626027fe9813860d2ac07f3728cbf4c654ded9e37c8fb`) from the GitHub release.
 
 ## Dev thread
 
@@ -28,7 +28,7 @@ Live on production — **Dev** — Curated-memory decay and versioned Tantivy ma
 - **Was** → decay could demote curated entries below the working tier, and reads did not restore cold or archived memories. **Now** → the configurable `[memory.decay]` policy protects importance ≥ 0.9 or helpful entries, promotes accessed entries, and records counters for doctor.
 - **Was** → legacy-index inspection fetched stored fields for every document, and schema mismatch handling could remove the existing path. **Now** → inspection reads live segment metadata and `doc_type` terms only, while versioned Tantivy paths preserve mismatched indexes for explicit reindex migration or quarantine.
 - **Was** → legacy repair materialized the complete entry-ID set before requeueing. **Now** → repair fetches stored IDs only on the repair path and requeues bounded batches before retirement.
-- Validation and artifact: locked metadata, `cargo check -p cas --locked`, migration-snapshot checks, `component_output_test`, and `git diff --check`; the published archives are `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and macOS are both available from CI.
+- Validation and artifact: locked metadata, `cargo check -p cas --locked`, migration-snapshot checks, `component_output_test`, and `git diff --check`; the published archives are `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `2b6b27e2452408c76978fc551e8964806799122e060d7bac041f2ef63e898eb4`) and `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `48b0125979f0ba566ce626027fe9813860d2ac07f3728cbf4c654ded9e37c8fb`). Linux and macOS are both available from CI.
 
 ## Posting sequence
 
@@ -38,11 +38,11 @@ Live on production — **Dev** — Curated-memory decay and versioned Tantivy ma
 
 ## POSTED
 
-Channel: `#cas-internal` (`C0B44GUKDK2`).
+Channel: `#cas-internal` (`C0B44GUKDK2`) · Posted 2026-08-31 via the approved Claude profile route.
 
 | Message | UTC timestamp | Permalink |
 | --- | --- | --- |
-| User top-level |  |  |
-| User reply (Was → Now) |  |  |
-| Dev top-level |  |  |
-| Dev reply (Was → Now) |  |  |
+| User top-level | 1788201088.912519 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788201088912519 |
+| User reply (Was → Now) | 1788201098.196099 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788201098196099?thread_ts=1788201088.912519&cid=C0B44GUKDK2 |
+| Dev top-level | 1788201098.687029 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788201098687029 |
+| Dev reply (Was → Now) | 1788201107.092019 | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788201107092019?thread_ts=1788201098.687029&cid=C0B44GUKDK2 |


### PR DESCRIPTION
## Summary

- Record the verified v3.7.4 published-asset digests and publication status.
- Record the four #cas-internal User/Dev Slack timestamps and permalinks.

## Receipts

- Published asset receipt: `/home/pippenz/.cas/artifacts/cas-132e/release-published-receipt.log` (exit 0; fresh downloads matched GitHub digests).
- Latency receipt: `/home/pippenz/.cas/artifacts/cas-132e/release-latency-receipt.log` (166 seconds, within 600-second budget).
- Host update: `/home/pippenz/.cas/artifacts/cas-132e/cas-update.log` (exit 0; 14 succeeded, 0 failed).
- Host version: `/home/pippenz/.cas/artifacts/cas-132e/host-version.log` (`cas 3.7.4 (c94bc4c 2026-08-31)`).
- Tag-sourced clean install: `/home/pippenz/.cas/artifacts/cas-132e/clean-install.log` (install and version exit 0; `cas 3.7.4 (c94bc4c 2026-08-31)`).
- Slack posting: `/home/pippenz/.cas/artifacts/cas-132e/slack-preflight.log` and `/home/pippenz/.cas/artifacts/cas-132e/slack-post.log`.

## Scope

Documentation only: `docs/release-notes/2026-08-31-v3.7.4-slack.md`.
