### PR TITLE
chore(release): prepare v3.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.7.5] - 2026-08-31
+
+### Added
+- `cas setup` guides a newly installed machine through PATH, cloud login and
+  team selection, device pairing, hub service, optional Viktor credentials, and
+  first-project initialization with safe reruns and dry-run status reporting.
+
+### Changed
+- `cas cloud push` drains the complete personal backlog by default, stops when
+  no progress is possible, and reports remaining team-scoped rows explicitly.
+
 ## [3.7.4] - 2026-08-31
 
 ### Changed
@@ -1578,7 +1589,8 @@ After upgrading, the new gates fire on `task.close` calls. If a worker hits the 
 ### Added
 - Initial stable release with core functionality.
 
-[Unreleased]: https://github.com/Richards-LLC/cassy/compare/v3.7.4...HEAD
+[Unreleased]: https://github.com/Richards-LLC/cassy/compare/v3.7.5...HEAD
+[3.7.5]: https://github.com/Richards-LLC/cassy/compare/v3.7.4...v3.7.5
 [3.7.4]: https://github.com/Richards-LLC/cassy/compare/v3.7.3...v3.7.4
 [3.7.3]: https://github.com/Richards-LLC/cassy/compare/v3.7.2...v3.7.3
 [3.7.2]: https://github.com/Richards-LLC/cassy/compare/v3.7.1...v3.7.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = [
  "anyhow",
  "blake3",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.7.4"
+version = "3.7.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.7.4"
+version = "3.7.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.7.4"
+version = "3.7.5"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.7.4"
+version = "3.7.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.7.4"
+version = "3.7.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.7.4"
+version = "3.7.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-31-v3.7.5-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.5-slack.md
@@ -1,0 +1,55 @@
+# Slack draft — Cassy v3.7.5 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — A complete machine setup and cloud sync now finish in one guided flow.
+
+**Reply (Was → Now):**
+- Was: getting Cassy ready meant separate install, login, pairing, service, and project steps. Now: `cas setup` walks all seven steps, can safely rerun, and shows exactly what still needs attention.
+- Was: pushing cloud work moved only a small batch and could leave team rows unclear. Now: `cas cloud push` drains the personal backlog until no progress remains and names team-scoped rows that still need an explicit scope.
+- Install: use `cas update` for an existing installation, or download the
+  v3.7.5 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — Setup orchestration and push draining now make first-run and sync state explicit.
+
+**Reply (Was → Now):**
+- Was: machine setup required callers to coordinate several commands without a shared status model. Now: `cas setup` owns seven ordered steps, delegates side effects to the existing CLI commands, supports `--yes` and `--dry-run`, and reports `ok`, `skipped`, or `action-needed` without dead-ending on unavailable native paths.
+- Was: `cas cloud push` could stop after one bounded batch while reporting completion. Now: personal rows drain through repeated batches with no-progress termination and an optional batch ceiling, while team-scoped rows are reported explicitly.
+- Validation and artifact: locked metadata, `cargo check -p cas --locked`, migration-snapshot checks, guarded component-output tests, and `git diff --check`. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |


### PR DESCRIPTION
Release prep for v3.7.5: bump six release packages and Cargo.lock, add the dated changelog entry, and add the rubric-compliant runtime Slack draft. Proofs: cargo metadata --locked, cargo check -p cas --locked, migration snapshot guard, guarded component_output_test (13/13), and git diff --check.