### PR TITLE
docs(release): record v3.7.7 Slack receipts

### DIFF
--- a/docs/release-notes/2026-09-01-v3.7.7-slack.md
+++ b/docs/release-notes/2026-09-01-v3.7.7-slack.md
@@ -2,9 +2,8 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
-assets and `release-published-receipt.sh --write-draft` replaces both checksum
-placeholders below.
+**Status:** Posted 2026-09-01 to #cas-internal. Both User and Dev threads have
+exactly one Was → Now reply; the receipt below records all four messages.
 
 ## User thread
 
@@ -15,8 +14,8 @@ Live on production — **User** — Cassy now notices when a delivery stalls and
 - Was: a delivery could sit unnoticed after a required check failed or its automatic merge action disappeared. Now: Cassy flags the stalled or failed delivery, and recognizes a new revision as a fresh delivery to watch.
 - Was: a reminder could compare against an out-of-date or unintended target branch. Now: Cassy checks the current remote target branch before waking you, stays pending when that refresh fails, and shows the verified ref and commit.
 - Install: use `cas update` for an existing installation, or download the
-  v3.7.7 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
-  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+  v3.7.7 archive for Linux x86_64 (SHA-256 `2552044c435d50ee1b21958efcef98ee3285a384fee925cea7e4dc765f6570d4`) or macOS ARM64
+  (SHA-256 `6575e0c7ed7ee0a7ed439ccfc736694445e5ab19a259a49124eb2d46d54f3c3e`) from the GitHub release.
 
 ## Dev thread
 
@@ -27,8 +26,8 @@ Live on production — **Dev** — Factory delivery and external-wake checks now
 - Was: delivery monitoring focused on merge-queue ejections and could miss a failed required PR lane or a silently disarmed automatic merge. Now: current factory PR heads are checked for `Scoped Validation (factory/PR)` failures and vanished auto-merge arms after green checks, with notifications deduplicated by PR and head SHA and re-armed for a new head.
 - Was: `branch_contained_in` resolved its target through local or stale ref state and did not identify the compared revision. Now: a bounded fetch refreshes `refs/remotes/origin/<target_branch>`, fetch failure leaves the reminder pending, and fired descriptions include the compared ref and SHA.
 - Validation and artifact: `cargo metadata --locked`, `cargo check -p cas --locked`, migration-snapshot checks, guarded `component_output_test`, and `git diff --check`. The published archives are
-  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
-  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `2552044c435d50ee1b21958efcef98ee3285a384fee925cea7e4dc765f6570d4`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `6575e0c7ed7ee0a7ed439ccfc736694445e5ab19a259a49124eb2d46d54f3c3e`). Linux and
   macOS are both available from CI, regardless of the tagger's host.
 
 ## Posting sequence
@@ -49,7 +48,7 @@ Channel: `#cas-internal` (`C0B44GUKDK2`).
 
 | Message | UTC timestamp | Permalink |
 | --- | --- | --- |
-| User top-level |  |  |
-| User reply (Was → Now) |  |  |
-| Dev top-level |  |  |
-| Dev reply (Was → Now) |  |  |
+| User top-level | 2026-09-01T01:59:06.994729Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788227946994729) |
+| User reply (Was → Now) | 2026-09-01T01:59:13.115699Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788227953115699?thread_ts=1788227946.994729&cid=C0B44GUKDK2) |
+| Dev top-level | 2026-09-01T01:59:17.085249Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788227957085249) |
+| Dev reply (Was → Now) | 2026-09-01T01:59:24.559519Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788227964559519?thread_ts=1788227957.085249&cid=C0B44GUKDK2) |


### PR DESCRIPTION
Record the four approved #cas-internal v3.7.7 announcement timestamps and permalinks, plus the published Linux/macOS asset digests and release proof status.