### PR TITLE
docs(release): record v3.7.6 publication receipts

### DIFF
--- a/docs/release-notes/2026-08-31-v3.7.6-slack.md
+++ b/docs/release-notes/2026-08-31-v3.7.6-slack.md
@@ -2,9 +2,8 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
-assets and `release-published-receipt.sh --write-draft` has replaced both
-checksum placeholders below.
+**Status:** Posted 2026-08-31 to #cas-internal. Both User and Dev threads have
+exactly one Was → Now reply; the receipt below records all four messages.
 
 ## User thread
 
@@ -15,8 +14,8 @@ Live on production — **User** — Claude account selection now stays with the 
 - Was: a slow or failed login check could leave a launch on the wrong Claude account. Now: checks time out quickly, failed checks no longer guess the main account, and workers keep the exact credential store selected by the person who started them.
 - Was: custom Claude profile directories could appear as the main profile. Now: account badges show the actual profile name.
 - Install: use `cas update` for an existing installation, or download the
-  v3.7.6 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
-  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+  v3.7.6 archive for Linux x86_64 (SHA-256 `e9b21f4d31967664ce0df628c1f50aa1fab1c60ab3e87614fd209f2ad01d6351`) or macOS ARM64
+  (SHA-256 `3520d1ed4e333f1b2629c29e2e79d22b73a366b09f66e99a4f0cff5cbb2799bc`) from the GitHub release.
 
 ## Dev thread
 
@@ -27,8 +26,8 @@ Live on production — **Dev** — Claude account routing now preserves its inte
 - Was: queued spawns carried one account selector, probes could block without a deadline, and probe failures silently selected main. Now: config and secure-storage selectors propagate independently with unset/empty/set semantics, probes use a bounded child timeout with kill/reap, and bare launches preserve inherited selectors with an explicit warning.
 - Was: arbitrary profile paths were normalized to `main`. Now: custom paths render truthfully in account badges.
 - Validation and artifact: `cargo metadata --locked`, `cargo check -p cas --locked`, migration-snapshot checks, guarded `component_output_test`, and `git diff --check`. The published archives are
-  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
-  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `e9b21f4d31967664ce0df628c1f50aa1fab1c60ab3e87614fd209f2ad01d6351`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `3520d1ed4e333f1b2629c29e2e79d22b73a366b09f66e99a4f0cff5cbb2799bc`). Linux and
   macOS are both available from CI, regardless of the tagger's host.
 
 ## Posting sequence
@@ -49,7 +48,7 @@ Channel: `#cas-internal` (`C0B44GUKDK2`).
 
 | Message | UTC timestamp | Permalink |
 | --- | --- | --- |
-| User top-level |  |  |
-| User reply (Was → Now) |  |  |
-| Dev top-level |  |  |
-| Dev reply (Was → Now) |  |  |
+| User top-level | 2026-08-31T22:51:31Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788216691277399 |
+| User reply (Was → Now) | 2026-08-31T22:51:37Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788216697190959?thread_ts=1788216691.277399&cid=C0B44GUKDK2 |
+| Dev top-level | 2026-08-31T22:51:39Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788216699833259 |
+| Dev reply (Was → Now) | 2026-08-31T22:51:46Z | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788216706350489?thread_ts=1788216699.833259&cid=C0B44GUKDK2 |


### PR DESCRIPTION
Record the v3.7.6 publication evidence after the release landed.

- Fill published Linux/macOS digests from fresh GitHub downloads.
- Mark the draft posted and record all four #cas-internal timestamps/permalinks.
- Preserve the two-thread User/Dev shape with one reply each.

Validation: release-published-receipt.sh, release-latency-receipt.sh, host update, tag-sourced clean install, and git diff --check.