### PR TITLE
fix(cloud): cas cloud push drains the full backlog and names skipped team rows

### DIFF
--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -11,9 +11,9 @@ use std::time::Duration;
 
 use crate::cli::Cli;
 use crate::cloud::{
-    BackfillOutcome, CloudConfig, FetchTeamsOutcome, PersonalScopeNotice, SyncQueue, TeamInfo,
-    fetch_and_cache_teams, maybe_apply_team_backfill, maybe_mark_personal_scope_notice,
-    teams_cache_stale, user_level_cloud_json_path,
+    BackfillOutcome, CloudConfig, CloudSyncerConfig, FetchTeamsOutcome, PersonalScopeNotice,
+    SyncQueue, TeamInfo, fetch_and_cache_teams, maybe_apply_team_backfill,
+    maybe_mark_personal_scope_notice, teams_cache_stale, user_level_cloud_json_path,
 };
 use crate::ui::components::Formatter;
 use crate::ui::theme::ActiveTheme;
@@ -132,6 +132,16 @@ pub struct CloudProjectSetArgs {
     pub canonical_id: String,
 }
 
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| format!("expected a positive integer, got {value:?}"))?;
+    if parsed == 0 {
+        return Err("expected a positive integer, got 0".to_string());
+    }
+    Ok(parsed)
+}
+
 #[derive(Parser)]
 pub struct CloudPushArgs {
     /// Push only entries
@@ -145,6 +155,10 @@ pub struct CloudPushArgs {
     /// Dry run (don't actually push)
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Stop after this many queue batches instead of draining the full backlog.
+    #[arg(long, value_parser = parse_positive_usize)]
+    pub max_batches: Option<usize>,
 
     /// Allow re-homing existing cloud entities to the current project slug.
     ///
@@ -2396,12 +2410,50 @@ fn push_result_counts(
         .collect()
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+struct SkippedTeamBacklog {
+    team_id: String,
+    pending: usize,
+    failed: usize,
+    command: &'static str,
+}
+
+impl SkippedTeamBacklog {
+    fn total(&self) -> usize {
+        self.pending + self.failed
+    }
+}
+
+/// Personal `cloud push` deliberately does not send the team endpoint. Make
+/// that boundary visible whenever the active team's queue has rows, so a
+/// successful personal push cannot falsely imply that the whole queue moved.
+fn active_team_backlog(
+    queue: &SyncQueue,
+    config: &CloudConfig,
+) -> anyhow::Result<Option<SkippedTeamBacklog>> {
+    let Some(team_id) = config.active_team_id() else {
+        return Ok(None);
+    };
+    let pending =
+        queue.pending_count_for_team(&team_id, CloudSyncerConfig::default().max_retries)?;
+    let failed = queue.failed_count_for_team(&team_id, CloudSyncerConfig::default().max_retries)?;
+    if pending == 0 && failed == 0 {
+        return Ok(None);
+    }
+    Ok(Some(SkippedTeamBacklog {
+        team_id,
+        pending,
+        failed,
+        command: "cas cloud sync",
+    }))
+}
+
 /// Queue-driven personal push, rooted explicitly at `cas_root`.
 #[doc(hidden)]
 pub fn execute_push(args: &CloudPushArgs, cli: &Cli, cas_root: &Path) -> anyhow::Result<()> {
     use std::sync::Arc;
 
-    use crate::cloud::{CloudSyncer, CloudSyncerConfig, PushScope, resolve_canonical_id};
+    use crate::cloud::{CloudSyncer, PushScope, resolve_canonical_id};
 
     let config = CloudConfig::load_from_cas_dir_inheriting_user_credentials(cas_root)?;
     if config.token.is_none() {
@@ -2421,29 +2473,32 @@ pub fn execute_push(args: &CloudPushArgs, cli: &Cli, cas_root: &Path) -> anyhow:
     queue.init()?;
     let syncer = CloudSyncer::new_for_project(
         queue.clone(),
-        config,
+        config.clone(),
         CloudSyncerConfig::default(),
         project_id.clone(),
         cas_root,
     );
     let plan = syncer.plan_push(scope)?;
+    let team_backlog = active_team_backlog(&queue, &config)?;
 
     if args.dry_run {
         if cli.json {
-            println!(
-                "{}",
-                serde_json::json!({
+            let mut output = serde_json::json!({
                     "dry_run": true,
                     "root": cas_root,
                     "project_canonical_id": project_id,
                     "plan": plan,
-                })
-            );
+                    "max_batches": args.max_batches,
+            });
+            if let Some(backlog) = &team_backlog {
+                output["team_backlog_skipped"] = serde_json::to_value(backlog)?;
+            }
+            println!("{output}");
         } else {
             let mut out = io::stdout();
             let mut fmt = Formatter::stdout(&mut out, ActiveTheme::default());
             fmt.write_accent("  \u{2192} ")?;
-            fmt.write_raw("Dry run - next queued push batch:")?;
+            fmt.write_raw("Dry run - would drain all matching queued push batches:")?;
             fmt.newline()?;
             fmt.write_raw(&format!("    root: {}", cas_root.display()))?;
             fmt.newline()?;
@@ -2451,14 +2506,28 @@ pub fn execute_push(args: &CloudPushArgs, cli: &Cli, cas_root: &Path) -> anyhow:
             fmt.newline()?;
             fmt.write_raw(&format!("    scope: {}", scope.label()))?;
             fmt.newline()?;
-            for (key, count) in &plan.counts {
-                fmt.write_raw(&format!("    {count} {key}"))?;
+            fmt.write_raw(&format!(
+                "    matching backlog: {} row(s)",
+                plan.total_matching
+            ))?;
+            fmt.newline()?;
+            fmt.write_raw(&format!(
+                "    batch limit: {} row(s) per request",
+                plan.batch_limit
+            ))?;
+            fmt.newline()?;
+            if let Some(max_batches) = args.max_batches {
+                fmt.write_raw(&format!("    max batches: {max_batches}"))?;
                 fmt.newline()?;
             }
-            if plan.batch_limit_reached {
+            for (key, count) in &plan.counts {
+                fmt.write_raw(&format!("    next batch: {count} {key}"))?;
+                fmt.newline()?;
+            }
+            if let Some(backlog) = &team_backlog {
                 fmt.write_raw(&format!(
-                    "    batch limit {} reached; the total matching backlog may be larger",
-                    plan.batch_limit
+                    "    team backlog skipped: {} row(s); run `cas cloud sync`",
+                    backlog.total()
                 ))?;
                 fmt.newline()?;
             }
@@ -2480,44 +2549,73 @@ pub fn execute_push(args: &CloudPushArgs, cli: &Cli, cas_root: &Path) -> anyhow:
         return Ok(());
     }
 
-    let result = syncer.push_scoped(scope)?;
+    let result = match args.max_batches {
+        Some(max_batches) => syncer.push_scoped_with_max_batches(scope, max_batches)?,
+        None => syncer.push_scoped(scope)?,
+    };
     if result.errors.is_empty() {
         if let Err(error) = queue.set_metadata("last_push_canonical_id", &project_id) {
             tracing::warn!(%error, %project_id, "failed to record last push project scope");
         }
     }
     let counts = push_result_counts(&result, scope);
+    let personal_complete = result.errors.is_empty()
+        && result.remaining_backlog.pending == 0
+        && result.remaining_backlog.failed == 0;
+    let push_complete = personal_complete && team_backlog.is_none();
 
     if cli.json {
-        println!(
-            "{}",
-            serde_json::json!({
-                "status": if result.errors.is_empty() { "ok" } else { "partial" },
+        let mut output = serde_json::json!({
+                "status": if push_complete { "ok" } else { "partial" },
                 "source": "sync_queue",
                 "root": cas_root,
                 "project_canonical_id": project_id,
                 "scope": scope,
                 "pushed": counts,
+                "total_pushed": result.total_pushed(),
+                "batches_run": result.batches_run,
+                "remaining_backlog": result.remaining_backlog,
                 "errors": result.concise_errors(),
-            })
-        );
+        });
+        if let Some(backlog) = &team_backlog {
+            output["team_backlog_skipped"] = serde_json::to_value(backlog)?;
+        }
+        println!("{output}");
     } else {
         let mut out = io::stdout();
         let mut fmt = Formatter::stdout(&mut out, ActiveTheme::default());
-        if result.errors.is_empty() {
+        if push_complete {
             fmt.success("Push complete")?;
         } else {
             let warning_color = fmt.theme().palette.status_warning;
             fmt.write_colored("  ! ", warning_color)?;
-            fmt.write_raw("Push incomplete; failed rows remain queued")?;
+            fmt.write_raw("Push incomplete; queued rows remain")?;
             fmt.newline()?;
         }
+        fmt.write_raw(&format!("    batches: {}", result.batches_run))?;
+        fmt.newline()?;
+        fmt.write_raw(&format!(
+            "    remaining: {} pending, {} failed/parked",
+            result.remaining_backlog.pending, result.remaining_backlog.failed
+        ))?;
+        fmt.newline()?;
         for (key, count) in counts {
             fmt.write_raw(&format!("    {key}: {count} pushed"))?;
             fmt.newline()?;
         }
+        for error in &result.remaining_backlog.failed_errors {
+            fmt.write_raw(&format!("    remaining error: {error}"))?;
+            fmt.newline()?;
+        }
         for error in result.concise_errors() {
             fmt.write_raw(&format!("    error: {error}"))?;
+            fmt.newline()?;
+        }
+        if let Some(backlog) = team_backlog {
+            fmt.write_raw(&format!(
+                "    team backlog skipped: {} row(s); run `cas cloud sync`",
+                backlog.total()
+            ))?;
             fmt.newline()?;
         }
     }
@@ -2924,6 +3022,7 @@ pub fn execute_sync(args: &CloudSyncArgs, cli: &Cli, cas_root: &Path) -> anyhow:
             entries_only: false,
             tasks_only: false,
             dry_run: args.dry_run,
+            max_batches: None,
             rehome: args.rehome,
         },
         cli,
@@ -4622,6 +4721,43 @@ mod team_cmd_tests {
     use tempfile::TempDir;
     use wiremock::matchers::{header, method, path, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn active_team_backlog_is_reported_with_sync_command() {
+        let root = TempDir::new().unwrap();
+        let queue = SyncQueue::open(root.path()).unwrap();
+        queue.init().unwrap();
+        queue
+            .enqueue_for_team(
+                crate::cloud::EntityType::Entry,
+                "team-entry",
+                crate::cloud::SyncOperation::Upsert,
+                Some(r#"{"id":"team-entry"}"#),
+                "team-42",
+            )
+            .unwrap();
+        queue
+            .enqueue_for_team(
+                crate::cloud::EntityType::Task,
+                "team-task",
+                crate::cloud::SyncOperation::Upsert,
+                Some(r#"{"id":"team-task"}"#),
+                "team-42",
+            )
+            .unwrap();
+
+        let config = CloudConfig {
+            team_id: Some("team-42".to_string()),
+            ..Default::default()
+        };
+        let backlog = active_team_backlog(&queue, &config).unwrap().unwrap();
+
+        assert_eq!(backlog.team_id, "team-42");
+        assert_eq!(backlog.pending, 2);
+        assert_eq!(backlog.failed, 0);
+        assert_eq!(backlog.command, "cas cloud sync");
+        assert_eq!(backlog.total(), 2);
+    }
 
     #[test]
     fn local_unlink_removes_only_the_project_cloud_link() {

--- a/cas-cli/src/cloud/sync_queue/maintenance.rs
+++ b/cas-cli/src/cloud/sync_queue/maintenance.rs
@@ -91,6 +91,61 @@ impl SyncQueue {
         Ok(count as usize)
     }
 
+    /// Get the number of pending personal rows for one entity scope.
+    pub fn pending_count_for_entity_type(
+        &self,
+        entity_type: Option<crate::cloud::EntityType>,
+        max_retries: i32,
+    ) -> Result<usize, CasError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            r#"
+            SELECT COUNT(*) FROM sync_queue
+            WHERE retry_count < ?1 AND (team_id IS NULL OR team_id = '')
+              AND entity_type != 'knowledge_page'
+              AND (?2 IS NULL OR entity_type = ?2)
+            "#,
+            params![max_retries, entity_type.map(|kind| kind.as_str())],
+            |row| row.get(0),
+        )?;
+        Ok(count as usize)
+    }
+
+    /// Get the number of failed personal rows for one entity scope.
+    pub fn failed_count_for_entity_type(
+        &self,
+        entity_type: Option<crate::cloud::EntityType>,
+        max_retries: i32,
+    ) -> Result<usize, CasError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            r#"
+            SELECT COUNT(*) FROM sync_queue
+            WHERE retry_count >= ?1 AND (team_id IS NULL OR team_id = '')
+              AND entity_type != 'knowledge_page'
+              AND (?2 IS NULL OR entity_type = ?2)
+            "#,
+            params![max_retries, entity_type.map(|kind| kind.as_str())],
+            |row| row.get(0),
+        )?;
+        Ok(count as usize)
+    }
+
+    /// Get the number of failed rows for one active team.
+    pub fn failed_count_for_team(
+        &self,
+        team_id: &str,
+        max_retries: i32,
+    ) -> Result<usize, CasError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM sync_queue WHERE retry_count >= ?1 AND team_id = ?2",
+            params![max_retries, team_id],
+            |row| row.get(0),
+        )?;
+        Ok(count as usize)
+    }
+
     /// Clear failed items older than the specified number of days.
     pub fn prune_failed(&self, older_than_days: i64, max_retries: i32) -> Result<usize, CasError> {
         let conn = self.conn.lock().unwrap();

--- a/cas-cli/src/cloud/sync_queue/queue_ops.rs
+++ b/cas-cli/src/cloud/sync_queue/queue_ops.rs
@@ -146,6 +146,40 @@ impl SyncQueue {
         Ok(items)
     }
 
+    /// Get retained failed personal rows for operator-facing diagnostics.
+    pub fn failed_for_entity_type(
+        &self,
+        entity_type: Option<EntityType>,
+        max_retries: i32,
+        limit: usize,
+    ) -> Result<Vec<QueuedSync>, CasError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            r#"
+            SELECT id, entity_type, entity_id, operation, payload, team_id, created_at, retry_count, last_error
+            FROM sync_queue
+            WHERE retry_count >= ?1 AND (team_id IS NULL OR team_id = '')
+              AND entity_type != 'knowledge_page'
+              AND (?3 IS NULL OR entity_type = ?3)
+            ORDER BY id DESC
+            LIMIT ?2
+            "#,
+        )?;
+
+        let items = stmt
+            .query_map(
+                params![
+                    max_retries,
+                    limit as i64,
+                    entity_type.map(|kind| kind.as_str())
+                ],
+                Self::map_row,
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(items)
+    }
+
     /// Get pending items for a specific team.
     pub fn pending_for_team(
         &self,

--- a/cas-cli/src/cloud/syncer/mod.rs
+++ b/cas-cli/src/cloud/syncer/mod.rs
@@ -23,6 +23,16 @@ mod team_push;
 #[cfg(test)]
 mod tests;
 
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+pub struct PushBacklog {
+    /// Rows still eligible for a push attempt.
+    pub pending: usize,
+    /// Rows retained after reaching the retry limit (including parked rows).
+    pub failed: usize,
+    /// Operator-facing diagnostics from retained failed rows.
+    pub failed_errors: Vec<String>,
+}
+
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct SyncResult {
     /// Number of entries pushed
@@ -75,6 +85,10 @@ pub struct SyncResult {
     pub conflicts_resolved: usize,
     /// Errors encountered during sync
     pub errors: Vec<String>,
+    /// Number of personal queue batches fetched and attempted.
+    pub batches_run: usize,
+    /// Personal queue rows that remain after this push invocation.
+    pub remaining_backlog: PushBacklog,
     /// Duration of sync in milliseconds
     pub duration_ms: u64,
     /// Task lifecycle changes actually applied by a pull. These are kept
@@ -149,6 +163,8 @@ pub struct PushPlan {
     pub scope: PushScope,
     pub counts: BTreeMap<String, usize>,
     pub total_in_next_batch: usize,
+    /// Total eligible personal rows in the selected scope.
+    pub total_matching: usize,
     pub batch_limit: usize,
     /// Conservative saturation marker. At exactly the query limit the queue
     /// read cannot prove whether more matching rows exist, so callers must not

--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -1375,6 +1375,8 @@ impl CloudSyncer {
                 pull_result.errors,
             ]
             .concat(),
+            batches_run: push_result.batches_run + team_push_result.batches_run,
+            remaining_backlog: push_result.remaining_backlog,
             duration_ms: start.elapsed().as_millis() as u64,
         })
     }

--- a/cas-cli/src/cloud/syncer/push.rs
+++ b/cas-cli/src/cloud/syncer/push.rs
@@ -5,8 +5,9 @@ use std::io::Write;
 use std::time::Instant;
 use tracing::warn;
 
+use crate::cloud::sync_queue::PendingByType;
 use crate::cloud::syncer::{
-    CloudSyncer, PushItemizedFailure, PushPlan, PushResponse, PushScope, SyncResult,
+    CloudSyncer, PushBacklog, PushItemizedFailure, PushPlan, PushResponse, PushScope, SyncResult,
 };
 use crate::cloud::{QueuedSync, SyncOperation};
 use crate::error::CasError;
@@ -25,6 +26,9 @@ impl CloudSyncer {
             batch_limit,
             self.config.max_retries,
         )?;
+        let total_matching = self
+            .queue
+            .pending_count_for_entity_type(scope.entity_type(), self.config.max_retries)?;
         let mut counts = scope
             .planned_keys()
             .iter()
@@ -41,6 +45,7 @@ impl CloudSyncer {
             scope,
             counts,
             total_in_next_batch: items.len(),
+            total_matching,
             batch_limit,
             batch_limit_reached: items.len() == batch_limit,
         })
@@ -49,6 +54,17 @@ impl CloudSyncer {
     /// Push only queue rows selected by `scope`.
     pub fn push_scoped(&self, scope: PushScope) -> Result<SyncResult, CasError> {
         self.push_scoped_with_sessions(scope, &[])
+    }
+
+    /// Push at most `max_batches` queue batches. This is an escape hatch for
+    /// operators who need to bound a large backlog; the default remains an
+    /// unbounded drain with the per-request limits in [`CloudSyncerConfig`].
+    pub fn push_scoped_with_max_batches(
+        &self,
+        scope: PushScope,
+        max_batches: usize,
+    ) -> Result<SyncResult, CasError> {
+        self.push_scoped_with_sessions_and_limit(scope, &[], Some(max_batches.max(1)))
     }
 
     /// Push queued changes and sessions to cloud
@@ -61,6 +77,15 @@ impl CloudSyncer {
         scope: PushScope,
         sessions: &[Session],
     ) -> Result<SyncResult, CasError> {
+        self.push_scoped_with_sessions_and_limit(scope, sessions, None)
+    }
+
+    fn push_scoped_with_sessions_and_limit(
+        &self,
+        scope: PushScope,
+        sessions: &[Session],
+        max_batches: Option<usize>,
+    ) -> Result<SyncResult, CasError> {
         let mut result = SyncResult::default();
         let start = Instant::now();
 
@@ -69,151 +94,54 @@ impl CloudSyncer {
         }
 
         let batch_limit = self.config.batch_size.max(1);
-        let pending = match scope.entity_type() {
-            Some(entity_type) => self.queue.pending_by_type_for_entity(
-                entity_type,
-                batch_limit,
-                self.config.max_retries,
-            )?,
-            None => self
-                .queue
-                .pending_by_type(batch_limit, self.config.max_retries)?,
-        };
-
-        // Check if there's anything to push
-        if pending.is_empty() && sessions.is_empty() {
-            result.duration_ms = start.elapsed().as_millis() as u64;
-            return Ok(result);
-        }
-
         let token = self
             .cloud_config
             .token
             .as_ref()
             .ok_or_else(|| CasError::Other("Not logged in".to_string()))?;
 
-        // Push each entity type
-        if !pending.entries.is_empty() {
-            match self.push_batch(&pending.entries, "entries", token) {
-                Ok(count) => result.pushed_entries = count,
-                Err(e) => {
-                    result.errors.push(format!("Entry push failed: {e}"));
-                }
+        loop {
+            if max_batches.is_some_and(|limit| result.batches_run >= limit) {
+                break;
             }
-        }
 
-        if !pending.tasks.is_empty() {
-            match self.push_batch(&pending.tasks, "tasks", token) {
-                Ok(count) => result.pushed_tasks = count,
-                Err(e) => {
-                    result.errors.push(format!("Task push failed: {e}"));
-                }
-            }
-        }
+            let pending = match scope.entity_type() {
+                Some(entity_type) => self.queue.pending_by_type_for_entity(
+                    entity_type,
+                    batch_limit,
+                    self.config.max_retries,
+                )?,
+                None => self
+                    .queue
+                    .pending_by_type(batch_limit, self.config.max_retries)?,
+            };
 
-        if !pending.rules.is_empty() {
-            match self.push_batch(&pending.rules, "rules", token) {
-                Ok(count) => result.pushed_rules = count,
-                Err(e) => {
-                    result.errors.push(format!("Rule push failed: {e}"));
+            if pending.is_empty() {
+                if !sessions.is_empty() {
+                    result.batches_run += 1;
+                    match self.push_sessions(sessions, token) {
+                        Ok(count) => result.pushed_sessions += count,
+                        Err(e) => result.errors.push(format!("Session push failed: {e}")),
+                    }
                 }
+                break;
             }
-        }
 
-        if !pending.skills.is_empty() {
-            match self.push_batch(&pending.skills, "skills", token) {
-                Ok(count) => result.pushed_skills = count,
-                Err(e) => {
-                    result.errors.push(format!("Skill push failed: {e}"));
-                }
-            }
-        }
+            let before = self
+                .queue
+                .pending_count_for_entity_type(scope.entity_type(), self.config.max_retries)?;
+            let round = self.push_pending_batch(&pending, token);
+            result.batches_run += 1;
+            Self::merge_push_result(&mut result, round);
 
-        // Push sessions (queued or directly passed)
-        if !pending.sessions.is_empty() {
-            match self.push_batch(&pending.sessions, "sessions", token) {
-                Ok(count) => result.pushed_sessions = count,
-                Err(e) => {
-                    result.errors.push(format!("Session push failed: {e}"));
-                }
-            }
-        } else if !sessions.is_empty() {
-            // Fallback to directly-passed sessions
-            match self.push_sessions(sessions, token) {
-                Ok(count) => result.pushed_sessions = count,
-                Err(e) => {
-                    result.errors.push(format!("Session push failed: {e}"));
-                }
-            }
-        }
-
-        // Push verifications
-        if !pending.verifications.is_empty() {
-            match self.push_batch(&pending.verifications, "verifications", token) {
-                Ok(count) => result.pushed_verifications = count,
-                Err(e) => {
-                    result.errors.push(format!("Verification push failed: {e}"));
-                }
-            }
-        }
-
-        // Push events
-        if !pending.events.is_empty() {
-            match self.push_batch(&pending.events, "events", token) {
-                Ok(count) => result.pushed_events = count,
-                Err(e) => {
-                    result.errors.push(format!("Event push failed: {e}"));
-                }
-            }
-        }
-
-        // Push prompts
-        if !pending.prompts.is_empty() {
-            match self.push_batch(&pending.prompts, "prompts", token) {
-                Ok(count) => result.pushed_prompts = count,
-                Err(e) => {
-                    result.errors.push(format!("Prompt push failed: {e}"));
-                }
-            }
-        }
-
-        // Push file changes
-        if !pending.file_changes.is_empty() {
-            match self.push_batch(&pending.file_changes, "file_changes", token) {
-                Ok(count) => result.pushed_file_changes = count,
-                Err(e) => {
-                    result.errors.push(format!("FileChange push failed: {e}"));
-                }
-            }
-        }
-
-        // Push commit links
-        if !pending.commit_links.is_empty() {
-            match self.push_batch(&pending.commit_links, "commit_links", token) {
-                Ok(count) => result.pushed_commit_links = count,
-                Err(e) => {
-                    result.errors.push(format!("CommitLink push failed: {e}"));
-                }
-            }
-        }
-
-        // Push agents
-        if !pending.agents.is_empty() {
-            match self.push_batch(&pending.agents, "agents", token) {
-                Ok(count) => result.pushed_agents = count,
-                Err(e) => {
-                    result.errors.push(format!("Agent push failed: {e}"));
-                }
-            }
-        }
-
-        // Push worktrees
-        if !pending.worktrees.is_empty() {
-            match self.push_batch(&pending.worktrees, "worktrees", token) {
-                Ok(count) => result.pushed_worktrees = count,
-                Err(e) => {
-                    result.errors.push(format!("Worktree push failed: {e}"));
-                }
+            let after = self
+                .queue
+                .pending_count_for_entity_type(scope.entity_type(), self.config.max_retries)?;
+            if after >= before {
+                result.errors.push(format!(
+                    "Push stopped after making no progress; {after} matching row(s) remain pending"
+                ));
+                break;
             }
         }
 
@@ -222,8 +150,129 @@ impl CloudSyncer {
             .queue
             .set_metadata("last_push_at", &Utc::now().to_rfc3339());
 
+        result.remaining_backlog = self.remaining_backlog(scope)?;
         result.duration_ms = start.elapsed().as_millis() as u64;
         Ok(result)
+    }
+
+    fn push_pending_batch(&self, pending: &PendingByType, token: &str) -> SyncResult {
+        let mut result = SyncResult::default();
+
+        macro_rules! push_type {
+            ($field:ident, $items:expr, $label:literal, $error:literal) => {
+                if !$items.is_empty() {
+                    match self.push_batch($items, $label, token) {
+                        Ok(count) => result.$field = count,
+                        Err(e) => result.errors.push(format!(concat!($error, ": {}"), e)),
+                    }
+                }
+            };
+        }
+
+        push_type!(
+            pushed_entries,
+            &pending.entries,
+            "entries",
+            "Entry push failed"
+        );
+        push_type!(pushed_tasks, &pending.tasks, "tasks", "Task push failed");
+        push_type!(pushed_rules, &pending.rules, "rules", "Rule push failed");
+        push_type!(
+            pushed_skills,
+            &pending.skills,
+            "skills",
+            "Skill push failed"
+        );
+        push_type!(
+            pushed_sessions,
+            &pending.sessions,
+            "sessions",
+            "Session push failed"
+        );
+        push_type!(
+            pushed_verifications,
+            &pending.verifications,
+            "verifications",
+            "Verification push failed"
+        );
+        push_type!(
+            pushed_events,
+            &pending.events,
+            "events",
+            "Event push failed"
+        );
+        push_type!(
+            pushed_prompts,
+            &pending.prompts,
+            "prompts",
+            "Prompt push failed"
+        );
+        push_type!(
+            pushed_file_changes,
+            &pending.file_changes,
+            "file_changes",
+            "FileChange push failed"
+        );
+        push_type!(
+            pushed_commit_links,
+            &pending.commit_links,
+            "commit_links",
+            "CommitLink push failed"
+        );
+        push_type!(
+            pushed_agents,
+            &pending.agents,
+            "agents",
+            "Agent push failed"
+        );
+        push_type!(
+            pushed_worktrees,
+            &pending.worktrees,
+            "worktrees",
+            "Worktree push failed"
+        );
+
+        result
+    }
+
+    fn merge_push_result(target: &mut SyncResult, source: SyncResult) {
+        target.pushed_entries += source.pushed_entries;
+        target.pushed_tasks += source.pushed_tasks;
+        target.pushed_rules += source.pushed_rules;
+        target.pushed_skills += source.pushed_skills;
+        target.pushed_sessions += source.pushed_sessions;
+        target.pushed_verifications += source.pushed_verifications;
+        target.pushed_events += source.pushed_events;
+        target.pushed_prompts += source.pushed_prompts;
+        target.pushed_file_changes += source.pushed_file_changes;
+        target.pushed_commit_links += source.pushed_commit_links;
+        target.pushed_agents += source.pushed_agents;
+        target.pushed_worktrees += source.pushed_worktrees;
+        target.errors.extend(source.errors);
+    }
+
+    fn remaining_backlog(&self, scope: PushScope) -> Result<PushBacklog, CasError> {
+        const ERROR_LIMIT: usize = 20;
+        let failed = self
+            .queue
+            .failed_count_for_entity_type(scope.entity_type(), self.config.max_retries)?;
+        let failed_errors = self
+            .queue
+            .failed_for_entity_type(scope.entity_type(), self.config.max_retries, ERROR_LIMIT)?
+            .into_iter()
+            .filter_map(|item| {
+                item.last_error
+                    .map(|error| format!("{} {}: {error}", item.entity_type, item.entity_id))
+            })
+            .collect();
+
+        Ok(PushBacklog {
+            pending: self
+                .queue
+                .pending_count_for_entity_type(scope.entity_type(), self.config.max_retries)?,
+            failed,
+            failed_errors,
+        })
     }
 
     /// Push sessions to cloud

--- a/cas-cli/src/cloud/syncer/push.rs
+++ b/cas-cli/src/cloud/syncer/push.rs
@@ -131,12 +131,16 @@ impl CloudSyncer {
                 .queue
                 .pending_count_for_entity_type(scope.entity_type(), self.config.max_retries)?;
             let round = self.push_pending_batch(&pending, token);
+            let round_had_errors = !round.errors.is_empty();
             result.batches_run += 1;
             Self::merge_push_result(&mut result, round);
 
             let after = self
                 .queue
                 .pending_count_for_entity_type(scope.entity_type(), self.config.max_retries)?;
+            if round_had_errors {
+                break;
+            }
             if after >= before {
                 result.errors.push(format!(
                     "Push stopped after making no progress; {after} matching row(s) remain pending"

--- a/cas-cli/src/cloud/syncer/push.rs
+++ b/cas-cli/src/cloud/syncer/push.rs
@@ -138,13 +138,13 @@ impl CloudSyncer {
             let after = self
                 .queue
                 .pending_count_for_entity_type(scope.entity_type(), self.config.max_retries)?;
-            if round_had_errors {
-                break;
-            }
             if after >= before {
                 result.errors.push(format!(
                     "Push stopped after making no progress; {after} matching row(s) remain pending"
                 ));
+                break;
+            }
+            if round_had_errors {
                 break;
             }
         }

--- a/cas-cli/tests/push_queue_scoping_test.rs
+++ b/cas-cli/tests/push_queue_scoping_test.rs
@@ -234,6 +234,7 @@ async fn entries_only_push_is_root_and_project_bound() {
         entries_only: true,
         tasks_only: false,
         dry_run: false,
+        max_batches: None,
         rehome: false,
     };
     let cli = common::make_cli_json();
@@ -318,6 +319,135 @@ async fn personal_push_omits_team_id_even_when_the_project_has_an_active_team() 
         body.get("team_id").is_none(),
         "the personal push path must remain account-scoped — got {body}"
     );
+}
+
+#[tokio::test]
+async fn personal_push_drains_more_than_two_queue_batches_in_one_invocation() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/push"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    let root = TempDir::new().unwrap();
+    seed_project(&root, &server.uri(), "drain-project");
+    let queue = Arc::new(SyncQueue::open(root.path()).unwrap());
+    for index in 0..101 {
+        enqueue(
+            &queue,
+            EntityType::Entry,
+            &format!("drain-entry-{index}"),
+            8,
+        );
+    }
+
+    let syncer = CloudSyncer::new_for_project(
+        queue.clone(),
+        CloudConfig {
+            endpoint: server.uri(),
+            token: Some("test-token".to_string()),
+            ..Default::default()
+        },
+        CloudSyncerConfig::default(),
+        "drain-project".to_string(),
+        root.path(),
+    );
+    let result = tokio::task::spawn_blocking(move || syncer.push())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.pushed_entries, 101);
+    assert!(queue.pending(200, 5).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn personal_push_stops_after_a_failed_batch_without_replaying_forever() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/push"))
+        .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let root = TempDir::new().unwrap();
+    let queue = Arc::new(SyncQueue::open(root.path()).unwrap());
+    queue.init().unwrap();
+    enqueue(&queue, EntityType::Entry, "stalled-entry", 8);
+    let syncer = CloudSyncer::new_for_project(
+        queue.clone(),
+        CloudConfig {
+            endpoint: server.uri(),
+            token: Some("test-token".to_string()),
+            ..Default::default()
+        },
+        CloudSyncerConfig::default(),
+        "stalled-project".to_string(),
+        root.path(),
+    );
+
+    let result = tokio::task::spawn_blocking(move || syncer.push())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.batches_run, 1);
+    assert_eq!(result.remaining_backlog.pending, 1);
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|error| error.contains("no progress"))
+    );
+    assert_eq!(queue.pending(10, 5).unwrap()[0].retry_count, 1);
+}
+
+#[tokio::test]
+async fn max_batches_bounds_a_personal_push_without_changing_request_size() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/push"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let root = TempDir::new().unwrap();
+    let queue = Arc::new(SyncQueue::open(root.path()).unwrap());
+    queue.init().unwrap();
+    for index in 0..101 {
+        enqueue(
+            &queue,
+            EntityType::Entry,
+            &format!("bounded-entry-{index}"),
+            8,
+        );
+    }
+    let syncer = CloudSyncer::new_for_project(
+        queue.clone(),
+        CloudConfig {
+            endpoint: server.uri(),
+            token: Some("test-token".to_string()),
+            ..Default::default()
+        },
+        CloudSyncerConfig::default(),
+        "bounded-project".to_string(),
+        root.path(),
+    );
+
+    let result =
+        tokio::task::spawn_blocking(move || syncer.push_scoped_with_max_batches(PushScope::All, 1))
+            .await
+            .unwrap()
+            .unwrap();
+
+    assert_eq!(result.batches_run, 1);
+    assert_eq!(result.pushed_entries, 50);
+    assert_eq!(result.remaining_backlog.pending, 51);
+    assert_eq!(queue.pending(200, 5).unwrap().len(), 51);
 }
 
 /// cas-7719: the shared personal-envelope builder must send the same
@@ -422,6 +552,7 @@ async fn failed_cli_push_leaves_the_row_retryable() {
         entries_only: false,
         tasks_only: false,
         dry_run: false,
+        max_batches: None,
         rehome: false,
     };
     let cli = common::make_cli_json();
@@ -467,6 +598,7 @@ fn dry_run_plans_apply_scope_before_the_batch_limit() {
     let entries = syncer.plan_push(PushScope::EntriesOnly).unwrap();
     assert_eq!(entries.counts.len(), 1);
     assert_eq!(entries.counts["entries"], 2);
+    assert_eq!(entries.total_matching, 2);
     assert_eq!(entries.total_in_next_batch, 2);
     assert!(entries.batch_limit_reached, "count == LIMIT is saturated");
     assert!(!entries.counts.contains_key("tasks"));
@@ -474,12 +606,14 @@ fn dry_run_plans_apply_scope_before_the_batch_limit() {
     let tasks = syncer.plan_push(PushScope::TasksOnly).unwrap();
     assert_eq!(tasks.counts.len(), 1);
     assert_eq!(tasks.counts["tasks"], 1);
+    assert_eq!(tasks.total_matching, 1);
     assert!(!tasks.batch_limit_reached);
 
     let all = syncer.plan_push(PushScope::All).unwrap();
     assert_eq!(all.total_in_next_batch, 2);
     assert_eq!(all.counts["tasks"], 1);
     assert_eq!(all.counts["entries"], 1);
+    assert_eq!(all.total_matching, 3);
     assert!(all.batch_limit_reached);
 }
 


### PR DESCRIPTION
## Summary
`cas cloud push` previously pushed exactly one 50-row batch and printed "Push complete", leaving any larger backlog silently queued (field report: 2,163 rows stranded for months). It also silently skipped team-scoped queue rows.

- Personal push now loops batches to exhaustion by default, with guaranteed termination: a batch that makes no progress stops the loop and reports the remaining rows.
- New `--max-batches N` bounds a run without changing the per-request batch size.
- Output (human + `--json`) now reports batches run, totals pushed, and the remaining backlog (pending + failed/parked with their recorded errors). "Push complete" only prints when nothing matching remains.
- An active team's queued rows are named explicitly ("team backlog skipped: N row(s); run `cas cloud sync`") in both dry-run and real output; JSON status stays `partial` while they exist.
- `cas cloud sync` behavior unchanged (drains via its own team-push step as before).

## Testing
- `push_queue_scoping_test`: multi-batch drain (>2 batches in one invocation), failed-batch stop without replay, `--max-batches` bounding, scoping/delete regressions.
- Unit test for the team-backlog reporting struct.

Task: cas-f64f

🤖 Generated with [Claude Code](https://claude.com/claude-code)
