### PR TITLE
fix(close-gate): never pass a negative @-timestamp to git --since — deflakes commit_claim_integrity_tests, unwedges merge queue

### DIFF
--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -9041,10 +9041,10 @@ const COMMIT_RECEIPT_CLOCK_SKEW_SECS: i64 = 5;
 /// Build the Git date filter used when attributing commits to a task.
 ///
 /// Git interprets a negative `@<epoch>` value as a different date expression
-/// (currently effectively "now"), not as an epoch before Unix time. Keep the
-/// omit the filter for synthetic/legacy task fixtures whose adjusted floor is
-/// at or before Unix epoch, while real positive task floors retain their
-/// clock-skew allowance.
+/// (currently effectively "now"), not as an epoch before Unix time. Omit the
+/// filter for synthetic/legacy task fixtures whose adjusted floor is at or
+/// before Unix epoch, while real positive task floors retain their clock-skew
+/// allowance.
 fn task_commit_receipt_since(task_floor: chrono::DateTime<chrono::Utc>) -> Option<String> {
     let earliest_epoch = task_floor
         .timestamp()
@@ -23363,7 +23363,8 @@ mod commit_claim_integrity_tests {
         std::fs::write(dir.path().join("backdated.rs"), "fn backdated() {}\n").unwrap();
         // This commit is several seconds behind any test invocation. The
         // pre-fix `@-5` expression is parsed by Git as "now" and drops it;
-        // the clamped `@0` window must retain it deterministically.
+        // the omitted filter for the non-positive floor must retain it
+        // deterministically.
         git(dir.path(), &["add", "backdated.rs"]);
         git_at(
             dir.path(),

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -9044,6 +9044,21 @@ pub(crate) enum ZeroCommitCloseOutcome {
 
 const COMMIT_RECEIPT_CLOCK_SKEW_SECS: i64 = 5;
 
+/// Build the Git date filter used when attributing commits to a task.
+///
+/// Git interprets a negative `@<epoch>` value as a different date expression
+/// (currently effectively "now"), not as an epoch before Unix time. Keep the
+/// lower bound at Unix epoch so synthetic/legacy task fixtures still include
+/// all attributable commits while real positive task floors retain their
+/// clock-skew allowance.
+fn task_commit_receipt_since(task_floor: chrono::DateTime<chrono::Utc>) -> String {
+    let earliest_epoch = task_floor
+        .timestamp()
+        .saturating_sub(COMMIT_RECEIPT_CLOCK_SKEW_SECS)
+        .max(0);
+    format!("@{earliest_epoch}")
+}
+
 /// Durable lower bound used to attribute a receipt to one task work cycle.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TaskCommitReceiptWindow {
@@ -23240,6 +23255,26 @@ mod commit_claim_integrity_tests {
         assert!(status.success(), "git {args:?} failed");
     }
 
+    fn git_at(dir: &Path, args: &[&str], committer_epoch: i64) {
+        let date = chrono::DateTime::from_timestamp(committer_epoch, 0)
+            .unwrap()
+            .to_rfc3339();
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "test@test")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "test@test")
+            .env("GIT_AUTHOR_DATE", &date)
+            .env("GIT_COMMITTER_DATE", &date)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .status()
+            .expect("git");
+        assert!(status.success(), "git {args:?} failed");
+    }
+
     /// Minimal worker repo: `main` with one seed commit, then branch off
     /// to `factory/test-worker`. Caller can add commits on top.
     fn init_worker_repo() -> TempDir {
@@ -23322,6 +23357,48 @@ mod commit_claim_integrity_tests {
         assert!(
             stat.is_empty(),
             "diff stat must be empty when no commits exist beyond base; got: {stat}"
+        );
+    }
+
+    #[test]
+    fn task_commit_receipt_since_clamps_negative_epoch_cas_653f() {
+        let epoch = chrono::DateTime::from_timestamp(0, 0).unwrap();
+        assert_eq!(task_commit_receipt_since(epoch), "@0");
+
+        let positive_floor = chrono::DateTime::from_timestamp(10, 0).unwrap();
+        assert_eq!(task_commit_receipt_since(positive_floor), "@5");
+    }
+
+    #[test]
+    fn task_attributed_diff_includes_backdated_commit_cas_653f() {
+        let dir = init_worker_repo();
+        std::fs::write(dir.path().join("backdated.rs"), "fn backdated() {}\n").unwrap();
+        // This commit is several seconds behind any test invocation. The
+        // pre-fix `@-5` expression is parsed by Git as "now" and drops it;
+        // the clamped `@0` window must retain it deterministically.
+        git(dir.path(), &["add", "backdated.rs"]);
+        git_at(
+            dir.path(),
+            &["commit", "-q", "-m", "fix(cas-653f): backdated fixture"],
+            2,
+        );
+
+        let epoch = chrono::DateTime::from_timestamp(0, 0).unwrap();
+        let window = TaskCommitReceiptWindow {
+            not_before: epoch,
+            basis: "task creation time (test)",
+            task_floor: epoch,
+            identity: TaskCommitIdentity {
+                task_id: Some("cas-653f".to_string()),
+                known_commits: Vec::new(),
+            },
+        };
+        let measurement = get_task_attributable_diff_stat(dir.path(), "main", &window)
+            .expect("backdated task commit must produce an attributable measurement");
+        assert!(
+            measurement.stat.contains("backdated.rs"),
+            "backdated task commit must be included in the diff stat: {}",
+            measurement.stat
         );
     }
 

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -8732,19 +8732,13 @@ fn get_task_attributable_diff_stat(
     if !is_safe_git_refname(parent_branch) || window.identity.is_empty() {
         return None;
     }
-    let since = format!(
-        "@{}",
-        window.task_floor.timestamp() - COMMIT_RECEIPT_CLOCK_SKEW_SECS
-    );
-    let history = Command::new("git")
-        .args([
-            "log",
-            "--reverse",
-            "--first-parent",
-            &format!("--since={since}"),
-            "--format=%H%x1f%B%x1e",
-            "HEAD",
-        ])
+    let mut history_command = Command::new("git");
+    history_command.args(["log", "--reverse", "--first-parent"]);
+    if let Some(since) = task_commit_receipt_since(window.task_floor) {
+        history_command.arg(format!("--since={since}"));
+    }
+    let history = history_command
+        .args(["--format=%H%x1f%B%x1e", "HEAD"])
         .current_dir(repo_path)
         .output()
         .ok()?;
@@ -9048,15 +9042,14 @@ const COMMIT_RECEIPT_CLOCK_SKEW_SECS: i64 = 5;
 ///
 /// Git interprets a negative `@<epoch>` value as a different date expression
 /// (currently effectively "now"), not as an epoch before Unix time. Keep the
-/// lower bound at Unix epoch so synthetic/legacy task fixtures still include
-/// all attributable commits while real positive task floors retain their
+/// omit the filter for synthetic/legacy task fixtures whose adjusted floor is
+/// at or before Unix epoch, while real positive task floors retain their
 /// clock-skew allowance.
-fn task_commit_receipt_since(task_floor: chrono::DateTime<chrono::Utc>) -> String {
+fn task_commit_receipt_since(task_floor: chrono::DateTime<chrono::Utc>) -> Option<String> {
     let earliest_epoch = task_floor
         .timestamp()
-        .saturating_sub(COMMIT_RECEIPT_CLOCK_SKEW_SECS)
-        .max(0);
-    format!("@{earliest_epoch}")
+        .saturating_sub(COMMIT_RECEIPT_CLOCK_SKEW_SECS);
+    (earliest_epoch > 0).then(|| format!("@{earliest_epoch}"))
 }
 
 /// Durable lower bound used to attribute a receipt to one task work cycle.
@@ -12199,18 +12192,13 @@ pub(crate) fn has_task_attributable_reviewable_changes(
         return None;
     }
 
-    let since = format!(
-        "@{}",
-        window.not_before.timestamp() - COMMIT_RECEIPT_CLOCK_SKEW_SECS
-    );
-    let log_out = Command::new("git")
-        .args([
-            "log",
-            &format!("--since={since}"),
-            "--name-only",
-            "--pretty=format:",
-            &format!("{merge_base}..HEAD"),
-        ])
+    let mut log_command = Command::new("git");
+    log_command.args(["log", "--name-only", "--pretty=format:"]);
+    if let Some(since) = task_commit_receipt_since(window.not_before) {
+        log_command.arg(format!("--since={since}"));
+    }
+    let log_out = log_command
+        .arg(format!("{merge_base}..HEAD"))
         .current_dir(repo_path)
         .output()
         .ok()?;
@@ -23361,12 +23349,12 @@ mod commit_claim_integrity_tests {
     }
 
     #[test]
-    fn task_commit_receipt_since_clamps_negative_epoch_cas_653f() {
+    fn task_commit_receipt_since_omits_non_positive_epoch_cas_653f() {
         let epoch = chrono::DateTime::from_timestamp(0, 0).unwrap();
-        assert_eq!(task_commit_receipt_since(epoch), "@0");
+        assert_eq!(task_commit_receipt_since(epoch), None);
 
         let positive_floor = chrono::DateTime::from_timestamp(10, 0).unwrap();
-        assert_eq!(task_commit_receipt_since(positive_floor), "@5");
+        assert_eq!(task_commit_receipt_since(positive_floor), Some("@5".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The merge queue has been ejecting every PR since ~00:13Z on `commit_claim_integrity_tests`. Root cause: `get_task_attributable_diff_stat` builds `--since=@{task_floor - clock_skew}`; with epoch fixtures that value is negative, and git parses a negative `@` timestamp as approximately **now** (`git rev-parse --since=@-600` → `--max-age=<current second>`). The intended include-everything window becomes include-only-this-second, so the tests pass only when all fixture commits and the log call land in one epoch second — a race that loaded queue runners lose.

- New `task_commit_receipt_since` returns `None` for non-positive floors (the `--since` flag is omitted → correct include-all semantics) and `@N` unchanged for positive floors; applied at both call sites.
- Unit test pins the non-negative contract; a backdated-fixture regression (commits via `GIT_COMMITTER_DATE`) fails on pre-fix code and passes now, so the same-second race can never mask the window again.

## Testing
- `scripts/run-scoped-tests.sh -p cas --lib close_ops::commit_claim_integrity` — twice, plus the backdated variant.
- This PR modifies close_ops.rs, so the fixed tests gate this queue run itself.

Task: cas-653f

🤖 Generated with [Claude Code](https://claude.com/claude-code)
