### PR TITLE
v3.8.0: cross-project task identity, move-task-to-project, project-scoped board, hub pairing/lifecycle fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.8.0] - 2026-09-01
+
+### Added
+- `mcp__cas__task` list/ready/blocked/available accept `include_foreign`; the
+  board is scoped to the current project by default and prints how many
+  foreign-origin rows were hidden. `show` on a foreign task names its owner.
+- Supervisor `task update origin_project=<project>` now moves the task in the
+  team cloud: the old project-keyed row is deleted before the row is upserted
+  under the new owner (delete failure withholds the upsert), the destination
+  must be a registered team project, and a decision note records the move.
+- `cas hub authorize` resolves the Commander origin without `--hub-url`
+  (explicit flag, then the hub process record, then `[hub].public_url`, then
+  the last origin that worked), accepts bare hostnames as HTTPS, and prints the
+  requested/granted scopes once.
+
+### Changed
+- Team push no longer overwrites an explicit `origin_project` with the pushing
+  project; only rows with a missing or blank origin inherit it, and Global
+  tasks stay unstamped.
+- Team pull keeps foreign-keyed task rows and arbitrates duplicates in favor of
+  the owning project; a stale replica can no longer reopen a task its owner
+  closed (discarded rows are logged as `owner_wins`).
+- `cas cloud purge-foreign` classifies only rows explicitly attributed to
+  another project as foreign; tasks with no attribution and every local rule are
+  kept, and it refuses (even with `--force`) to remove more than half of the
+  tasks or any proven rule.
+- Bare `cas hub` shows status (with both the running and installed versions);
+  `cas hub start` on a live hub whose version or flags differ restarts it
+  instead of failing; `cas update` restarts a running hub left on the old
+  binary.
+- `cas list` reports the live registered worker count for a factory session
+  instead of stale session metadata.
+
 ## [3.7.7] - 2026-09-01
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.7.7"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.7.7"
+version = "3.8.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.7.7"
+version = "3.8.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.7.7"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.7.7"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.7.7"
+version = "3.8.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.7.7"
+version = "3.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/cas-cli/src/bridge/server/types.rs
+++ b/cas-cli/src/bridge/server/types.rs
@@ -140,6 +140,7 @@ pub(crate) struct SessionJson {
     pub(crate) epic_id: Option<String>,
     pub(crate) supervisor: String,
     pub(crate) workers: Vec<String>,
+    pub(crate) worker_count: usize,
     pub(crate) is_running: bool,
     pub(crate) socket_exists: bool,
     pub(crate) can_attach: bool,
@@ -238,6 +239,7 @@ pub(crate) struct PaneTailJson {
 }
 
 pub(crate) fn session_json(s: &crate::ui::factory::SessionInfo) -> SessionJson {
+    let workers = s.worker_names();
     SessionJson {
         name: s.name.clone(),
         created_at: s.metadata.created_at.clone(),
@@ -247,7 +249,8 @@ pub(crate) fn session_json(s: &crate::ui::factory::SessionInfo) -> SessionJson {
         project_dir: s.metadata.project_dir.clone(),
         epic_id: s.metadata.epic_id.clone(),
         supervisor: s.metadata.supervisor.name.clone(),
-        workers: s.metadata.workers.iter().map(|w| w.name.clone()).collect(),
+        worker_count: workers.len(),
+        workers,
         is_running: s.is_running,
         socket_exists: s.socket_exists,
         can_attach: s.can_attach(),

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -5466,6 +5466,101 @@ mod purge_foreign_safety_tests {
     use rusqlite::Connection;
     use tempfile::TempDir;
 
+    fn seed_project_scoped_db(conn: &Connection) {
+        conn.execute_batch(
+            r#"
+            CREATE TABLE entries (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                content TEXT NOT NULL,
+                project_canonical_id TEXT
+            );
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                origin_project TEXT
+            );
+            CREATE TABLE rules (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                status TEXT NOT NULL,
+                project_canonical_id TEXT
+            );
+            CREATE TABLE skills (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                project_canonical_id TEXT
+            );
+            CREATE TABLE dependencies (from_id TEXT, to_id TEXT);
+
+            INSERT INTO tasks (id, title, origin_project) VALUES
+                ('own-1', 'own task 1', 'cas-src'),
+                ('own-2', 'own task 2', 'cas-src'),
+                ('legacy', 'legacy local task', NULL),
+                ('foreign-1', 'foreign task 1', 'gabber-studio'),
+                ('foreign-2', 'foreign task 2', 'pulse-card');
+            INSERT INTO rules (id, content, status, project_canonical_id)
+                VALUES ('proven-own', 'keep me', 'proven', 'cas-src');
+            INSERT INTO dependencies (from_id, to_id) VALUES
+                ('foreign-1', 'own-1'), ('own-2', 'legacy');
+            "#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn project_scoped_classifier_only_lists_explicitly_foreign_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_project_scoped_db(&conn);
+
+        let set = collect_purge_delete_set(&conn, "cas-src").unwrap();
+
+        assert_eq!(
+            set.tasks.iter().map(|task| task.id.as_str()).collect::<Vec<_>>(),
+            vec!["foreign-1", "foreign-2"]
+        );
+        assert!(set.entries.is_empty());
+        assert!(set.rules.is_empty(), "the proven local rule is protected");
+        assert!(set.skills.is_empty());
+        assert_eq!(set.dependencies, 1);
+        assert!(set.tasks.len() <= 5, "delete count cannot exceed rows present");
+    }
+
+    #[test]
+    fn foreign_task_majority_is_a_hard_purge_refusal() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_project_scoped_db(&conn);
+
+        let set = collect_purge_delete_set(&conn, "cas-src").unwrap();
+        let refusals = evaluate_purge_hard_guards(&set, 5, 0);
+
+        assert!(refusals.iter().any(|refusal| {
+            refusal.code() == "too_many_foreign_tasks"
+                && refusal.reason().contains("2 of 5")
+        }));
+    }
+
+    #[test]
+    fn proven_foreign_rule_is_a_hard_purge_refusal() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_project_scoped_db(&conn);
+        conn.execute(
+            "INSERT INTO rules (id, content, status, project_canonical_id)
+             VALUES ('proven-foreign', 'do not delete', 'proven', 'other-project')",
+            [],
+        )
+        .unwrap();
+
+        let set = collect_purge_delete_set(&conn, "cas-src").unwrap();
+        assert_eq!(set.rules.len(), 1);
+        let refusals = evaluate_purge_hard_guards(&set, 5, 1);
+
+        assert!(refusals.iter().any(|refusal| {
+            refusal.code() == "proven_rule"
+                && refusal.reason().contains("1 proven rule")
+        }));
+    }
+
     /// Minimal shape of the tables purge-foreign touches.
     fn seed_db(conn: &Connection) {
         conn.execute_batch(

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -228,9 +228,10 @@ pub struct CloudPurgeForeignArgs {
     #[arg(long)]
     pub dry_run: bool,
 
-    /// Proceed even when the safety guard refuses (stale pull state, or local
-    /// rows that were never pushed to cloud). Destructive — the refusal reason
-    /// is still printed.
+    /// Proceed even when the recoverability guard refuses (stale pull state, or
+    /// local rows that were never pushed to cloud). Classifier hard stops for a
+    /// task majority or proven rule cannot be overridden. Destructive — the
+    /// refusal reason is still printed.
     #[arg(long)]
     pub force: bool,
 
@@ -4165,7 +4166,8 @@ pub struct PurgeDeleteSet {
     pub tasks: Vec<PurgeEntity>,
     pub rules: Vec<PurgeEntity>,
     pub skills: Vec<PurgeEntity>,
-    /// Dependency edges are deleted wholesale and have no user-facing title.
+    /// Dependency edges attached to deleted foreign tasks; they have no
+    /// user-facing title.
     pub dependencies: usize,
 }
 
@@ -4200,58 +4202,153 @@ impl PurgeDeleteSet {
     }
 }
 
+/// Canonical attribution fields that have existed in cloud payloads. The local
+/// content stores do not currently persist one for entries, rules, or skills,
+/// so an absent field means that kind is not an eligible purge candidate.
+const PURGE_PROJECT_COLUMNS: &[&str] = &[
+    "origin_project",
+    "project_canonical_id",
+    "origin_project_id",
+    "project_id",
+];
+
+fn first_existing_project_column(
+    conn: &rusqlite::Connection,
+    table: &str,
+    preferred: &[&'static str],
+) -> anyhow::Result<Option<&'static str>> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let columns = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    let existing: BTreeSet<String> = columns.collect::<Result<_, _>>()?;
+    Ok(preferred
+        .iter()
+        .copied()
+        .find(|column| existing.contains(*column)))
+}
+
+/// Read ids + labels only when a row explicitly carries a project attribution
+/// different from the current canonical id. Missing tables or attribution
+/// columns are treated as empty: legacy rows are not safe to call foreign.
+fn attributed_rows(
+    conn: &rusqlite::Connection,
+    kind: &'static str,
+    table: &str,
+    label_sql: &str,
+    current_project: &str,
+) -> anyhow::Result<Vec<PurgeEntity>> {
+    let Some(project_column) = first_existing_project_column(
+        conn,
+        table,
+        if table == "tasks" {
+            &[
+                "origin_project",
+                "project_canonical_id",
+                "origin_project_id",
+                "project_id",
+            ]
+        } else {
+            PURGE_PROJECT_COLUMNS
+        },
+    )? else {
+        return Ok(Vec::new());
+    };
+
+    let sql = format!(
+        "SELECT id, {label_sql} FROM {table}
+         WHERE NULLIF(trim({project_column}), '') IS NOT NULL
+           AND trim({project_column}) <> ?1
+         ORDER BY id"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mapped = stmt.query_map([current_project], |row| {
+        Ok(PurgeEntity {
+            kind,
+            id: row.get::<_, String>(0)?,
+            label: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+        })
+    })?;
+    mapped.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+fn count_proven_attributed_rules(
+    conn: &rusqlite::Connection,
+    current_project: &str,
+) -> anyhow::Result<usize> {
+    let Some(project_column) =
+        first_existing_project_column(conn, "rules", PURGE_PROJECT_COLUMNS)?
+    else {
+        return Ok(0);
+    };
+    if first_existing_project_column(conn, "rules", &["status"])?.is_none() {
+        return Ok(0);
+    }
+    let sql = format!(
+        "SELECT COUNT(*) FROM rules
+         WHERE lower(status) = 'proven'
+           AND NULLIF(trim({project_column}), '') IS NOT NULL
+           AND trim({project_column}) <> ?1"
+    );
+    Ok(conn.query_row(&sql, [current_project], |row| row.get::<_, i64>(0))? as usize)
+}
+
+fn count_purge_dependencies(
+    conn: &rusqlite::Connection,
+    foreign_tasks: &[PurgeEntity],
+) -> anyhow::Result<usize> {
+    let foreign_ids: BTreeSet<&str> = foreign_tasks
+        .iter()
+        .map(|task| task.id.as_str())
+        .collect();
+    if foreign_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut stmt = match conn.prepare("SELECT from_id, to_id FROM dependencies") {
+        Ok(stmt) => stmt,
+        Err(error) if error.to_string().contains("no such table") => return Ok(0),
+        Err(error) => return Err(error.into()),
+    };
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut count = 0;
+    for row in rows {
+        let (from_id, to_id) = row?;
+        if foreign_ids.contains(from_id.as_str()) || foreign_ids.contains(to_id.as_str()) {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
 /// Read the ids + labels of every row a purge would delete.
 ///
 /// Missing tables are treated as empty rather than fatal: a database that
-/// predates one of these stores must still be previewable.
-fn collect_purge_delete_set(conn: &rusqlite::Connection) -> anyhow::Result<PurgeDeleteSet> {
-    fn rows(
-        conn: &rusqlite::Connection,
-        kind: &'static str,
-        sql: &str,
-    ) -> anyhow::Result<Vec<PurgeEntity>> {
-        let mut stmt = match conn.prepare(sql) {
-            Ok(stmt) => stmt,
-            // Table absent (older database) — nothing of this kind to delete.
-            // Any other failure is real and must not be silently reported as
-            // "nothing would be deleted".
-            Err(e) if e.to_string().contains("no such table") => return Ok(Vec::new()),
-            Err(e) => return Err(e.into()),
-        };
-        let mapped = stmt.query_map([], |row| {
-            Ok(PurgeEntity {
-                kind,
-                id: row.get::<_, String>(0)?,
-                label: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
-            })
-        })?;
-        let mut out = Vec::new();
-        for r in mapped {
-            out.push(r?);
-        }
-        Ok(out)
-    }
-
-    let dependencies: usize = conn
-        .query_row("SELECT COUNT(*) FROM dependencies", [], |r| {
-            r.get::<_, i64>(0)
-        })
-        .unwrap_or(0) as usize;
-
+/// predates one of these stores must still be previewable. Rows without an
+/// explicit project attribution remain local legacy data and are retained.
+fn collect_purge_delete_set(
+    conn: &rusqlite::Connection,
+    current_project: &str,
+) -> anyhow::Result<PurgeDeleteSet> {
+    let tasks = attributed_rows(conn, "task", "tasks", "title", current_project)?;
     Ok(PurgeDeleteSet {
-        entries: rows(
+        entries: attributed_rows(
             conn,
             "entry",
-            "SELECT id, COALESCE(NULLIF(title, ''), substr(content, 1, 80)) FROM entries ORDER BY id",
+            "entries",
+            "COALESCE(NULLIF(title, ''), substr(content, 1, 80))",
+            current_project,
         )?,
-        tasks: rows(conn, "task", "SELECT id, title FROM tasks ORDER BY id")?,
-        rules: rows(
+        tasks: tasks.clone(),
+        rules: attributed_rows(
             conn,
             "rule",
-            "SELECT id, substr(content, 1, 80) FROM rules ORDER BY id",
+            "rules",
+            "substr(content, 1, 80)",
+            current_project,
         )?,
-        skills: rows(conn, "skill", "SELECT id, name FROM skills ORDER BY id")?,
-        dependencies,
+        skills: attributed_rows(conn, "skill", "skills", "name", current_project)?,
+        dependencies: count_purge_dependencies(conn, &tasks)?,
     })
 }
 
@@ -4272,6 +4369,11 @@ pub enum PurgeRefusal {
     /// Local rows are still queued for push: deleting them loses work the
     /// cloud has never seen, and the re-pull cannot restore it.
     UnpushedRows { pending: usize, sample: Vec<String> },
+    /// More than half of all local tasks would be removed. This is a hard
+    /// stop because a project-scoped classifier has likely lost attribution.
+    TooManyForeignTasks { foreign: usize, total: usize },
+    /// A proven rule would be removed. Proven rules are never force-deletable.
+    ProvenRule { count: usize },
 }
 
 impl PurgeRefusal {
@@ -4301,6 +4403,14 @@ unknown is not safe for a destructive purge"
 cloud (e.g. {}) — the purge would delete them and the re-pull cannot bring them back",
                 sample.join(", ")
             ),
+            PurgeRefusal::TooManyForeignTasks { foreign, total } => format!(
+                "refusing to purge foreign tasks: {foreign} of {total} local tasks exceed the 50% \
+safety limit — review project attribution before deleting anything"
+            ),
+            PurgeRefusal::ProvenRule { count } => format!(
+                "refusing to purge {count} proven rule{} — proven rules are protected even with --force",
+                if *count == 1 { "" } else { "s" }
+            ),
         }
     }
 
@@ -4311,8 +4421,90 @@ cloud (e.g. {}) — the purge would delete them and the re-pull cannot bring the
             PurgeRefusal::StalePull { .. } => "stale_pull",
             PurgeRefusal::UnreadablePullTimestamp { .. } => "unreadable_pull_timestamp",
             PurgeRefusal::UnpushedRows { .. } => "unpushed_rows",
+            PurgeRefusal::TooManyForeignTasks { .. } => "too_many_foreign_tasks",
+            PurgeRefusal::ProvenRule { .. } => "proven_rule",
         }
     }
+
+    fn is_hard(&self) -> bool {
+        matches!(
+            self,
+            PurgeRefusal::TooManyForeignTasks { .. } | PurgeRefusal::ProvenRule { .. }
+        )
+    }
+}
+
+/// Safety limits that are intrinsic to the classifier and cannot be bypassed
+/// by `--force`. `proven_rule_count` is computed from the same attribution
+/// predicate as the delete set, so a proven local rule never trips this guard.
+fn evaluate_purge_hard_guards(
+    delete_set: &PurgeDeleteSet,
+    total_tasks: usize,
+    proven_rule_count: usize,
+) -> Vec<PurgeRefusal> {
+    let mut refusals = Vec::new();
+    if total_tasks > 0 && delete_set.tasks.len().saturating_mul(2) > total_tasks {
+        refusals.push(PurgeRefusal::TooManyForeignTasks {
+            foreign: delete_set.tasks.len(),
+            total: total_tasks,
+        });
+    }
+    if proven_rule_count > 0 {
+        refusals.push(PurgeRefusal::ProvenRule {
+            count: proven_rule_count,
+        });
+    }
+    refusals
+}
+
+/// Apply a previously classified delete set atomically. This function accepts
+/// only concrete row ids from `PurgeDeleteSet`; it never re-runs an unscoped
+/// `DELETE FROM <table>` predicate.
+fn delete_purge_rows(
+    conn: &mut rusqlite::Connection,
+    delete_set: &PurgeDeleteSet,
+) -> anyhow::Result<()> {
+    let tx = conn.transaction()?;
+    for (table, rows) in [
+        ("entries", &delete_set.entries),
+        ("tasks", &delete_set.tasks),
+        ("rules", &delete_set.rules),
+        ("skills", &delete_set.skills),
+    ] {
+        for row in rows {
+            let sql = format!("DELETE FROM {table} WHERE id = ?1");
+            match tx.execute(&sql, [&row.id]) {
+                Ok(_) => {}
+                Err(error) if error.to_string().contains("no such table") => break,
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
+    // Remove only dependency edges attached to a foreign task. Edges between
+    // retained local/legacy tasks must survive the purge.
+    for task in &delete_set.tasks {
+        match tx.execute(
+            "DELETE FROM dependencies WHERE from_id = ?1 OR to_id = ?1",
+            [&task.id],
+        ) {
+            Ok(_) => {}
+            Err(error) if error.to_string().contains("no such table") => break,
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    // Reset last_pull_at only when rows were actually removed so a no-op
+    // cleanup does not force an unnecessary full pull.
+    if delete_set.total() > 0 {
+        match tx.execute("DELETE FROM sync_metadata WHERE key = 'last_pull_at'", []) {
+            Ok(_) => {}
+            Err(error) if error.to_string().contains("no such table") => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    tx.commit()?;
+    Ok(())
 }
 
 /// Parse a `last_pull_at` value. Accepts RFC3339 (what the syncer writes) and
@@ -4485,7 +4677,8 @@ fn execute_purge_foreign(
     // would be lost and a real run can refuse when losing it is unrecoverable.
     let (delete_set, refusals) = {
         let conn = rusqlite::Connection::open(&db_path)?;
-        let delete_set = collect_purge_delete_set(&conn)?;
+        let delete_set = collect_purge_delete_set(&conn, &project_id)?;
+        let proven_rule_count = count_proven_attributed_rules(&conn, &project_id)?;
         let last_pull_at: Option<String> = conn
             .query_row(
                 "SELECT value FROM sync_metadata WHERE key = 'last_pull_at'",
@@ -4494,12 +4687,17 @@ fn execute_purge_foreign(
             )
             .ok();
         let pending = pending_content_pushes(&conn)?;
-        let refusals = evaluate_purge_safety(
+        let mut refusals = evaluate_purge_safety(
             last_pull_at.as_deref(),
             &pending,
             chrono::Utc::now(),
             args.stale_days,
         );
+        refusals.extend(evaluate_purge_hard_guards(
+            &delete_set,
+            tasks_before,
+            proven_rule_count,
+        ));
         (delete_set, refusals)
     };
 
@@ -4521,7 +4719,9 @@ fn execute_purge_foreign(
                     "refusals": refusals.iter()
                         .map(|r| serde_json::json!({"code": r.code(), "reason": r.reason()}))
                         .collect::<Vec<_>>(),
-                    "would_refuse": !refusals.is_empty() && !args.force,
+                    "would_refuse": refusals.iter().any(|refusal| {
+                        refusal.is_hard() || !args.force
+                    }),
                 })
             );
             return Ok(());
@@ -4598,6 +4798,13 @@ fn execute_purge_foreign(
             .map(|r| format!("  - {}", r.reason()))
             .collect::<Vec<_>>()
             .join("\n");
+        if refusals.iter().any(PurgeRefusal::is_hard) {
+            anyhow::bail!(
+                "Refusing to purge {} local rows:\n{reasons}\n\
+These classifier safety limits cannot be overridden with --force.",
+                delete_set.total()
+            );
+        }
         if !args.force {
             anyhow::bail!(
                 "Refusing to purge {} local rows:\n{reasons}\n\
@@ -4615,20 +4822,14 @@ Re-run 'cas cloud pull' first, or pass --force to purge anyway (destructive).",
         backup_database_crash_safe(&db_path, &backup_path)?;
     }
 
-    // Step 2: Delete all content entities via direct SQL
+    // Step 2: Delete only the classified foreign rows via direct SQL. The
+    // classifier is deliberately resolved before the backup, and this phase
+    // consumes its concrete ids rather than repeating a broader predicate.
     // (Preserves: sync_queue, sync_metadata, agents, sessions, verifications,
-    //  events, prompts, file_changes, commit_links, worktrees, dependencies, task_leases)
+    // events, prompts, file_changes, commit_links, worktrees and local rows.)
     {
-        let conn = rusqlite::Connection::open(&db_path)?;
-        conn.execute_batch(
-            "DELETE FROM entries;
-             DELETE FROM tasks;
-             DELETE FROM dependencies;
-             DELETE FROM rules;
-             DELETE FROM skills;",
-        )?;
-        // Reset last_pull_at so re-pull fetches everything
-        conn.execute("DELETE FROM sync_metadata WHERE key = 'last_pull_at'", [])?;
+        let mut conn = rusqlite::Connection::open(&db_path)?;
+        delete_purge_rows(&mut conn, &delete_set)?;
     }
 
     // Step 3: Re-pull from cloud with project-scoped filtering
@@ -5527,16 +5728,49 @@ mod purge_foreign_safety_tests {
     }
 
     #[test]
+    fn applying_the_delete_set_keeps_local_rows_and_edges() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        seed_project_scoped_db(&conn);
+        let set = collect_purge_delete_set(&conn, "cas-src").unwrap();
+
+        delete_purge_rows(&mut conn, &set).unwrap();
+
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM tasks", [], |row| {
+                row.get::<_, i64>(0)
+            })
+                .unwrap(),
+            3,
+            "the two foreign tasks are deleted; own and legacy rows remain"
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM dependencies",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            1,
+            "the local-to-legacy edge remains"
+        );
+    }
+
+    #[test]
     fn foreign_task_majority_is_a_hard_purge_refusal() {
         let conn = Connection::open_in_memory().unwrap();
         seed_project_scoped_db(&conn);
+        conn.execute(
+            "UPDATE tasks SET origin_project = 'other-project' WHERE origin_project IS NULL OR origin_project = 'cas-src'",
+            [],
+        )
+        .unwrap();
 
         let set = collect_purge_delete_set(&conn, "cas-src").unwrap();
         let refusals = evaluate_purge_hard_guards(&set, 5, 0);
 
         assert!(refusals.iter().any(|refusal| {
             refusal.code() == "too_many_foreign_tasks"
-                && refusal.reason().contains("2 of 5")
+                && refusal.reason().contains("5 of 5")
         }));
     }
 
@@ -5565,10 +5799,28 @@ mod purge_foreign_safety_tests {
     fn seed_db(conn: &Connection) {
         conn.execute_batch(
             r#"
-            CREATE TABLE entries (id TEXT PRIMARY KEY, title TEXT, content TEXT NOT NULL);
-            CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT NOT NULL);
-            CREATE TABLE rules (id TEXT PRIMARY KEY, content TEXT NOT NULL);
-            CREATE TABLE skills (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+            CREATE TABLE entries (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                content TEXT NOT NULL,
+                project_canonical_id TEXT
+            );
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                origin_project TEXT
+            );
+            CREATE TABLE rules (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'draft',
+                project_canonical_id TEXT
+            );
+            CREATE TABLE skills (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                project_canonical_id TEXT
+            );
             CREATE TABLE dependencies (from_id TEXT, to_id TEXT);
             CREATE TABLE sync_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
             CREATE TABLE sync_queue (
@@ -5578,12 +5830,15 @@ mod purge_foreign_safety_tests {
                 operation TEXT NOT NULL
             );
 
-            INSERT INTO entries (id, title, content) VALUES
-                ('e1', 'Local learning', 'body one'),
-                ('e2', NULL, 'untitled body falls back to content');
-            INSERT INTO tasks (id, title) VALUES ('cas-0001', 'Fix the purge guard');
-            INSERT INTO rules (id, content) VALUES ('r1', 'always verify');
-            INSERT INTO skills (id, name) VALUES ('s1', 'release-notes');
+            INSERT INTO entries (id, title, content, project_canonical_id) VALUES
+                ('e1', 'Local learning', 'body one', 'other-project'),
+                ('e2', NULL, 'untitled body falls back to content', 'other-project');
+            INSERT INTO tasks (id, title, origin_project)
+                VALUES ('cas-0001', 'Fix the purge guard', 'other-project');
+            INSERT INTO rules (id, content, project_canonical_id)
+                VALUES ('r1', 'always verify', 'other-project');
+            INSERT INTO skills (id, name, project_canonical_id)
+                VALUES ('s1', 'release-notes', 'other-project');
             INSERT INTO dependencies (from_id, to_id) VALUES ('cas-0001', 'cas-0002');
             "#,
         )
@@ -5603,7 +5858,7 @@ mod purge_foreign_safety_tests {
         let conn = Connection::open_in_memory().unwrap();
         seed_db(&conn);
 
-        let set = collect_purge_delete_set(&conn).unwrap();
+        let set = collect_purge_delete_set(&conn, "test-project").unwrap();
 
         assert_eq!(set.total(), 5, "2 entries + 1 task + 1 rule + 1 skill");
         assert_eq!(set.dependencies, 1);
@@ -5625,7 +5880,7 @@ mod purge_foreign_safety_tests {
         let conn = Connection::open_in_memory().unwrap();
         seed_db(&conn);
 
-        let json = collect_purge_delete_set(&conn).unwrap().to_json();
+        let json = collect_purge_delete_set(&conn, "test-project").unwrap().to_json();
 
         assert_eq!(json["total"], 5);
         assert_eq!(json["tasks"][0]["id"], "cas-0001");
@@ -5641,9 +5896,9 @@ mod purge_foreign_safety_tests {
         conn.execute("INSERT INTO tasks VALUES ('cas-1', 'only table')", [])
             .unwrap();
 
-        let set = collect_purge_delete_set(&conn).unwrap();
+        let set = collect_purge_delete_set(&conn, "test-project").unwrap();
 
-        assert_eq!(set.tasks.len(), 1);
+        assert!(set.tasks.is_empty(), "tasks without attribution are retained");
         assert!(set.entries.is_empty());
         assert_eq!(set.dependencies, 0);
     }
@@ -5888,7 +6143,7 @@ mod purge_foreign_safety_tests {
         backup_database_crash_safe(&db_path, &backup).unwrap();
 
         let restored = Connection::open(&backup).unwrap();
-        let set = collect_purge_delete_set(&restored).unwrap();
+        let set = collect_purge_delete_set(&restored, "test-project").unwrap();
         assert_eq!(
             set.total(),
             5,

--- a/cas-cli/src/cli/factory/queries.rs
+++ b/cas-cli/src/cli/factory/queries.rs
@@ -699,6 +699,7 @@ struct SessionJson {
     epic_id: Option<String>,
     supervisor: String,
     workers: Vec<String>,
+    worker_count: usize,
     is_running: bool,
     socket_exists: bool,
     can_attach: bool,
@@ -709,6 +710,7 @@ struct SessionJson {
 
 impl SessionJson {
     fn from_session_info(session: &SessionInfo, include_metadata: bool) -> Self {
+        let workers = session.worker_names();
         Self {
             name: session.name.clone(),
             created_at: session.metadata.created_at.clone(),
@@ -718,12 +720,8 @@ impl SessionJson {
             project_dir: session.metadata.project_dir.clone(),
             epic_id: session.metadata.epic_id.clone(),
             supervisor: session.metadata.supervisor.name.clone(),
-            workers: session
-                .metadata
-                .workers
-                .iter()
-                .map(|w| w.name.clone())
-                .collect(),
+            worker_count: workers.len(),
+            workers,
             is_running: session.is_running,
             socket_exists: session.socket_exists,
             can_attach: session.can_attach(),

--- a/cas-cli/src/cli/hub.rs
+++ b/cas-cli/src/cli/hub.rs
@@ -790,3 +790,122 @@ pub(super) fn record_is_live(record: &HubProcessRecord) -> bool {
                 && health.get("ready").and_then(|value| value.as_bool()) == Some(true)
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(version: &str, port: u16, tailscale_serve_port: Option<u16>) -> HubProcessRecord {
+        HubProcessRecord {
+            pid: 42,
+            bind: "127.0.0.1".to_owned(),
+            port,
+            version: version.to_owned(),
+            started_at: "2026-09-01T12:00:00Z".to_owned(),
+            public_url: tailscale_serve_port.map(|port| format!("https://hub.example:{port}")),
+            tailscale_serve_port,
+            tailscale_cli: tailscale_serve_port.map(|_| "tailscale".to_owned()),
+            transport_warning: None,
+        }
+    }
+
+    #[test]
+    fn bare_hub_defaults_to_status() {
+        assert!(matches!(default_hub_command(), HubCommands::Status));
+    }
+
+    #[test]
+    fn live_start_decision_table_covers_version_and_flag_drift() {
+        let same_args = HubServeArgs::default();
+        let cases = [
+            (
+                "same version and flags",
+                record(env!("CARGO_PKG_VERSION"), DEFAULT_HUB_PORT, None),
+                same_args.clone(),
+                false,
+                443,
+                HubStartDecision::Keep,
+            ),
+            (
+                "different version",
+                record("3.4.1", DEFAULT_HUB_PORT, None),
+                same_args.clone(),
+                false,
+                443,
+                HubStartDecision::Restart {
+                    version_drift: true,
+                    flags_differ: false,
+                },
+            ),
+            (
+                "different listener port",
+                record(env!("CARGO_PKG_VERSION"), DEFAULT_HUB_PORT, None),
+                HubServeArgs {
+                    port: DEFAULT_HUB_PORT + 1,
+                    ..same_args.clone()
+                },
+                false,
+                443,
+                HubStartDecision::Restart {
+                    version_drift: false,
+                    flags_differ: true,
+                },
+            ),
+            (
+                "different tailscale flag",
+                record(env!("CARGO_PKG_VERSION"), DEFAULT_HUB_PORT, None),
+                same_args,
+                true,
+                443,
+                HubStartDecision::Restart {
+                    version_drift: false,
+                    flags_differ: true,
+                },
+            ),
+        ];
+
+        for (name, live, args, tailscale_serve, tailscale_port, expected) in cases {
+            assert_eq!(
+                decide_live_start(
+                    &live,
+                    &args,
+                    tailscale_serve,
+                    tailscale_port,
+                    env!("CARGO_PKG_VERSION"),
+                ),
+                expected,
+                "case: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn status_rendering_shows_record_and_binary_versions() {
+        let rendered = render_status(
+            &record("3.4.1", DEFAULT_HUB_PORT, None),
+            true,
+            "3.7.7",
+        );
+
+        assert!(rendered.contains("version 3.4.1"), "{rendered}");
+        assert!(rendered.contains("binary: 3.7.7"), "{rendered}");
+    }
+
+    #[test]
+    fn update_restart_spec_is_present_only_for_a_stale_live_record() {
+        let stale = restart_spec_for_record(&record("3.4.1", 4310, Some(8443)), "3.7.7")
+            .unwrap()
+            .expect("stale hub must be restarted");
+        assert_eq!(stale.bind, "127.0.0.1".parse::<IpAddr>().unwrap());
+        assert_eq!(stale.port, 4310);
+        assert!(stale.tailscale_serve);
+        assert_eq!(stale.tailscale_port, 8443);
+
+        assert!(
+            restart_spec_for_record(&record("3.7.7", 4310, Some(8443)), "3.7.7")
+                .unwrap()
+                .is_none(),
+            "matching hub version must not trigger update restart"
+        );
+    }
+}

--- a/cas-cli/src/cli/hub.rs
+++ b/cas-cli/src/cli/hub.rs
@@ -142,11 +142,102 @@ impl Default for HubServeArgs {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HubStartDecision {
+    Keep,
+    Restart {
+        version_drift: bool,
+        flags_differ: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HubRestartSpec {
+    bind: IpAddr,
+    port: u16,
+    tailscale_serve: bool,
+    tailscale_port: u16,
+}
+
+fn default_hub_command() -> HubCommands {
+    HubCommands::Status
+}
+
+fn tailscale_enabled(record: &HubProcessRecord) -> bool {
+    record.tailscale_cli.is_some()
+        || record.tailscale_serve_port.is_some()
+        || record.public_url.is_some()
+}
+
+fn decide_live_start(
+    record: &HubProcessRecord,
+    args: &HubServeArgs,
+    tailscale_serve: bool,
+    tailscale_port: u16,
+    binary_version: &str,
+) -> HubStartDecision {
+    let version_drift = record.version != binary_version;
+    let tailscale_flags_differ = tailscale_enabled(record) != tailscale_serve
+        || (tailscale_serve
+            && record
+                .tailscale_serve_port
+                .is_some_and(|port| port != tailscale_port));
+    let flags_differ = record.bind != args.bind.to_string()
+        || record.port != args.port
+        || tailscale_flags_differ;
+
+    if version_drift || flags_differ {
+        HubStartDecision::Restart {
+            version_drift,
+            flags_differ,
+        }
+    } else {
+        HubStartDecision::Keep
+    }
+}
+
+fn restart_spec_for_record(
+    record: &HubProcessRecord,
+    binary_version: &str,
+) -> Result<Option<HubRestartSpec>> {
+    if record.version == binary_version {
+        return Ok(None);
+    }
+    Ok(Some(HubRestartSpec {
+        bind: record
+            .bind
+            .parse()
+            .with_context(|| format!("invalid bind address in hub record: {}", record.bind))?,
+        port: record.port,
+        tailscale_serve: tailscale_enabled(record),
+        tailscale_port: record.tailscale_serve_port.unwrap_or(443),
+    }))
+}
+
+fn render_status(record: &HubProcessRecord, live: bool, binary_version: &str) -> String {
+    if live {
+        let endpoint = record
+            .public_url
+            .as_deref()
+            .map(str::to_owned)
+            .unwrap_or_else(|| format!("http://{}:{}", record.bind, record.port));
+        format!(
+            "Cassy hub is running at {endpoint} (pid {}, version {}, binary: {binary_version})",
+            record.pid, record.version
+        )
+    } else {
+        format!(
+            "Cassy hub is not running; stale record for pid {} remains (version {}, binary: {binary_version})",
+            record.pid, record.version
+        )
+    }
+}
+
 pub fn execute(args: &HubArgs, cli: &Cli) -> Result<()> {
     match args
         .command
         .clone()
-        .unwrap_or(HubCommands::Start(HubServeArgs::default()))
+        .unwrap_or_else(default_hub_command)
     {
         HubCommands::Start(serve) => {
             start(&serve, cli, args.tailscale_serve, args.tailscale_serve_port)
@@ -647,21 +738,18 @@ fn status(cli: &Cli) -> Result<()> {
     let record = paths.read_process_record()?;
     let live = record_is_live(&record);
     if cli.json {
-        println!("{}", serde_json::json!({"running":live,"record":record}));
-    } else if live {
-        let endpoint = record
-            .public_url
-            .as_deref()
-            .map(str::to_owned)
-            .unwrap_or_else(|| format!("http://{}:{}", record.bind, record.port));
         println!(
-            "Cassy hub is running at {} (pid {}, version {})",
-            endpoint, record.pid, record.version
+            "{}",
+            serde_json::json!({
+                "running": live,
+                "record": record,
+                "binary": env!("CARGO_PKG_VERSION"),
+            })
         );
     } else {
         println!(
-            "Cassy hub is not running; stale record for pid {} remains",
-            record.pid
+            "{}",
+            render_status(&record, live, env!("CARGO_PKG_VERSION"))
         );
     }
     anyhow::ensure!(live, "cas hub is not running");

--- a/cas-cli/src/cli/hub.rs
+++ b/cas-cli/src/cli/hub.rs
@@ -264,6 +264,16 @@ pub fn execute(args: &HubArgs, cli: &Cli) -> Result<()> {
 }
 
 fn start(args: &HubServeArgs, cli: &Cli, tailscale_serve: bool, tailscale_port: u16) -> Result<()> {
+    start_with_output(args, cli, tailscale_serve, tailscale_port, true)
+}
+
+fn start_with_output(
+    args: &HubServeArgs,
+    cli: &Cli,
+    tailscale_serve: bool,
+    tailscale_port: u16,
+    emit_output: bool,
+) -> Result<()> {
     let paths = HubRuntimePaths::default_for_user()?;
     validate_control_bind(
         SocketAddr::new(args.bind, args.port),
@@ -272,16 +282,64 @@ fn start(args: &HubServeArgs, cli: &Cli, tailscale_serve: bool, tailscale_port: 
     crate::hub::ensure_private_dir(paths.root())?;
     match paths.read_process_record() {
         Ok(record) if record_is_live(&record) => {
-            let endpoint = record
-                .public_url
-                .clone()
-                .unwrap_or_else(|| format!("http://{}:{}", record.bind, record.port));
-            anyhow::bail!(
-                "cas hub is already running at {} (pid {}, version {})",
-                endpoint,
-                record.pid,
-                record.version
-            );
+            match decide_live_start(
+                &record,
+                args,
+                tailscale_serve,
+                tailscale_port,
+                env!("CARGO_PKG_VERSION"),
+            ) {
+                HubStartDecision::Keep => {
+                    if emit_output {
+                        if cli.json {
+                            println!(
+                                "{}",
+                                serde_json::json!({
+                                    "running": true,
+                                    "record": record,
+                                    "binary": env!("CARGO_PKG_VERSION"),
+                                })
+                            );
+                        } else {
+                            println!(
+                                "{}",
+                                render_status(&record, true, env!("CARGO_PKG_VERSION"))
+                            );
+                        }
+                    }
+                    return Ok(());
+                }
+                HubStartDecision::Restart {
+                    version_drift,
+                    flags_differ,
+                } => {
+                    if emit_output && !cli.json {
+                        let detail = match (version_drift, flags_differ) {
+                            (true, true) => format!(
+                                "binary is {} / flags differ",
+                                env!("CARGO_PKG_VERSION")
+                            ),
+                            (true, false) => {
+                                format!("binary is {}", env!("CARGO_PKG_VERSION"))
+                            }
+                            (false, true) => "flags differ".to_owned(),
+                            (false, false) => unreachable!("restart requires drift"),
+                        };
+                        println!(
+                            "hub running (pid {}, version {}) — {detail}; restarting…",
+                            record.pid, record.version
+                        );
+                    }
+                    stop_with_output(cli, emit_output)?;
+                    return start_with_output(
+                        args,
+                        cli,
+                        tailscale_serve,
+                        tailscale_port,
+                        emit_output,
+                    );
+                }
+            }
         }
         Ok(_) | Err(_) => {}
     }
@@ -336,9 +394,9 @@ fn start(args: &HubServeArgs, cli: &Cli, tailscale_serve: bool, tailscale_port: 
     while Instant::now() < deadline {
         if let Ok(record) = paths.read_process_record() {
             if record_is_live(&record) {
-                if cli.json {
+                if emit_output && cli.json {
                     println!("{}", serde_json::to_string(&record)?);
-                } else {
+                } else if emit_output {
                     let endpoint = record
                         .public_url
                         .as_deref()
@@ -757,6 +815,10 @@ fn status(cli: &Cli) -> Result<()> {
 }
 
 fn stop(cli: &Cli) -> Result<()> {
+    stop_with_output(cli, true)
+}
+
+fn stop_with_output(cli: &Cli, emit_output: bool) -> Result<()> {
     let paths = HubRuntimePaths::default_for_user()?;
     let record = paths.read_process_record().ok();
     let tailscale_manager = TailscaleServeManager::new(paths.root());
@@ -794,7 +856,7 @@ fn stop(cli: &Cli) -> Result<()> {
         Err(error) => Err(error),
     };
     paths.remove_process_record()?;
-    if cli.json {
+    if emit_output && cli.json {
         println!(
             "{}",
             serde_json::json!({
@@ -804,7 +866,7 @@ fn stop(cli: &Cli) -> Result<()> {
                 "tailscale_warning":tailscale_outcome.as_ref().err().map(ToString::to_string),
             })
         );
-    } else {
+    } else if emit_output {
         if let Some(record) = &record {
             println!("Cassy hub stopped (pid {})", record.pid);
         } else {

--- a/cas-cli/src/cli/hub.rs
+++ b/cas-cli/src/cli/hub.rs
@@ -887,6 +887,42 @@ fn stop_with_output(cli: &Cli, emit_output: bool) -> Result<()> {
     Ok(())
 }
 
+/// Restart a live hub left behind by an older Cassy binary. This is called by
+/// `cas update` after the replacement version is known; a missing, dead, or
+/// already-current hub is intentionally a no-op.
+pub(crate) fn restart_stale_hub(binary_version: &str, cli: &Cli) -> Result<bool> {
+    let paths = HubRuntimePaths::default_for_user()?;
+    let Ok(record) = paths.read_process_record() else {
+        return Ok(false);
+    };
+    if !record_is_live(&record) {
+        return Ok(false);
+    }
+    let Some(spec) = restart_spec_for_record(&record, binary_version)? else {
+        return Ok(false);
+    };
+
+    if !cli.json {
+        println!(
+            "cas update: restarting stale hub (pid {}, version {} -> {})",
+            record.pid, record.version, binary_version
+        );
+    }
+    stop_with_output(cli, !cli.json)?;
+    let args = HubServeArgs {
+        bind: spec.bind,
+        port: spec.port,
+    };
+    start_with_output(
+        &args,
+        cli,
+        spec.tailscale_serve,
+        spec.tailscale_port,
+        !cli.json,
+    )?;
+    Ok(true)
+}
+
 fn wait_for_process_and_lock_release(
     paths: &HubRuntimePaths,
     pid: u32,

--- a/cas-cli/src/cli/hub_reverse_pairing.rs
+++ b/cas-cli/src/cli/hub_reverse_pairing.rs
@@ -22,6 +22,7 @@ use crate::hub::{AuthStore, HubRuntimePaths, MachineIdentityStore, Scope};
 
 const RELAY_PREFIX: &str = "/api/hub/pairing";
 const WIRE_VERSION: u8 = 1;
+const LAST_HUB_URL_FILE: &str = "last-public-url";
 
 #[derive(Debug, Deserialize)]
 struct ClaimResponse {
@@ -282,7 +283,11 @@ pub(super) fn authorize(args: &HubAuthorizeArgs, cli: &Cli) -> Result<()> {
     };
     let relay = RelayClient::from_config(cloud)?;
     let paths = HubRuntimePaths::default_for_user()?;
-    authorize_with_relay(args, cli, &relay, &paths)
+    let configured_hub_url = crate::store::find_cas_root()
+        .ok()
+        .and_then(|cas_root| crate::config::Config::load(&cas_root).ok())
+        .and_then(|config| config.hub.and_then(|hub| hub.public_url));
+    authorize_with_relay(args, cli, &relay, &paths, configured_hub_url.as_deref())
 }
 
 fn authorize_with_relay(
@@ -290,11 +295,12 @@ fn authorize_with_relay(
     cli: &Cli,
     relay: &impl PairingRelay,
     paths: &HubRuntimePaths,
+    configured_hub_url: Option<&str>,
 ) -> Result<()> {
     let code = args.code.trim().to_ascii_uppercase();
     anyhow::ensure!(!code.is_empty(), "pairing code must not be empty");
     let override_scopes = parse_override_scopes(args.scopes.as_deref())?;
-    let hub_url = resolve_hub_url(paths, args.hub_url.as_deref())?;
+    let hub_url = resolve_hub_url(paths, args.hub_url.as_deref(), configured_hub_url)?;
     let machine = MachineIdentityStore::new(paths.root()).load_or_create()?;
     let auth = AuthStore::open(paths.root(), machine.id)?;
     let machine_label = hostname::get()
@@ -432,7 +438,11 @@ fn is_control_scope(scope: Scope) -> bool {
     )
 }
 
-fn resolve_hub_url(paths: &HubRuntimePaths, explicit: Option<&str>) -> Result<String> {
+fn resolve_hub_url(
+    paths: &HubRuntimePaths,
+    explicit: Option<&str>,
+    configured_hub_url: Option<&str>,
+) -> Result<String> {
     let record = paths.read_process_record()?;
     anyhow::ensure!(
         record_is_live(&record),
@@ -723,6 +733,73 @@ mod tests {
         }
     }
 
+    #[test]
+    fn bare_hub_hosts_are_https_and_bare_ip_loopback_is_http() {
+        assert_eq!(
+            validate_hub_url("hub.petrastella.io")
+                .unwrap()
+                .origin()
+                .ascii_serialization(),
+            "https://hub.petrastella.io"
+        );
+        assert_eq!(
+            validate_hub_url("127.0.0.1:4173")
+                .unwrap()
+                .origin()
+                .ascii_serialization(),
+            "http://127.0.0.1:4173"
+        );
+    }
+
+    #[test]
+    fn hub_url_resolution_obeys_explicit_record_config_then_remembered_precedence() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = HubRuntimePaths::new(temp.path().join("hub"));
+        let (port, health) = serve_ready_health_checks(1);
+        write_live_record(&paths, port, Some("https://record.example"));
+
+        assert_eq!(
+            resolve_hub_url(&paths, Some("explicit.example"), Some("config.example"))
+                .unwrap(),
+            "https://explicit.example"
+        );
+        assert_eq!(
+            resolve_hub_url(&paths, None, Some("config.example")).unwrap(),
+            "https://record.example"
+        );
+
+        write_live_record(&paths, port, None);
+        assert_eq!(
+            resolve_hub_url(&paths, None, Some("config.example")).unwrap(),
+            "https://config.example"
+        );
+        fs::create_dir_all(paths.root()).unwrap();
+        fs::write(
+            paths.root().join(LAST_HUB_URL_FILE),
+            "remembered.example\n",
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_hub_url(&paths, None, None).unwrap(),
+            "https://remembered.example"
+        );
+        health.join().unwrap();
+    }
+
+    #[test]
+    fn running_hub_without_public_origin_has_state_aware_recovery() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = HubRuntimePaths::new(temp.path().join("hub"));
+        let (port, health) = serve_ready_health_checks(1);
+        write_live_record(&paths, port, None);
+
+        let error = resolve_hub_url(&paths, None, None).unwrap_err().to_string();
+        assert!(error.contains("hub is running without a public URL"));
+        assert!(error.contains("cas hub restart --tailscale-serve"));
+        assert!(!error.contains("cas hub --tailscale-serve start"));
+        health.join().unwrap();
+    }
+
     #[derive(Default)]
     struct RecordingRelay {
         claims: std::sync::Mutex<Vec<(String, String)>>,
@@ -863,18 +940,20 @@ mod tests {
         let relay = RecordingRelay::default();
         let args = authorize_args("K7MW-4H2Q");
 
-        let stopped = authorize_with_relay(&args, &test_cli(), &relay, &paths).unwrap_err();
+        let stopped =
+            authorize_with_relay(&args, &test_cli(), &relay, &paths, None).unwrap_err();
         assert!(stopped.to_string().contains("no cas hub runtime record"));
         assert!(relay.claims.lock().unwrap().is_empty());
 
         let (port, health) = serve_ready_health_checks(2);
         write_live_record(&paths, port, None);
-        let unpublished = authorize_with_relay(&args, &test_cli(), &relay, &paths).unwrap_err();
+        let unpublished =
+            authorize_with_relay(&args, &test_cli(), &relay, &paths, None).unwrap_err();
         assert!(unpublished.to_string().contains("Hub has no public URL"));
         assert!(relay.claims.lock().unwrap().is_empty());
 
         write_live_record(&paths, port, Some("https://workstation.tail.example/"));
-        authorize_with_relay(&args, &test_cli(), &relay, &paths).unwrap();
+        authorize_with_relay(&args, &test_cli(), &relay, &paths, None).unwrap();
         health.join().unwrap();
 
         let claims = relay.claims.lock().unwrap();
@@ -895,9 +974,10 @@ mod tests {
         let (port, health) = serve_ready_health_checks(2);
         write_live_record(&paths, port, Some("https://workstation.tail.example/"));
 
-        let first = authorize_with_relay(&args, &test_cli(), &relay, &paths).unwrap_err();
+        let first =
+            authorize_with_relay(&args, &test_cli(), &relay, &paths, None).unwrap_err();
         assert!(first.to_string().contains("deliberate completion failure"));
-        authorize_with_relay(&args, &test_cli(), &relay, &paths).unwrap();
+        authorize_with_relay(&args, &test_cli(), &relay, &paths, None).unwrap();
         health.join().unwrap();
 
         let claims = relay.claims.lock().unwrap();

--- a/cas-cli/src/cli/hub_reverse_pairing.rs
+++ b/cas-cli/src/cli/hub_reverse_pairing.rs
@@ -318,7 +318,7 @@ fn authorize_with_relay_with_config(
     let code = args.code.trim().to_ascii_uppercase();
     anyhow::ensure!(!code.is_empty(), "pairing code must not be empty");
     let override_scopes = parse_override_scopes(args.scopes.as_deref())?;
-    let hub_url = resolve_hub_url_with_config(paths, args.hub_url.as_deref(), configured_hub_url)?;
+    let hub_url = resolve_hub_url(paths, args.hub_url.as_deref(), configured_hub_url)?;
     let machine = MachineIdentityStore::new(paths.root()).load_or_create()?;
     let auth = AuthStore::open(paths.root(), machine.id)?;
     let machine_label = hostname::get()
@@ -460,15 +460,7 @@ fn is_control_scope(scope: Scope) -> bool {
     )
 }
 
-fn resolve_hub_url(paths: &HubRuntimePaths, explicit: Option<&str>) -> Result<String> {
-    let configured_hub_url = crate::store::find_cas_root()
-        .ok()
-        .and_then(|cas_root| crate::config::Config::load(&cas_root).ok())
-        .and_then(|config| config.hub.and_then(|hub| hub.public_url));
-    resolve_hub_url_with_config(paths, explicit, configured_hub_url.as_deref())
-}
-
-fn resolve_hub_url_with_config(
+fn resolve_hub_url(
     paths: &HubRuntimePaths,
     explicit: Option<&str>,
     configured_hub_url: Option<&str>,
@@ -886,24 +878,23 @@ mod tests {
         write_live_record(&paths, port, Some("https://record.example"));
 
         assert_eq!(
-            resolve_hub_url_with_config(&paths, Some("explicit.example"), Some("config.example"),)
-                .unwrap(),
+            resolve_hub_url(&paths, Some("explicit.example"), Some("config.example")).unwrap(),
             "https://explicit.example"
         );
         assert_eq!(
-            resolve_hub_url_with_config(&paths, None, Some("config.example")).unwrap(),
+            resolve_hub_url(&paths, None, Some("config.example")).unwrap(),
             "https://record.example"
         );
 
         write_live_record(&paths, port, None);
         assert_eq!(
-            resolve_hub_url_with_config(&paths, None, Some("config.example")).unwrap(),
+            resolve_hub_url(&paths, None, Some("config.example")).unwrap(),
             "https://config.example"
         );
         fs::create_dir_all(paths.root()).unwrap();
         fs::write(paths.root().join(LAST_HUB_URL_FILE), "remembered.example\n").unwrap();
         assert_eq!(
-            resolve_hub_url_with_config(&paths, None, None).unwrap(),
+            resolve_hub_url(&paths, None, None).unwrap(),
             "https://remembered.example"
         );
         health.join().unwrap();
@@ -916,9 +907,7 @@ mod tests {
         let (port, health) = serve_ready_health_checks(1);
         write_live_record(&paths, port, None);
 
-        let error = resolve_hub_url_with_config(&paths, None, None)
-            .unwrap_err()
-            .to_string();
+        let error = resolve_hub_url(&paths, None, None).unwrap_err().to_string();
         assert!(error.contains("hub is running without a public URL"));
         assert!(error.contains("cas hub restart --tailscale-serve"));
         assert!(!error.contains("cas hub --tailscale-serve start"));

--- a/cas-cli/src/cli/hub_reverse_pairing.rs
+++ b/cas-cli/src/cli/hub_reverse_pairing.rs
@@ -283,11 +283,19 @@ pub(super) fn authorize(args: &HubAuthorizeArgs, cli: &Cli) -> Result<()> {
     };
     let relay = RelayClient::from_config(cloud)?;
     let paths = HubRuntimePaths::default_for_user()?;
-    let configured_hub_url = crate::store::find_cas_root()
-        .ok()
-        .and_then(|cas_root| crate::config::Config::load(&cas_root).ok())
+    let config_root = crate::store::find_cas_root().ok();
+    let configured_hub_url = config_root
+        .as_deref()
+        .and_then(|cas_root| crate::config::Config::load(cas_root).ok())
         .and_then(|config| config.hub.and_then(|hub| hub.public_url));
-    authorize_with_relay(args, cli, &relay, &paths, configured_hub_url.as_deref())
+    authorize_with_relay_with_config(
+        args,
+        cli,
+        &relay,
+        &paths,
+        configured_hub_url.as_deref(),
+        config_root.as_deref(),
+    )
 }
 
 fn authorize_with_relay(
@@ -295,12 +303,22 @@ fn authorize_with_relay(
     cli: &Cli,
     relay: &impl PairingRelay,
     paths: &HubRuntimePaths,
+) -> Result<()> {
+    authorize_with_relay_with_config(args, cli, relay, paths, None, None)
+}
+
+fn authorize_with_relay_with_config(
+    args: &HubAuthorizeArgs,
+    cli: &Cli,
+    relay: &impl PairingRelay,
+    paths: &HubRuntimePaths,
     configured_hub_url: Option<&str>,
+    config_root: Option<&Path>,
 ) -> Result<()> {
     let code = args.code.trim().to_ascii_uppercase();
     anyhow::ensure!(!code.is_empty(), "pairing code must not be empty");
     let override_scopes = parse_override_scopes(args.scopes.as_deref())?;
-    let hub_url = resolve_hub_url(paths, args.hub_url.as_deref(), configured_hub_url)?;
+    let hub_url = resolve_hub_url_with_config(paths, args.hub_url.as_deref(), configured_hub_url)?;
     let machine = MachineIdentityStore::new(paths.root()).load_or_create()?;
     let auth = AuthStore::open(paths.root(), machine.id)?;
     let machine_label = hostname::get()
@@ -353,6 +371,12 @@ fn authorize_with_relay(
         complete.pairing_request_id == claim.pairing_request_id,
         "relay completion response did not match the claimed request"
     );
+    persist_last_hub_url(paths, &hub_url)?;
+    if args.hub_url.is_some()
+        && let Some(config_root) = config_root
+    {
+        persist_configured_hub_url(config_root, &hub_url)?;
+    }
     attempt.finish()?;
     if cli.json {
         println!("{}", serde_json::to_string(&complete)?);
@@ -392,22 +416,20 @@ fn confirm(yes: bool, cli: &Cli, claim: &ClaimResponse, granted: &BTreeSet<Scope
 fn print_confirmation_summary(claim: &ClaimResponse, granted: &BTreeSet<Scope>) {
     println!("Commander origin to verify: {}", claim.controller_origin);
     println!(
-        "Read access requested: {}",
-        display_scopes_by_kind(&claim.requested_scopes, false)
-    );
-    println!(
-        "CONTROL ACCESS REQUESTED: {}",
-        display_scopes_by_kind(&claim.requested_scopes, true)
-    );
-    println!(
-        "Read access to grant: {}",
-        display_scopes_by_kind(granted, false)
-    );
-    println!(
-        "CONTROL ACCESS TO GRANT: {}",
-        display_scopes_by_kind(granted, true)
+        "{summary}",
+        summary = confirmation_scope_summary(claim, granted)
     );
     println!("Verify the Commander origin before approving this one-time invitation.");
+}
+
+fn confirmation_scope_summary(claim: &ClaimResponse, granted: &BTreeSet<Scope>) -> String {
+    format!(
+        "Scopes requested: read: {}; control: {}\nScopes granted: read: {}; control: {}",
+        display_scopes_by_kind(&claim.requested_scopes, false),
+        display_scopes_by_kind(&claim.requested_scopes, true),
+        display_scopes_by_kind(granted, false),
+        display_scopes_by_kind(granted, true),
+    )
 }
 
 fn display_scopes_by_kind(
@@ -438,7 +460,15 @@ fn is_control_scope(scope: Scope) -> bool {
     )
 }
 
-fn resolve_hub_url(
+fn resolve_hub_url(paths: &HubRuntimePaths, explicit: Option<&str>) -> Result<String> {
+    let configured_hub_url = crate::store::find_cas_root()
+        .ok()
+        .and_then(|cas_root| crate::config::Config::load(&cas_root).ok())
+        .and_then(|config| config.hub.and_then(|hub| hub.public_url));
+    resolve_hub_url_with_config(paths, explicit, configured_hub_url.as_deref())
+}
+
+fn resolve_hub_url_with_config(
     paths: &HubRuntimePaths,
     explicit: Option<&str>,
     configured_hub_url: Option<&str>,
@@ -448,15 +478,21 @@ fn resolve_hub_url(
         record_is_live(&record),
         "cas hub is not running; start it before authorizing a Commander page"
     );
-    let url = explicit.or(record.public_url.as_deref()).context(
-        "Hub has no public URL. Start it with `cas hub --tailscale-serve start` or pass --hub-url.",
-    )?;
+    let remembered_hub_url = read_last_hub_url(paths)?;
+    let url = explicit
+        .or(record.public_url.as_deref())
+        .or(configured_hub_url)
+        .or(remembered_hub_url.as_deref())
+        .context(
+            "hub is running without a public URL; pass --hub-url https://<commander-host> (remembered for next time) or `cas hub restart --tailscale-serve`",
+        )?;
     let parsed = validate_hub_url(url)?;
     Ok(parsed.origin().ascii_serialization())
 }
 
 fn validate_hub_url(url: &str) -> Result<Url> {
-    let parsed = Url::parse(url).context("invalid hub URL")?;
+    let normalized = normalize_hub_url(url);
+    let parsed = Url::parse(&normalized).context("invalid hub URL")?;
     anyhow::ensure!(
         parsed.username().is_empty()
             && parsed.password().is_none()
@@ -467,10 +503,81 @@ fn validate_hub_url(url: &str) -> Result<Url> {
         "hub URL must be an HTTPS origin or an HTTP IP-loopback origin"
     );
     anyhow::ensure!(
-        parsed.scheme() == "https" || is_loopback_origin(url),
+        parsed.scheme() == "https" || is_loopback_origin(&normalized),
         "hub URL must be an HTTPS origin or an HTTP IP-loopback origin"
     );
     Ok(parsed)
+}
+
+fn normalize_hub_url(url: &str) -> String {
+    let trimmed = url.trim();
+    if trimmed.contains("://") {
+        return trimmed.to_owned();
+    }
+
+    // A literal IP-loopback address is safe for local development over HTTP;
+    // other bare hosts default to HTTPS so Commander origins remain secure.
+    let loopback_candidate = format!("http://{trimmed}");
+    if is_loopback_origin(&loopback_candidate) {
+        loopback_candidate
+    } else {
+        format!("https://{trimmed}")
+    }
+}
+
+fn last_hub_url_path(paths: &HubRuntimePaths) -> PathBuf {
+    paths.root().join(LAST_HUB_URL_FILE)
+}
+
+fn read_last_hub_url(paths: &HubRuntimePaths) -> Result<Option<String>> {
+    let path = last_hub_url_path(paths);
+    match fs::read_to_string(&path) {
+        Ok(url) => {
+            let url = url.trim();
+            Ok((!url.is_empty()).then(|| url.to_owned()))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => {
+            Err(error).with_context(|| format!("read remembered hub URL at {}", path.display()))
+        }
+    }
+}
+
+fn persist_last_hub_url(paths: &HubRuntimePaths, hub_url: &str) -> Result<()> {
+    crate::hub::ensure_private_dir(paths.root())?;
+    let target = last_hub_url_path(paths);
+    let temporary = paths
+        .root()
+        .join(format!(".{LAST_HUB_URL_FILE}.{}.tmp", std::process::id()));
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&temporary)
+        .with_context(|| format!("open remembered hub URL at {}", temporary.display()))?;
+    file.write_all(hub_url.as_bytes())?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    fs::rename(&temporary, &target)
+        .with_context(|| format!("save remembered hub URL at {}", target.display()))?;
+    Ok(())
+}
+
+fn persist_configured_hub_url(cas_root: &Path, hub_url: &str) -> Result<()> {
+    let mut config = crate::config::Config::load(cas_root)
+        .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+    config
+        .hub
+        .get_or_insert_with(crate::config::HubConfig::default)
+        .public_url = Some(hub_url.to_owned());
+    config
+        .save_toml(cas_root)
+        .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+    Ok(())
 }
 
 fn is_loopback_origin(origin: &str) -> bool {
@@ -707,6 +814,26 @@ mod tests {
     }
 
     #[test]
+    fn confirmation_scope_summary_prints_requested_and_granted_blocks_once() {
+        let scopes = [Scope::MachineRead, Scope::SessionRead, Scope::PaneInput];
+        let claim = ClaimResponse {
+            wire_version: WIRE_VERSION,
+            authorization_id: "authorization".to_owned(),
+            pairing_request_id: "pairing-request".to_owned(),
+            controller_origin: "https://commander.example".to_owned(),
+            requested_scopes: scopes.to_vec(),
+            claim_expires_at: Utc::now(),
+        };
+        let granted: BTreeSet<_> = scopes.iter().copied().collect();
+        let summary = confirmation_scope_summary(&claim, &granted);
+
+        assert_eq!(summary.matches("Scopes requested:").count(), 1);
+        assert_eq!(summary.matches("Scopes granted:").count(), 1);
+        assert!(summary.contains("read: machine:read, session:read"));
+        assert!(summary.contains("control: pane:input"));
+    }
+
+    #[test]
     fn loopback_hub_url_requires_a_literal_http_loopback_origin() {
         for origin in [
             "http://127.0.0.1",
@@ -755,32 +882,28 @@ mod tests {
     fn hub_url_resolution_obeys_explicit_record_config_then_remembered_precedence() {
         let temp = tempfile::tempdir().unwrap();
         let paths = HubRuntimePaths::new(temp.path().join("hub"));
-        let (port, health) = serve_ready_health_checks(1);
+        let (port, health) = serve_ready_health_checks(4);
         write_live_record(&paths, port, Some("https://record.example"));
 
         assert_eq!(
-            resolve_hub_url(&paths, Some("explicit.example"), Some("config.example"))
+            resolve_hub_url_with_config(&paths, Some("explicit.example"), Some("config.example"),)
                 .unwrap(),
             "https://explicit.example"
         );
         assert_eq!(
-            resolve_hub_url(&paths, None, Some("config.example")).unwrap(),
+            resolve_hub_url_with_config(&paths, None, Some("config.example")).unwrap(),
             "https://record.example"
         );
 
         write_live_record(&paths, port, None);
         assert_eq!(
-            resolve_hub_url(&paths, None, Some("config.example")).unwrap(),
+            resolve_hub_url_with_config(&paths, None, Some("config.example")).unwrap(),
             "https://config.example"
         );
         fs::create_dir_all(paths.root()).unwrap();
-        fs::write(
-            paths.root().join(LAST_HUB_URL_FILE),
-            "remembered.example\n",
-        )
-        .unwrap();
+        fs::write(paths.root().join(LAST_HUB_URL_FILE), "remembered.example\n").unwrap();
         assert_eq!(
-            resolve_hub_url(&paths, None, None).unwrap(),
+            resolve_hub_url_with_config(&paths, None, None).unwrap(),
             "https://remembered.example"
         );
         health.join().unwrap();
@@ -793,7 +916,9 @@ mod tests {
         let (port, health) = serve_ready_health_checks(1);
         write_live_record(&paths, port, None);
 
-        let error = resolve_hub_url(&paths, None, None).unwrap_err().to_string();
+        let error = resolve_hub_url_with_config(&paths, None, None)
+            .unwrap_err()
+            .to_string();
         assert!(error.contains("hub is running without a public URL"));
         assert!(error.contains("cas hub restart --tailscale-serve"));
         assert!(!error.contains("cas hub --tailscale-serve start"));
@@ -940,20 +1065,22 @@ mod tests {
         let relay = RecordingRelay::default();
         let args = authorize_args("K7MW-4H2Q");
 
-        let stopped =
-            authorize_with_relay(&args, &test_cli(), &relay, &paths, None).unwrap_err();
+        let stopped = authorize_with_relay(&args, &test_cli(), &relay, &paths).unwrap_err();
         assert!(stopped.to_string().contains("no cas hub runtime record"));
         assert!(relay.claims.lock().unwrap().is_empty());
 
         let (port, health) = serve_ready_health_checks(2);
         write_live_record(&paths, port, None);
-        let unpublished =
-            authorize_with_relay(&args, &test_cli(), &relay, &paths, None).unwrap_err();
-        assert!(unpublished.to_string().contains("Hub has no public URL"));
+        let unpublished = authorize_with_relay(&args, &test_cli(), &relay, &paths).unwrap_err();
+        assert!(
+            unpublished
+                .to_string()
+                .contains("hub is running without a public URL")
+        );
         assert!(relay.claims.lock().unwrap().is_empty());
 
         write_live_record(&paths, port, Some("https://workstation.tail.example/"));
-        authorize_with_relay(&args, &test_cli(), &relay, &paths, None).unwrap();
+        authorize_with_relay(&args, &test_cli(), &relay, &paths).unwrap();
         health.join().unwrap();
 
         let claims = relay.claims.lock().unwrap();
@@ -963,6 +1090,41 @@ mod tests {
             *relay.completed_hub_urls.lock().unwrap(),
             ["https://workstation.tail.example"]
         );
+        assert_eq!(
+            read_last_hub_url(&paths).unwrap().as_deref(),
+            Some("https://workstation.tail.example")
+        );
+    }
+
+    #[test]
+    fn successful_explicit_origin_is_saved_to_project_hub_config() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = HubRuntimePaths::new(temp.path().join("hub"));
+        let config_root = temp.path().join("cas");
+        fs::create_dir_all(&config_root).unwrap();
+        crate::config::Config::default()
+            .save_toml(&config_root)
+            .unwrap();
+        let (port, health) = serve_ready_health_checks(1);
+        write_live_record(&paths, port, None);
+        let mut args = authorize_args("K7MW-4H2Q");
+        args.hub_url = Some("configured.example".to_owned());
+
+        authorize_with_relay_with_config(
+            &args,
+            &test_cli(),
+            &RecordingRelay::default(),
+            &paths,
+            None,
+            Some(&config_root),
+        )
+        .unwrap();
+        let config = crate::config::Config::load(&config_root).unwrap();
+        assert_eq!(
+            config.hub.and_then(|hub| hub.public_url),
+            Some("https://configured.example".to_owned())
+        );
+        health.join().unwrap();
     }
 
     #[test]
@@ -974,10 +1136,9 @@ mod tests {
         let (port, health) = serve_ready_health_checks(2);
         write_live_record(&paths, port, Some("https://workstation.tail.example/"));
 
-        let first =
-            authorize_with_relay(&args, &test_cli(), &relay, &paths, None).unwrap_err();
+        let first = authorize_with_relay(&args, &test_cli(), &relay, &paths).unwrap_err();
         assert!(first.to_string().contains("deliberate completion failure"));
-        authorize_with_relay(&args, &test_cli(), &relay, &paths, None).unwrap();
+        authorize_with_relay(&args, &test_cli(), &relay, &paths).unwrap();
         health.join().unwrap();
 
         let claims = relay.claims.lock().unwrap();

--- a/cas-cli/src/cli/init.rs
+++ b/cas-cli/src/cli/init.rs
@@ -351,6 +351,7 @@ impl WizardConfig {
             code_review: None,
             issues: None,
             memory: None,
+            hub: None,
             project: None,
         }
     }

--- a/cas-cli/src/cli/list.rs
+++ b/cas-cli/src/cli/list.rs
@@ -4,7 +4,8 @@ use clap::Args;
 
 /// Arguments for listing running factory sessions.
 ///
-/// This stays lightweight and local-only (reads session metadata under ~/.cas).
+/// This stays lightweight and local-only (reads session metadata and the local
+/// agent registry under ~/.cas).
 #[derive(Args, Debug, Clone, Default)]
 pub struct ListArgs {
     /// Filter to a specific session name (exact match)

--- a/cas-cli/src/cli/update.rs
+++ b/cas-cli/src/cli/update.rs
@@ -230,7 +230,9 @@ pub fn execute(args: &UpdateArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
     // Full update: binary + every local project's migration/sync/cloud state.
     let mut steps = UpdateStepTracker::new(2, !cli.json);
     steps.run("Updating Cassy binary", || {
-        perform_update(args, current_version, cli)
+        let installed_version = perform_update(args, current_version, cli)?;
+        super::hub::restart_stale_hub(&installed_version, cli)?;
+        Ok(installed_version)
     })?;
     if !cli.json {
         let mut out = io::stdout();
@@ -1515,7 +1517,7 @@ fn check_for_updates(
 }
 
 /// Download and install the latest (or specified) version
-fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow::Result<()> {
+fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow::Result<String> {
     use self_update::Status;
     use self_update::backends::github::Update;
 
@@ -1563,7 +1565,7 @@ fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow
             fmt.newline()?;
             fmt.write_raw("  ")?;
             fmt.success("Already on the latest version")?;
-            return Ok(());
+            return Ok(current_version.to_owned());
         }
 
         fmt.newline()?;
@@ -1584,14 +1586,14 @@ fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow
             updated,
             version.trim_start_matches('v')
         );
-        return Ok(());
+        return Ok(version.trim_start_matches('v').to_owned());
     }
 
     let mut out = io::stdout();
     let theme = ActiveTheme::default();
     let mut fmt = Formatter::stdout(&mut out, theme);
 
-    match status {
+    let installed_version = match status {
         Status::UpToDate(v) => {
             fmt.newline()?;
             fmt.write_raw("  ")?;
@@ -1599,6 +1601,7 @@ fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow
                 "Already up to date ({})",
                 v.trim_start_matches('v')
             ))?;
+            v.trim_start_matches('v').to_owned()
         }
         Status::Updated(v) => {
             fmt.newline()?;
@@ -1612,10 +1615,11 @@ fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow
             fmt.write_accent("cas changelog")?;
             fmt.write_raw(" to see what's new")?;
             fmt.newline()?;
+            v.trim_start_matches('v').to_owned()
         }
-    }
+    };
 
-    Ok(())
+    Ok(installed_version)
 }
 
 /// Try to get a GitHub auth token from `gh auth token` or GITHUB_TOKEN env var.

--- a/cas-cli/src/cloud/sync_queue/queue_ops.rs
+++ b/cas-cli/src/cloud/sync_queue/queue_ops.rs
@@ -42,8 +42,8 @@ impl SyncQueue {
 
     /// Queue a sync operation.
     ///
-    /// Uses upsert semantics - if an item with the same entity_type,
-    /// entity_id, and team_id exists, it is replaced with the new operation.
+    /// Uses upsert semantics - if an item with the same entity/project/team
+    /// identity exists, it is replaced with the new operation.
     pub fn enqueue(
         &self,
         entity_type: EntityType,
@@ -63,7 +63,7 @@ impl SyncQueue {
         payload: Option<&str>,
         team_id: &str,
     ) -> Result<(), CasError> {
-        self.enqueue_with_team(entity_type, entity_id, operation, payload, team_id)
+        self.enqueue_with_team_project(entity_type, entity_id, operation, payload, team_id, None)
     }
 
     fn enqueue_with_team(
@@ -74,17 +74,30 @@ impl SyncQueue {
         payload: Option<&str>,
         team_id: &str,
     ) -> Result<(), CasError> {
+        self.enqueue_with_team_project(entity_type, entity_id, operation, payload, team_id, None)
+    }
+
+    fn enqueue_with_team_project(
+        &self,
+        entity_type: EntityType,
+        entity_id: &str,
+        operation: SyncOperation,
+        payload: Option<&str>,
+        team_id: &str,
+        project_id: Option<&str>,
+    ) -> Result<(), CasError> {
         let conn = self.conn.lock().unwrap();
         let now = Utc::now().to_rfc3339();
 
         conn.execute(
             r#"
-            INSERT INTO sync_queue (entity_type, entity_id, operation, payload, team_id, created_at, retry_count)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0)
-            ON CONFLICT(entity_type, entity_id, team_id) DO UPDATE SET
+            INSERT INTO sync_queue (entity_type, entity_id, operation, payload, team_id, project_id, created_at, retry_count)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0)
+            ON CONFLICT DO UPDATE SET
                 operation = excluded.operation,
                 payload = excluded.payload,
                 created_at = excluded.created_at,
+                project_id = excluded.project_id,
                 retry_count = 0,
                 last_error = NULL
             "#,
@@ -94,10 +107,67 @@ impl SyncQueue {
                 operation.as_str(),
                 payload,
                 team_id,
-                now
+                project_id,
+                now,
             ],
         )?;
 
+        Ok(())
+    }
+
+    /// Queue the two team operations needed to move a task between project
+    /// identities. Both rows are inserted in one transaction so a pending
+    /// move cannot expose only one side of the cloud-key rewrite.
+    pub fn enqueue_team_move(
+        &self,
+        entity_type: EntityType,
+        entity_id: &str,
+        old_project_id: &str,
+        payload: &str,
+        team_id: &str,
+    ) -> Result<(), CasError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+
+        let delete_time = Utc::now().to_rfc3339();
+        tx.execute(
+            r#"
+            INSERT INTO sync_queue (entity_type, entity_id, operation, payload, team_id, project_id, created_at, retry_count)
+            VALUES (?1, ?2, 'delete', NULL, ?3, ?4, ?5, 0)
+            ON CONFLICT DO UPDATE SET
+                operation = excluded.operation,
+                payload = NULL,
+                project_id = excluded.project_id,
+                created_at = excluded.created_at,
+                retry_count = 0,
+                last_error = NULL
+            "#,
+            params![
+                entity_type.as_str(),
+                entity_id,
+                team_id,
+                old_project_id,
+                delete_time,
+            ],
+        )?;
+
+        let upsert_time = Utc::now().to_rfc3339();
+        tx.execute(
+            r#"
+            INSERT INTO sync_queue (entity_type, entity_id, operation, payload, team_id, project_id, created_at, retry_count)
+            VALUES (?1, ?2, 'upsert', ?3, ?4, NULL, ?5, 0)
+            ON CONFLICT DO UPDATE SET
+                operation = excluded.operation,
+                payload = excluded.payload,
+                project_id = NULL,
+                created_at = excluded.created_at,
+                retry_count = 0,
+                last_error = NULL
+            "#,
+            params![entity_type.as_str(), entity_id, payload, team_id, upsert_time],
+        )?;
+
+        tx.commit()?;
         Ok(())
     }
 
@@ -122,12 +192,12 @@ impl SyncQueue {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             r#"
-            SELECT id, entity_type, entity_id, operation, payload, team_id, created_at, retry_count, last_error
+            SELECT id, entity_type, entity_id, operation, payload, team_id, project_id, created_at, retry_count, last_error
             FROM sync_queue
             WHERE retry_count < ?1 AND (team_id IS NULL OR team_id = '')
               AND entity_type != 'knowledge_page'
               AND (?3 IS NULL OR entity_type = ?3)
-            ORDER BY created_at ASC
+            ORDER BY created_at ASC, id ASC
             LIMIT ?2
             "#,
         )?;
@@ -156,7 +226,7 @@ impl SyncQueue {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             r#"
-            SELECT id, entity_type, entity_id, operation, payload, team_id, created_at, retry_count, last_error
+            SELECT id, entity_type, entity_id, operation, payload, team_id, project_id, created_at, retry_count, last_error
             FROM sync_queue
             WHERE retry_count >= ?1 AND (team_id IS NULL OR team_id = '')
               AND entity_type != 'knowledge_page'
@@ -190,10 +260,10 @@ impl SyncQueue {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             r#"
-            SELECT id, entity_type, entity_id, operation, payload, team_id, created_at, retry_count, last_error
+            SELECT id, entity_type, entity_id, operation, payload, team_id, project_id, created_at, retry_count, last_error
             FROM sync_queue
             WHERE retry_count < ?1 AND team_id = ?2
-            ORDER BY created_at ASC
+            ORDER BY created_at ASC, id ASC
             LIMIT ?3
             "#,
         )?;
@@ -226,7 +296,7 @@ impl SyncQueue {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             r#"
-            SELECT id, entity_type, entity_id, operation, payload, team_id, created_at, retry_count, last_error
+            SELECT id, entity_type, entity_id, operation, payload, team_id, project_id, created_at, retry_count, last_error
             FROM sync_queue
             ORDER BY created_at DESC
             LIMIT ?1
@@ -243,10 +313,13 @@ impl SyncQueue {
     pub(super) fn map_row(row: &rusqlite::Row) -> Result<QueuedSync, rusqlite::Error> {
         let entity_type_str: String = row.get(1)?;
         let operation_str: String = row.get(3)?;
-        let created_str: String = row.get(6)?;
+        let created_str: String = row.get(7)?;
         let team_id: Option<String> = row
             .get::<_, Option<String>>(5)?
             .filter(|value| !value.is_empty());
+        let project_id: Option<String> = row
+            .get::<_, Option<String>>(6)?
+            .filter(|value| !value.trim().is_empty());
 
         Ok(QueuedSync {
             id: row.get(0)?,
@@ -255,11 +328,12 @@ impl SyncQueue {
             operation: SyncOperation::parse(&operation_str).unwrap_or(SyncOperation::Upsert),
             payload: row.get(4)?,
             team_id,
+            project_id,
             created_at: DateTime::parse_from_rfc3339(&created_str)
                 .map(|dt| dt.with_timezone(&Utc))
                 .unwrap_or_else(|_| Utc::now()),
-            retry_count: row.get(7)?,
-            last_error: row.get(8)?,
+            retry_count: row.get(8)?,
+            last_error: row.get(9)?,
         })
     }
 }

--- a/cas-cli/src/cloud/sync_queue/schema.rs
+++ b/cas-cli/src/cloud/sync_queue/schema.rs
@@ -11,15 +11,14 @@ CREATE TABLE IF NOT EXISTS sync_queue (
     operation TEXT NOT NULL,
     payload TEXT,
     team_id TEXT,
+    project_id TEXT,
     created_at TEXT NOT NULL,
     retry_count INTEGER NOT NULL DEFAULT 0,
-    last_error TEXT,
-    UNIQUE(entity_type, entity_id, team_id)
+    last_error TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sync_queue_created ON sync_queue(created_at);
 CREATE INDEX IF NOT EXISTS idx_sync_queue_retry ON sync_queue(retry_count);
-CREATE INDEX IF NOT EXISTS idx_sync_queue_team ON sync_queue(team_id);
 
 CREATE TABLE IF NOT EXISTS sync_metadata (
     key TEXT PRIMARY KEY,
@@ -40,7 +39,7 @@ CREATE INDEX IF NOT EXISTS idx_sync_conflicts_resolved_at ON sync_conflicts(reso
 "#;
 
 impl SyncQueue {
-    /// Add team_id column to existing sync_queue tables.
+    /// Add team/project identity columns to existing sync_queue tables.
     pub(super) fn migrate_team_id(&self, conn: &Connection) -> Result<(), CasError> {
         let has_team_id: bool = conn
             .query_row(
@@ -50,14 +49,27 @@ impl SyncQueue {
             )
             .unwrap_or(false);
 
-        if !has_team_id {
-            conn.execute_batch(
-                r#"
-                ALTER TABLE sync_queue ADD COLUMN team_id TEXT;
-                CREATE INDEX IF NOT EXISTS idx_sync_queue_team ON sync_queue(team_id);
-                "#,
-            )?;
+        let has_project_id: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM pragma_table_info('sync_queue') WHERE name = 'project_id'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
 
+        if !has_team_id {
+            conn.execute_batch("ALTER TABLE sync_queue ADD COLUMN team_id TEXT;")?;
+        }
+        if !has_project_id {
+            conn.execute_batch("ALTER TABLE sync_queue ADD COLUMN project_id TEXT;")?;
+        }
+
+        // The original table had an inline UNIQUE(entity_type, entity_id,
+        // team_id). SQLite cannot replace that constraint with an expression
+        // index in place, so rebuild once when either identity column was
+        // added. Existing rows retain NULL project_id and therefore continue
+        // to coalesce under COALESCE(project_id, '').
+        if !has_team_id || !has_project_id {
             conn.execute_batch(
                 r#"
                 CREATE TABLE IF NOT EXISTS sync_queue_new (
@@ -67,29 +79,38 @@ impl SyncQueue {
                     operation TEXT NOT NULL,
                     payload TEXT,
                     team_id TEXT,
+                    project_id TEXT,
                     created_at TEXT NOT NULL,
                     retry_count INTEGER NOT NULL DEFAULT 0,
-                    last_error TEXT,
-                    UNIQUE(entity_type, entity_id, team_id)
+                    last_error TEXT
                 );
-                INSERT INTO sync_queue_new (id, entity_type, entity_id, operation, payload, team_id, created_at, retry_count, last_error)
-                    SELECT id, entity_type, entity_id, operation, payload, COALESCE(team_id, ''), created_at, retry_count, last_error FROM sync_queue;
+                INSERT INTO sync_queue_new (id, entity_type, entity_id, operation, payload, team_id, project_id, created_at, retry_count, last_error)
+                    SELECT id, entity_type, entity_id, operation, payload, COALESCE(team_id, ''), project_id, created_at, retry_count, last_error FROM sync_queue;
                 DROP TABLE sync_queue;
                 ALTER TABLE sync_queue_new RENAME TO sync_queue;
                 CREATE INDEX IF NOT EXISTS idx_sync_queue_created ON sync_queue(created_at);
                 CREATE INDEX IF NOT EXISTS idx_sync_queue_retry ON sync_queue(retry_count);
                 CREATE INDEX IF NOT EXISTS idx_sync_queue_team ON sync_queue(team_id);
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_queue_entity_team_project
+                    ON sync_queue(entity_type, entity_id, team_id, COALESCE(project_id, ''));
                 "#,
             )?;
         }
 
         // Normalize any pre-migration NULL team_ids to '' so the UNIQUE
-        // constraint (entity_type, entity_id, team_id) properly deduplicates
+        // identity index properly deduplicates
         // personal-queue items. In SQLite, NULL != NULL and NULL != '' under
         // UNIQUE, so a row with team_id=NULL and a subsequent enqueue with
         // team_id='' would create duplicates (defect C / cas-8dd8).
         // This UPDATE is idempotent — a no-op when no NULLs remain.
         conn.execute_batch("UPDATE sync_queue SET team_id = '' WHERE team_id IS NULL;")?;
+        conn.execute_batch(
+            r#"
+            CREATE INDEX IF NOT EXISTS idx_sync_queue_team ON sync_queue(team_id);
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_queue_entity_team_project
+                ON sync_queue(entity_type, entity_id, team_id, COALESCE(project_id, ''));
+            "#,
+        )?;
 
         Ok(())
     }

--- a/cas-cli/src/cloud/sync_queue/tests.rs
+++ b/cas-cli/src/cloud/sync_queue/tests.rs
@@ -621,6 +621,58 @@ fn test_null_team_id_normalized_to_empty_on_migration() {
 }
 
 #[test]
+fn project_id_migration_preserves_legacy_rows_and_allows_move_pair() {
+    use rusqlite::Connection;
+
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("cas.db");
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE sync_queue (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                operation TEXT NOT NULL,
+                payload TEXT,
+                team_id TEXT,
+                created_at TEXT NOT NULL,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT,
+                UNIQUE(entity_type, entity_id, team_id)
+            );
+            INSERT INTO sync_queue
+                (entity_type, entity_id, operation, payload, team_id, created_at)
+            VALUES ('task', 'legacy-task', 'upsert', '{"id":"legacy-task"}', 'team-123', '2026-01-01T00:00:00Z');
+            "#,
+        )
+        .unwrap();
+    }
+
+    let queue = SyncQueue::open(temp.path()).unwrap();
+    queue.init().unwrap();
+    let legacy = queue.pending_for_team("team-123", 10, 5).unwrap();
+    assert_eq!(legacy.len(), 1);
+    assert_eq!(legacy[0].project_id, None);
+
+    queue
+        .enqueue_team_move(
+            EntityType::Task,
+            "move-after-migration",
+            "project-a",
+            r#"{"id":"move-after-migration","origin_project":"project-b"}"#,
+            "team-123",
+        )
+        .unwrap();
+    let moved = queue.pending_for_team("team-123", 10, 5).unwrap();
+    assert_eq!(moved.len(), 3);
+    assert_eq!(moved[1].operation, SyncOperation::Delete);
+    assert_eq!(moved[1].project_id.as_deref(), Some("project-a"));
+    assert_eq!(moved[2].operation, SyncOperation::Upsert);
+}
+
+#[test]
 fn test_team_coalesce_updates() {
     let (_temp, queue) = create_test_queue();
 

--- a/cas-cli/src/cloud/sync_queue/types.rs
+++ b/cas-cli/src/cloud/sync_queue/types.rs
@@ -136,6 +136,9 @@ pub struct QueuedSync {
     pub payload: Option<String>,
     /// Team ID for team-scoped sync (None for personal sync)
     pub team_id: Option<String>,
+    /// Project identity targeted by a project-scoped delete. `None` preserves
+    /// the normal behavior of using the project performing the push.
+    pub project_id: Option<String>,
     /// When the item was queued
     pub created_at: DateTime<Utc>,
     /// Number of sync attempts

--- a/cas-cli/src/cloud/syncer/mod.rs
+++ b/cas-cli/src/cloud/syncer/mod.rs
@@ -928,32 +928,3 @@ pub struct TeamMemoriesData {
     #[serde(default)]
     pub skills: Vec<Skill>,
 }
-
-/// Grouped queued items by entity type and operation
-#[derive(Default)]
-struct GroupedQueuedItems {
-    upsert_entries: Vec<serde_json::Value>,
-    upsert_tasks: Vec<serde_json::Value>,
-    upsert_rules: Vec<serde_json::Value>,
-    upsert_skills: Vec<serde_json::Value>,
-    upsert_sessions: Vec<serde_json::Value>,
-    upsert_verifications: Vec<serde_json::Value>,
-    upsert_events: Vec<serde_json::Value>,
-    upsert_prompts: Vec<serde_json::Value>,
-    upsert_file_changes: Vec<serde_json::Value>,
-    upsert_commit_links: Vec<serde_json::Value>,
-    upsert_agents: Vec<serde_json::Value>,
-    upsert_worktrees: Vec<serde_json::Value>,
-    delete_entries: Vec<String>,
-    delete_tasks: Vec<String>,
-    delete_rules: Vec<String>,
-    delete_skills: Vec<String>,
-    delete_sessions: Vec<String>,
-    delete_verifications: Vec<String>,
-    delete_events: Vec<String>,
-    delete_prompts: Vec<String>,
-    delete_file_changes: Vec<String>,
-    delete_commit_links: Vec<String>,
-    delete_agents: Vec<String>,
-    delete_worktrees: Vec<String>,
-}

--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Instant;
 
 use chrono::{DateTime, Utc};
@@ -265,6 +266,84 @@ pub(crate) fn entity_matches_project(
     }
 }
 
+fn task_wire_id(raw: &serde_json::Value) -> Option<&str> {
+    raw.get("id").and_then(serde_json::Value::as_str)
+}
+
+fn task_wire_origin_project(raw: &serde_json::Value) -> Option<&str> {
+    raw.get("origin_project")
+        .and_then(serde_json::Value::as_str)
+}
+
+/// Return the project key that owns a task row on the cloud. The team pull
+/// endpoint currently exposes this as `project_id` (some builds use
+/// `project_canonical_id`); when it is absent, the requested scope is the
+/// only available signal and is therefore used as a documented fallback.
+fn task_wire_cloud_project<'a>(raw: &'a serde_json::Value, requested_project: &'a str) -> &'a str {
+    raw.get("project_canonical_id")
+        .or_else(|| raw.get("project_id"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or(requested_project)
+}
+
+fn task_wire_is_owner(raw: &serde_json::Value, requested_project: &str) -> bool {
+    task_wire_origin_project(raw)
+        .is_some_and(|origin| origin == task_wire_cloud_project(raw, requested_project))
+}
+
+fn task_wire_updated_at(raw: &serde_json::Value) -> Option<DateTime<Utc>> {
+    raw.get("updated_at")
+        .or_else(|| raw.get("updatedAt"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
+}
+
+/// Collapse duplicate task IDs in a team envelope before deserialization and
+/// upsert. A row whose origin matches its cloud project key is the owner row;
+/// owner status wins even when a foreign replica row has a newer timestamp.
+/// Rows without an owner signal retain timestamp ordering, but are still
+/// reduced to one row so wire order cannot make the result nondeterministic.
+fn select_owner_task_rows(
+    raw_tasks: Vec<serde_json::Value>,
+    requested_project: &str,
+) -> (Vec<serde_json::Value>, Vec<(String, serde_json::Value)>) {
+    let mut grouped = BTreeMap::<String, Vec<serde_json::Value>>::new();
+    let mut unkeyed = Vec::new();
+    for raw in raw_tasks {
+        let Some(id) = task_wire_id(&raw) else {
+            unkeyed.push(raw);
+            continue;
+        };
+        grouped.entry(id.to_owned()).or_default().push(raw);
+    }
+
+    let mut selected = unkeyed;
+    let mut discarded = Vec::new();
+    for (id, mut rows) in grouped {
+        if rows.len() == 1 {
+            selected.push(rows.pop().expect("one-row task group is non-empty"));
+            continue;
+        }
+
+        let winner_index = rows
+            .iter()
+            .enumerate()
+            .max_by(|(left_index, left), (right_index, right)| {
+                task_wire_is_owner(left, requested_project)
+                    .cmp(&task_wire_is_owner(right, requested_project))
+                    .then_with(|| task_wire_updated_at(left).cmp(&task_wire_updated_at(right)))
+                    .then_with(|| left_index.cmp(right_index))
+            })
+            .map(|(index, _)| index)
+            .expect("multi-row task group is non-empty");
+        let winner = rows.swap_remove(winner_index);
+        discarded.extend(rows.into_iter().map(|row| (id.clone(), row)));
+        selected.push(winner);
+    }
+    (selected, discarded)
+}
+
 /// cas-fc52: detect a teammate's web-initiated close (cloud contract §4).
 ///
 /// The cloud server records a web close as a soft tombstone merged into the
@@ -445,6 +524,111 @@ fn append_sync_status_provenance(merged: &mut Task, local: &Task, sync_id: &str,
 }
 
 impl CloudSyncer {
+    fn record_owner_conflict_value(
+        &self,
+        task_id: &str,
+        discarded_row: &serde_json::Value,
+    ) -> Result<(), CasError> {
+        let discarded_row_json = serde_json::to_string(&serde_json::json!({
+            "rejected_remote": discarded_row,
+            "reason": "owner_wins",
+        }))
+        .map_err(|error| {
+            CasError::Other(format!("Could not serialize owner sync conflict: {error}"))
+        })?;
+        self.queue.record_conflict(
+            EntityType::Task.as_str(),
+            task_id,
+            &discarded_row_json,
+            "owner",
+            "owner_wins",
+        )?;
+        Ok(())
+    }
+
+    fn upsert_owner_task(
+        &self,
+        store: &dyn TaskStore,
+        task: Task,
+        sync_id: &str,
+        source: &str,
+    ) -> Result<UpsertResult, CasError> {
+        match store.get(&task.id) {
+            Ok(local) => {
+                if rejects_terminal_regression(&local, &task) {
+                    self.record_terminal_regression_conflict(&local, &task)?;
+                    return Ok(UpsertResult::Skipped);
+                }
+                let notes_differ = local.notes != task.notes;
+                self.journal_local_overwrite(
+                    EntityType::Task,
+                    &task.id,
+                    &local,
+                    "owner",
+                    "owner_wins",
+                )?;
+                let mut merged = task;
+                if notes_differ {
+                    merged.notes = merge_task_notes(&local.notes, &merged.notes);
+                }
+                append_sync_status_provenance(&mut merged, &local, sync_id, source);
+                store.update(&merged)?;
+                Ok(UpsertResult::Updated)
+            }
+            Err(cas_store::StoreError::TaskNotFound(_)) => {
+                store.add(&task)?;
+                Ok(UpsertResult::Created)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Apply owner identity before the ordinary timestamp/strategy resolver.
+    /// A local row carrying a different owner is a replica and cannot replace
+    /// the owner row. Conversely, an owner row replaces a foreign replica even
+    /// when its timestamp is older. Terminal regressions still use the
+    /// existing explicit-reopen guard.
+    fn upsert_task_with_owner_preference(
+        &self,
+        store: &dyn TaskStore,
+        task: Task,
+        incoming_is_owner: bool,
+        strategy: Option<ConflictResolution>,
+        sync_id: &str,
+        source: &str,
+    ) -> Result<UpsertResult, CasError> {
+        if let Ok(local) = store.get(&task.id) {
+            let origins_differ = local.origin_project != task.origin_project;
+            if incoming_is_owner && origins_differ {
+                return self.upsert_owner_task(store, task, sync_id, source);
+            }
+            if !incoming_is_owner && origins_differ && local.origin_project.is_some() {
+                // Preserve the existing terminal guard's conflict strategy and
+                // audit shape for an active row attempting to reopen a close.
+                if local.is_terminal() && !task.is_terminal() {
+                    return match strategy {
+                        Some(strategy) => {
+                            self.upsert_task_with_strategy(store, task, strategy, sync_id, source)
+                        }
+                        None => self.upsert_task(store, task, sync_id, source),
+                    };
+                }
+                let discarded = serde_json::to_value(&task).map_err(|error| {
+                    CasError::Other(format!("Could not serialize owner sync conflict: {error}"))
+                })?;
+                self.record_owner_conflict_value(&task.id, &discarded)?;
+                return Ok(UpsertResult::Skipped);
+            }
+        }
+
+        match strategy {
+            Some(strategy) => {
+                self.upsert_task_with_strategy(store, task, strategy, sync_id, source)
+            }
+            None => self.upsert_task(store, task, sync_id, source),
+        }
+    }
+
     fn record_terminal_regression_conflict(
         &self,
         local: &Task,
@@ -645,10 +829,13 @@ impl CloudSyncer {
                     continue;
                 }
             };
-            // The scoped response proves which project supplied the row; use
-            // that same resolved identity as the local ownership stamp rather
-            // than trusting an optional payload field from an older server.
-            remote_task.origin_project = Some(current_project_id.to_string());
+            // The scoped response proves which project supplied a legacy row;
+            // preserve an explicit origin stamped by the cloud.
+            if remote_task.origin_project.is_none() {
+                remote_task.origin_project = Some(current_project_id.to_string());
+            }
+            let incoming_is_owner =
+                remote_task.origin_project.as_deref() == Some(current_project_id);
             let previous_status = task_store.get(&remote_task.id).ok().map(|task| task.status);
             let task_outcome = if web_close {
                 reconcile_web_close(
@@ -658,9 +845,11 @@ impl CloudSyncer {
                     "personal_pull",
                 )
             } else {
-                self.upsert_task(
+                self.upsert_task_with_owner_preference(
                     task_store,
                     remote_task.clone(),
+                    incoming_is_owner,
+                    None,
                     &task_sync_id,
                     "personal_pull",
                 )
@@ -1395,7 +1584,9 @@ impl CloudSyncer {
     ///   "second project sees stale `since=` from the first" regression
     ///   that surfaced as hypothesis #2 of the cas-ffc4 bug doc).
     /// - The `project_id=` URL query param.
-    /// - The client-side `entity_matches_project` filter.
+    /// - The client-side `entity_matches_project` filter for non-task rows.
+    ///   Task rows retain their wire project/origin identity so duplicate
+    ///   owner rows can win over stale replica copies.
     pub fn pull_team(
         &self,
         team_id: &str,
@@ -1503,11 +1694,18 @@ impl CloudSyncer {
 
         // Process tasks
         let task_sync_id = uuid::Uuid::new_v4().to_string();
-        for mut raw_task in body.tasks.unwrap_or_default() {
-            if !entity_matches_project(&raw_task, &current_project_id, "task") {
-                continue;
-            }
+        // Unlike entries/rules/skills, team tasks may be replicas keyed by a
+        // different project. Group them before any project filtering so the
+        // owner row can win over a stale foreign-keyed row.
+        let (raw_tasks, discarded_task_rows) =
+            select_owner_task_rows(body.tasks.unwrap_or_default(), current_project_id);
+        for (task_id, discarded_row) in discarded_task_rows {
+            self.record_owner_conflict_value(&task_id, &discarded_row)?;
+            result.conflicts_resolved += 1;
+        }
+        for mut raw_task in raw_tasks {
             render_task_proposal_provenance(&mut raw_task);
+            let wire_is_owner = task_wire_is_owner(&raw_task, current_project_id);
             let mut remote_task: Task = match deserialize_pulled_entity(raw_task, "task") {
                 Ok(t) => t,
                 Err(e) => {
@@ -1515,15 +1713,19 @@ impl CloudSyncer {
                     continue;
                 }
             };
-            // Team pulls are already filtered by the scoped project ID; stamp
-            // the accepted row explicitly so subsequent local surfaces cannot
-            // mistake an unscoped legacy payload for a local task.
-            remote_task.origin_project = Some(current_project_id.to_string());
+            // Preserve the cloud's owner identity. For legacy rows without an
+            // origin, the requested scope is the only available signal.
+            if remote_task.origin_project.is_none() {
+                remote_task.origin_project = Some(current_project_id.to_string());
+            }
+            let incoming_is_owner =
+                wire_is_owner || remote_task.origin_project.as_deref() == Some(current_project_id);
             let previous_status = task_store.get(&remote_task.id).ok().map(|task| task.status);
-            match self.upsert_task_with_strategy(
+            match self.upsert_task_with_owner_preference(
                 task_store,
                 remote_task.clone(),
-                strategy,
+                incoming_is_owner,
+                Some(strategy),
                 &task_sync_id,
                 "team_pull",
             ) {

--- a/cas-cli/src/cloud/syncer/team_push.rs
+++ b/cas-cli/src/cloud/syncer/team_push.rs
@@ -10,6 +10,13 @@ use chrono::Utc;
 
 fn stamp_task_origin_project(value: &mut serde_json::Value, project_id: &str) {
     if let Some(task) = value.as_object_mut() {
+        // Global tasks are personal-only and deliberately carry no project
+        // identity in their queued payload. Leave both fields untouched if a
+        // legacy caller routes one through this helper.
+        if task.get("scope").and_then(serde_json::Value::as_str) == Some("global") {
+            return;
+        }
+
         // Team task rows are project-scoped. Legacy queue payloads may have
         // been serialized before Task::scope existed, but the cloud contract
         // requires the explicit field or it may accept the batch while
@@ -18,10 +25,20 @@ fn stamp_task_origin_project(value: &mut serde_json::Value, project_id: &str) {
             "scope".to_string(),
             serde_json::Value::String("project".to_string()),
         );
-        task.insert(
-            "origin_project".to_string(),
-            serde_json::Value::String(project_id.to_string()),
-        );
+
+        // Supervisor reassignment is carried by a non-empty origin_project in
+        // the queued payload. Only legacy rows without a usable identity need
+        // to inherit the project performing the push.
+        let has_explicit_origin = task
+            .get("origin_project")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|origin| !origin.trim().is_empty());
+        if !has_explicit_origin {
+            task.insert(
+                "origin_project".to_string(),
+                serde_json::Value::String(project_id.to_string()),
+            );
+        }
     }
 }
 
@@ -793,6 +810,71 @@ mod tests {
         assert_eq!(
             value.get("origin_project").and_then(|value| value.as_str()),
             Some("acme/accounting")
+        );
+    }
+
+    #[test]
+    fn explicit_task_origin_project_survives_team_push_stamping() {
+        let mut value = serde_json::json!({
+            "id": "cas-reassigned",
+            "scope": "project",
+            "origin_project": "pulse-card",
+        });
+
+        super::stamp_task_origin_project(&mut value, "acme/accounting");
+
+        assert_eq!(
+            value.get("origin_project").and_then(|value| value.as_str()),
+            Some("pulse-card")
+        );
+    }
+
+    #[test]
+    fn missing_task_origin_project_receives_current_project_identity() {
+        let mut value = serde_json::json!({"id": "cas-legacy", "scope": "project"});
+
+        super::stamp_task_origin_project(&mut value, "acme/accounting");
+
+        assert_eq!(
+            value.get("origin_project").and_then(|value| value.as_str()),
+            Some("acme/accounting")
+        );
+    }
+
+    #[test]
+    fn empty_task_origin_project_receives_current_project_identity() {
+        let mut value = serde_json::json!({
+            "id": "cas-legacy",
+            "scope": "project",
+            "origin_project": "",
+        });
+
+        super::stamp_task_origin_project(&mut value, "acme/accounting");
+
+        assert_eq!(
+            value.get("origin_project").and_then(|value| value.as_str()),
+            Some("acme/accounting")
+        );
+    }
+
+    #[test]
+    fn global_task_origin_project_remains_unstamped() {
+        let mut value = serde_json::json!({
+            "id": "cas-global",
+            "scope": "global",
+            "origin_project": null,
+        });
+
+        super::stamp_task_origin_project(&mut value, "acme/accounting");
+
+        assert_eq!(
+            value.get("scope").and_then(|value| value.as_str()),
+            Some("global")
+        );
+        assert!(
+            value
+                .get("origin_project")
+                .is_some_and(serde_json::Value::is_null)
         );
     }
 }

--- a/cas-cli/src/cloud/syncer/team_push.rs
+++ b/cas-cli/src/cloud/syncer/team_push.rs
@@ -1,8 +1,8 @@
+use std::collections::HashSet;
 use std::time::Instant;
 
 use crate::cloud::syncer::{
-    CloudSyncer, GroupedQueuedItems, PushItemizedFailure, SyncResult, TeamPushResponse,
-    itemized_failures_for,
+    CloudSyncer, PushItemizedFailure, SyncResult, TeamPushResponse, itemized_failures_for,
 };
 use crate::cloud::{EntityType, QueuedSync, SyncOperation, get_project_canonical_id};
 use crate::error::CasError;
@@ -78,7 +78,7 @@ impl CloudSyncer {
         // immediately replay the destructive team delete.
         let mut sendable = Vec::with_capacity(queued.len());
         for item in queued {
-            if item.operation == SyncOperation::Delete {
+            if item.operation == SyncOperation::Delete && item.project_id.is_none() {
                 match self.queue.neutralize_delete_if_local_entity_exists(&item) {
                     Ok(true) => {
                         tracing::warn!(
@@ -111,11 +111,6 @@ impl CloudSyncer {
             return Ok(result);
         }
 
-        // Group deletes for the existing one-per-entity delete path. Upserts
-        // stay associated with their queue rows below so sub-batches can be
-        // marked synced/failed independently.
-        let grouped = self.group_queued_items(&queued);
-
         // Include project_canonical_id (required for project scoping)
         let project_id = get_project_canonical_id().ok_or_else(|| {
             CasError::Other("Cannot sync: not inside a Cassy project directory".to_string())
@@ -129,18 +124,39 @@ impl CloudSyncer {
             .ok()
             .and_then(|cas_root| crate::cloud::normalized_git_remote_for_push(&cas_root));
 
-        let has_deletes = !grouped.delete_entries.is_empty()
-            || !grouped.delete_tasks.is_empty()
-            || !grouped.delete_rules.is_empty()
-            || !grouped.delete_skills.is_empty()
-            || !grouped.delete_sessions.is_empty()
-            || !grouped.delete_verifications.is_empty()
-            || !grouped.delete_events.is_empty()
-            || !grouped.delete_prompts.is_empty()
-            || !grouped.delete_file_changes.is_empty()
-            || !grouped.delete_commit_links.is_empty()
-            || !grouped.delete_agents.is_empty()
-            || !grouped.delete_worktrees.is_empty();
+        let has_deletes = queued
+            .iter()
+            .any(|item| item.operation == SyncOperation::Delete);
+
+        // A project move must remove the old (project, id) key before the
+        // replacement upsert is sent. A failed move-delete blocks only its
+        // matching upsert, leaving both rows queued with the same diagnostic.
+        let move_deletes: Vec<&QueuedSync> = queued
+            .iter()
+            .filter(|item| item.operation == SyncOperation::Delete && item.project_id.is_some())
+            .collect();
+        let mut blocked_upserts = HashSet::new();
+        if !move_deletes.is_empty() {
+            let (successful, failures) =
+                self.send_team_deletes(team_id, &move_deletes, token, &project_id);
+            for queue_id in successful {
+                let _ = self.queue.mark_synced(queue_id);
+            }
+            for (queue_id, error) in failures {
+                let _ = self.queue.mark_failed(queue_id, &error);
+                if let Some(delete) = queued.iter().find(|item| item.id == queue_id) {
+                    for upsert in queued.iter().filter(|item| {
+                        item.operation == SyncOperation::Upsert
+                            && item.entity_type == delete.entity_type
+                            && item.entity_id == delete.entity_id
+                    }) {
+                        let _ = self.queue.mark_failed(upsert.id, &error);
+                        blocked_upserts.insert(upsert.id);
+                    }
+                }
+                result.errors.push(error);
+            }
+        }
 
         for (entity_type, entity_key) in [
             (EntityType::Entry, "entries"),
@@ -164,30 +180,26 @@ impl CloudSyncer {
                 token,
                 &project_id,
                 git_remote.as_deref(),
+                &blocked_upserts,
             );
             Self::add_team_count(&mut result, entity_key, synced);
             result.errors.extend(errors);
         }
 
-        if result.errors.is_empty() && has_deletes {
-            // Process deletes (after successful upserts or if no upserts)
-            let (deleted_count, delete_errors) =
-                self.send_team_deletes(team_id, &grouped, token, &project_id);
-            // Track successful deletes (deleted_count is total across all types)
-            if deleted_count > 0 {
-                // Note: delete counts aren't tracked separately in SyncResult,
-                // they're part of the overall push operation
-                let _ = deleted_count; // Acknowledge the count
+        let normal_deletes: Vec<&QueuedSync> = queued
+            .iter()
+            .filter(|item| item.operation == SyncOperation::Delete && item.project_id.is_none())
+            .collect();
+        if result.errors.is_empty() && has_deletes && !normal_deletes.is_empty() {
+            // Ordinary deletes retain the historical after-upsert ordering.
+            let (successful, failures) =
+                self.send_team_deletes(team_id, &normal_deletes, token, &project_id);
+            for queue_id in successful {
+                let _ = self.queue.mark_synced(queue_id);
             }
-            if !delete_errors.is_empty() {
-                result.errors.extend(delete_errors);
-            } else {
-                for item in queued
-                    .iter()
-                    .filter(|item| item.operation == SyncOperation::Delete)
-                {
-                    let _ = self.queue.mark_synced(item.id);
-                }
+            for (queue_id, error) in failures {
+                let _ = self.queue.mark_failed(queue_id, &error);
+                result.errors.push(error);
             }
         }
 
@@ -212,11 +224,14 @@ impl CloudSyncer {
         token: &str,
         project_id: &str,
         git_remote: Option<&str>,
+        blocked_upserts: &HashSet<i64>,
     ) -> (usize, Vec<String>) {
         let mut upserts = Vec::new();
 
         for item in queued.iter().filter(|item| {
-            item.operation == SyncOperation::Upsert && item.entity_type == entity_type
+            item.operation == SyncOperation::Upsert
+                && item.entity_type == entity_type
+                && !blocked_upserts.contains(&item.id)
         }) {
             match item.payload.as_deref() {
                 Some(payload) => match serde_json::from_str::<serde_json::Value>(payload) {
@@ -585,172 +600,37 @@ impl CloudSyncer {
         }
     }
 
-    /// Group queued items by entity type and operation
-    fn group_queued_items(&self, items: &[QueuedSync]) -> GroupedQueuedItems {
-        let mut result = GroupedQueuedItems::default();
-
-        for item in items {
-            match item.operation {
-                SyncOperation::Upsert => {
-                    if let Some(payload) = &item.payload {
-                        if let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) {
-                            match item.entity_type {
-                                EntityType::Entry => result.upsert_entries.push(value),
-                                EntityType::Task => result.upsert_tasks.push(value),
-                                EntityType::Rule => result.upsert_rules.push(value),
-                                EntityType::Skill => result.upsert_skills.push(value),
-                                EntityType::Session => result.upsert_sessions.push(value),
-                                EntityType::Verification => result.upsert_verifications.push(value),
-                                EntityType::Event => result.upsert_events.push(value),
-                                EntityType::Prompt => result.upsert_prompts.push(value),
-                                EntityType::FileChange => result.upsert_file_changes.push(value),
-                                EntityType::CommitLink => result.upsert_commit_links.push(value),
-                                EntityType::Agent => result.upsert_agents.push(value),
-                                EntityType::Worktree => result.upsert_worktrees.push(value),
-                                // Pages ship via `push_knowledge_pages` (it
-                                // needs the body from disk), so nothing
-                                // enqueues them today. Arm kept explicit so a
-                                // future queue producer is a compile error.
-                                EntityType::KnowledgePage => {}
-                            }
-                        }
-                    }
-                }
-                SyncOperation::Delete => match item.entity_type {
-                    EntityType::Entry => result.delete_entries.push(item.entity_id.clone()),
-                    EntityType::Task => result.delete_tasks.push(item.entity_id.clone()),
-                    EntityType::Rule => result.delete_rules.push(item.entity_id.clone()),
-                    EntityType::Skill => result.delete_skills.push(item.entity_id.clone()),
-                    EntityType::Session => result.delete_sessions.push(item.entity_id.clone()),
-                    EntityType::Verification => {
-                        result.delete_verifications.push(item.entity_id.clone())
-                    }
-                    EntityType::Event => result.delete_events.push(item.entity_id.clone()),
-                    EntityType::Prompt => result.delete_prompts.push(item.entity_id.clone()),
-                    EntityType::FileChange => {
-                        result.delete_file_changes.push(item.entity_id.clone())
-                    }
-                    EntityType::CommitLink => {
-                        result.delete_commit_links.push(item.entity_id.clone())
-                    }
-                    EntityType::Agent => result.delete_agents.push(item.entity_id.clone()),
-                    EntityType::Worktree => result.delete_worktrees.push(item.entity_id.clone()),
-                    EntityType::KnowledgePage => {}
-                },
-            }
-        }
-
-        result
-    }
-
-    /// Send team delete requests for each entity type
+    /// Send team delete requests in queue order, retaining each row's target
+    /// project when this is a project move. Normal deletes use the current
+    /// pushing project as before.
     fn send_team_deletes(
         &self,
         team_id: &str,
-        grouped: &GroupedQueuedItems,
+        items: &[&QueuedSync],
         token: &str,
         project_id: &str,
-    ) -> (usize, Vec<String>) {
-        let mut deleted = 0;
+    ) -> (Vec<i64>, Vec<(i64, String)>) {
+        let mut successful = Vec::new();
         let mut errors = Vec::new();
 
-        // Delete entries
-        for cas_id in &grouped.delete_entries {
-            match self.send_team_delete(team_id, EntityType::Entry, cas_id, token, project_id) {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("Entry delete {cas_id}: {e}")),
-            }
-        }
-
-        // Delete tasks
-        for cas_id in &grouped.delete_tasks {
-            match self.send_team_delete(team_id, EntityType::Task, cas_id, token, project_id) {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("Task delete {cas_id}: {e}")),
-            }
-        }
-
-        // Delete rules
-        for cas_id in &grouped.delete_rules {
-            match self.send_team_delete(team_id, EntityType::Rule, cas_id, token, project_id) {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("Rule delete {cas_id}: {e}")),
-            }
-        }
-
-        // Delete skills
-        for cas_id in &grouped.delete_skills {
-            match self.send_team_delete(team_id, EntityType::Skill, cas_id, token, project_id) {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("Skill delete {cas_id}: {e}")),
-            }
-        }
-
-        // Delete sessions
-        for cas_id in &grouped.delete_sessions {
-            match self.send_team_delete(team_id, EntityType::Session, cas_id, token, project_id) {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("Session delete {cas_id}: {e}")),
-            }
-        }
-
-        // Delete verifications
-        for cas_id in &grouped.delete_verifications {
+        for item in items {
+            let target_project = item.project_id.as_deref().unwrap_or(project_id);
             match self.send_team_delete(
                 team_id,
-                EntityType::Verification,
-                cas_id,
+                item.entity_type,
+                &item.entity_id,
                 token,
-                project_id,
+                target_project,
             ) {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("Verification delete {cas_id}: {e}")),
+                Ok(()) => successful.push(item.id),
+                Err(error) => errors.push((
+                    item.id,
+                    format!("{} delete {}: {error}", item.entity_type, item.entity_id),
+                )),
             }
         }
 
-        // Delete events
-        for cas_id in &grouped.delete_events {
-            match self.send_team_delete(team_id, EntityType::Event, cas_id, token, project_id) {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("Event delete {cas_id}: {e}")),
-            }
-        }
-
-        // Delete prompts
-        for cas_id in &grouped.delete_prompts {
-            match self.send_team_delete(team_id, EntityType::Prompt, cas_id, token, project_id) {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("Prompt delete {cas_id}: {e}")),
-            }
-        }
-
-        // Delete file changes
-        for cas_id in &grouped.delete_file_changes {
-            match self.send_team_delete(team_id, EntityType::FileChange, cas_id, token, project_id)
-            {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("FileChange delete {cas_id}: {e}")),
-            }
-        }
-
-        // Delete commit links
-        for cas_id in &grouped.delete_commit_links {
-            match self.send_team_delete(team_id, EntityType::CommitLink, cas_id, token, project_id)
-            {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("CommitLink delete {cas_id}: {e}")),
-            }
-        }
-
-        // Delete agents
-        for cas_id in &grouped.delete_agents {
-            match self.send_team_delete(team_id, EntityType::Agent, cas_id, token, project_id) {
-                Ok(()) => deleted += 1,
-                Err(e) => errors.push(format!("Agent delete {cas_id}: {e}")),
-            }
-        }
-
-        (deleted, errors)
+        (successful, errors)
     }
 
     /// Send a single team delete request

--- a/cas-cli/src/cloud/syncer/tests.rs
+++ b/cas-cli/src/cloud/syncer/tests.rs
@@ -1,6 +1,10 @@
+use std::sync::Arc;
 use std::time::Duration;
 
+use crate::cloud::SyncQueue;
 use crate::cloud::syncer::*;
+use crate::store::TaskStore;
+use crate::types::{Task, TaskStatus};
 
 #[test]
 fn test_sync_result_totals() {
@@ -492,5 +496,190 @@ fn push_response_skipped_count_threshold_drives_warn_path() {
         resp.skipped_count_for("tasks"),
         Ok(0),
         "non-targeted entity types must not fire the warn-path"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-project team-task ownership (cas-2125).
+// ---------------------------------------------------------------------------
+
+fn team_task_fixture(
+    id: &str,
+    status: TaskStatus,
+    project_id: &str,
+    origin_project: &str,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> serde_json::Value {
+    let mut task = Task::new(id.to_string(), format!("task {id}"));
+    task.status = status;
+    task.updated_at = updated_at;
+    if task.is_terminal() {
+        task.closed_at = Some(updated_at);
+        task.close_reason = Some("owner closed".to_string());
+    }
+    let mut raw = serde_json::to_value(task).unwrap();
+    raw["project_id"] = serde_json::json!(project_id);
+    raw["origin_project"] = serde_json::json!(origin_project);
+    raw
+}
+
+async fn pull_team_task_fixtures(
+    project_id: &str,
+    tasks: Vec<serde_json::Value>,
+    local_task: Option<Task>,
+) -> (
+    tempfile::TempDir,
+    SyncResult,
+    Arc<dyn TaskStore>,
+    Arc<SyncQueue>,
+) {
+    use crate::cloud::{CloudConfig, CloudSyncer, CloudSyncerConfig};
+    use crate::store::{
+        open_rule_store_local, open_skill_store_local, open_store_local, open_task_store_local,
+    };
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let team_id = "team-cas-2125";
+    Mock::given(method("GET"))
+        .and(path(format!("/api/teams/{team_id}/sync/pull")))
+        .and(query_param("project_id", project_id))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": [],
+            "tasks": tasks,
+            "rules": [],
+            "skills": [],
+            "pulled_at": "2026-09-01T12:00:00Z",
+            "team_id": team_id,
+            "status": "ok",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let temp = TempDir::new().unwrap();
+    let queue = Arc::new(SyncQueue::open(temp.path()).unwrap());
+    queue.init().unwrap();
+    let store = open_store_local(temp.path()).unwrap();
+    let task_store = open_task_store_local(temp.path()).unwrap();
+    if let Some(local_task) = local_task {
+        task_store.add(&local_task).unwrap();
+    }
+    let rule_store = open_rule_store_local(temp.path()).unwrap();
+    let skill_store = open_skill_store_local(temp.path()).unwrap();
+    let syncer = CloudSyncer::new(
+        Arc::clone(&queue),
+        CloudConfig {
+            endpoint: server.uri(),
+            token: Some("test-token".to_string()),
+            ..Default::default()
+        },
+        CloudSyncerConfig::default(),
+    );
+    let result = syncer
+        .pull_team(
+            team_id,
+            project_id,
+            store.as_ref(),
+            task_store.as_ref(),
+            rule_store.as_ref(),
+            skill_store.as_ref(),
+        )
+        .unwrap();
+    (temp, result, task_store, queue)
+}
+
+#[tokio::test]
+async fn team_pull_duplicate_task_id_prefers_owner_closed_row() {
+    let now = chrono::Utc::now();
+    let tasks = vec![
+        // The owner row is older and keyed by the owner project. The foreign
+        // replica row is newer and active; wire order must not decide status.
+        team_task_fixture(
+            "cas-2125-owner-closed",
+            TaskStatus::Closed,
+            "owner-project",
+            "owner-project",
+            now - chrono::Duration::hours(1),
+        ),
+        team_task_fixture(
+            "cas-2125-owner-closed",
+            TaskStatus::Open,
+            "replica-project",
+            "owner-project",
+            now,
+        ),
+    ];
+    let (_temp, result, task_store, queue) =
+        pull_team_task_fixtures("replica-project", tasks, None).await;
+
+    assert!(
+        result.errors.is_empty(),
+        "unexpected pull errors: {:?}",
+        result.errors
+    );
+    let task = task_store.get("cas-2125-owner-closed").unwrap();
+    assert_eq!(task.status, TaskStatus::Closed);
+    assert_eq!(task.origin_project.as_deref(), Some("owner-project"));
+    let conflicts = queue.list_conflicts(10).unwrap();
+    assert_eq!(conflicts.len(), 1);
+    assert_eq!(conflicts[0].strategy, "owner_wins");
+    assert!(conflicts[0].discarded_row_json.contains("replica-project"));
+}
+
+#[tokio::test]
+async fn team_pull_single_foreign_open_row_preserves_wire_origin_project() {
+    let task = team_task_fixture(
+        "cas-2125-foreign-absent",
+        TaskStatus::Open,
+        "foreign-project",
+        "foreign-project",
+        chrono::Utc::now(),
+    );
+    let (_temp, result, task_store, _queue) =
+        pull_team_task_fixtures("replica-project", vec![task], None).await;
+
+    assert!(
+        result.errors.is_empty(),
+        "unexpected pull errors: {:?}",
+        result.errors
+    );
+    let task = task_store.get("cas-2125-foreign-absent").unwrap();
+    assert_eq!(task.status, TaskStatus::Open);
+    assert_eq!(task.origin_project.as_deref(), Some("foreign-project"));
+}
+
+#[tokio::test]
+async fn team_pull_foreign_open_row_cannot_reopen_local_owner_close() {
+    let now = chrono::Utc::now();
+    let tasks = vec![team_task_fixture(
+        "cas-2125-local-closed",
+        TaskStatus::Open,
+        "foreign-project",
+        "foreign-project",
+        now,
+    )];
+    let mut local = Task::new(
+        "cas-2125-local-closed".to_string(),
+        "owner closed task".to_string(),
+    );
+    local.status = TaskStatus::Closed;
+    local.origin_project = Some("owner-project".to_string());
+    local.closed_at = Some(now - chrono::Duration::hours(1));
+    local.close_reason = Some("owner closed".to_string());
+    local.updated_at = now - chrono::Duration::hours(1);
+    let (_temp, result, task_store, _queue) =
+        pull_team_task_fixtures("replica-project", tasks, Some(local)).await;
+
+    assert!(
+        result.errors.is_empty(),
+        "unexpected pull errors: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        task_store.get("cas-2125-local-closed").unwrap().status,
+        TaskStatus::Closed
     );
 }

--- a/cas-cli/src/cloud/team_registration.rs
+++ b/cas-cli/src/cloud/team_registration.rs
@@ -160,6 +160,28 @@ impl<'a> TeamRegistration<'a> {
         self
     }
 
+    /// Verify that the project is already registered with the team without
+    /// creating a registration as a side effect. Reassignment uses this
+    /// read-only path so an invalid destination is rejected before the local
+    /// task or its sync queue changes.
+    pub fn verify_registered(&self) -> Result<(), RegistrationFailure> {
+        if self.lookup(self.canonical_id)?.is_some() {
+            return Ok(());
+        }
+
+        Err(RegistrationFailure {
+            reason: format!(
+                "Project '{}' is not registered with team {} on {}.",
+                self.canonical_id, self.team_id, self.endpoint
+            ),
+            interaction: format!(
+                "GET {} -> 200 but no project with canonical_id \"{}\"",
+                self.projects_url(),
+                self.canonical_id
+            ),
+        })
+    }
+
     fn projects_url(&self) -> String {
         format!("{}/api/teams/{}/projects", self.endpoint, self.team_id)
     }

--- a/cas-cli/src/config/mod.rs
+++ b/cas-cli/src/config/mod.rs
@@ -133,6 +133,10 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory: Option<MemoryConfig>,
 
+    /// `[hub]` — public origin used for Commander reverse pairing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hub: Option<HubConfig>,
+
     /// `[project]` — project-scoped configuration (cas-1ced). Holds the
     /// canonical project slug for cloud-sync scoping. Set eagerly by
     /// `cas cloud team set` (auto-derived from git remote) or manually
@@ -178,6 +182,7 @@ impl Config {
         merge_option!(code_review);
         merge_option!(issues);
         merge_option!(memory);
+        merge_option!(hub);
         merge_option!(project);
         changed
     }

--- a/cas-cli/src/config/settings.rs
+++ b/cas-cli/src/config/settings.rs
@@ -1,6 +1,14 @@
 use cas_factory::AutoPromptConfig;
 use serde::{Deserialize, Serialize};
 
+/// Hub origin configuration. Lives at `[hub]` in `.cas/config.toml`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HubConfig {
+    /// Public origin used when authorizing a Commander page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_url: Option<String>,
+}
+
 /// Project-scoped GitHub issue intake configuration. Lives at `[issues]` in
 /// `.cas/config.toml`.
 ///

--- a/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/task_claiming.rs
@@ -578,7 +578,7 @@ impl CasCore {
     /// List tasks available for claiming
     pub async fn cas_tasks_available(
         &self,
-        Parameters(req): Parameters<LimitRequest>,
+        Parameters(req): Parameters<TaskAvailableRequest>,
     ) -> Result<CallToolResult, McpError> {
         let task_store = self.open_task_store()?;
         let agent_store = self.open_agent_store()?;
@@ -595,11 +595,25 @@ impl CasCore {
         let claimed_ids: std::collections::HashSet<_> =
             active_leases.iter().map(|l| l.task_id.as_str()).collect();
 
-        // Filter to unclaimed tasks
+        // Filter to unclaimed tasks. Legacy rows with no origin remain visible;
+        // explicitly foreign rows require the opt-in flag.
         let project_id = super::super::task::current_project_id(&self.cas_root);
+        let hidden_foreign = if req.include_foreign {
+            0
+        } else {
+            ready_tasks
+                .iter()
+                .filter(|task| {
+                    !super::super::task::task_visible_in_project(task, project_id.as_deref())
+                })
+                .count()
+        };
         let mut available: Vec<_> = ready_tasks
             .iter()
-            .filter(|t| super::super::task::task_belongs_to_project(t, project_id.as_deref()))
+            .filter(|t| {
+                req.include_foreign
+                    || super::super::task::task_visible_in_project(t, project_id.as_deref())
+            })
             .filter(|t| !claimed_ids.contains(t.id.as_str()))
             .collect();
 
@@ -617,9 +631,12 @@ impl CasCore {
         crate::mcp::tools::sort_task_refs(&mut available, &sort_opts);
 
         if available.is_empty() {
-            return Ok(Self::success(
-                "No available tasks (all claimed or none ready)",
-            ));
+            let mut output = "No available tasks (all claimed or none ready)".to_string();
+            if let Some(footer) = super::super::task::foreign_tasks_hidden_footer(hidden_foreign) {
+                output.push('\n');
+                output.push_str(&footer);
+            }
+            return Ok(Self::success(output));
         }
 
         // cas-e163 (GH #109): the total here was already honest, but nothing
@@ -646,6 +663,10 @@ impl CasCore {
             ));
         }
         output.push_str(&crate::mcp::tools::truncated_list_footer(total, shown));
+        if let Some(footer) = super::super::task::foreign_tasks_hidden_footer(hidden_foreign) {
+            output.push('\n');
+            output.push_str(&footer);
+        }
 
         Ok(Self::success(output))
     }

--- a/cas-cli/src/mcp/tools/core/task.rs
+++ b/cas-cli/src/mcp/tools/core/task.rs
@@ -7,14 +7,23 @@ pub(crate) mod repo_context;
 mod update;
 
 /// Return the canonical identity of the project represented by a Cassy root.
-/// Task surfaces must fail closed when the identity cannot be derived: an
-/// unassigned legacy row cannot safely be ranked as local in that case.
 pub(crate) fn current_project_id(cas_root: &std::path::Path) -> Option<String> {
     crate::cloud::resolve_canonical_id(cas_root)
 }
 
 pub(crate) fn task_belongs_to_project(task: &cas_types::Task, project_id: Option<&str>) -> bool {
     project_id.is_some_and(|project_id| task.origin_project.as_deref() == Some(project_id))
+}
+
+/// Task board reads retain legacy rows that have no origin attribution. Rows
+/// with an origin are local only when that origin matches the current project.
+pub(crate) fn task_visible_in_project(task: &cas_types::Task, project_id: Option<&str>) -> bool {
+    task.origin_project.is_none() || task_belongs_to_project(task, project_id)
+}
+
+pub(crate) fn foreign_tasks_hidden_footer(hidden: usize) -> Option<String> {
+    (hidden > 0)
+        .then(|| format!("{hidden} foreign-origin tasks hidden (include_foreign=true to show)"))
 }
 
 #[cfg(test)]

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -737,7 +737,17 @@ impl CasCore {
         };
 
         let project_id = super::current_project_id(&self.cas_root);
-        tasks.retain(|task| super::task_belongs_to_project(task, project_id.as_deref()));
+        let hidden_foreign = if req.include_foreign {
+            0
+        } else {
+            tasks
+                .iter()
+                .filter(|task| !super::task_visible_in_project(task, project_id.as_deref()))
+                .count()
+        };
+        if !req.include_foreign {
+            tasks.retain(|task| super::task_visible_in_project(task, project_id.as_deref()));
+        }
 
         // Apply sorting. cas-06f9 (GH #104): unspecified means priority order
         // here, not creation order — this is the "what should I pick up next"
@@ -755,7 +765,12 @@ impl CasCore {
             } else {
                 "No ready tasks"
             };
-            return Ok(Self::success(msg));
+            let mut output = msg.to_string();
+            if let Some(footer) = super::foreign_tasks_hidden_footer(hidden_foreign) {
+                output.push_str("\n");
+                output.push_str(&footer);
+            }
+            return Ok(Self::success(output));
         }
 
         // cas-06f9 (GH #104): the cap stays (an unbounded dump is its own
@@ -774,6 +789,10 @@ impl CasCore {
             ));
         }
         output.push_str(&crate::mcp::tools::truncated_list_footer(total, shown));
+        if let Some(footer) = super::foreign_tasks_hidden_footer(hidden_foreign) {
+            output.push_str("\n");
+            output.push_str(&footer);
+        }
 
         Ok(Self::success(output))
     }

--- a/cas-cli/src/mcp/tools/core/task/proposals.rs
+++ b/cas-cli/src/mcp/tools/core/task/proposals.rs
@@ -527,6 +527,7 @@ mod tests {
                 epic: None,
                 sort: None,
                 sort_order: None,
+                include_foreign: false,
             }))
             .await
             .unwrap();
@@ -548,6 +549,7 @@ mod tests {
                 epic: None,
                 sort: None,
                 sort_order: None,
+                include_foreign: false,
             }))
             .await
             .unwrap_err();

--- a/cas-cli/src/mcp/tools/core/task/query.rs
+++ b/cas-cli/src/mcp/tools/core/task/query.rs
@@ -20,6 +20,21 @@ impl CasCore {
             .map(|target| format!("{} @ {}", target.repo_selector, target.target_branch))
             .unwrap_or_else(|| "(none — trunk fallback)".to_string());
 
+        let project_id = super::current_project_id(&self.cas_root);
+        let origin = task
+            .origin_project
+            .as_deref()
+            .unwrap_or("unassigned legacy row");
+        let origin = if project_id
+            .as_deref()
+            .is_some_and(|project_id| task.origin_project.as_deref() != Some(project_id))
+            && task.origin_project.is_some()
+        {
+            format!("{origin} — this task is owned elsewhere")
+        } else {
+            origin.to_string()
+        };
+
         let mut output = format!(
             "Task: {}\n{}\n\nTitle: {}\nStatus: {:?}\nPriority: P{}\nType: {}\nDepth: {}\nOrigin project: {}\nTarget: {}\n",
             task.id,
@@ -29,9 +44,7 @@ impl CasCore {
             task.priority.0,
             task.task_type,
             task.depth,
-            task.origin_project
-                .as_deref()
-                .unwrap_or("unassigned legacy row"),
+            origin,
             target
         );
 
@@ -441,7 +454,17 @@ impl CasCore {
         };
 
         let project_id = super::current_project_id(&self.cas_root);
-        blocked.retain(|(task, _)| super::task_belongs_to_project(task, project_id.as_deref()));
+        let hidden_foreign = if req.include_foreign {
+            0
+        } else {
+            blocked
+                .iter()
+                .filter(|(task, _)| !super::task_visible_in_project(task, project_id.as_deref()))
+                .count()
+        };
+        if !req.include_foreign {
+            blocked.retain(|(task, _)| super::task_visible_in_project(task, project_id.as_deref()));
+        }
 
         // Apply sorting to the task field of each tuple. cas-06f9 (GH #104):
         // same defaulting as `ready` — this is the same triage surface, and it
@@ -458,7 +481,12 @@ impl CasCore {
             } else {
                 "No blocked tasks"
             };
-            return Ok(Self::success(msg));
+            let mut output = msg.to_string();
+            if let Some(footer) = super::foreign_tasks_hidden_footer(hidden_foreign) {
+                output.push_str("\n");
+                output.push_str(&footer);
+            }
+            return Ok(Self::success(output));
         }
 
         let limit = req.limit.unwrap_or(10);
@@ -491,6 +519,10 @@ impl CasCore {
             ));
         }
         output.push_str(&crate::mcp::tools::truncated_list_footer(total, shown));
+        if let Some(footer) = super::foreign_tasks_hidden_footer(hidden_foreign) {
+            output.push_str("\n");
+            output.push_str(&footer);
+        }
 
         Ok(Self::success(output))
     }
@@ -534,10 +566,10 @@ impl CasCore {
             })?
         };
 
-        // Apply filters
+        // Apply filters. Count foreign rows after the user-supplied filters so
+        // the footer describes rows hidden by this exact query.
         let mut filtered: Vec<_> = tasks
             .into_iter()
-            .filter(|task| super::task_belongs_to_project(task, project_id.as_deref()))
             .filter(|task| {
                 // Status filter — use Display (snake_case) for matching so
                 // "pending_supervisor_review", "in_progress", etc. all round-trip
@@ -576,6 +608,17 @@ impl CasCore {
                 true
             })
             .collect();
+        let hidden_foreign = if req.include_foreign {
+            0
+        } else {
+            filtered
+                .iter()
+                .filter(|task| !super::task_visible_in_project(task, project_id.as_deref()))
+                .count()
+        };
+        if !req.include_foreign {
+            filtered.retain(|task| super::task_visible_in_project(task, project_id.as_deref()));
+        }
 
         // Apply sorting
         let sort_opts =
@@ -598,9 +641,12 @@ impl CasCore {
             )
         };
         if filtered.is_empty() {
-            return Ok(Self::success(format!(
-                "No tasks found matching filters.\n{scope_note}."
-            )));
+            let mut output = format!("No tasks found matching filters.\n{scope_note}.");
+            if let Some(footer) = super::foreign_tasks_hidden_footer(hidden_foreign) {
+                output.push_str("\n");
+                output.push_str(&footer);
+            }
+            return Ok(Self::success(output));
         }
 
         let limit = req.limit.unwrap_or(20);
@@ -638,6 +684,10 @@ impl CasCore {
 
         if filtered.len() > limit {
             output.push_str(&format!("\n... and {} more", filtered.len() - limit));
+        }
+        if let Some(footer) = super::foreign_tasks_hidden_footer(hidden_foreign) {
+            output.push_str("\n");
+            output.push_str(&footer);
         }
 
         Ok(Self::success(output))

--- a/cas-cli/src/mcp/tools/core/task/update.rs
+++ b/cas-cli/src/mcp/tools/core/task/update.rs
@@ -1,5 +1,7 @@
 use crate::mcp::tools::core::imports::*;
 
+use crate::cloud::{CloudConfig, TeamRegistration};
+
 /// Heartbeat staleness window for epic_verification_owner transfer targets
 /// (cas-cc74). Aligned with claim/close assignee liveness (~5 min).
 const EPIC_OWNER_TARGET_STALE_SECS: i64 = 300;
@@ -48,6 +50,54 @@ fn assignee_batch_abort(fields: &[&str], rejection: impl std::fmt::Display) -> S
         "TASK UPDATE BATCH ABORTED: assignee validation rejected the request; no requested task fields were applied. Fields not applied: [{}]. Rejection: {rejection}",
         fields.join(", ")
     )
+}
+
+fn verify_origin_project_registered(
+    cas_root: &std::path::Path,
+    origin_project: &str,
+) -> Result<(), McpError> {
+    let cloud_config = CloudConfig::load_from_cas_dir_inheriting_user_credentials(cas_root)
+        .map_err(|error| McpError {
+            code: ErrorCode::INVALID_PARAMS,
+            message: Cow::from(format!(
+                "TASK UPDATE REJECTED: origin_project reassignment requires an active cloud team configuration: {error}"
+            )),
+            data: None,
+        })?;
+    let team_id = cloud_config.active_team_id().ok_or_else(|| McpError {
+        code: ErrorCode::INVALID_PARAMS,
+        message: Cow::from(
+            "TASK UPDATE REJECTED: origin_project reassignment requires an active registered team project; configure a team before moving the task.",
+        ),
+        data: None,
+    })?;
+    let token = cloud_config
+        .token
+        .as_deref()
+        .filter(|token| !token.trim().is_empty())
+        .ok_or_else(|| McpError {
+            code: ErrorCode::INVALID_PARAMS,
+            message: Cow::from(
+                "TASK UPDATE REJECTED: origin_project reassignment requires an authenticated cloud session.",
+            ),
+            data: None,
+        })?;
+
+    TeamRegistration::new(
+        &cloud_config.endpoint,
+        token,
+        &team_id,
+        origin_project,
+    )
+    .verify_registered()
+    .map_err(|error| McpError {
+        code: ErrorCode::INVALID_PARAMS,
+        message: Cow::from(format!(
+            "TASK UPDATE REJECTED: destination origin_project '{}' must already be registered with team {}: {}",
+            origin_project, team_id, error
+        )),
+        data: None,
+    })
 }
 
 /// Normalize `epic_verification_owner` at write boundaries (cas-cc74 discovery).
@@ -321,8 +371,8 @@ impl CasCore {
                 })
             })
             .transpose()?;
-        if req.origin_project.is_some() {
-            self.resolve_live_supervisor_authority().map_err(|error| {
+        let origin_project_supervisor = if req.origin_project.is_some() {
+            Some(self.resolve_live_supervisor_authority().map_err(|error| {
                 McpError {
                     code: ErrorCode::INVALID_PARAMS,
                     message: Cow::from(format!(
@@ -330,7 +380,14 @@ impl CasCore {
                     )),
                     data: None,
                 }
-            })?;
+            })?)
+        } else {
+            None
+        };
+        if let Some(origin_project) = origin_project.as_deref()
+            && task.origin_project.as_deref() != Some(origin_project)
+        {
+            verify_origin_project_registered(&self.cas_root, origin_project)?;
         }
         // Validate before applying any ordinary task fields. The store repeats
         // this validation while holding its write lock, so a malformed patch
@@ -706,10 +763,14 @@ impl CasCore {
                     .as_deref()
                     .unwrap_or("unassigned legacy row");
                 let audit = format!(
-                    "[{}] DECISION: origin_project reassigned {} → {} by live supervisor (cas-e0c5)",
+                    "[{}] DECISION: moved from {} to {} by {} (origin_project reassignment, cas-e0c5)",
                     chrono::Utc::now().format("%Y-%m-%d %H:%M"),
                     previous,
                     origin_project,
+                    origin_project_supervisor
+                        .as_ref()
+                        .map(|supervisor| supervisor.name.as_str())
+                        .unwrap_or("live supervisor"),
                 );
                 task.notes = if task.notes.is_empty() {
                     audit

--- a/cas-cli/src/mcp/tools/service/core.rs
+++ b/cas-cli/src/mcp/tools/service/core.rs
@@ -525,6 +525,7 @@ impl CasService {
             epic: req.epic,
             sort: req.sort.clone(),
             sort_order: req.sort_order.clone(),
+            include_foreign: req.include_foreign.unwrap_or(false),
         };
         self.inner.cas_task_list(Parameters(inner_req)).await
     }
@@ -537,6 +538,7 @@ impl CasService {
             sort: req.sort.clone(),
             sort_order: req.sort_order.clone(),
             epic: req.epic,
+            include_foreign: req.include_foreign.unwrap_or(false),
         };
         self.inner.cas_task_ready(Parameters(inner_req)).await
     }
@@ -549,6 +551,7 @@ impl CasService {
             sort: req.sort.clone(),
             sort_order: req.sort_order.clone(),
             epic: req.epic,
+            include_foreign: req.include_foreign.unwrap_or(false),
         };
         self.inner.cas_task_blocked(Parameters(inner_req)).await
     }
@@ -681,13 +684,13 @@ impl CasService {
         &self,
         req: TaskRequest,
     ) -> Result<CallToolResult, McpError> {
-        use crate::mcp::tools::LimitRequest;
-        let inner_req = LimitRequest {
+        use crate::mcp::tools::TaskAvailableRequest;
+        let inner_req = TaskAvailableRequest {
             limit: req.limit,
             scope: req.scope.unwrap_or_else(|| "all".to_string()),
             sort: req.sort.clone(),
             sort_order: req.sort_order.clone(),
-            team_id: None, // TaskRequest team_id support added in separate task
+            include_foreign: req.include_foreign.unwrap_or(false),
         };
         self.inner.cas_tasks_available(Parameters(inner_req)).await
     }

--- a/cas-cli/src/mcp/tools/types/common.rs
+++ b/cas-cli/src/mcp/tools/types/common.rs
@@ -59,6 +59,37 @@ pub struct LimitRequest {
     pub team_id: Option<String>,
 }
 
+/// Request for the task `available` query. Kept separate from the shared
+/// limit request so unrelated memory, rule, skill, and agent operations do
+/// not grow a task-specific field.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TaskAvailableRequest {
+    /// Maximum number of items
+    #[schemars(description = "Maximum items to return")]
+    #[serde(default)]
+    pub limit: Option<usize>,
+
+    /// Scope filter
+    #[schemars(description = "Filter by scope: 'project' or 'all'")]
+    #[serde(default = "default_scope_all")]
+    pub scope: String,
+
+    /// Sort field
+    #[schemars(description = "Sort by: 'created', 'updated', 'priority', 'title'")]
+    #[serde(default)]
+    pub sort: Option<String>,
+
+    /// Sort order
+    #[schemars(description = "Sort order (default: desc for dates, asc for priority)")]
+    #[serde(default)]
+    pub sort_order: Option<String>,
+
+    /// Include rows whose origin belongs to another project.
+    #[schemars(description = "Include foreign-origin task rows (default: false)")]
+    #[serde(default)]
+    pub include_foreign: bool,
+}
+
 /// Request type for task ready/blocked operations with epic filtering
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TaskReadyBlockedRequest {
@@ -88,6 +119,11 @@ pub struct TaskReadyBlockedRequest {
     #[schemars(description = "Filter to subtasks of this epic ID")]
     #[serde(default)]
     pub epic: Option<String>,
+
+    /// Include rows whose origin belongs to another project.
+    #[schemars(description = "Include foreign-origin task rows (default: false)")]
+    #[serde(default)]
+    pub include_foreign: bool,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -140,4 +176,9 @@ pub struct TaskListRequest {
     )]
     #[serde(default)]
     pub sort_order: Option<String>,
+
+    /// Include rows whose origin belongs to another project.
+    #[schemars(description = "Include foreign-origin task rows (default: false)")]
+    #[serde(default)]
+    pub include_foreign: bool,
 }

--- a/cas-cli/src/store/notifying_task.rs
+++ b/cas-cli/src/store/notifying_task.rs
@@ -75,6 +75,10 @@ impl TaskStore for NotifyingTaskStore {
         self.inner.generate_id()
     }
 
+    fn project_id(&self) -> Option<&str> {
+        self.inner.project_id()
+    }
+
     fn add(&self, task: &Task) -> Result<()> {
         self.inner.add(task)?;
         self.notify_created(task);

--- a/cas-cli/src/store/syncing_task.rs
+++ b/cas-cli/src/store/syncing_task.rs
@@ -6,11 +6,11 @@
 
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
 use crate::cloud::{CloudConfig, EntityType, SyncOperation, SyncQueue};
 use crate::store::share_policy::{eligible_for_team_task, resolve_team_id};
 use crate::store::{Result, TaskStore};
 use crate::types::{Dependency, DependencyType, Scope, Task, TaskStatus};
+use chrono::{DateTime, Utc};
 use serde_json::Value;
 
 /// A task store wrapper that queues changes for cloud sync
@@ -47,12 +47,7 @@ impl SyncingTaskStore {
             Err(_) => return,
         };
 
-        let _ = self.queue.enqueue(
-            EntityType::Task,
-            &task.id,
-            SyncOperation::Upsert,
-            Some(&payload),
-        );
+        self.queue_personal_upsert(task, &payload);
 
         if let Some(team_id) = self.team_id.as_deref()
             && eligible_for_team_task(task)
@@ -62,6 +57,35 @@ impl SyncingTaskStore {
                 &task.id,
                 SyncOperation::Upsert,
                 Some(&payload),
+                team_id,
+            );
+        }
+    }
+
+    fn queue_personal_upsert(&self, task: &Task, payload: &str) {
+        let _ = self.queue.enqueue(
+            EntityType::Task,
+            &task.id,
+            SyncOperation::Upsert,
+            Some(payload),
+        );
+    }
+
+    fn queue_origin_project_move(&self, task: &Task, old_project_id: &str) {
+        let payload = match serde_json::to_string(task) {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        self.queue_personal_upsert(task, &payload);
+
+        if let Some(team_id) = self.team_id.as_deref()
+            && eligible_for_team_task(task)
+        {
+            let _ = self.queue.enqueue_team_move(
+                EntityType::Task,
+                &task.id,
+                old_project_id,
+                &payload,
                 team_id,
             );
         }
@@ -146,6 +170,7 @@ impl TaskStore for SyncingTaskStore {
     }
 
     fn update(&self, task: &Task) -> Result<DateTime<Utc>> {
+        let previous = self.inner.get(&task.id)?;
         let persisted_at = self.inner.update(task)?;
         // The inner store may enforce transition invariants while persisting
         // (for example, clearing a prior close-cycle branch anchor when a
@@ -156,7 +181,16 @@ impl TaskStore for SyncingTaskStore {
         if task.scope == Scope::Global {
             persisted.origin_project = None;
         }
-        self.queue_upsert(&persisted);
+        if let Some(old_project_id) = previous.origin_project.as_deref()
+            && persisted
+                .origin_project
+                .as_deref()
+                .is_some_and(|new_project_id| new_project_id != old_project_id)
+        {
+            self.queue_origin_project_move(&persisted, old_project_id);
+        } else {
+            self.queue_upsert(&persisted);
+        }
         Ok(persisted_at)
     }
 
@@ -205,7 +239,8 @@ impl TaskStore for SyncingTaskStore {
         to_id: &str,
         dep_type: DependencyType,
     ) -> Result<bool> {
-        self.inner.remove_dependency_of_type(from_id, to_id, dep_type)
+        self.inner
+            .remove_dependency_of_type(from_id, to_id, dep_type)
     }
 
     fn get_dependencies(&self, task_id: &str) -> Result<Vec<Dependency>> {
@@ -444,6 +479,35 @@ mod tests {
     }
 
     #[test]
+    fn task_origin_project_move_queues_old_delete_before_new_upsert() {
+        let (temp, store) = create_team_store(None);
+        let queue = SyncQueue::open(temp.path()).unwrap();
+
+        let mut task = Task::new("p-task-move-001".to_string(), "move me".to_string());
+        task.origin_project = Some("project-a".to_string());
+        store.add(&task).unwrap();
+        queue.clear().unwrap();
+
+        task.origin_project = Some("project-b".to_string());
+        store.update(&task).unwrap();
+
+        let pending = queue.pending_for_team(TEST_TEAM, 10, 5).unwrap();
+        assert_eq!(pending.len(), 2, "a move must retain both team operations");
+        assert_eq!(pending[0].operation, SyncOperation::Delete);
+        assert_eq!(pending[0].entity_id, task.id);
+        assert_eq!(pending[0].project_id.as_deref(), Some("project-a"));
+        assert_eq!(pending[1].operation, SyncOperation::Upsert);
+        assert_eq!(pending[1].entity_id, task.id);
+        assert_eq!(pending[1].project_id, None);
+        assert!(
+            pending[1]
+                .payload
+                .as_deref()
+                .is_some_and(|payload| payload.contains("\"origin_project\":\"project-b\""))
+        );
+    }
+
+    #[test]
     fn task_delete_personal_only_when_kill_switch_engaged() {
         let (temp, store) = create_team_store(Some(false));
         let queue = SyncQueue::open(temp.path()).unwrap();
@@ -491,7 +555,10 @@ mod tests {
 
         let queue = SyncQueue::open(temp.path()).unwrap();
         let (personal, team) = queue_counts(&queue);
-        assert_eq!(personal, 1, "personal project must enqueue to personal queue");
+        assert_eq!(
+            personal, 1,
+            "personal project must enqueue to personal queue"
+        );
         assert_eq!(
             team, 0,
             "cas-f8e3: personal project (no team_id) must NOT enqueue to team queue \

--- a/cas-cli/src/store/syncing_task.rs
+++ b/cas-cli/src/store/syncing_task.rs
@@ -112,6 +112,10 @@ impl TaskStore for SyncingTaskStore {
         self.inner.generate_id()
     }
 
+    fn project_id(&self) -> Option<&str> {
+        self.inner.project_id()
+    }
+
     fn add(&self, task: &Task) -> Result<()> {
         self.inner.add(task)?;
         let persisted = self.persisted_for_queue(task)?;

--- a/cas-cli/src/ui/factory/session.rs
+++ b/cas-cli/src/ui/factory/session.rs
@@ -559,4 +559,65 @@ mod tests {
                 || result.unwrap().metadata.project_dir != Some("/some/project".to_string())
         );
     }
+
+    #[test]
+    fn worker_count_uses_live_factory_registry_workers() {
+        use crate::store::{AgentStore, SqliteAgentStore, init_cas_dir};
+        use cas_types::{AgentRole, AgentStatus, AgentType};
+
+        let env = crate::test_support::TestEnvGuard::temp_home();
+        let project = tempfile::tempdir().unwrap();
+        let cas_root = init_cas_dir(project.path()).unwrap();
+        let session_name = "factory-registry-count";
+        let metadata = create_metadata(
+            session_name,
+            std::process::id(),
+            "supervisor",
+            &[],
+            None,
+            Some(project.path().to_str().unwrap()),
+            None,
+        );
+        let session = SessionInfo {
+            name: session_name.to_string(),
+            metadata,
+            is_running: true,
+            socket_exists: false,
+        };
+        let agents = SqliteAgentStore::open(&cas_root).unwrap();
+        agents.init().unwrap();
+
+        for index in 0..5 {
+            let mut worker = cas_types::Agent::new(
+                format!("registry-worker-{index}"),
+                format!("worker-{index}"),
+            );
+            worker.agent_type = AgentType::Worker;
+            worker.role = AgentRole::Worker;
+            worker.factory_session = Some(session_name.to_string());
+            agents.register(&worker).unwrap();
+        }
+
+        assert_eq!(
+            session.worker_count(),
+            5,
+            "live registry workers must replace an empty metadata roster"
+        );
+
+        let mut shutdown = agents.get("registry-worker-0").unwrap();
+        shutdown.status = AgentStatus::Shutdown;
+        agents.update(&shutdown).unwrap();
+        assert_eq!(session.worker_count(), 4, "shutdown workers are not live");
+
+        let mut stale = agents.get("registry-worker-1").unwrap();
+        stale.last_heartbeat = chrono::Utc::now() - chrono::Duration::seconds(31);
+        agents.update(&stale).unwrap();
+        assert_eq!(
+            session.worker_count(),
+            3,
+            "workers with stale heartbeats are not live"
+        );
+
+        drop(env);
+    }
 }

--- a/cas-cli/src/ui/factory/session.rs
+++ b/cas-cli/src/ui/factory/session.rs
@@ -6,8 +6,10 @@
 //! For unified session metadata (worker count, epic ID, etc.), use
 //! `cas_factory::SessionSummary` and `cas_factory::UnifiedSessionManager`.
 
+use crate::store::{find_cas_root_from, open_agent_store};
 use crate::ui::factory::protocol::{AgentInfo, SessionMetadata};
 use cas_factory::{SessionState, SessionSummary, SessionType};
+use cas_types::{AgentStatus, AgentType};
 use chrono::Utc;
 use std::collections::HashMap;
 use std::fs;
@@ -300,9 +302,44 @@ impl SessionInfo {
         &self.metadata.socket_path
     }
 
-    /// Get worker count from daemon metadata
+    /// Get the names of live workers from the registry, falling back to the
+    /// daemon roster when the session's registry cannot be read.
+    pub fn worker_names(&self) -> Vec<String> {
+        self.live_registry_worker_names().unwrap_or_else(|| {
+            self.metadata
+                .workers
+                .iter()
+                .map(|w| w.name.clone())
+                .collect()
+        })
+    }
+
+    fn live_registry_worker_names(&self) -> Option<Vec<String>> {
+        let project_dir = self.metadata.project_dir.as_deref()?;
+        let cas_root = find_cas_root_from(Path::new(project_dir)).ok()?;
+        let agent_store = open_agent_store(&cas_root).ok()?;
+        let agents = agent_store.list(None).ok()?;
+
+        Some(
+            agents
+                .into_iter()
+                .filter(|agent| {
+                    agent.agent_type == AgentType::Worker
+                        && agent.factory_session.as_deref() == Some(self.name.as_str())
+                        && matches!(agent.status, AgentStatus::Active | AgentStatus::Idle)
+                        && !agent.is_heartbeat_expired(
+                            crate::mcp::tools::service::agent_liveness::WORKER_STALE_SECS,
+                        )
+                })
+                .map(|agent| agent.name)
+                .collect(),
+        )
+    }
+
+    /// Get the number of live workers from the registry, falling back to
+    /// daemon metadata only when the registry is unreachable.
     pub fn worker_count(&self) -> usize {
-        self.metadata.workers.len()
+        self.worker_names().len()
     }
 
     /// Convert to a unified SessionSummary with full metadata.
@@ -322,7 +359,7 @@ impl SessionInfo {
             } else {
                 SessionState::Paused
             },
-            worker_count: self.metadata.workers.len(),
+            worker_count: self.worker_count(),
             supervisor_name: Some(self.metadata.supervisor.name.clone()),
             created_at,
             project_dir: self
@@ -603,6 +640,7 @@ mod tests {
             5,
             "live registry workers must replace an empty metadata roster"
         );
+        assert_eq!(session.to_session_summary().worker_count, 5);
 
         let mut shutdown = agents.get("registry-worker-0").unwrap();
         shutdown.status = AgentStatus::Shutdown;
@@ -616,6 +654,30 @@ mod tests {
             session.worker_count(),
             3,
             "workers with stale heartbeats are not live"
+        );
+
+        let fallback_metadata = create_metadata(
+            "factory-registry-unavailable",
+            std::process::id(),
+            "supervisor",
+            &[
+                "metadata-worker-a".to_string(),
+                "metadata-worker-b".to_string(),
+            ],
+            None,
+            None,
+            None,
+        );
+        let fallback = SessionInfo {
+            name: "factory-registry-unavailable".to_string(),
+            metadata: fallback_metadata,
+            is_running: true,
+            socket_exists: false,
+        };
+        assert_eq!(
+            fallback.worker_count(),
+            2,
+            "metadata is retained when the registry cannot be reached"
         );
 
         drop(env);

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -6969,6 +6969,7 @@ async fn test_a844_show_and_list_distinguish_merge_conflict() {
             epic: None,
             sort: None,
             sort_order: None,
+            include_foreign: false,
         }))
         .await
         .expect("list");

--- a/cas-cli/tests/mcp_tools_test/field_coverage_tests.rs
+++ b/cas-cli/tests/mcp_tools_test/field_coverage_tests.rs
@@ -35,6 +35,7 @@ fn task_list_field_coverage() {
         epic: None,
         sort: None,
         sort_order: None,
+        include_foreign: false,
     };
 
     assert_eq!(

--- a/cas-cli/tests/mcp_tools_test/server_protocol/mod.rs
+++ b/cas-cli/tests/mcp_tools_test/server_protocol/mod.rs
@@ -680,6 +680,7 @@ async fn test_task_list_type_filter() {
         epic: None,
         sort: None,
         sort_order: None,
+        include_foreign: false,
     };
     let result = service
         .cas_task_list(Parameters(list_req))
@@ -786,6 +787,7 @@ async fn test_task_list_epic_filter() {
         epic: Some(epic_id.to_string()),
         sort: None,
         sort_order: None,
+        include_foreign: false,
     };
     let result = service
         .cas_task_list(Parameters(list_req))

--- a/cas-cli/tests/mcp_tools_test/task_tools/cancellation.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/cancellation.rs
@@ -64,6 +64,7 @@ async fn cancel_without_commits_persists_pointer_and_lists_as_no_delivery() {
             epic: None,
             sort: None,
             sort_order: None,
+            include_foreign: false,
         }))
         .await
         .unwrap(),

--- a/cas-cli/tests/mcp_tools_test/task_tools/create_and_epic.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/create_and_epic.rs
@@ -288,6 +288,7 @@ async fn test_task_create_invalid_epic_does_not_persist_task() {
         epic: None,
         sort: None,
         sort_order: None,
+        include_foreign: false,
     };
     let list_result = service
         .cas_task_list(Parameters(list_req))
@@ -376,6 +377,7 @@ async fn test_task_create_surfaces_dependency_write_failure() {
                 epic: None,
                 sort: None,
                 sort_order: None,
+                include_foreign: false,
             }))
             .await
             .expect("task_list should succeed"),

--- a/cas-cli/tests/mcp_tools_test/task_tools/dependencies.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/dependencies.rs
@@ -86,6 +86,7 @@ async fn test_dep_add_blocks_confirmation_states_blocked_by_in_plain_words() {
                 sort: None,
                 sort_order: None,
                 epic: None,
+                include_foreign: false,
             }))
             .await
             .expect("blocked should succeed"),

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -1,10 +1,132 @@
 use crate::support::*;
+use cas::cloud::CloudConfig;
 use cas::mcp::CasCore;
 use cas::mcp::tools::*;
 use cas::store::{open_agent_store, open_event_store, open_task_store};
 use cas::types::EventType;
 use rmcp::handler::server::wrapper::Parameters;
 use rusqlite::Connection;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const MOVE_TEAM: &str = "move-team-uuid";
+
+fn promote_default_test_agent(cas_dir: &std::path::Path) {
+    let agent_store = open_agent_store(cas_dir).expect("agent store");
+    let id = format!("test-session-{}", std::process::id());
+    let mut agent = agent_store.get(&id).expect("default test agent");
+    agent.role = cas::types::AgentRole::Supervisor;
+    agent.heartbeat();
+    agent_store.update(&agent).expect("promote test agent");
+}
+
+#[tokio::test]
+async fn origin_project_move_refuses_unregistered_destination_before_local_write() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    promote_default_test_agent(&cas_dir);
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/api/teams/{MOVE_TEAM}/projects")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "projects": []
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut cloud_config = CloudConfig::default();
+    cloud_config.endpoint = server.uri();
+    cloud_config.token = Some("test-token".to_string());
+    cloud_config.set_team(MOVE_TEAM, "move-team");
+    cloud_config.save_to_cas_dir(&cas_dir).unwrap();
+
+    let local_store = cas::store::open_task_store_local(&cas_dir).unwrap();
+    let mut task = cas::types::Task::new("cas-move-refuse".into(), "move refusal".into());
+    task.origin_project = Some("project-a".into());
+    local_store.add(&task).unwrap();
+
+    let request: TaskUpdateRequest = serde_json::from_value(serde_json::json!({
+        "id": task.id,
+        "origin_project": "project-b"
+    }))
+    .unwrap();
+    let error = core
+        .cas_task_update(Parameters(request))
+        .await
+        .expect_err("an unregistered destination must be rejected");
+    assert!(
+        error.message.contains("not registered"),
+        "{}",
+        error.message
+    );
+    assert_eq!(
+        local_store.get(&task.id).unwrap().origin_project.as_deref(),
+        Some("project-a")
+    );
+}
+
+#[tokio::test]
+async fn origin_project_move_updates_local_row_audit_and_team_queue() {
+    let (temp, core) = setup_cas();
+    let _env_lock = env_test_lock();
+    let cas_dir = temp.path().join(".cas");
+    promote_default_test_agent(&cas_dir);
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/api/teams/{MOVE_TEAM}/projects")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "projects": [{
+                "id": "project-b-uuid",
+                "canonical_id": "project-b",
+                "name": "Project B",
+                "contributor_count": 1,
+                "memory_count": 0
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut cloud_config = CloudConfig::default();
+    cloud_config.endpoint = server.uri();
+    cloud_config.token = Some("test-token".to_string());
+    cloud_config.set_team(MOVE_TEAM, "move-team");
+    cloud_config.save_to_cas_dir(&cas_dir).unwrap();
+
+    let local_store = cas::store::open_task_store_local(&cas_dir).unwrap();
+    let mut task = cas::types::Task::new("cas-move-local".into(), "move local".into());
+    task.origin_project = Some("project-a".into());
+    local_store.add(&task).unwrap();
+
+    let request: TaskUpdateRequest = serde_json::from_value(serde_json::json!({
+        "id": task.id,
+        "origin_project": "project-b"
+    }))
+    .unwrap();
+    core.cas_task_update(Parameters(request))
+        .await
+        .expect("registered destination move should succeed");
+
+    let updated = local_store.get(&task.id).unwrap();
+    assert_eq!(updated.origin_project.as_deref(), Some("project-b"));
+    assert!(
+        updated
+            .notes
+            .contains("DECISION: moved from project-a to project-b by test-agent"),
+        "audit note missing: {}",
+        updated.notes
+    );
+    let queue = cas::cloud::SyncQueue::open(&cas_dir).unwrap();
+    let pending = queue.pending_for_team(MOVE_TEAM, 10, 5).unwrap();
+    assert_eq!(pending.len(), 2);
+    assert_eq!(pending[0].operation, cas::cloud::SyncOperation::Delete);
+    assert_eq!(pending[0].project_id.as_deref(), Some("project-a"));
+    assert_eq!(pending[1].operation, cas::cloud::SyncOperation::Upsert);
+}
 
 /// cas-0447 (GH #187): a context-poor worker needs a bounded start response
 /// that preserves its own task notes without inheriting an epic's potentially

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -1,8 +1,8 @@
 use crate::support::*;
-use cas::mcp::CasCore;
+use cas::mcp::{CasCore, CasService};
 use cas::mcp::tools::*;
-use cas::store::{open_agent_store, open_event_store, open_task_store};
-use cas::types::EventType;
+use cas::store::{open_agent_store, open_event_store, open_task_store, SqliteTaskStore, TaskStore};
+use cas::types::{EventType, Task};
 use rmcp::handler::server::wrapper::Parameters;
 use rusqlite::Connection;
 
@@ -1150,6 +1150,108 @@ async fn test_task_ready_excludes_foreign_origin_project_and_show_exposes_it() {
     assert!(
         extract_text(shown).contains("Origin project: acme/other"),
         "show must expose foreign origin for diagnosis"
+    );
+}
+
+#[tokio::test]
+async fn test_task_board_hides_foreign_rows_by_default_and_supports_include_foreign() {
+    let (temp, core) = setup_cas();
+    let cas_dir = temp.path().join(".cas");
+    std::fs::write(
+        cas_dir.join("config.toml"),
+        "[project]\ncanonical_id = \"cas-src\"\n",
+    )
+    .expect("project identity config should be writable");
+
+    // Use a store opened without a default origin to retain the null-origin
+    // fixture row. The MCP core resolves the current project from config.toml.
+    let fixture_store = SqliteTaskStore::open(&cas_dir).expect("fixture task store");
+    fixture_store.init().expect("fixture task store init");
+    let mut null_origin = Task::new(
+        "cas-null1".to_string(),
+        "Own null-origin task".to_string(),
+    );
+    null_origin.origin_project = None;
+    fixture_store.add(&null_origin).expect("add null-origin task");
+
+    let mut own = Task::new("cas-own1".to_string(), "Own explicit task".to_string());
+    own.origin_project = Some("cas-src".to_string());
+    fixture_store.add(&own).expect("add own task");
+
+    for (id, title) in [
+        ("cas-for1", "Foreign ready task one"),
+        ("cas-for2", "Foreign ready task two"),
+    ] {
+        let mut foreign = Task::new(id.to_string(), title.to_string());
+        foreign.origin_project = Some("gabber-studio".to_string());
+        fixture_store.add(&foreign).expect("add foreign task");
+    }
+
+    let service = CasService::new(core, None);
+    let default_ready: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
+        "action": "ready",
+        "limit": 20,
+    }))
+    .expect("default ready request");
+    let default_ready_text = extract_text(
+        service
+            .task(Parameters(default_ready))
+            .await
+            .expect("default ready should succeed"),
+    );
+    assert!(default_ready_text.contains("cas-null1"), "null-origin own row hidden: {default_ready_text}");
+    assert!(default_ready_text.contains("cas-own1"), "own row hidden: {default_ready_text}");
+    assert!(!default_ready_text.contains("cas-for1"), "foreign row leaked: {default_ready_text}");
+    assert!(!default_ready_text.contains("cas-for2"), "foreign row leaked: {default_ready_text}");
+    assert!(
+        default_ready_text.contains("2 foreign-origin tasks hidden (include_foreign=true to show)"),
+        "hidden count footer missing: {default_ready_text}"
+    );
+
+    let all_ready: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
+        "action": "ready",
+        "limit": 20,
+        "include_foreign": true,
+    }))
+    .expect("include_foreign ready request");
+    let all_ready_text = extract_text(
+        service
+            .task(Parameters(all_ready))
+            .await
+            .expect("include_foreign ready should succeed"),
+    );
+    for id in ["cas-null1", "cas-own1", "cas-for1", "cas-for2"] {
+        assert!(all_ready_text.contains(id), "include_foreign omitted {id}: {all_ready_text}");
+    }
+    assert!(!all_ready_text.contains("foreign-origin tasks hidden"), "opt-in still reports hidden rows: {all_ready_text}");
+
+    let default_list: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
+        "action": "list",
+        "limit": 20,
+    }))
+    .expect("default list request");
+    let default_list_text = extract_text(
+        service
+            .task(Parameters(default_list))
+            .await
+            .expect("default list should succeed"),
+    );
+    assert!(!default_list_text.contains("cas-for1"), "foreign list row leaked: {default_list_text}");
+    assert!(default_list_text.contains("2 foreign-origin tasks hidden"), "list hidden footer missing: {default_list_text}");
+
+    let show_foreign: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
+        "action": "show",
+        "id": "cas-for1",
+        "with_deps": false,
+    }))
+    .expect("show foreign request");
+    let shown = service
+        .task(Parameters(show_foreign))
+        .await
+        .expect("show foreign task");
+    assert!(
+        extract_text(shown).contains("Origin project: gabber-studio — this task is owned elsewhere"),
+        "foreign ownership banner missing"
     );
 }
 

--- a/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/operations.rs
@@ -1039,6 +1039,7 @@ async fn test_task_list() {
         epic: None,
         sort: None,
         sort_order: None,
+        include_foreign: false,
     };
     let result = service
         .cas_task_list(Parameters(list_req))
@@ -1085,6 +1086,7 @@ async fn test_task_ready() {
         sort: None,
         sort_order: None,
         epic: None,
+        include_foreign: false,
     };
     let result = service
         .cas_task_ready(Parameters(ready_req))
@@ -1127,6 +1129,7 @@ async fn test_task_ready_excludes_foreign_origin_project_and_show_exposes_it() {
                 sort: None,
                 sort_order: None,
                 epic: None,
+                include_foreign: false,
             }))
             .await
             .expect("task_ready should succeed"),
@@ -1167,12 +1170,11 @@ async fn test_task_board_hides_foreign_rows_by_default_and_supports_include_fore
     // fixture row. The MCP core resolves the current project from config.toml.
     let fixture_store = SqliteTaskStore::open(&cas_dir).expect("fixture task store");
     fixture_store.init().expect("fixture task store init");
-    let mut null_origin = Task::new(
-        "cas-null1".to_string(),
-        "Own null-origin task".to_string(),
-    );
+    let mut null_origin = Task::new("cas-null1".to_string(), "Own null-origin task".to_string());
     null_origin.origin_project = None;
-    fixture_store.add(&null_origin).expect("add null-origin task");
+    fixture_store
+        .add(&null_origin)
+        .expect("add null-origin task");
 
     let mut own = Task::new("cas-own1".to_string(), "Own explicit task".to_string());
     own.origin_project = Some("cas-src".to_string());
@@ -1199,10 +1201,22 @@ async fn test_task_board_hides_foreign_rows_by_default_and_supports_include_fore
             .await
             .expect("default ready should succeed"),
     );
-    assert!(default_ready_text.contains("cas-null1"), "null-origin own row hidden: {default_ready_text}");
-    assert!(default_ready_text.contains("cas-own1"), "own row hidden: {default_ready_text}");
-    assert!(!default_ready_text.contains("cas-for1"), "foreign row leaked: {default_ready_text}");
-    assert!(!default_ready_text.contains("cas-for2"), "foreign row leaked: {default_ready_text}");
+    assert!(
+        default_ready_text.contains("cas-null1"),
+        "null-origin own row hidden: {default_ready_text}"
+    );
+    assert!(
+        default_ready_text.contains("cas-own1"),
+        "own row hidden: {default_ready_text}"
+    );
+    assert!(
+        !default_ready_text.contains("cas-for1"),
+        "foreign row leaked: {default_ready_text}"
+    );
+    assert!(
+        !default_ready_text.contains("cas-for2"),
+        "foreign row leaked: {default_ready_text}"
+    );
     assert!(
         default_ready_text.contains("2 foreign-origin tasks hidden (include_foreign=true to show)"),
         "hidden count footer missing: {default_ready_text}"
@@ -1221,9 +1235,15 @@ async fn test_task_board_hides_foreign_rows_by_default_and_supports_include_fore
             .expect("include_foreign ready should succeed"),
     );
     for id in ["cas-null1", "cas-own1", "cas-for1", "cas-for2"] {
-        assert!(all_ready_text.contains(id), "include_foreign omitted {id}: {all_ready_text}");
+        assert!(
+            all_ready_text.contains(id),
+            "include_foreign omitted {id}: {all_ready_text}"
+        );
     }
-    assert!(!all_ready_text.contains("foreign-origin tasks hidden"), "opt-in still reports hidden rows: {all_ready_text}");
+    assert!(
+        !all_ready_text.contains("foreign-origin tasks hidden"),
+        "opt-in still reports hidden rows: {all_ready_text}"
+    );
 
     let default_list: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
         "action": "list",
@@ -1236,8 +1256,37 @@ async fn test_task_board_hides_foreign_rows_by_default_and_supports_include_fore
             .await
             .expect("default list should succeed"),
     );
-    assert!(!default_list_text.contains("cas-for1"), "foreign list row leaked: {default_list_text}");
-    assert!(default_list_text.contains("2 foreign-origin tasks hidden"), "list hidden footer missing: {default_list_text}");
+    assert!(
+        !default_list_text.contains("cas-for1"),
+        "foreign list row leaked: {default_list_text}"
+    );
+    assert!(
+        default_list_text.contains("2 foreign-origin tasks hidden"),
+        "list hidden footer missing: {default_list_text}"
+    );
+
+    let all_list: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
+        "action": "list",
+        "limit": 20,
+        "include_foreign": true,
+    }))
+    .expect("include_foreign list request");
+    let all_list_text = extract_text(
+        service
+            .task(Parameters(all_list))
+            .await
+            .expect("include_foreign list should succeed"),
+    );
+    for id in ["cas-null1", "cas-own1", "cas-for1", "cas-for2"] {
+        assert!(
+            all_list_text.contains(id),
+            "include_foreign list omitted {id}: {all_list_text}"
+        );
+    }
+    assert!(
+        !all_list_text.contains("foreign-origin tasks hidden"),
+        "include_foreign list still reports hidden rows: {all_list_text}"
+    );
 
     let show_foreign: cas_mcp::TaskRequest = serde_json::from_value(serde_json::json!({
         "action": "show",
@@ -1250,7 +1299,8 @@ async fn test_task_board_hides_foreign_rows_by_default_and_supports_include_fore
         .await
         .expect("show foreign task");
     assert!(
-        extract_text(shown).contains("Origin project: gabber-studio — this task is owned elsewhere"),
+        extract_text(shown)
+            .contains("Origin project: gabber-studio — this task is owned elsewhere"),
         "foreign ownership banner missing"
     );
 }
@@ -1325,6 +1375,7 @@ async fn test_task_ready_is_priority_sorted_and_states_the_true_total() {
                 sort: None,
                 sort_order: None,
                 epic: None,
+                include_foreign: false,
             }))
             .await
             .expect("task_ready should succeed"),
@@ -1376,8 +1427,6 @@ async fn test_task_ready_is_priority_sorted_and_states_the_true_total() {
 /// never learn which call shows the rest.
 #[tokio::test]
 async fn test_tasks_available_names_withheld_rows() {
-    use cas::mcp::tools::LimitRequest;
-
     let (_temp, service) = setup_cas();
     for i in 0..25 {
         service
@@ -1404,12 +1453,12 @@ async fn test_tasks_available_names_withheld_rows() {
 
     let text = extract_text(
         service
-            .cas_tasks_available(Parameters(LimitRequest {
+            .cas_tasks_available(Parameters(TaskAvailableRequest {
                 limit: None, // the default cap is what hides rows
                 scope: "all".to_string(),
                 sort: None,
                 sort_order: None,
-                team_id: None,
+                include_foreign: false,
             }))
             .await
             .expect("tasks_available should succeed"),
@@ -1435,8 +1484,6 @@ async fn test_tasks_available_names_withheld_rows() {
 /// to tell. The last of the advertised-but-inert family.
 #[tokio::test]
 async fn test_tasks_available_honours_an_explicit_sort() {
-    use cas::mcp::tools::LimitRequest;
-
     let (_temp, service) = setup_cas();
     // Priority order and title order disagree, so the assertion can only pass
     // if the requested field is the one actually applied.
@@ -1465,12 +1512,12 @@ async fn test_tasks_available_honours_an_explicit_sort() {
 
     let by_title = extract_text(
         service
-            .cas_tasks_available(Parameters(LimitRequest {
+            .cas_tasks_available(Parameters(TaskAvailableRequest {
                 limit: None,
                 scope: "all".to_string(),
                 sort: Some("title".to_string()),
                 sort_order: Some("asc".to_string()),
-                team_id: None,
+                include_foreign: false,
             }))
             .await
             .expect("tasks_available should succeed"),
@@ -1491,12 +1538,12 @@ async fn test_tasks_available_honours_an_explicit_sort() {
     // Default is unchanged: priority first.
     let by_default = extract_text(
         service
-            .cas_tasks_available(Parameters(LimitRequest {
+            .cas_tasks_available(Parameters(TaskAvailableRequest {
                 limit: None,
                 scope: "all".to_string(),
                 sort: None,
                 sort_order: None,
-                team_id: None,
+                include_foreign: false,
             }))
             .await
             .expect("tasks_available should succeed"),
@@ -1518,8 +1565,6 @@ async fn test_tasks_available_honours_an_explicit_sort() {
 /// — silently wrong.
 #[tokio::test]
 async fn test_tasks_available_sorts_before_truncating() {
-    use cas::mcp::tools::LimitRequest;
-
     let (_temp, service) = setup_cas();
     // Creation order is load-bearing and easy to get backwards: `list_ready`
     // returns priority ASC, created_at DESC, so the NEWEST task is already
@@ -1555,12 +1600,12 @@ async fn test_tasks_available_sorts_before_truncating() {
 
     let text = extract_text(
         service
-            .cas_tasks_available(Parameters(LimitRequest {
+            .cas_tasks_available(Parameters(TaskAvailableRequest {
                 limit: Some(1),
                 scope: "all".to_string(),
                 sort: Some("title".to_string()),
                 sort_order: Some("asc".to_string()),
-                team_id: None,
+                include_foreign: false,
             }))
             .await
             .expect("tasks_available should succeed"),
@@ -1580,8 +1625,6 @@ async fn test_tasks_available_sorts_before_truncating() {
 /// it does on ready/blocked — keep the priority field, flip the direction.
 #[tokio::test]
 async fn test_tasks_available_sort_order_alone_flips_priority_direction() {
-    use cas::mcp::tools::LimitRequest;
-
     let (_temp, service) = setup_cas();
     for (priority, title) in [(0u8, "critical one"), (3, "low one")] {
         service
@@ -1608,12 +1651,12 @@ async fn test_tasks_available_sort_order_alone_flips_priority_direction() {
 
     let text = extract_text(
         service
-            .cas_tasks_available(Parameters(LimitRequest {
+            .cas_tasks_available(Parameters(TaskAvailableRequest {
                 limit: None,
                 scope: "all".to_string(),
                 sort: None,
                 sort_order: Some("desc".to_string()),
-                team_id: None,
+                include_foreign: false,
             }))
             .await
             .expect("tasks_available should succeed"),
@@ -1631,8 +1674,6 @@ async fn test_tasks_available_sort_order_alone_flips_priority_direction() {
 /// on ready/blocked — it must not silently resurrect creation order.
 #[tokio::test]
 async fn test_tasks_available_unparseable_sort_falls_back_to_priority() {
-    use cas::mcp::tools::LimitRequest;
-
     let (_temp, service) = setup_cas();
     // Order matters: the P0 is created FIRST, so a fallback to created/desc
     // (the trap #104 fixed) would put "low one" at the top and the row
@@ -1662,12 +1703,12 @@ async fn test_tasks_available_unparseable_sort_falls_back_to_priority() {
 
     let text = extract_text(
         service
-            .cas_tasks_available(Parameters(LimitRequest {
+            .cas_tasks_available(Parameters(TaskAvailableRequest {
                 limit: None,
                 scope: "all".to_string(),
                 sort: Some("highest".to_string()), // not a valid field
                 sort_order: None,
-                team_id: None,
+                include_foreign: false,
             }))
             .await
             .expect("tasks_available should succeed"),
@@ -1687,8 +1728,6 @@ async fn test_tasks_available_unparseable_sort_falls_back_to_priority() {
 /// ("pass limit=N") a lie.
 #[tokio::test]
 async fn test_tasks_available_footer_tracks_an_explicit_limit() {
-    use cas::mcp::tools::LimitRequest;
-
     let (_temp, service) = setup_cas();
     for i in 0..25 {
         service
@@ -1715,12 +1754,12 @@ async fn test_tasks_available_footer_tracks_an_explicit_limit() {
 
     let text = extract_text(
         service
-            .cas_tasks_available(Parameters(LimitRequest {
+            .cas_tasks_available(Parameters(TaskAvailableRequest {
                 limit: Some(5),
                 scope: "all".to_string(),
                 sort: None,
                 sort_order: None,
-                team_id: None,
+                include_foreign: false,
             }))
             .await
             .expect("tasks_available should succeed"),
@@ -1743,8 +1782,6 @@ async fn test_tasks_available_footer_tracks_an_explicit_limit() {
 /// and must not inflate either the total or the withheld count.
 #[tokio::test]
 async fn test_tasks_available_total_excludes_claimed_tasks() {
-    use cas::mcp::tools::LimitRequest;
-
     let (temp, service) = setup_cas();
     let cas_dir = temp.path().join(".cas");
     let mut ids = Vec::new();
@@ -1787,12 +1824,12 @@ async fn test_tasks_available_total_excludes_claimed_tasks() {
 
     let text = extract_text(
         service
-            .cas_tasks_available(Parameters(LimitRequest {
+            .cas_tasks_available(Parameters(TaskAvailableRequest {
                 limit: None,
                 scope: "all".to_string(),
                 sort: None,
                 sort_order: None,
-                team_id: None,
+                include_foreign: false,
             }))
             .await
             .expect("tasks_available should succeed"),
@@ -1811,8 +1848,6 @@ async fn test_tasks_available_total_excludes_claimed_tasks() {
 /// cas-e163: a list that fits must not claim anything was withheld.
 #[tokio::test]
 async fn test_tasks_available_has_no_footer_when_nothing_is_withheld() {
-    use cas::mcp::tools::LimitRequest;
-
     let (_temp, service) = setup_cas();
     for i in 0..3 {
         service
@@ -1839,12 +1874,12 @@ async fn test_tasks_available_has_no_footer_when_nothing_is_withheld() {
 
     let text = extract_text(
         service
-            .cas_tasks_available(Parameters(LimitRequest {
+            .cas_tasks_available(Parameters(TaskAvailableRequest {
                 limit: None,
                 scope: "all".to_string(),
                 sort: None,
                 sort_order: None,
-                team_id: None,
+                include_foreign: false,
             }))
             .await
             .expect("tasks_available should succeed"),
@@ -1944,6 +1979,7 @@ async fn test_task_blocked_is_priority_sorted_and_states_the_true_total() {
                 sort: None,
                 sort_order: None,
                 epic: None,
+                include_foreign: false,
             }))
             .await
             .expect("task_blocked should succeed"),
@@ -2003,6 +2039,7 @@ async fn test_task_ready_unparseable_sort_falls_back_to_priority_not_creation_or
                 sort: Some("highest".to_string()), // not a valid sort field
                 sort_order: None,
                 epic: None,
+                include_foreign: false,
             }))
             .await
             .expect("task_ready should succeed"),
@@ -2055,6 +2092,7 @@ async fn test_task_ready_header_is_plain_when_nothing_is_withheld() {
                 sort: None,
                 sort_order: None,
                 epic: None,
+                include_foreign: false,
             }))
             .await
             .expect("task_ready should succeed"),
@@ -2101,6 +2139,7 @@ async fn test_task_ready_explicit_sort_overrides_the_priority_default() {
                 sort: Some("created".to_string()),
                 sort_order: Some("desc".to_string()),
                 epic: None,
+                include_foreign: false,
             }))
             .await
             .expect("task_ready should succeed"),
@@ -2206,6 +2245,7 @@ async fn test_task_ready_epic_filter() {
             sort: None,
             sort_order: None,
             epic: Some(epic_id.clone()),
+            include_foreign: false,
         }))
         .await
         .expect("task_ready with epic filter should succeed");
@@ -2227,6 +2267,7 @@ async fn test_task_ready_epic_filter() {
             sort: None,
             sort_order: None,
             epic: None,
+            include_foreign: false,
         }))
         .await
         .expect("task_ready without epic filter should succeed");
@@ -2671,6 +2712,7 @@ async fn test_task_update_invalid_epic_keeps_original_parent_dependency() {
             epic: Some(epic_1_id),
             sort: None,
             sort_order: None,
+            include_foreign: false,
         }))
         .await
         .expect("task list by epic should succeed");
@@ -3322,6 +3364,7 @@ async fn test_release_active_started_task_resets_status_to_open_and_ready() {
             sort: None,
             sort_order: None,
             epic: None,
+            include_foreign: false,
         }))
         .await
         .expect("ready after release");

--- a/cas-cli/tests/openclaw_bridge_test.rs
+++ b/cas-cli/tests/openclaw_bridge_test.rs
@@ -3,7 +3,7 @@
 use assert_cmd::Command;
 use tempfile::TempDir;
 
-use cas::store::open_prompt_queue_store;
+use cas::store::{open_agent_store, open_prompt_queue_store};
 use cas::ui::factory::{SessionManager, create_metadata};
 
 #[path = "../src/test_env_guard.rs"]
@@ -49,6 +49,18 @@ fn openclaw_cli_bridge_smoke() {
     let manager = SessionManager::new();
     manager.save_metadata(&metadata).unwrap();
 
+    let agent_store = open_agent_store(&project.path().join(".cas")).unwrap();
+    for index in 0..5 {
+        let mut worker = cas_types::Agent::new(
+            format!("registry-worker-{index}"),
+            format!("registry-worker-{index}"),
+        );
+        worker.agent_type = cas_types::AgentType::Worker;
+        worker.role = cas_types::AgentRole::Worker;
+        worker.factory_session = Some(session_name.to_string());
+        agent_store.register(&worker).unwrap();
+    }
+
     // Make it attachable by creating the socket file path referenced in metadata.
     let sock_path = std::path::Path::new(&metadata.socket_path);
     if let Some(parent) = sock_path.parent() {
@@ -65,6 +77,8 @@ fn openclaw_cli_bridge_smoke() {
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     assert_eq!(v["schema_version"], 1);
     assert_eq!(v["sessions"][0]["name"], session_name);
+    assert_eq!(v["sessions"][0]["worker_count"], 5);
+    assert_eq!(v["sessions"][0]["workers"].as_array().unwrap().len(), 5);
 
     // `cas factory targets --json` should resolve targets.
     let out = cas_cmd(project.path(), home.path())

--- a/cas-cli/tests/team_registration_test.rs
+++ b/cas-cli/tests/team_registration_test.rs
@@ -155,6 +155,38 @@ fn decode_gzip_json(body: &[u8]) -> serde_json::Value {
     serde_json::from_slice(&decoded).expect("team request must decode as JSON")
 }
 
+/// A move destination must already belong to the active team. The check is
+/// deliberately read-only: unlike `ensure`, it must not register a typo or a
+/// project the caller is not authorized to move into.
+#[tokio::test]
+async fn move_destination_verification_rejects_unregistered_project() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_project_list_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let endpoint = server.uri();
+    let error = cas::cloud::TeamRegistration::new(
+        &endpoint,
+        "test-token",
+        TEST_TEAM,
+        "unregistered-destination",
+    )
+    .verify_registered()
+    .expect_err("an unregistered destination must be refused");
+    assert!(error.reason.contains("not registered"), "{error}");
+    assert!(error.interaction.contains(&projects_path()), "{error}");
+}
+
 /// THE regression test for the reported defect: the server accepts everything
 /// but never lists the project. Before the fix this was a green, exit-0 sync;
 /// now `execute_sync` fails with a non-zero exit and names the real reason.

--- a/cas-cli/tests/team_sync_test.rs
+++ b/cas-cli/tests/team_sync_test.rs
@@ -66,6 +66,164 @@ fn decode_gzip_json(body: &[u8]) -> serde_json::Value {
     serde_json::from_slice(&decoded).expect("request body should decode to JSON")
 }
 
+fn seed_team_task_move(queue: &SyncQueue, task_id: &str) {
+    queue
+        .enqueue_team_move(
+            EntityType::Task,
+            task_id,
+            "project-a",
+            &format!(
+                r#"{{"id":"{task_id}","title":"moved","scope":"project","origin_project":"project-b"}}"#
+            ),
+            TEST_TEAM,
+        )
+        .unwrap();
+}
+
+#[tokio::test]
+async fn team_task_move_deletes_old_project_before_upserting_new_owner() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/api/teams/{TEST_TEAM}/sync/task/move-order-task"
+        )))
+        .and(query_param("project_id", "project-a"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/api/teams/{TEST_TEAM}/sync/push")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "synced": { "tasks": { "inserted": 1, "updated": 0, "skipped": 0 } }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let queue = Arc::new(SyncQueue::open(tmp.path()).unwrap());
+    queue.init().unwrap();
+    seed_team_task_move(&queue, "move-order-task");
+    let syncer = CloudSyncer::new(
+        queue.clone(),
+        make_cloud_config(server.uri()),
+        CloudSyncerConfig::default(),
+    );
+
+    tokio::task::spawn_blocking(move || syncer.push_team(TEST_TEAM))
+        .await
+        .unwrap()
+        .expect("move push should succeed");
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].method.as_str(), "DELETE");
+    assert_eq!(requests[1].method.as_str(), "POST");
+    assert!(queue.pending_for_team(TEST_TEAM, 10, 5).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn team_task_move_delete_failure_blocks_upsert_and_retains_both_rows() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/api/teams/{TEST_TEAM}/sync/task/move-delete-failure"
+        )))
+        .and(query_param("project_id", "project-a"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("delete failed"))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/api/teams/{TEST_TEAM}/sync/push")))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let queue = Arc::new(SyncQueue::open(tmp.path()).unwrap());
+    queue.init().unwrap();
+    seed_team_task_move(&queue, "move-delete-failure");
+    let syncer = CloudSyncer::new(
+        queue.clone(),
+        make_cloud_config(server.uri()),
+        CloudSyncerConfig::default(),
+    );
+
+    let result = tokio::task::spawn_blocking(move || syncer.push_team(TEST_TEAM))
+        .await
+        .unwrap()
+        .expect("push returns a result for an HTTP delete failure");
+
+    assert!(!result.errors.is_empty());
+    let pending = queue.pending_for_team(TEST_TEAM, 10, 5).unwrap();
+    assert_eq!(pending.len(), 2, "both move rows must remain retryable");
+    assert!(pending.iter().all(|item| item.retry_count > 0));
+    assert!(pending.iter().all(|item| item.last_error.is_some()));
+    assert!(
+        server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .all(|request| { request.method.as_str() == "DELETE" })
+    );
+}
+
+#[tokio::test]
+async fn team_task_move_upsert_failure_retains_only_upsert_for_retry() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/api/teams/{TEST_TEAM}/sync/task/move-upsert-failure"
+        )))
+        .and(query_param("project_id", "project-a"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/api/teams/{TEST_TEAM}/sync/push")))
+        .respond_with(ResponseTemplate::new(500).set_body_string("upsert failed"))
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let queue = Arc::new(SyncQueue::open(tmp.path()).unwrap());
+    queue.init().unwrap();
+    seed_team_task_move(&queue, "move-upsert-failure");
+    let syncer = CloudSyncer::new(
+        queue.clone(),
+        make_cloud_config(server.uri()),
+        CloudSyncerConfig::default(),
+    );
+
+    let result = tokio::task::spawn_blocking(move || syncer.push_team(TEST_TEAM))
+        .await
+        .unwrap()
+        .expect("push returns a result for an HTTP upsert failure");
+
+    assert!(!result.errors.is_empty());
+    let pending = queue.pending_for_team(TEST_TEAM, 10, 5).unwrap();
+    assert_eq!(
+        pending.len(),
+        1,
+        "successful old-key delete must be settled"
+    );
+    assert_eq!(pending[0].operation, SyncOperation::Upsert);
+    assert!(pending[0].retry_count > 0);
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests[0].method.as_str(), "DELETE");
+    assert!(
+        requests[1..]
+            .iter()
+            .all(|request| request.method.as_str() == "POST")
+    );
+}
+
 /// Happy path: team configured + queued items → POST fires against
 /// `/api/teams/{uuid}/sync/push`, queue is drained.
 ///

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.7.7"
+version = "3.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-core/src/hooks/context/build_start.rs
+++ b/crates/cas-core/src/hooks/context/build_start.rs
@@ -213,7 +213,7 @@ pub fn build_context_with_stores(
 
     // Check for blocked in-progress tasks (important alert - always show full)
     if let Some(ts) = stores.task_store {
-        if let Ok(blocked) = ts.list_blocked() {
+        if let Ok(blocked) = ts.list_blocked_scoped(ts.project_id(), false) {
             let blocked_in_progress: Vec<_> = blocked
                 .iter()
                 .filter(|(task, _)| task.status == TaskStatus::InProgress)
@@ -393,7 +393,7 @@ pub fn build_context_with_stores(
     // Add ready tasks (progressive disclosure - summaries only)
     // Skip in minimal mode but track availability
     if let Some(ts) = stores.task_store {
-        if let Ok(ready_tasks) = ts.list_ready() {
+        if let Ok(ready_tasks) = ts.list_ready_scoped(ts.project_id(), false) {
             let all_tasks: Vec<_> = ready_tasks
                 .iter()
                 .filter(|t| t.status != TaskStatus::InProgress)

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.7.7"
+version = "3.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-mcp/src/types.rs
+++ b/crates/cas-mcp/src/types.rs
@@ -433,6 +433,14 @@ pub struct TaskRequest {
     #[serde(default, deserialize_with = "deser::option_usize")]
     pub limit: Option<usize>,
 
+    /// Include rows whose origin belongs to another project. Task list
+    /// surfaces hide foreign replicas by default.
+    #[schemars(
+        description = "For list, ready, blocked, and available: include foreign-origin task rows (default: false)"
+    )]
+    #[serde(default, deserialize_with = "deser::option_bool")]
+    pub include_foreign: Option<bool>,
+
     /// Scope filter
     #[schemars(description = "Scope: 'global', 'project', or 'all'")]
     #[serde(default)]

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.7.7"
+version = "3.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.7.7"
+version = "3.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-store/src/lib.rs
+++ b/crates/cas-store/src/lib.rs
@@ -540,6 +540,13 @@ pub trait TaskStore: Send + Sync {
     /// Add a new task
     fn add(&self, task: &Task) -> Result<()>;
 
+    /// Canonical project identity attached to this store, when available.
+    /// Used by shared context builders that cannot depend on the CLI's cloud
+    /// configuration module.
+    fn project_id(&self) -> Option<&str> {
+        None
+    }
+
     /// Atomically create a task and its initial dependencies.
     ///
     /// The default implementation is non-transactional and exists for compatibility with
@@ -630,8 +637,51 @@ pub trait TaskStore: Send + Sync {
     /// List tasks that are ready to work on (open, not blocked)
     fn list_ready(&self) -> Result<Vec<Task>>;
 
+    /// List ready tasks scoped to a project identity.
+    fn list_ready_scoped(
+        &self,
+        project_id: Option<&str>,
+        include_foreign: bool,
+    ) -> Result<Vec<Task>> {
+        let tasks = self.list_ready()?;
+        if include_foreign {
+            return Ok(tasks);
+        }
+        Ok(tasks
+            .into_iter()
+            .filter(|task| {
+                task.origin_project.is_none()
+                    || project_id.is_some_and(|project_id| {
+                        task.origin_project.as_deref() == Some(project_id)
+                    })
+            })
+            .collect())
+    }
+
     /// List blocked tasks with their blockers
     fn list_blocked(&self) -> Result<Vec<(Task, Vec<Task>)>>;
+
+    /// List blocked tasks scoped to a project identity. Blocker payloads are
+    /// preserved so an explicitly requested foreign task remains diagnosable.
+    fn list_blocked_scoped(
+        &self,
+        project_id: Option<&str>,
+        include_foreign: bool,
+    ) -> Result<Vec<(Task, Vec<Task>)>> {
+        let blocked = self.list_blocked()?;
+        if include_foreign {
+            return Ok(blocked);
+        }
+        Ok(blocked
+            .into_iter()
+            .filter(|(task, _)| {
+                task.origin_project.is_none()
+                    || project_id.is_some_and(|project_id| {
+                        task.origin_project.as_deref() == Some(project_id)
+                    })
+            })
+            .collect())
+    }
 
     /// List tasks with pending_verification=true (for PreToolUse jail check)
     fn list_pending_verification(&self) -> Result<Vec<Task>>;

--- a/crates/cas-store/src/task_store.rs
+++ b/crates/cas-store/src/task_store.rs
@@ -560,6 +560,10 @@ impl TaskStore for SqliteTaskStore {
         Ok(())
     }
 
+    fn project_id(&self) -> Option<&str> {
+        self.origin_project.as_deref()
+    }
+
     fn generate_id(&self) -> Result<String> {
         self.generate_hash_id()
     }

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.7.7"
+version = "3.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-09-01-v3.8.0-slack.md
+++ b/docs/release-notes/2026-09-01-v3.8.0-slack.md
@@ -1,0 +1,46 @@
+# Slack draft — Cassy v3.8.0 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** DRAFT — digests and timestamps are filled by
+`release-published-receipt.sh --write-draft` after the tag publishes.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Your Cassy board now shows only your project's work, moving a task to the project that owns it finally sticks, and pairing a Commander page works on the first try.
+
+**Reply (Was → Now):**
+- Was: the task board mixed in other projects' tasks, often at an out-of-date status, so a closed task elsewhere could still look open here. Now: the board is scoped to your project, tells you how many foreign tasks it hid, and a task closed by its owner can no longer be shown as open.
+- Was: reassigning a task to another project was silently undone on the next sync. Now: the move is carried through to the shared cloud, the old copy is removed, and a note records who moved it.
+- Was: cleaning foreign data out of a project could have wiped everything, and the guard was the only thing stopping it. Now: only data explicitly owned by another project is eligible, and Cassy refuses to remove more than half of your tasks or any proven rule.
+- Was: `cas hub authorize` needed the exact `https://` Commander URL every time and pointed you at a restart that failed because the hub was already running; a hub left over from an older install stayed running after updates. Now: it remembers the Commander origin, accepts a bare hostname, explains the real fix, `cas hub` shows status, and `cas update` restarts a stale hub.
+- Install: use `cas update` for an existing installation, or download the
+  v3.8.0 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — Team task identity is now (owner project, id): push preserves explicit `origin_project`, pull arbitrates owner-over-replica, and reassignment rewrites the cloud key.
+
+**Reply (Was → Now):**
+- Was: `team_push` stamped `origin_project` with the pushing project on every upsert, so a supervisor reassignment could never reach cloud and each replica push forked a second `(project, id)` row. Now: only missing/blank origins inherit the pusher; Global tasks stay unstamped; `task update origin_project` enqueues DELETE(old project, id) before UPSERT(new owner) with a per-row `sync_queue.project_id` (additive migration, `COALESCE(project_id,'')` unique index), withholds the upsert if the delete fails, and requires a registered destination project.
+- Was: team pull dropped foreign-keyed task rows or applied whichever row arrived, and the terminal-status guard only protected a store that already held the close. Now: duplicate ids resolve to the owner row (timestamp tie-break), non-owner rows cannot regress a terminal status, discarded rows are recorded as `owner_wins`.
+- Was: `purge-foreign` selected every local row with no `WHERE`. Now: foreign = non-blank attribution ≠ current project; hard refusals for >50% of tasks or any proven rule, not overridable by `--force`.
+- Was: `task ready/list/blocked/available` returned every replica. Now: scoped to `origin_project IS NULL OR = current`, `include_foreign` opt-in, hidden-count footer, SessionStart ready/blocked use the same filter.
+- Was: `resolve_hub_url` accepted only the tailscale-serve record or `--hub-url`; bare hosts failed `Url::parse`; `cas hub` defaulted to `start` and bailed on a live record regardless of version/flags; `cas update` never touched the hub. Now: explicit → record → `[hub].public_url` → remembered origin, `https://` auto-prefix, state-aware error, `cas hub` = status with both versions, drift-aware restart, post-update stale-hub restart.
+- Was: `cas list` counted `metadata.workers`, which the MCP spawn path never wrote. Now: live registry count.
+- Validation and artifact: `cargo check --workspace --tests`, scoped suites on the merged tree (`mcp_tools_test` + `team_sync_test` 378 passed), merge-queue validation of the single integration PR. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`).
+
+## Posting sequence
+
+1. Tag the fetched `origin/main` landing and run `./scripts/release.sh --publish-tag`.
+2. Run `release-published-receipt.sh --write-draft` against this draft to fill the digests.
+3. Post the User top-level and its only reply, then the Dev top-level and its only reply; append the receipt.
+
+## POSTED
+
+(pending)


### PR DESCRIPTION
## Summary
- Team push preserves an explicit `origin_project` (only missing/blank rows inherit the pushing project; Global tasks unstamped).
- Team pull arbitrates duplicate task ids in favor of the owning project; a stale foreign replica can no longer reopen an owner-closed task (`owner_wins` conflicts logged).
- Supervisor `task update origin_project=<project>` moves the task in cloud: DELETE(old project, id) before UPSERT(new owner), per-row `sync_queue.project_id` (additive migration + `COALESCE` unique index), delete failure withholds the upsert, destination must be a registered team project.
- `cas cloud purge-foreign` classifies only explicitly attributed foreign rows; hard refusals for >50% of tasks or any proven rule (not `--force`-able).
- `mcp__cas__task` list/ready/blocked/available scoped to the current project with `include_foreign` opt-in and a hidden-count footer; `show` names a foreign task's owner.
- `cas hub authorize` resolves the Commander origin (flag → record → `[hub].public_url` → remembered), accepts bare hostnames, state-aware error text, single scope block.
- Bare `cas hub` = status with running + binary versions; `cas hub start` on a live hub with version/flag drift restarts it; `cas update` restarts a stale running hub.
- `cas list` counts live registry workers.
- Release prep v3.8.0 (CHANGELOG + Slack draft) carried as the final commit — tag the merge commit after landing.

## Validation (local, epic tree 889ffb71 + prep commit)
- `cargo check --workspace --tests`: ok
- `cargo nextest run -p cas`: 6234 passed, 76 skipped, 0 failed
- `cargo test -p cas --doc`: ok
- `cargo metadata --locked`: consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)