### PR TITLE
docs(cas-d653): add workspace test-compile handoff gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ cargo build                          # Dev build
 cargo build --release                # Release build (LTO, strip)
 cargo build --profile release-fast   # Fast release (thin LTO, 16 codegen units)
 cargo check -p cas --lib --tests     # Worker iteration: compile feedback, no test linking/runs
+cargo check --workspace --tests      # Before handoff when the diff spans crates or changes a pub fn signature
 scripts/run-scoped-tests.sh -p cas --lib module_name
 scripts/run-scoped-tests.sh -p cas --test cli_test
 cargo nextest run -p cas             # Full suite: supervisor integration/release gates only
@@ -51,6 +52,15 @@ nextest and rejects a silent zero-test success. Factory workers should iterate
 with `cargo check`, then run only the affected `--lib` or `--test` target; the
 PreToolUse guard rejects an unscoped worker test run. Full suites are owned by
 the supervisor integration merge and release gate.
+
+Before handoff or `awaiting_merge`, inspect the diff against its target branch.
+When it touches more than one crate or changes any `pub fn` signature, run
+`cargo check --workspace --tests` and include its exit-0 in the delivery
+receipt. This is compile-only: it does not execute test suites or change which
+scoped tests run. The gate follows PR #655 (run 33430464567), where a scoped
+proof missed a broken `cloud::syncer` test, and PR #657 (run 33435093275), where
+a new spawn argument left `cas-mux` integration-test call sites uncompilable.
+Single-crate, non-signature diffs keep the cheaper scoped recipe above.
 
 Factory worker spawns use `sccache` automatically when it is installed, while
 keeping a separate target directory per worktree so concurrent Cargo builds do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,6 @@ cargo build                          # Dev build
 cargo build --release                # Release build (LTO, strip)
 cargo build --profile release-fast   # Fast release (thin LTO, 16 codegen units)
 cargo check -p cas --lib --tests     # Worker iteration: compile feedback, no test linking/runs
-cargo check --workspace --tests      # Before handoff when the diff spans crates or changes a pub fn signature
 scripts/run-scoped-tests.sh -p cas --lib module_name
 scripts/run-scoped-tests.sh -p cas --test cli_test
 cargo nextest run -p cas             # Full suite: supervisor integration/release gates only
@@ -53,14 +52,7 @@ with `cargo check`, then run only the affected `--lib` or `--test` target; the
 PreToolUse guard rejects an unscoped worker test run. Full suites are owned by
 the supervisor integration merge and release gate.
 
-Before handoff or `awaiting_merge`, inspect the diff against its target branch.
-When it touches more than one crate or changes any `pub fn` signature, run
-`cargo check --workspace --tests` and include its exit-0 in the delivery
-receipt. This is compile-only: it does not execute test suites or change which
-scoped tests run. The gate follows PR #655 (run 33430464567), where a scoped
-proof missed a broken `cloud::syncer` test, and PR #657 (run 33435093275), where
-a new spawn argument left `cas-mux` integration-test call sites uncompilable.
-Single-crate, non-signature diffs keep the cheaper scoped recipe above.
+Gate evidence: PR #655/run 33430464567; PR #657/run 33435093275.
 
 Factory worker spawns use `sccache` automatically when it is installed, while
 keeping a separate target directory per worktree so concurrent Cargo builds do

--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -130,6 +130,15 @@ Before setting `status=blocked`, re-read with `action=show`. If it already shows
 
 **Batch the fixes, then verify once.** **Inner loop:** `cargo check -p <crate> --lib --tests`. **Final proof:** run the affected `--lib <module>` / `--test <name>` target through `cargo nextest run`, at most twice (post-batch + pre-push). Never run the full suite from a worker. Background long runs; never foreground-`sleep`.
 
+Before handoff or `awaiting_merge`, inspect the diff against its target branch.
+When it touches more than one crate or changes any `pub fn` signature, run
+`cargo check --workspace --tests` and include its exit-0 in the delivery
+receipt. This is compile-only: it does not execute test suites or change which
+scoped tests run. The gate follows PR #655 (run 33430464567), where a scoped
+proof missed a broken `cloud::syncer` test, and PR #657 (run 33435093275), where
+a new spawn argument left `cas-mux` integration-test call sites uncompilable.
+Single-crate, non-signature diffs keep the cheaper scoped recipe above.
+
 For env-reading code, check the clean-CI shape with `make -C cas-cli test-clean-env`.
 
 ## References

--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -128,16 +128,7 @@ Before setting `status=blocked`, re-read with `action=show`. If it already shows
 
 ## Running Tests in a Worker
 
-**Batch the fixes, then verify once.** **Inner loop:** `cargo check -p <crate> --lib --tests`. **Final proof:** run the affected `--lib <module>` / `--test <name>` target through `cargo nextest run`, at most twice (post-batch + pre-push). Never run the full suite from a worker. Background long runs; never foreground-`sleep`.
-
-Before handoff or `awaiting_merge`, inspect the diff against its target branch.
-When it touches more than one crate or changes any `pub fn` signature, run
-`cargo check --workspace --tests` and include its exit-0 in the delivery
-receipt. This is compile-only: it does not execute test suites or change which
-scoped tests run. The gate follows PR #655 (run 33430464567), where a scoped
-proof missed a broken `cloud::syncer` test, and PR #657 (run 33435093275), where
-a new spawn argument left `cas-mux` integration-test call sites uncompilable.
-Single-crate, non-signature diffs keep the cheaper scoped recipe above.
+**Batch fixes, then verify.** Inner loop: `cargo check -p <crate> --lib --tests`. Before handoff/awaiting_merge, if diff spans >1 crate or changes a `pub fn` signature, run `cargo check --workspace --tests` (compile-only; no suite change) and record exit 0. Otherwise run targets through `cargo nextest run` at most twice.
 
 For env-reading code, check the clean-CI shape with `make -C cas-cli test-clean-env`.
 

--- a/cas-cli/src/builtins/codex/skills/cas-worker.md
+++ b/cas-cli/src/builtins/codex/skills/cas-worker.md
@@ -128,7 +128,7 @@ Before setting `status=blocked`, re-read with `action=show`. If it already shows
 
 ## Running Tests in a Worker
 
-**Batch fixes, then verify.** Inner loop: `cargo check -p <crate> --lib --tests`. Before handoff/awaiting_merge, if diff spans >1 crate or changes a `pub fn` signature, run `cargo check --workspace --tests` (compile-only; no suite change) and record exit 0. Otherwise run targets through `cargo nextest run` at most twice.
+**Batch the fixes.** Inner loop: `cargo check -p <crate> --lib --tests`; before handoff/awaiting_merge, multi-crate/pub fn signature diffs require `cargo check --workspace --tests` (compile-only; exit-0 receipt). Final proof: cargo nextest run --lib <module>/--test <name>, at most twice; no foreground sleep; never full suite.
 
 For env-reading code, check the clean-CI shape with `make -C cas-cli test-clean-env`.
 

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -130,6 +130,15 @@ Before setting `status=blocked`, re-read with `action=show`. If it already shows
 
 **Batch the fixes, then verify once.** **Inner loop:** `cargo check -p <crate> --lib --tests`. **Final proof:** run the affected `--lib <module>` / `--test <name>` target through `cargo nextest run`, at most twice (post-batch + pre-push). Never run the full suite from a worker. Background long runs; never foreground-`sleep`.
 
+Before handoff or `awaiting_merge`, inspect the diff against its target branch.
+When it touches more than one crate or changes any `pub fn` signature, run
+`cargo check --workspace --tests` and include its exit-0 in the delivery
+receipt. This is compile-only: it does not execute test suites or change which
+scoped tests run. The gate follows PR #655 (run 33430464567), where a scoped
+proof missed a broken `cloud::syncer` test, and PR #657 (run 33435093275), where
+a new spawn argument left `cas-mux` integration-test call sites uncompilable.
+Single-crate, non-signature diffs keep the cheaper scoped recipe above.
+
 For env-reading code, check the clean-CI shape with `make -C cas-cli test-clean-env`.
 
 ## References

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -128,16 +128,7 @@ Before setting `status=blocked`, re-read with `action=show`. If it already shows
 
 ## Running Tests in a Worker
 
-**Batch the fixes, then verify once.** **Inner loop:** `cargo check -p <crate> --lib --tests`. **Final proof:** run the affected `--lib <module>` / `--test <name>` target through `cargo nextest run`, at most twice (post-batch + pre-push). Never run the full suite from a worker. Background long runs; never foreground-`sleep`.
-
-Before handoff or `awaiting_merge`, inspect the diff against its target branch.
-When it touches more than one crate or changes any `pub fn` signature, run
-`cargo check --workspace --tests` and include its exit-0 in the delivery
-receipt. This is compile-only: it does not execute test suites or change which
-scoped tests run. The gate follows PR #655 (run 33430464567), where a scoped
-proof missed a broken `cloud::syncer` test, and PR #657 (run 33435093275), where
-a new spawn argument left `cas-mux` integration-test call sites uncompilable.
-Single-crate, non-signature diffs keep the cheaper scoped recipe above.
+**Batch fixes, then verify.** Inner loop: `cargo check -p <crate> --lib --tests`. Before handoff/awaiting_merge, if diff spans >1 crate or changes a `pub fn` signature, run `cargo check --workspace --tests` (compile-only; no suite change) and record exit 0. Otherwise run targets through `cargo nextest run` at most twice.
 
 For env-reading code, check the clean-CI shape with `make -C cas-cli test-clean-env`.
 

--- a/cas-cli/src/builtins/grok/skills/cas-worker.md
+++ b/cas-cli/src/builtins/grok/skills/cas-worker.md
@@ -128,7 +128,7 @@ Before setting `status=blocked`, re-read with `action=show`. If it already shows
 
 ## Running Tests in a Worker
 
-**Batch fixes, then verify.** Inner loop: `cargo check -p <crate> --lib --tests`. Before handoff/awaiting_merge, if diff spans >1 crate or changes a `pub fn` signature, run `cargo check --workspace --tests` (compile-only; no suite change) and record exit 0. Otherwise run targets through `cargo nextest run` at most twice.
+**Batch the fixes.** Inner loop: `cargo check -p <crate> --lib --tests`; before handoff/awaiting_merge, multi-crate/pub fn signature diffs require `cargo check --workspace --tests` (compile-only; exit-0 receipt). Final proof: cargo nextest run --lib <module>/--test <name>, at most twice; no foreground sleep; never full suite.
 
 For env-reading code, check the clean-CI shape with `make -C cas-cli test-clean-env`.
 

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -130,6 +130,15 @@ Before setting `status=blocked`, re-read with `action=show`. If it already shows
 
 **Batch the fixes, then verify once.** **Inner loop:** `cargo check -p <crate> --lib --tests`. **Final proof:** run the affected `--lib <module>` / `--test <name>` target through `cargo nextest run`, at most twice (post-batch + pre-push). Never run the full suite from a worker. Background long runs; never foreground-`sleep`.
 
+Before handoff or `awaiting_merge`, inspect the diff against its target branch.
+When it touches more than one crate or changes any `pub fn` signature, run
+`cargo check --workspace --tests` and include its exit-0 in the delivery
+receipt. This is compile-only: it does not execute test suites or change which
+scoped tests run. The gate follows PR #655 (run 33430464567), where a scoped
+proof missed a broken `cloud::syncer` test, and PR #657 (run 33435093275), where
+a new spawn argument left `cas-mux` integration-test call sites uncompilable.
+Single-crate, non-signature diffs keep the cheaper scoped recipe above.
+
 For env-reading code, check the clean-CI shape with `make -C cas-cli test-clean-env`.
 
 ## References

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -128,16 +128,7 @@ Before setting `status=blocked`, re-read with `action=show`. If it already shows
 
 ## Running Tests in a Worker
 
-**Batch the fixes, then verify once.** **Inner loop:** `cargo check -p <crate> --lib --tests`. **Final proof:** run the affected `--lib <module>` / `--test <name>` target through `cargo nextest run`, at most twice (post-batch + pre-push). Never run the full suite from a worker. Background long runs; never foreground-`sleep`.
-
-Before handoff or `awaiting_merge`, inspect the diff against its target branch.
-When it touches more than one crate or changes any `pub fn` signature, run
-`cargo check --workspace --tests` and include its exit-0 in the delivery
-receipt. This is compile-only: it does not execute test suites or change which
-scoped tests run. The gate follows PR #655 (run 33430464567), where a scoped
-proof missed a broken `cloud::syncer` test, and PR #657 (run 33435093275), where
-a new spawn argument left `cas-mux` integration-test call sites uncompilable.
-Single-crate, non-signature diffs keep the cheaper scoped recipe above.
+**Batch fixes, then verify.** Inner loop: `cargo check -p <crate> --lib --tests`. Before handoff/awaiting_merge, if diff spans >1 crate or changes a `pub fn` signature, run `cargo check --workspace --tests` (compile-only; no suite change) and record exit 0. Otherwise run targets through `cargo nextest run` at most twice.
 
 For env-reading code, check the clean-CI shape with `make -C cas-cli test-clean-env`.
 

--- a/cas-cli/src/builtins/skills/cas-worker.md
+++ b/cas-cli/src/builtins/skills/cas-worker.md
@@ -128,7 +128,7 @@ Before setting `status=blocked`, re-read with `action=show`. If it already shows
 
 ## Running Tests in a Worker
 
-**Batch fixes, then verify.** Inner loop: `cargo check -p <crate> --lib --tests`. Before handoff/awaiting_merge, if diff spans >1 crate or changes a `pub fn` signature, run `cargo check --workspace --tests` (compile-only; no suite change) and record exit 0. Otherwise run targets through `cargo nextest run` at most twice.
+**Batch the fixes.** Inner loop: `cargo check -p <crate> --lib --tests`; before handoff/awaiting_merge, multi-crate/pub fn signature diffs require `cargo check --workspace --tests` (compile-only; exit-0 receipt). Final proof: cargo nextest run --lib <module>/--test <name>, at most twice; no foreground sleep; never full suite.
 
 For env-reading code, check the clean-CI shape with `make -C cas-cli test-clean-env`.
 


### PR DESCRIPTION
Adds a conditional workspace test-compile gate to the worker delivery recipe and CLAUDE.md: multi-crate or pub fn signature diffs require  before handoff. The guidance keeps scoped test execution unchanged and cites PR #655/run 33430464567 and PR #657/run 33435093275. Builtin Claude/Codex/Grok mirrors remain synchronized.