### PR TITLE
chore(release): prepare v3.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.7.7] - 2026-09-01
+
+### Changed
+- Factory delivery monitoring now flags a failed required check while
+  auto-merge is armed, or an auto-merge arm that disappears after green checks,
+  with duplicate notifications suppressed per pull request and head commit
+  and new heads re-armed for notification.
+- `branch_contained_in` reminders now refresh the exact `origin/<target_branch>`
+  ref before checking containment, keep the reminder pending when that refresh
+  fails instead of trusting stale state, and show the compared ref and commit.
+
 ## [3.7.6] - 2026-08-31
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.7.6"
+version = "3.7.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.7.6"
+version = "3.7.7"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.7.6"
+version = "3.7.7"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.7.6"
+version = "3.7.7"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.7.6"
+version = "3.7.7"
 dependencies = [
  "anyhow",
  "blake3",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.7.6"
+version = "3.7.7"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.7.6"
+version = "3.7.7"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.7.6"
+version = "3.7.7"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.7.6"
+version = "3.7.7"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.7.6"
+version = "3.7.7"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.7.6"
+version = "3.7.7"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.7.6"
+version = "3.7.7"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-09-01-v3.7.7-slack.md
+++ b/docs/release-notes/2026-09-01-v3.7.7-slack.md
@@ -1,0 +1,55 @@
+# Slack draft — Cassy v3.7.7 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` replaces both checksum
+placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Cassy now notices when a delivery stalls and only wakes you when a target branch really contains your commit.
+
+**Reply (Was → Now):**
+- Was: a delivery could sit unnoticed after a required check failed or its automatic merge action disappeared. Now: Cassy flags the stalled or failed delivery, and recognizes a new revision as a fresh delivery to watch.
+- Was: a reminder could compare against an out-of-date or unintended target branch. Now: Cassy checks the current remote target branch before waking you, stays pending when that refresh fails, and shows the verified ref and commit.
+- Install: use `cas update` for an existing installation, or download the
+  v3.7.7 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — Factory delivery and external-wake checks now fail closed on stale state and surface actionable CI regressions.
+
+**Reply (Was → Now):**
+- Was: delivery monitoring focused on merge-queue ejections and could miss a failed required PR lane or a silently disarmed automatic merge. Now: current factory PR heads are checked for `Scoped Validation (factory/PR)` failures and vanished auto-merge arms after green checks, with notifications deduplicated by PR and head SHA and re-armed for a new head.
+- Was: `branch_contained_in` resolved its target through local or stale ref state and did not identify the compared revision. Now: a bounded fetch refreshes `refs/remotes/origin/<target_branch>`, fetch failure leaves the reminder pending, and fired descriptions include the compared ref and SHA.
+- Validation and artifact: `cargo metadata --locked`, `cargo check -p cas --locked`, migration-snapshot checks, guarded `component_output_test`, and `git diff --check`. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |


### PR DESCRIPTION
## Summary\n- bump all workspace package manifests and Cargo.lock to 3.7.7\n- document factory stall relays and fresh-origin branch containment reminders\n- add the v3.7.7 User/Dev #cas-internal release draft\n\n## Validation\n- cargo metadata --locked\n- cargo check -p cas --locked\n- scripts/check-release-migration-snapshots.sh\n- scripts/run-scoped-tests.sh -p cas --test component_output_test (13/13)\n- git diff --check