### PR TITLE
ci(cas-ad65): run snapshot integration tests for changed CLI surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,20 @@ jobs:
           ZIG: ${{ github.workspace }}/.context/zig/zig
         run: scripts/run-scoped-tests.sh -p cas --lib --no-fail-fast
 
+      # cas-ad65: the library-only invocation above cannot exercise integration
+      # snapshots. Route only their committed CLI-output input surfaces here;
+      # PRs #649/#650 and PR #657 run 33435790948 reached the queue before
+      # stale doctor_snapshot output was exercised. This remains one small
+      # target within Scoped Validation, never a new CI lane.
+      - name: Test snapshot-pinned CLI output surfaces
+        if: >-
+          steps.pr-dedupe.outputs.covered != 'true'
+          && steps.classify-diff.outputs.rust-unaffected != 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          ZERO_BASE_REF: origin/${{ github.event.repository.default_branch }}
+        run: scripts/check-scoped-snapshot-tests.sh --base-sha "$BASE_SHA" --zero-base-ref "$ZERO_BASE_REF"
+
       - name: Report why no Rust work ran
         if: >-
           steps.pr-dedupe.outputs.covered == 'true'

--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -225,6 +225,7 @@ test-ci-tiers:
 	cd .. && ./scripts/test-check-release-host.sh
 	cd .. && ./scripts/test-cas-install.sh
 	cd .. && ./scripts/test-check-release-migration-snapshots.sh
+	cd .. && ./scripts/test-check-scoped-snapshot-tests.sh
 
 # Type check
 check:

--- a/scripts/check-scoped-snapshot-tests.sh
+++ b/scripts/check-scoped-snapshot-tests.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Run integration snapshot tests when their committed CLI-output inputs change.
+#
+# Scoped Validation already runs the library target. This router covers
+# integration snapshots whose output is produced by a CLI command and therefore
+# is invisible to that library-only invocation. Keep the inventory explicit:
+# an unrecognized snapshot file must fail loudly instead of silently losing
+# pre-merge coverage.
+
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 [--base-sha <git-ref>] [--zero-base-ref <git-ref>]" >&2
+    exit 2
+}
+
+base_ref=""
+zero_base_ref=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base-sha)
+            [[ $# -ge 2 ]] || usage
+            base_ref="$2"
+            shift 2
+            ;;
+        --zero-base-ref)
+            [[ $# -ge 2 ]] || usage
+            zero_base_ref="$2"
+            shift 2
+            ;;
+        *) usage ;;
+    esac
+done
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "snapshot routing: cannot inspect a checkout outside a Git repository" >&2
+    exit 2
+}
+cd "$repo_root"
+
+# snapshot filename | input source surface | integration test target
+snapshot_mappings=(
+    "component_output_test__doctor_snapshot.snap|cas-cli/src/cli/doctor.rs|component_output_test"
+    "component_output_test__status_empty_snapshot.snap|cas-cli/src/cli/status.rs|component_output_test"
+)
+
+snapshot_dir="$repo_root/cas-cli/tests/snapshots"
+shopt -s nullglob
+snapshot_paths=("$snapshot_dir"/*.snap)
+if [[ ${#snapshot_paths[@]} -eq 0 ]]; then
+    echo "snapshot routing: no committed integration snapshots found in $snapshot_dir" >&2
+    exit 1
+fi
+
+mapping_for_snapshot() {
+    local wanted="$1" entry snapshot surface target
+    for entry in "${snapshot_mappings[@]}"; do
+        IFS='|' read -r snapshot surface target <<<"$entry"
+        if [[ "$snapshot" == "$wanted" ]]; then
+            printf '%s\n' "$entry"
+            return 0
+        fi
+    done
+    return 1
+}
+
+for snapshot_path in "${snapshot_paths[@]}"; do
+    snapshot_name="${snapshot_path#"$snapshot_dir/"}"
+    if ! mapping_for_snapshot "$snapshot_name" >/dev/null; then
+        echo "snapshot routing: no Scoped Validation mapping for $snapshot_name" >&2
+        echo "Add its snapshot, input surface, and integration target to snapshot_mappings." >&2
+        exit 1
+    fi
+done
+
+for entry in "${snapshot_mappings[@]}"; do
+    IFS='|' read -r snapshot surface target <<<"$entry"
+    if [[ ! -f "$snapshot_dir/$snapshot" ]]; then
+        echo "snapshot routing: mapping names missing snapshot $snapshot" >&2
+        exit 1
+    fi
+    if [[ ! -f "$repo_root/$surface" ]]; then
+        echo "snapshot routing: mapping names missing input surface $surface" >&2
+        exit 1
+    fi
+    if [[ ! -f "$repo_root/cas-cli/tests/$target.rs" ]]; then
+        echo "snapshot routing: mapping names missing test target cas-cli/tests/$target.rs" >&2
+        exit 1
+    fi
+done
+
+comparison_base="$base_ref"
+if [[ "$comparison_base" =~ ^0+$ && -n "$zero_base_ref" ]]; then
+    if git rev-parse --verify --quiet "$zero_base_ref^{commit}" >/dev/null; then
+        comparison_base="$zero_base_ref"
+        echo "snapshot routing: all-zero event base replaced with $zero_base_ref"
+    else
+        comparison_base=""
+        echo "snapshot routing: trusted fallback $zero_base_ref is unavailable; running all mapped snapshots"
+    fi
+fi
+
+changed_paths=()
+if [[ -n "$comparison_base" && ! "$comparison_base" =~ ^0+$ ]]; then
+    if merge_base="$(git merge-base "$comparison_base" HEAD 2>/dev/null)"; then
+        while IFS= read -r path; do
+            [[ -n "$path" ]] && changed_paths+=("$path")
+        done < <(git diff --name-only "$merge_base" HEAD)
+    else
+        echo "snapshot routing: cannot find merge-base with $comparison_base; running all mapped snapshots"
+        comparison_base=""
+    fi
+else
+    echo "snapshot routing: no comparable base; running all mapped snapshots"
+fi
+
+targets=()
+add_target() {
+    local wanted="$1" target
+    for target in "${targets[@]}"; do
+        [[ "$target" == "$wanted" ]] && return 0
+    done
+    targets+=("$wanted")
+}
+
+if [[ ${#changed_paths[@]} -eq 0 && -n "$comparison_base" ]]; then
+    echo "snapshot routing: no mapped CLI-output surface changed; integration snapshot tests not required"
+    exit 0
+fi
+
+for path in "${changed_paths[@]}"; do
+    for entry in "${snapshot_mappings[@]}"; do
+        IFS='|' read -r snapshot surface target <<<"$entry"
+        if [[ "$path" == "$surface" || "$path" == "cas-cli/tests/snapshots/$snapshot" || "$path" == "cas-cli/tests/$target.rs" ]]; then
+            add_target "$target"
+        fi
+    done
+done
+
+if [[ ${#changed_paths[@]} -eq 0 ]]; then
+    for entry in "${snapshot_mappings[@]}"; do
+        IFS='|' read -r _ surface target <<<"$entry"
+        add_target "$target"
+    done
+fi
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+    echo "snapshot routing: mapped snapshot inventory is unchanged; integration snapshot tests not required"
+    exit 0
+fi
+
+for target in "${targets[@]}"; do
+    echo "snapshot routing: changed input surface requires -p cas --test $target"
+    "$repo_root/scripts/run-scoped-tests.sh" -p cas --test "$target" --no-fail-fast
+done

--- a/scripts/test-check-scoped-snapshot-tests.sh
+++ b/scripts/test-check-scoped-snapshot-tests.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Self-test for check-scoped-snapshot-tests.sh.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+router="$script_dir/check-scoped-snapshot-tests.sh"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+mkdir -p "$repo/cas-cli/src/cli" "$repo/cas-cli/tests/snapshots" "$repo/scripts"
+cp "$router" "$repo/scripts/check-scoped-snapshot-tests.sh"
+
+cat >"$repo/scripts/run-scoped-tests.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${SNAPSHOT_ROUTER_LOG:?}"
+if [[ "${SNAPSHOT_ROUTER_STATUS:-0}" != 0 ]]; then
+    exit "$SNAPSHOT_ROUTER_STATUS"
+fi
+printf '%s\n' 'Summary [   0.001s] 2 tests run: 2 passed, 0 skipped'
+EOF
+chmod +x "$repo/scripts"/*.sh
+
+printf '%s\n' '// doctor implementation' >"$repo/cas-cli/src/cli/doctor.rs"
+printf '%s\n' '// status implementation' >"$repo/cas-cli/src/cli/status.rs"
+printf '%s\n' '// component output integration test' >"$repo/cas-cli/tests/component_output_test.rs"
+printf '%s\n' 'doctor snapshot' >"$repo/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap"
+printf '%s\n' 'status snapshot' >"$repo/cas-cli/tests/snapshots/component_output_test__status_empty_snapshot.snap"
+
+git -C "$repo" init -q -b main
+git -C "$repo" config user.email snapshot-routing@example.test
+git -C "$repo" config user.name snapshot-routing-test
+git -C "$repo" add .
+git -C "$repo" commit -qm baseline
+git -C "$repo" checkout -qb doctor-surface
+
+printf '%s\n' '// changed doctor output line' >>"$repo/cas-cli/src/cli/doctor.rs"
+git -C "$repo" add .
+git -C "$repo" commit -qm 'change doctor output'
+
+: >"$tmpdir/router.log"
+doctor_output="$(
+    cd "$repo"
+    SNAPSHOT_ROUTER_LOG="$tmpdir/router.log" ./scripts/check-scoped-snapshot-tests.sh --base-sha main
+)"
+grep -qF 'changed input surface requires -p cas --test component_output_test' <<<"$doctor_output"
+[[ "$(cat "$tmpdir/router.log")" == '-p cas --test component_output_test --no-fail-fast' ]]
+echo 'ok   doctor.rs change routes component_output_test'
+
+: >"$tmpdir/router.log"
+set +e
+failure_output="$(
+    cd "$repo"
+    SNAPSHOT_ROUTER_LOG="$tmpdir/router.log" SNAPSHOT_ROUTER_STATUS=101 \
+        ./scripts/check-scoped-snapshot-tests.sh --base-sha main 2>&1
+)"
+failure_status=$?
+set -e
+[[ "$failure_status" -eq 101 ]]
+grep -qF 'changed input surface requires -p cas --test component_output_test' <<<"$failure_output"
+echo 'ok   component_output_test failure propagates (simulates run 33435790948)'
+
+git -C "$repo" checkout -q main
+git -C "$repo" checkout -qb status-surface
+printf '%s\n' '// changed status output line' >>"$repo/cas-cli/src/cli/status.rs"
+git -C "$repo" add .
+git -C "$repo" commit -qm 'change status output'
+: >"$tmpdir/router.log"
+status_output="$(
+    cd "$repo"
+    SNAPSHOT_ROUTER_LOG="$tmpdir/router.log" ./scripts/check-scoped-snapshot-tests.sh --base-sha main
+)"
+grep -qF 'changed input surface requires -p cas --test component_output_test' <<<"$status_output"
+[[ "$(cat "$tmpdir/router.log")" == '-p cas --test component_output_test --no-fail-fast' ]]
+echo 'ok   status.rs change routes component_output_test'
+
+git -C "$repo" checkout -q main
+printf '%s\n' 'documentation only' >"$repo/README.md"
+git -C "$repo" add README.md
+git -C "$repo" commit -qm 'change documentation'
+: >"$tmpdir/router.log"
+docs_output="$(
+    cd "$repo"
+    SNAPSHOT_ROUTER_LOG="$tmpdir/router.log" ./scripts/check-scoped-snapshot-tests.sh --base-sha main
+)"
+grep -qF 'no mapped CLI-output surface changed' <<<"$docs_output"
+[[ ! -s "$tmpdir/router.log" ]]
+echo 'ok   unrelated change skips integration snapshots'
+
+printf '%s\n' 'new snapshot without a mapping' >"$repo/cas-cli/tests/snapshots/component_output_test__new_snapshot.snap"
+git -C "$repo" add .
+git -C "$repo" commit -qm 'add unmapped snapshot'
+set +e
+unmapped_output="$(
+    cd "$repo"
+    ./scripts/check-scoped-snapshot-tests.sh --base-sha main 2>&1
+)"
+unmapped_status=$?
+set -e
+[[ "$unmapped_status" -eq 1 ]]
+grep -qF 'no Scoped Validation mapping for component_output_test__new_snapshot.snap' <<<"$unmapped_output"
+echo 'ok   unmapped snapshot fails the routing guard'
+
+echo 'PASS: scoped snapshot routing verified.'

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -13,6 +13,8 @@ makefile="$repo_root/cas-cli/Makefile"
 verified="$repo_root/scripts/run-verified-tests.sh"
 real_store_guard="$repo_root/scripts/check-real-store-untouched.sh"
 migration_guard="$repo_root/scripts/check-release-migration-snapshots.sh"
+snapshot_router="$repo_root/scripts/check-scoped-snapshot-tests.sh"
+snapshot_router_test="$repo_root/scripts/test-check-scoped-snapshot-tests.sh"
 watchdog="$repo_root/.github/workflows/merge-queue-watchdog.yml"
 watchdog_script="$repo_root/scripts/cancel-stale-merge-group-runs.sh"
 runner_unit="$repo_root/ops/systemd/cassy-actions-runner.service"
@@ -334,6 +336,10 @@ require_text "$scoped" "github.event_name == 'pull_request'" 'pull requests use 
 require_text "$scoped" 'github.base_ref != github.event.repository.default_branch' 'scoped tier skips protected-default PRs'
 require_text "$scoped" 'cargo check -p cas --lib --tests' 'scoped tier checks target surface'
 require_text "$scoped" 'scripts/run-scoped-tests.sh -p cas --lib' 'scoped tier runs one guarded test binary'
+require_text "$scoped" 'Test snapshot-pinned CLI output surfaces' 'scoped tier names the snapshot surface target'
+require_text "$scoped" 'scripts/check-scoped-snapshot-tests.sh --base-sha' 'scoped tier routes mapped snapshot surfaces'
+require_text "$scoped" 'github.event.merge_group.base_sha' 'snapshot router receives merge-group base'
+require_text "$scoped" 'origin/${{ github.event.repository.default_branch }}' 'snapshot router has a trusted zero-base fallback'
 
 # Merge-latency contract for the scoped lane (cas-3e14). This lane is not a
 # required check, but it reports last on a factory PR, so a merge that waits for
@@ -371,7 +377,8 @@ for expensive in \
     './.github/actions/setup-rust-linux' \
     'taiki-e/install-action@nextest' \
     'cargo check -p cas --lib --tests' \
-    'scripts/run-scoped-tests.sh -p cas --lib'; do
+    'scripts/run-scoped-tests.sh -p cas --lib' \
+    'scripts/check-scoped-snapshot-tests.sh --base-sha'; do
     step_block="$(awk -v needle="$expensive" '
         /^      - / {
             if (block != "" && index(block, needle)) { printf "%s", block; found = 1; exit }
@@ -383,6 +390,33 @@ for expensive in \
     require_text "$step_block" "steps.pr-dedupe.outputs.covered != 'true'" "scoped lane step is dedupe-gated: $expensive"
     require_text "$step_block" "steps.classify-diff.outputs.rust-unaffected != 'true'" "scoped lane step is classification-gated: $expensive"
 done
+
+# The snapshot router is deliberately a separate, conditional target inside
+# Scoped Validation: it catches doctor_snapshot staleness before the merge
+# queue (PRs #649/#650; PR #657 run 33435790948) without creating a required
+# lane or widening ordinary library coverage.
+require_text "$(<"$snapshot_router")" 'component_output_test__doctor_snapshot.snap|cas-cli/src/cli/doctor.rs|component_output_test' \
+    'doctor.rs maps to component_output_test'
+require_text "$(<"$snapshot_router")" 'component_output_test__status_empty_snapshot.snap|cas-cli/src/cli/status.rs|component_output_test' \
+    'status.rs maps to component_output_test'
+require_text "$(<"$snapshot_router")" 'no Scoped Validation mapping' \
+    'unmapped committed snapshots fail loudly'
+if [[ -x "$snapshot_router" ]]; then
+    printf 'ok   snapshot router is executable\n'
+    pass=$((pass + 1))
+else
+    printf 'FAIL snapshot router must be executable\n'
+    fail=$((fail + 1))
+fi
+if [[ -x "$snapshot_router_test" ]]; then
+    printf 'ok   snapshot router has an executable self-test\n'
+    pass=$((pass + 1))
+else
+    printf 'FAIL snapshot router has no executable self-test\n'
+    fail=$((fail + 1))
+fi
+require_text "$(<"$makefile")" 'test-check-scoped-snapshot-tests.sh' \
+    'test-ci-tiers runs the snapshot router self-test'
 
 # Removing the factory push trigger in the name of dedupe would leave the
 # supervisor's `git merge --no-ff` integration path — which never opens a pull


### PR DESCRIPTION
## Summary
- route doctor.rs and status.rs snapshot-pinned output changes to component_output_test in Scoped Validation
- fail loudly when a committed integration snapshot lacks a routing mapping
- keep the existing library-only lane and CI-load policy unchanged

## Evidence
- scripts/test-check-scoped-snapshot-tests.sh
- scripts/test-ci-test-tiers.sh: 656/656 plus watchdog fixtures 18/18
- scripts/run-scoped-tests.sh -p cas --test component_output_test --no-fail-fast: 13/13
- cargo check -p cas --lib --tests
- simulated doctor surface change propagates a component_output_test failure (run 33435790948 incident shape)