### PR TITLE
docs(release): record v3.7.5 Slack receipts

### DIFF
--- a/docs/release-notes/2026-08-31-v3.7.5-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.5-slack.md
@@ -2,9 +2,8 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
-assets and `release-published-receipt.sh --write-draft` has replaced both
-checksum placeholders below.
+**Status:** Posted after the tagged GitHub workflow published both assets and
+`release-published-receipt.sh --write-draft` replaced both checksum placeholders.
 
 ## User thread
 
@@ -15,8 +14,8 @@ Live on production — **User** — A complete machine setup and cloud sync now 
 - Was: getting Cassy ready meant separate install, login, pairing, service, and project steps. Now: `cas setup` walks all seven steps, can safely rerun, and shows exactly what still needs attention.
 - Was: pushing cloud work moved only a small batch and could leave team rows unclear. Now: `cas cloud push` drains the personal backlog until no progress remains and names team-scoped rows that still need an explicit scope.
 - Install: use `cas update` for an existing installation, or download the
-  v3.7.5 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
-  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+  v3.7.5 archive for Linux x86_64 (SHA-256 `7bd0535169c6cb1dc8aeb7dc3192e006880602dd43659005228388b7912e603e`) or macOS ARM64
+  (SHA-256 `17ec786026779cf328970a2f7b9485c5547de597d2d3048aaa6e2c2ba55f5014`) from the GitHub release.
 
 ## Dev thread
 
@@ -27,8 +26,8 @@ Live on production — **Dev** — Setup orchestration and push draining now mak
 - Was: machine setup required callers to coordinate several commands without a shared status model. Now: `cas setup` owns seven ordered steps, delegates side effects to the existing CLI commands, supports `--yes` and `--dry-run`, and reports `ok`, `skipped`, or `action-needed` without dead-ending on unavailable native paths.
 - Was: `cas cloud push` could stop after one bounded batch while reporting completion. Now: personal rows drain through repeated batches with no-progress termination and an optional batch ceiling, while team-scoped rows are reported explicitly.
 - Validation and artifact: locked metadata, `cargo check -p cas --locked`, migration-snapshot checks, guarded component-output tests, and `git diff --check`. The published archives are
-  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
-  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `7bd0535169c6cb1dc8aeb7dc3192e006880602dd43659005228388b7912e603e`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `17ec786026779cf328970a2f7b9485c5547de597d2d3048aaa6e2c2ba55f5014`). Linux and
   macOS are both available from CI, regardless of the tagger's host.
 
 ## Posting sequence
@@ -49,7 +48,7 @@ Channel: `#cas-internal` (`C0B44GUKDK2`).
 
 | Message | UTC timestamp | Permalink |
 | --- | --- | --- |
-| User top-level |  |  |
-| User reply (Was → Now) |  |  |
-| Dev top-level |  |  |
-| Dev reply (Was → Now) |  |  |
+| User top-level | 2026-08-31T20:20:13.977519Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788207613977519) |
+| User reply (Was → Now) | 2026-08-31T20:20:20.756039Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788207620756039?thread_ts=1788207613.977519&cid=C0B44GUKDK2) |
+| Dev top-level | 2026-08-31T20:20:24.568949Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788207624568949) |
+| Dev reply (Was → Now) | 2026-08-31T20:20:31.491779Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788207631491779?thread_ts=1788207624.568949&cid=C0B44GUKDK2) |


### PR DESCRIPTION
Records the published v3.7.5 archive digests and the four #cas-internal Slack timestamps/permalinks after approved-route posting. Includes the empty hub-web diff verification in the release task receipt.