### PR TITLE
chore(release): prepare v3.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Claude worker launches preserve the requester's config and secure-storage
   selectors independently, auth checks stop waiting after a bounded timeout,
   and failed checks no longer silently choose the main account.
-- Worker proof guidance is now compact and mirrored across the Claude, Codex,
-  and Grok builtins while retaining the required compile and scoped-test gates.
 
 ### Fixed
 - Custom Claude profile directories now keep truthful names in account badges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.7.6] - 2026-08-31
+
+### Changed
+- Claude worker launches preserve the requester's config and secure-storage
+  selectors independently, auth checks stop waiting after a bounded timeout,
+  and failed checks no longer silently choose the main account.
+- Worker proof guidance is now compact and mirrored across the Claude, Codex,
+  and Grok builtins while retaining the required compile and scoped-test gates.
+
+### Fixed
+- Custom Claude profile directories now keep truthful names in account badges
+  instead of being mislabeled as the main profile.
+
 ## [3.7.5] - 2026-08-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.7.5"
+version = "3.7.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.7.5"
+version = "3.7.6"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.7.5"
+version = "3.7.6"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.7.5"
+version = "3.7.6"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.7.5"
+version = "3.7.6"
 dependencies = [
  "anyhow",
  "blake3",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.7.5"
+version = "3.7.6"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.7.5"
+version = "3.7.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.7.5"
+version = "3.7.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.7.5"
+version = "3.7.6"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.7.5"
+version = "3.7.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.7.5"
+version = "3.7.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.7.5"
+version = "3.7.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-08-31-v3.7.6-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.6-slack.md
@@ -1,0 +1,55 @@
+# Slack draft — Cassy v3.7.6 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Claude account selection now stays with the account you chose.
+
+**Reply (Was → Now):**
+- Was: a slow or failed login check could leave a launch on the wrong Claude account. Now: checks time out quickly, failed checks no longer guess the main account, and workers keep the exact credential store selected by the person who started them.
+- Was: custom Claude profile directories could appear as the main profile. Now: account badges show the actual profile name.
+- Install: use `cas update` for an existing installation, or download the
+  v3.7.6 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — Claude account routing and worker proof gates now preserve their intended boundaries.
+
+**Reply (Was → Now):**
+- Was: queued spawns carried one account selector, probes could block without a deadline, and probe failures silently selected main. Now: config and secure-storage selectors propagate independently with unset/empty/set semantics, probes use a bounded child timeout with kill/reap, and bare launches preserve inherited selectors with an explicit warning.
+- Was: arbitrary profile paths were normalized to `main`, and mirrored worker guidance repeated a large gate description. Now: custom paths render truthfully and the Claude, Codex, and Grok worker builtins use compact, equivalent workspace/scoped-proof guidance.
+- Validation and artifact: `cargo metadata --locked`, `cargo check -p cas --locked`, migration-snapshot checks, guarded `component_output_test`, and `git diff --check`. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |

--- a/docs/release-notes/2026-08-31-v3.7.6-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.6-slack.md
@@ -21,11 +21,11 @@ Live on production — **User** — Claude account selection now stays with the 
 ## Dev thread
 
 **Top-level:**
-Live on production — **Dev** — Claude account routing and worker proof gates now preserve their intended boundaries.
+Live on production — **Dev** — Claude account routing now preserves its intended boundaries.
 
 **Reply (Was → Now):**
 - Was: queued spawns carried one account selector, probes could block without a deadline, and probe failures silently selected main. Now: config and secure-storage selectors propagate independently with unset/empty/set semantics, probes use a bounded child timeout with kill/reap, and bare launches preserve inherited selectors with an explicit warning.
-- Was: arbitrary profile paths were normalized to `main`, and mirrored worker guidance repeated a large gate description. Now: custom paths render truthfully and the Claude, Codex, and Grok worker builtins use compact, equivalent workspace/scoped-proof guidance.
+- Was: arbitrary profile paths were normalized to `main`. Now: custom paths render truthfully in account badges.
 - Validation and artifact: `cargo metadata --locked`, `cargo check -p cas --locked`, migration-snapshot checks, guarded `component_output_test`, and `git diff --check`. The published archives are
   `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
   `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and


### PR DESCRIPTION
## Summary
Prepare v3.7.6 with multi-account hardening only.

- Propagate config and secure-storage selectors independently.
- Bound Claude auth probes and fail safely without main-account fallback.
- Keep custom account badge paths truthful.
- Update six package manifests, Cargo.lock, CHANGELOG, and the Slack draft.

## Validation
- cargo metadata --locked
- cargo check -p cas --locked
- scripts/check-release-migration-snapshots.sh
- scripts/run-scoped-tests.sh -p cas --test component_output_test (13/13)
- git diff --check

Worker proof-gate/builtin content is intentionally deferred to the next release.