### PR TITLE
v3.9.0: dependency-edge sync + self-heal, honest push outcomes, canonical project identity, cross-repo spawn, unblock wake, proxy allowlist (GH #639 #640 #652 #668 #669 #670 #672 #673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.9.0] - 2026-09-01
+
+### Added
+- Task dependency edges (epic→child, blocks, related, duplicate) sync to the
+  team cloud as a `task_dependencies` entity: enqueued on add/remove/epic
+  create, pushed in both envelopes, applied and deleted on pull, with dangling
+  edges parked instead of inserted.
+- Every pull/sync self-heals dependency edges: edges the cloud lacks are
+  re-pushed, edges the local store lacks are materialized, deletes in the same
+  envelope are honored, and a one-line "healed N edge(s)" summary appears only
+  when something changed (a second sync heals 0).
+- `spawn_workers` provisions the worker worktree inside the task's
+  `target_repo` (start point resolved there, worktree under that repo's
+  `.cas/worktrees/`) and fails fast with an explicit `cross-repo spawn:` message
+  when it cannot.
+- `cas update` runs the freshly installed binary's post-update hook after the
+  swap, so a stale running hub restarts on the same run even across a version
+  boundary.
+
+### Changed
+- One canonical project identity: git-remote and case variants of a project
+  slug resolve to the pinned slug for registration, push stamping, pull
+  ownership, dependency ownership and `purge-foreign`; `cas doctor` reports
+  rows still attributed to an alias and `cas cloud project --adopt-aliases`
+  rewrites them and re-pushes under the canonical identity.
+- Cloud push treats a last-write-wins skip as an acknowledgement, consumes
+  per-row outcomes/reasons when the server provides them (parking real
+  rejections without poisoning the batch), and requeues terminal
+  version-gated failures automatically once the client meets the server
+  minimum.
+- The PTY-timing test family uses bounded deadline polling instead of fixed
+  sleeps, ending the recurring merge-queue ejections.
+- Moving a task to another project keys the replacement upsert to the
+  destination project, so the old project no longer keeps a stale copy.
+- A task that becomes unblocked wakes its assigned worker with a start message
+  instead of waiting for the stall detector.
+- The worker MCP proxy allowlist uses one documented `<server>.<tool>` /
+  `<server>.*` format with alias normalization and live reload, denials name
+  the exact entry to add, and a missing stdio executable is reported as
+  `executable_missing` (also checked by `cas doctor`).
+- The sync queue collapses legacy duplicate rows during migration and upserts
+  on conflict, `cas cloud queue --retry --retry-reason <reason>` requeues only
+  matching parked rows, and `cas doctor` prints the exact counts blocking
+  `purge-foreign` with a runnable retry → push → purge remediation.
+
 ## [3.8.0] - 2026-09-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -269,9 +269,15 @@ pub struct CloudQueueArgs {
     #[arg(long)]
     pub prune: Option<i64>,
 
-    /// Requeue all terminally failed items, preserving their last error
+    /// Requeue all terminally failed items, preserving their last error.
+    /// Combine with --retry-reason to target only diagnostics containing a
+    /// repaired server reason.
     #[arg(long, conflicts_with_all = ["prune", "clear"])]
     pub retry: bool,
+
+    /// Requeue only terminal items whose diagnostic contains this reason.
+    #[arg(long, alias = "reason", requires = "retry")]
+    pub retry_reason: Option<String>,
 
     /// Clear all items from the queue
     #[arg(long)]
@@ -2203,14 +2209,30 @@ fn execute_queue(args: &CloudQueueArgs, cli: &Cli, cas_root: &Path) -> anyhow::R
     // gets another chance to accept them.
     if args.retry {
         let max_retries = 5;
-        let retried = queue.retry_failed(max_retries)?;
+        let retried = match args.retry_reason.as_deref() {
+            Some(reason) => queue.retry_failed_for_reason(reason, max_retries)?,
+            None => queue.retry_failed(max_retries)?,
+        };
         if cli.json {
-            println!(r#"{{"status":"ok","retried":{retried}}}"#);
+            let mut output = serde_json::json!({
+                "status": "ok",
+                "retried": retried,
+            });
+            if let Some(reason) = &args.retry_reason {
+                output["reason"] = serde_json::Value::String(reason.clone());
+            }
+            println!("{output}");
         } else {
             let theme = ActiveTheme::default();
             let mut out = io::stdout();
             let mut fmt = Formatter::stdout(&mut out, theme);
-            fmt.success(&format!("Requeued {retried} failed item(s)"))?;
+            let message = match &args.retry_reason {
+                Some(reason) => {
+                    format!("Requeued {retried} failed item(s) matching reason {reason:?}")
+                }
+                None => format!("Requeued {retried} failed item(s)"),
+            };
+            fmt.success(&message)?;
         }
         return Ok(());
     }
@@ -4572,7 +4594,9 @@ fn evaluate_purge_safety(
 /// decode) is propagated so the purge refuses loudly. Silently returning zero
 /// here would disable the unpushed-rows guard in a destructive path — the one
 /// place a reassuring wrong answer is most expensive.
-fn pending_content_pushes(conn: &rusqlite::Connection) -> anyhow::Result<Vec<(String, String)>> {
+pub(crate) fn pending_content_pushes(
+    conn: &rusqlite::Connection,
+) -> anyhow::Result<Vec<(String, String)>> {
     let mut stmt = match conn.prepare(
         "SELECT entity_type, entity_id FROM sync_queue
          WHERE lower(entity_type) IN ('entry', 'task', 'rule', 'skill')
@@ -4922,6 +4946,25 @@ mod team_cmd_tests {
     use tempfile::TempDir;
     use wiremock::matchers::{header, method, path, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn queue_retry_reason_is_available_as_a_targeted_retry_flag() {
+        use clap::Parser;
+
+        let args = CloudQueueArgs::try_parse_from([
+            "queue",
+            "--retry",
+            "--retry-reason",
+            "project_mismatch",
+        ])
+        .unwrap();
+        assert!(args.retry);
+        assert_eq!(args.retry_reason.as_deref(), Some("project_mismatch"));
+
+        let alias = CloudQueueArgs::try_parse_from(["queue", "--retry", "--reason", "timeout"])
+            .unwrap();
+        assert_eq!(alias.retry_reason.as_deref(), Some("timeout"));
+    }
 
     #[test]
     fn active_team_backlog_is_reported_with_sync_command() {

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -5728,6 +5728,24 @@ mod purge_foreign_safety_tests {
     }
 
     #[test]
+    fn alias_rows_are_not_classified_as_foreign() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_project_scoped_db(&conn);
+        conn.execute(
+            "UPDATE tasks SET origin_project = ?1 WHERE id = 'foreign-1'",
+            ["git@GitHub.com:Richards-LLC/gabber-studio.git"],
+        )
+        .unwrap();
+
+        let set = collect_purge_delete_set(&conn, "gabber-studio").unwrap();
+
+        assert_eq!(
+            set.tasks.iter().map(|task| task.id.as_str()).collect::<Vec<_>>(),
+            vec!["foreign-2"]
+        );
+    }
+
+    #[test]
     fn applying_the_delete_set_keeps_local_rows_and_edges() {
         let mut conn = Connection::open_in_memory().unwrap();
         seed_project_scoped_db(&conn);

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -2,7 +2,7 @@
 //!
 //! Enables syncing Cassy data with Cassy Cloud service.
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io;
@@ -42,8 +42,7 @@ pub enum CloudCommands {
     #[command(subcommand)]
     Team(CloudTeamCommands),
     /// Configure the project canonical slug (overrides auto-derivation)
-    #[command(subcommand)]
-    Project(CloudProjectCommands),
+    Project(CloudProjectArgs),
     /// List team projects in cloud
     Projects(CloudProjectsArgs),
     /// Pull team memories for the current project
@@ -124,6 +123,25 @@ pub enum CloudTeamAutoCommands {
 pub enum CloudProjectCommands {
     /// Set the project canonical id (writes `.cas/config.toml [project] canonical_id`)
     Set(CloudProjectSetArgs),
+    /// Rewrite local task origins that are aliases of this project's identity
+    /// and enqueue canonical upserts for the next cloud sync.
+    AdoptAliases,
+}
+
+/// Arguments for `cas cloud project`.
+///
+/// The alias-repair action is deliberately a flag so doctor can print one
+/// copy/pasteable command that does not require a positional project id.
+#[derive(Args)]
+pub struct CloudProjectArgs {
+    /// Rewrite local task origins that are aliases of this project's identity
+    /// and enqueue canonical upserts for the next cloud sync.
+    #[arg(long)]
+    pub adopt_aliases: bool,
+
+    /// Optional project subcommand (`set` or the legacy `adopt-aliases` form).
+    #[command(subcommand)]
+    pub command: Option<CloudProjectCommands>,
 }
 
 #[derive(Parser)]
@@ -298,7 +316,15 @@ pub fn execute(cmd: &CloudCommands, cli: &Cli, cas_root: &Path) -> anyhow::Resul
         CloudCommands::Pull(args) => execute_pull(args, cli, cas_root),
         CloudCommands::Sync(args) => execute_sync(args, cli, cas_root),
         CloudCommands::Team(cmd) => execute_team(cmd, cli, cas_root),
-        CloudCommands::Project(cmd) => execute_project(cmd, cli, cas_root),
+        CloudCommands::Project(args) => {
+            if args.adopt_aliases {
+                execute_project_adopt_aliases(cli, cas_root)
+            } else if let Some(cmd) = args.command.as_ref() {
+                execute_project(cmd, cli, cas_root)
+            } else {
+                anyhow::bail!("`cas cloud project` requires a subcommand or --adopt-aliases")
+            }
+        }
         CloudCommands::Projects(args) => execute_projects(args, cli),
         CloudCommands::TeamMemories(args) => execute_team_memories(args, cli, cas_root),
         CloudCommands::Unlink(args) => execute_unlink(args, cli, cas_root),
@@ -514,7 +540,7 @@ fn collect_unlink_records(
                         "scoped cloud pull returned `{key}` row without project_id; refusing unlink"
                     )
                 })?;
-            if row_project_id != project_id {
+            if !project_ids_match(row_project_id, project_id) {
                 anyhow::bail!(
                     "scoped cloud pull returned `{key}` row for foreign project `{row_project_id}`; refusing unlink"
                 );
@@ -959,6 +985,7 @@ pub fn execute_project(
 ) -> anyhow::Result<()> {
     match cmd {
         CloudProjectCommands::Set(args) => execute_project_set(args, cli, cas_root),
+        CloudProjectCommands::AdoptAliases => execute_project_adopt_aliases(cli, cas_root),
     }
 }
 
@@ -990,6 +1017,89 @@ fn execute_project_set(
         fmt.write_muted("  canonical_id: ")?;
         fmt.write_raw(&args.canonical_id)?;
         fmt.newline()?;
+    }
+    Ok(())
+}
+
+/// Rewrite task rows whose persisted `origin_project` is a remote/case alias
+/// of the current project. The change is local and queue-backed: every updated
+/// task receives both a personal upsert and, when team scope is active, the
+/// same team upsert that an ordinary task edit would produce.
+fn execute_project_adopt_aliases(cli: &Cli, cas_root: &Path) -> anyhow::Result<()> {
+    use crate::store::share_policy::eligible_for_team_task;
+
+    let project_id = crate::cloud::resolve_canonical_id(cas_root)
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine the current project identity"))?;
+    let task_store = crate::store::open_task_store_local(cas_root)?;
+    let queue = SyncQueue::open(cas_root)?;
+    queue.init()?;
+    let cloud_config = CloudConfig::load_from_cas_dir_inheriting_user_credentials(cas_root).ok();
+    let team_id = cloud_config.as_ref().and_then(CloudConfig::active_team_id);
+
+    let mut aliases = BTreeMap::<String, usize>::new();
+    let mut rewritten = 0usize;
+    let mut enqueued = 0usize;
+    for mut task in task_store.list(None)? {
+        let Some(origin) = task.origin_project.as_deref() else {
+            continue;
+        };
+        let Some(canonical_origin) =
+            crate::cloud::canonical_project_id_with_pin(origin, Some(&project_id))
+        else {
+            continue;
+        };
+        if canonical_origin != project_id || origin.trim() == project_id {
+            continue;
+        }
+
+        *aliases.entry(origin.to_string()).or_default() += 1;
+        task.origin_project = Some(project_id.clone());
+        task_store.update(&task)?;
+        let persisted = task_store.get(&task.id)?;
+        let payload = serde_json::to_string(&persisted)?;
+        queue.enqueue(
+            crate::cloud::EntityType::Task,
+            &persisted.id,
+            crate::cloud::SyncOperation::Upsert,
+            Some(&payload),
+        )?;
+        if let Some(team_id) = team_id.as_deref() && eligible_for_team_task(&persisted) {
+            queue.enqueue_for_team(
+                crate::cloud::EntityType::Task,
+                &persisted.id,
+                crate::cloud::SyncOperation::Upsert,
+                Some(&payload),
+                team_id,
+            )?;
+        }
+        rewritten += 1;
+        enqueued += 1;
+    }
+
+    if cli.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "status": "ok",
+                "project_id": project_id,
+                "aliases": aliases,
+                "rewritten": rewritten,
+                "enqueued_upserts": enqueued,
+            })
+        );
+    } else {
+        let theme = ActiveTheme::default();
+        let mut out = io::stdout();
+        let mut fmt = Formatter::stdout(&mut out, theme);
+        fmt.newline()?;
+        fmt.write_raw(&format!(
+            "  Adopted {rewritten} alias row(s) for project {project_id}; enqueued {enqueued} upsert(s)."
+        ))?;
+        fmt.newline()?;
+        for (alias, count) in aliases {
+            fmt.write_raw(&format!("  {count} row(s) rewritten from alias {alias}"))?;
+            fmt.newline()?;
+        }
     }
     Ok(())
 }
@@ -1461,7 +1571,9 @@ fn resolve_project_slug_for_team_set(cas_root: &Path) -> SlugResolution {
     if let Some(slug) = crate::cloud::canonical_id_from_config_toml(cas_root) {
         return SlugResolution::FromConfig(slug);
     }
-    if let Some(slug) = crate::cloud::derive_canonical_id_from_git_remote(cas_root) {
+    if let Some(slug) = crate::cloud::derive_canonical_id_from_git_remote(cas_root)
+        .and_then(|remote| crate::cloud::canonical_project_id(&remote))
+    {
         if crate::cloud::set_canonical_id_in_config_toml(cas_root, &slug).is_ok() {
             return SlugResolution::FromGitRemote(slug);
         }
@@ -2359,8 +2471,8 @@ pub fn check_canonical_id_rehome(
     match stored {
         None => Ok(()), // First push — no prior slug on record
         Some(ref stored_id)
-            if crate::cloud::normalize_project_canonical_id(stored_id)
-                == crate::cloud::normalize_project_canonical_id(project_id) =>
+            if crate::cloud::canonical_project_id(stored_id)
+                == crate::cloud::canonical_project_id(project_id) =>
         {
             Ok(()) // Case/protocol drift only — unchanged, safe.
         }
@@ -3147,9 +3259,11 @@ pub fn ensure_team_project_registration(
         .ok()
         .and_then(|root| crate::cloud::normalized_git_remote_for_push(&root));
 
+    let pinned_canonical_id = crate::cloud::canonical_id_from_config_toml(cas_root);
     let registration =
         crate::cloud::TeamRegistration::new(&cloud_config.endpoint, token, &team_id, &canonical_id)
-            .with_git_remote(git_remote.as_deref());
+            .with_git_remote(git_remote.as_deref())
+            .with_pinned_canonical_id(pinned_canonical_id.as_deref());
 
     match registration.ensure() {
         Ok(outcome) => {
@@ -4212,6 +4326,14 @@ const PURGE_PROJECT_COLUMNS: &[&str] = &[
     "project_id",
 ];
 
+fn project_ids_match(candidate: &str, current: &str) -> bool {
+    let Some(current) = crate::cloud::canonical_project_id(current) else {
+        return false;
+    };
+    crate::cloud::canonical_project_id_with_pin(candidate, Some(&current))
+        .is_some_and(|candidate| candidate == current)
+}
+
 fn first_existing_project_column(
     conn: &rusqlite::Connection,
     table: &str,
@@ -4254,20 +4376,27 @@ fn attributed_rows(
     };
 
     let sql = format!(
-        "SELECT id, {label_sql} FROM {table}
+        "SELECT id, {label_sql}, {project_column} FROM {table}
          WHERE NULLIF(trim({project_column}), '') IS NOT NULL
-           AND trim({project_column}) <> ?1
          ORDER BY id"
     );
     let mut stmt = conn.prepare(&sql)?;
-    let mapped = stmt.query_map([current_project], |row| {
-        Ok(PurgeEntity {
-            kind,
-            id: row.get::<_, String>(0)?,
-            label: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
-        })
+    let mapped = stmt.query_map([], |row| {
+        Ok((
+            PurgeEntity {
+                kind,
+                id: row.get::<_, String>(0)?,
+                label: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+            },
+            row.get::<_, String>(2)?,
+        ))
     })?;
-    mapped.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    let rows = mapped.collect::<Result<Vec<_>, _>>()?;
+    Ok(rows
+        .into_iter()
+        .filter(|(_, stored_project)| !project_ids_match(stored_project, current_project))
+        .map(|(row, _)| row)
+        .collect())
 }
 
 fn count_proven_attributed_rules(
@@ -4283,12 +4412,19 @@ fn count_proven_attributed_rules(
         return Ok(0);
     }
     let sql = format!(
-        "SELECT COUNT(*) FROM rules
+        "SELECT {project_column} FROM rules
          WHERE lower(status) = 'proven'
-           AND NULLIF(trim({project_column}), '') IS NOT NULL
-           AND trim({project_column}) <> ?1"
+           AND NULLIF(trim({project_column}), '') IS NOT NULL"
     );
-    Ok(conn.query_row(&sql, [current_project], |row| row.get::<_, i64>(0))? as usize)
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    let mut count = 0;
+    for row in rows {
+        if !project_ids_match(&row?, current_project) {
+            count += 1;
+        }
+    }
+    Ok(count)
 }
 
 fn count_purge_dependencies(
@@ -4922,6 +5058,25 @@ mod team_cmd_tests {
     use tempfile::TempDir;
     use wiremock::matchers::{header, method, path, query_param, query_param_is_missing};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn alias_project_command_accepts_adopt_aliases_flag() {
+        let cli = crate::cli::try_parse_from_with_wordmark([
+            "cas",
+            "cloud",
+            "project",
+            "--adopt-aliases",
+        ])
+        .expect("the doctor-provided alias adoption command must parse");
+
+        match cli.command {
+            Some(crate::cli::Commands::Cloud(CloudCommands::Project(args))) => {
+                assert!(args.adopt_aliases);
+                assert!(args.command.is_none());
+            }
+            _ => panic!("unexpected command parsed"),
+        }
+    }
 
     #[test]
     fn active_team_backlog_is_reported_with_sync_command() {
@@ -5664,6 +5819,8 @@ mod team_cmd_tests {
 #[cfg(test)]
 mod purge_foreign_safety_tests {
     use super::*;
+    use crate::store::init_cas_dir;
+    use crate::types::Task;
     use rusqlite::Connection;
     use tempfile::TempDir;
 
@@ -5732,6 +5889,11 @@ mod purge_foreign_safety_tests {
         let conn = Connection::open_in_memory().unwrap();
         seed_project_scoped_db(&conn);
         conn.execute(
+            "UPDATE tasks SET origin_project = 'gabber-studio' WHERE id IN ('own-1', 'own-2')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
             "UPDATE tasks SET origin_project = ?1 WHERE id = 'foreign-1'",
             ["git@GitHub.com:Richards-LLC/gabber-studio.git"],
         )
@@ -5742,6 +5904,64 @@ mod purge_foreign_safety_tests {
         assert_eq!(
             set.tasks.iter().map(|task| task.id.as_str()).collect::<Vec<_>>(),
             vec!["foreign-2"]
+        );
+    }
+
+    #[test]
+    fn alias_adoption_rewrites_tasks_and_enqueues_canonical_upserts() {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("gabber-studio");
+        let cas_root = init_cas_dir(&project).unwrap();
+        crate::cloud::set_canonical_id_in_config_toml(&cas_root, "gabber-studio").unwrap();
+
+        let task_store = crate::store::open_task_store_local(&cas_root).unwrap();
+        let mut alias_task = Task::new("alias-adopt-1".to_string(), "legacy alias".to_string());
+        alias_task.origin_project =
+            Some("https://GitHub.com/Richards-LLC/gabber-studio.git/".to_string());
+        task_store.add(&alias_task).unwrap();
+
+        let mut canonical_task = Task::new(
+            "canonical-adopt-1".to_string(),
+            "already canonical".to_string(),
+        );
+        canonical_task.origin_project = Some("gabber-studio".to_string());
+        task_store.add(&canonical_task).unwrap();
+
+        let cli = Cli {
+            json: true,
+            full: false,
+            verbose: false,
+            command: None,
+        };
+        execute_project_adopt_aliases(&cli, &cas_root).unwrap();
+
+        assert_eq!(
+            task_store
+                .get("alias-adopt-1")
+                .unwrap()
+                .origin_project
+                .as_deref(),
+            Some("gabber-studio")
+        );
+        assert_eq!(
+            task_store
+                .get("canonical-adopt-1")
+                .unwrap()
+                .origin_project
+                .as_deref(),
+            Some("gabber-studio")
+        );
+
+        let queue = SyncQueue::open(&cas_root).unwrap();
+        queue.init().unwrap();
+        let queued = queue.pending(10, 5).unwrap();
+        assert_eq!(queued.len(), 1, "only the rewritten alias should enqueue");
+        assert_eq!(queued[0].entity_id, "alias-adopt-1");
+        assert!(
+            queued[0]
+                .payload
+                .as_deref()
+                .is_some_and(|payload| payload.contains("\"origin_project\":\"gabber-studio\""))
         );
     }
 

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -4961,8 +4961,8 @@ mod team_cmd_tests {
         assert!(args.retry);
         assert_eq!(args.retry_reason.as_deref(), Some("project_mismatch"));
 
-        let alias = CloudQueueArgs::try_parse_from(["queue", "--retry", "--reason", "timeout"])
-            .unwrap();
+        let alias =
+            CloudQueueArgs::try_parse_from(["queue", "--retry", "--reason", "timeout"]).unwrap();
         assert_eq!(alias.retry_reason.as_deref(), Some("timeout"));
     }
 

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -1623,11 +1623,13 @@ pub(crate) fn check_bucket_ambiguity(
     resolved_id: &str,
     projects: &[crate::cloud::TeamProject],
 ) -> Option<(String, u32, u32)> {
-    let resolved = projects.iter().find(|p| p.canonical_id == resolved_id)?;
+    let resolved = projects
+        .iter()
+        .find(|p| project_ids_match(&p.canonical_id, resolved_id))?;
 
     let richest = projects
         .iter()
-        .filter(|p| p.canonical_id != resolved_id)
+        .filter(|p| !project_ids_match(&p.canonical_id, resolved_id))
         .max_by_key(|p| p.memory_count)?;
 
     if richest.memory_count >= 50
@@ -4008,7 +4010,7 @@ fn execute_team_memories(
     let project = projects_body
         .projects
         .iter()
-        .find(|p| p.canonical_id == canonical_id);
+        .find(|p| project_ids_match(&p.canonical_id, &canonical_id));
 
     let project_uuid = match project {
         Some(p) => p.id.clone(),
@@ -4327,11 +4329,7 @@ const PURGE_PROJECT_COLUMNS: &[&str] = &[
 ];
 
 fn project_ids_match(candidate: &str, current: &str) -> bool {
-    let Some(current) = crate::cloud::canonical_project_id(current) else {
-        return false;
-    };
-    crate::cloud::canonical_project_id_with_pin(candidate, Some(&current))
-        .is_some_and(|candidate| candidate == current)
+    crate::cloud::project_ids_match(candidate, current)
 }
 
 fn first_existing_project_column(
@@ -5765,6 +5763,21 @@ mod team_cmd_tests {
             check_bucket_ambiguity("new-project", &projects).is_none(),
             "should not warn when resolved id is absent from project list"
         );
+    }
+
+    #[test]
+    fn bucket_ambiguity_matches_project_aliases_case_insensitively() {
+        let projects = vec![
+            make_project("https://GitHub.com/Richards-LLC/gabber-studio.git", 20),
+            make_project("other-project", 1_000),
+        ];
+
+        let result = check_bucket_ambiguity("gabber-studio", &projects);
+        let (richer_id, resolved_count, richer_count) =
+            result.expect("remote project alias must match the resolved slug");
+        assert_eq!(richer_id, "other-project");
+        assert_eq!(resolved_count, 20);
+        assert_eq!(richer_count, 1_000);
     }
 
     #[test]

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -2396,6 +2396,52 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "mcp-proxy")]
+    #[test]
+    fn doctor_proxy_stdio_check_names_missing_commands_and_passes_resolved_commands() {
+        let temp = TempDir::new().unwrap();
+        let cas_root = temp.path().join(".cas");
+        fs::create_dir_all(&cas_root).unwrap();
+        let executable = temp.path().join("stdio-server");
+        fs::write(&executable, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&executable).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&executable, permissions).unwrap();
+        }
+
+        let mut config = cmcp_core::config::Config::default();
+        config.add_server(
+            "working".to_string(),
+            cmcp_core::config::ServerConfig::Stdio {
+                command: executable.to_string_lossy().into_owned(),
+                args: Vec::new(),
+                env: BTreeMap::new().into_iter().collect(),
+            },
+        );
+        config.add_server(
+            "missing".to_string(),
+            cmcp_core::config::ServerConfig::Stdio {
+                command: temp
+                    .path()
+                    .join("removed-interpreter")
+                    .to_string_lossy()
+                    .into_owned(),
+                args: Vec::new(),
+                env: BTreeMap::new().into_iter().collect(),
+            },
+        );
+        config.save_to(&cas_root.join("proxy.toml")).unwrap();
+
+        let check = proxy_stdio_commands_check(&cas_root);
+        assert!(matches!(check.status, CheckStatus::Warning));
+        assert!(check.message.contains("missing"), "{}", check.message);
+        assert!(check.message.contains("removed-interpreter"), "{}", check.message);
+        assert!(check.message.contains("working"), "{}", check.message);
+    }
+
     #[test]
     fn foreign_rows_check_warns_when_a_peer_db_could_not_be_read_cas_fc6fa() {
         use crate::cli::foreign_rows::{ForeignRowReport, UnreadablePeer};

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -835,6 +835,7 @@ pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
         if args.foreign_rows {
             return output_foreign_rows_detail(report, cli);
         }
+        checks.push(cloud_queue_check(&cas_root));
         checks.push(foreign_rows_check(report.as_ref()));
     } else if args.foreign_rows {
         anyhow::bail!(
@@ -1947,6 +1948,67 @@ fn format_lag(secs: i64) -> String {
 fn integration_checks(project_root: &Path) -> Vec<crate::cli::integrate::doctor::DoctorRow> {
     let reports = crate::cli::integrate::doctor::collect_reports(project_root);
     crate::cli::integrate::doctor::render_for_doctor(&reports)
+}
+
+/// Surface the exact content queue rows that keep `purge-foreign` fail-closed.
+/// The remediation is intentionally executable in order: reset terminal rows,
+/// push them, then preview the purge again. A count from the generic queue
+/// stats would include knowledge pages, so this reuses the purge's own content
+/// predicate instead.
+fn cloud_queue_check(cas_root: &Path) -> Check {
+    let db_path = cas_root.join("cas.db");
+    let conn = match rusqlite::Connection::open_with_flags(
+        &db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    ) {
+        Ok(conn) => conn,
+        Err(error) => {
+            return Check {
+                name: "cloud sync queue".to_string(),
+                status: CheckStatus::Warning,
+                message: format!("cannot count queued content changes: {error}"),
+            };
+        }
+    };
+
+    let pending = match crate::cli::cloud::pending_content_pushes(&conn) {
+        Ok(pending) => pending,
+        Err(error) => {
+            return Check {
+                name: "cloud sync queue".to_string(),
+                status: CheckStatus::Warning,
+                message: format!("cannot count queued content changes: {error}"),
+            };
+        }
+    };
+
+    let mut by_type = BTreeMap::<String, usize>::new();
+    for (entity_type, _) in &pending {
+        *by_type.entry(entity_type.clone()).or_default() += 1;
+    }
+    let breakdown = by_type
+        .iter()
+        .map(|(entity_type, count)| format!("{entity_type}: {count}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let remediation = "Run `cas cloud queue --retry`, then `cas cloud push`, then `cas cloud purge-foreign --dry-run`; repeat the push until this count reaches 0.";
+
+    if pending.is_empty() {
+        Check {
+            name: "cloud sync queue".to_string(),
+            status: CheckStatus::Ok,
+            message: format!("0 queued content change(s) block purge-foreign; {remediation}"),
+        }
+    } else {
+        Check {
+            name: "cloud sync queue".to_string(),
+            status: CheckStatus::Warning,
+            message: format!(
+                "{} queued content change(s) block purge-foreign ({breakdown}); {remediation}",
+                pending.len()
+            ),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -825,6 +825,7 @@ pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
         &cas_root,
         collect_local_root_identities(),
     ));
+    checks.extend(canonical_alias_checks(&cas_root));
 
     // Check 15: residual cross-project contamination from the cas-ed15 pull
     // leak (cas-fc6fa / GH #133). Read-only comparison of this project's task
@@ -1196,7 +1197,8 @@ fn collect_local_root_identities() -> Result<Vec<crate::cloud::LocalRootIdentity
             let cas_root = project_root.join(".cas");
             let canonical_id = crate::cloud::resolve_canonical_id(&cas_root)?;
             Some(crate::cloud::LocalRootIdentity {
-                git_remote: crate::cloud::derive_canonical_id_from_git_remote(&cas_root),
+                git_remote: crate::cloud::derive_canonical_id_from_git_remote(&cas_root)
+                    .and_then(|remote| crate::cloud::canonical_project_id(&remote)),
                 project_root,
                 canonical_id,
             })
@@ -1228,7 +1230,7 @@ fn canonical_id_checks(
     // restores the old one, rather than letting sync quietly re-home.
     if source == crate::cloud::CanonicalIdSource::GitRemote
         && let Some(folder) = crate::cloud::canonical_id_from_cas_root(cas_root)
-        && folder != canonical_id
+        && crate::cloud::canonical_project_id(&folder).as_deref() != Some(canonical_id.as_str())
     {
         message.push_str(&format!(
             ". Earlier releases used the folder name `{folder}`; if that is where \
@@ -1278,6 +1280,94 @@ fn canonical_id_checks(
     }
 
     checks
+}
+
+/// Report persisted task origins that are equivalent to the current project
+/// but retain a legacy spelling. Doctor is intentionally report-only; users
+/// opt into the local rewrite with `cas cloud project --adopt-aliases`.
+fn canonical_alias_checks(cas_root: &Path) -> Vec<Check> {
+    let Some(current_project) = crate::cloud::resolve_canonical_id(cas_root) else {
+        return Vec::new();
+    };
+    let db_path = cas_root.join("cas.db");
+    if !db_path.is_file() {
+        return Vec::new();
+    }
+    let conn = match rusqlite::Connection::open_with_flags(
+        &db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    ) {
+        Ok(conn) => conn,
+        Err(error) => {
+            return vec![Check {
+                name: "project aliases".to_string(),
+                status: CheckStatus::Warning,
+                message: format!("Could not inspect task project aliases: {error}"),
+            }];
+        }
+    };
+    let has_origin_project = conn
+        .prepare("PRAGMA table_info(tasks)")
+        .and_then(|mut stmt| {
+            let names = stmt.query_map([], |row| row.get::<_, String>(1))?;
+            names.collect::<Result<Vec<_>, _>>()
+        })
+        .map(|columns| columns.iter().any(|column| column == "origin_project"))
+        .unwrap_or(false);
+    if !has_origin_project {
+        return Vec::new();
+    }
+
+    let mut stmt = match conn.prepare(
+        "SELECT origin_project FROM tasks
+         WHERE NULLIF(trim(origin_project), '') IS NOT NULL
+         ORDER BY origin_project",
+    ) {
+        Ok(stmt) => stmt,
+        Err(error) => {
+            return vec![Check {
+                name: "project aliases".to_string(),
+                status: CheckStatus::Warning,
+                message: format!("Could not inspect task project aliases: {error}"),
+            }];
+        }
+    };
+    let rows = match stmt.query_map([], |row| row.get::<_, String>(0)) {
+        Ok(rows) => rows,
+        Err(error) => {
+            return vec![Check {
+                name: "project aliases".to_string(),
+                status: CheckStatus::Warning,
+                message: format!("Could not inspect task project aliases: {error}"),
+            }];
+        }
+    };
+    let origins = rows.filter_map(Result::ok).collect::<Vec<_>>();
+    canonical_alias_counts(&origins, &current_project)
+        .into_iter()
+        .map(|(alias, count)| Check {
+            name: "project aliases".to_string(),
+            status: CheckStatus::Warning,
+            message: format!(
+                "{count} rows use alias `{alias}` of this project; run `cas cloud project \
+                 --adopt-aliases` to rewrite and enqueue them"
+            ),
+        })
+        .collect()
+}
+
+fn canonical_alias_counts(origins: &[String], current_project: &str) -> BTreeMap<String, usize> {
+    origins
+        .iter()
+        .filter(|origin| {
+            crate::cloud::canonical_project_id_with_pin(origin, Some(current_project))
+                .is_some_and(|canonical| canonical == current_project)
+                && origin.trim() != current_project
+        })
+        .fold(BTreeMap::new(), |mut counts, origin| {
+            *counts.entry(origin.clone()).or_default() += 1;
+            counts
+        })
 }
 
 /// Observed state of the tree-sitter symbol index for the current project (cas-499c).
@@ -2332,6 +2422,26 @@ mod tests {
         assert!(msg.contains("folder name"), "got: {msg}");
         // No collision row when only one root is known.
         assert!(messages(&checks, "canonical id collision").is_empty());
+    }
+
+    #[test]
+    fn alias_doctor_counts_case_and_remote_spellings_but_not_owned_rows() {
+        let origins = vec![
+            "gabber-studio".to_string(),
+            "GABBER-STUDIO".to_string(),
+            "git@GitHub.com:Richards-LLC/gabber-studio.git".to_string(),
+            "github.com/other/pixel-hive".to_string(),
+        ];
+
+        let counts = canonical_alias_counts(&origins, "gabber-studio");
+
+        assert_eq!(counts.get("GABBER-STUDIO"), Some(&1));
+        assert_eq!(
+            counts.get("git@GitHub.com:Richards-LLC/gabber-studio.git"),
+            Some(&1)
+        );
+        assert!(!counts.contains_key("gabber-studio"));
+        assert!(!counts.contains_key("github.com/other/pixel-hive"));
     }
 
     #[test]

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -2284,6 +2284,50 @@ mod tests {
     }
 
     #[test]
+    fn doctor_queue_check_names_retry_push_purge_and_exact_blocking_counts() {
+        use rusqlite::Connection;
+
+        let temp = TempDir::new().unwrap();
+        let cas_root = temp.path().join(".cas");
+        fs::create_dir_all(&cas_root).unwrap();
+        let conn = Connection::open(cas_root.join("cas.db")).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE sync_queue (
+                id INTEGER PRIMARY KEY,
+                entity_type TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                operation TEXT NOT NULL,
+                payload TEXT,
+                team_id TEXT,
+                project_id TEXT,
+                created_at TEXT NOT NULL,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT
+            );
+            INSERT INTO sync_queue
+                (id, entity_type, entity_id, operation, created_at, retry_count)
+            VALUES
+                (1, 'entry', 'entry-a', 'upsert', '2026-09-01T00:00:00Z', 0),
+                (2, 'entry', 'entry-b', 'upsert', '2026-09-01T00:00:01Z', 5),
+                (3, 'task', 'task-a', 'upsert', '2026-09-01T00:00:02Z', 0),
+                (4, 'knowledge_page', 'page-a', 'upsert', '2026-09-01T00:00:03Z', 0);
+            "#,
+        )
+        .unwrap();
+
+        let check = cloud_queue_check(&cas_root);
+        assert!(matches!(check.status, CheckStatus::Warning));
+        assert!(check.message.contains("3 queued content change(s)"));
+        assert!(check.message.contains("entry: 2"));
+        assert!(check.message.contains("task: 1"));
+        let retry = check.message.find("cas cloud queue --retry").unwrap();
+        let push = check.message.find("cas cloud push").unwrap();
+        let purge = check.message.find("cas cloud purge-foreign --dry-run").unwrap();
+        assert!(retry < push && push < purge, "{message}", message = check.message);
+    }
+
+    #[test]
     fn foreign_rows_check_warns_when_a_peer_db_could_not_be_read_cas_fc6fa() {
         use crate::cli::foreign_rows::{ForeignRowReport, UnreadablePeer};
 

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -2385,8 +2385,15 @@ mod tests {
         assert!(check.message.contains("task: 1"));
         let retry = check.message.find("cas cloud queue --retry").unwrap();
         let push = check.message.find("cas cloud push").unwrap();
-        let purge = check.message.find("cas cloud purge-foreign --dry-run").unwrap();
-        assert!(retry < push && push < purge, "{message}", message = check.message);
+        let purge = check
+            .message
+            .find("cas cloud purge-foreign --dry-run")
+            .unwrap();
+        assert!(
+            retry < push && push < purge,
+            "{message}",
+            message = check.message
+        );
     }
 
     #[test]

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -582,6 +582,9 @@ pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
         }
     }
 
+    #[cfg(feature = "mcp-proxy")]
+    checks.push(proxy_stdio_commands_check(&cas_root));
+
     // Check 6: Sync target
     let config = Config::load(&cas_root).unwrap_or_default();
     if config.sync.enabled {
@@ -2011,6 +2014,62 @@ fn cloud_queue_check(cas_root: &Path) -> Check {
     }
 }
 
+#[cfg(feature = "mcp-proxy")]
+fn proxy_stdio_commands_check(cas_root: &Path) -> Check {
+    let proxy_path = cas_root.join("proxy.toml");
+    let config = match cmcp_core::config::Config::load_merged(
+        proxy_path.exists().then_some(proxy_path.as_path()),
+    ) {
+        Ok(config) => config,
+        Err(error) => {
+            return Check {
+                name: "MCP stdio upstreams".to_string(),
+                status: CheckStatus::Warning,
+                message: format!("cannot validate registered stdio commands: {error}"),
+            };
+        }
+    };
+
+    let mut commands = config
+        .servers
+        .iter()
+        .filter_map(|(name, config)| match config {
+            cmcp_core::config::ServerConfig::Stdio { command, .. } => {
+                Some((name.as_str(), command.as_str()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    commands.sort_unstable_by_key(|(name, _)| *name);
+    let missing = commands
+        .iter()
+        .filter(|(_, command)| cmcp_core::resolve_stdio_executable(command).is_none())
+        .map(|(name, command)| format!("{name} = {command}"))
+        .collect::<Vec<_>>();
+
+    if missing.is_empty() {
+        Check {
+            name: "MCP stdio upstreams".to_string(),
+            status: CheckStatus::Ok,
+            message: format!(
+                "{} registered command(s) resolve to executable files",
+                commands.len()
+            ),
+        }
+    } else {
+        Check {
+            name: "MCP stdio upstreams".to_string(),
+            status: CheckStatus::Warning,
+            message: format!(
+                "{} of {} registered command(s) do not resolve: {}; repair proxy.toml before restarting cas serve",
+                missing.len(),
+                commands.len(),
+                missing.join(", ")
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2399,47 +2458,71 @@ mod tests {
     #[cfg(feature = "mcp-proxy")]
     #[test]
     fn doctor_proxy_stdio_check_names_missing_commands_and_passes_resolved_commands() {
-        let temp = TempDir::new().unwrap();
-        let cas_root = temp.path().join(".cas");
-        fs::create_dir_all(&cas_root).unwrap();
-        let executable = temp.path().join("stdio-server");
-        fs::write(&executable, "#!/bin/sh\nexit 0\n").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut permissions = fs::metadata(&executable).unwrap().permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&executable, permissions).unwrap();
-        }
+        crate::test_support::TestEnvGuard::run_with_temp_home(|_| {
+            let temp = TempDir::new().unwrap();
+            let cas_root = temp.path().join(".cas");
+            fs::create_dir_all(&cas_root).unwrap();
+            let executable = temp.path().join("stdio-server");
+            fs::write(&executable, "#!/bin/sh\nexit 0\n").unwrap();
+            let stale_interpreter = temp.path().join("stale-interpreter");
+            fs::write(&stale_interpreter, "#!/missing/interpreter\nexit 0\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut permissions = fs::metadata(&executable).unwrap().permissions();
+                permissions.set_mode(0o755);
+                fs::set_permissions(&executable, permissions).unwrap();
+                let mut permissions = fs::metadata(&stale_interpreter).unwrap().permissions();
+                permissions.set_mode(0o755);
+                fs::set_permissions(&stale_interpreter, permissions).unwrap();
+            }
 
-        let mut config = cmcp_core::config::Config::default();
-        config.add_server(
-            "working".to_string(),
-            cmcp_core::config::ServerConfig::Stdio {
-                command: executable.to_string_lossy().into_owned(),
-                args: Vec::new(),
-                env: BTreeMap::new().into_iter().collect(),
-            },
-        );
-        config.add_server(
-            "missing".to_string(),
-            cmcp_core::config::ServerConfig::Stdio {
-                command: temp
-                    .path()
-                    .join("removed-interpreter")
-                    .to_string_lossy()
-                    .into_owned(),
-                args: Vec::new(),
-                env: BTreeMap::new().into_iter().collect(),
-            },
-        );
-        config.save_to(&cas_root.join("proxy.toml")).unwrap();
+            let mut config = cmcp_core::config::Config::default();
+            config.add_server(
+                "working".to_string(),
+                cmcp_core::config::ServerConfig::Stdio {
+                    command: executable.to_string_lossy().into_owned(),
+                    args: Vec::new(),
+                    env: BTreeMap::new().into_iter().collect(),
+                },
+            );
+            config.add_server(
+                "missing".to_string(),
+                cmcp_core::config::ServerConfig::Stdio {
+                    command: temp
+                        .path()
+                        .join("removed-interpreter")
+                        .to_string_lossy()
+                        .into_owned(),
+                    args: Vec::new(),
+                    env: BTreeMap::new().into_iter().collect(),
+                },
+            );
+            config.add_server(
+                "stale-interpreter".to_string(),
+                cmcp_core::config::ServerConfig::Stdio {
+                    command: stale_interpreter.to_string_lossy().into_owned(),
+                    args: Vec::new(),
+                    env: BTreeMap::new().into_iter().collect(),
+                },
+            );
+            config.save_to(&cas_root.join("proxy.toml")).unwrap();
 
-        let check = proxy_stdio_commands_check(&cas_root);
-        assert!(matches!(check.status, CheckStatus::Warning));
-        assert!(check.message.contains("missing"), "{}", check.message);
-        assert!(check.message.contains("removed-interpreter"), "{}", check.message);
-        assert!(check.message.contains("working"), "{}", check.message);
+            let check = proxy_stdio_commands_check(&cas_root);
+            assert!(matches!(check.status, CheckStatus::Warning));
+            assert!(check.message.contains("missing"), "{}", check.message);
+            assert!(
+                check.message.contains("removed-interpreter"),
+                "{}",
+                check.message
+            );
+            assert!(
+                check.message.contains("stale-interpreter"),
+                "{}",
+                check.message
+            );
+            assert!(!check.message.contains("working ="), "{}", check.message);
+        });
     }
 
     #[test]

--- a/cas-cli/src/cli/mod.rs
+++ b/cas-cli/src/cli/mod.rs
@@ -418,6 +418,15 @@ fn auth_requirement(command: &Option<Commands>) -> AuthRequirement {
         Commands::Cloud(cloud::CloudCommands::Unlink(args)) if !args.purge_remote => {
             AuthRequirement::NotRequired
         }
+        Commands::Cloud(cloud::CloudCommands::Project(args))
+            if args.adopt_aliases
+                || matches!(
+                    args.command.as_ref(),
+                    Some(cloud::CloudProjectCommands::AdoptAliases)
+                ) =>
+        {
+            AuthRequirement::NotRequired
+        }
         Commands::Cloud(_) => AuthRequirement::Required,
 
         Commands::Device(_) => AuthRequirement::Required,

--- a/cas-cli/src/cli/update.rs
+++ b/cas-cli/src/cli/update.rs
@@ -1536,11 +1536,7 @@ fn check_for_updates(
 fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow::Result<String> {
     use self_update::Status;
     use self_update::backends::github::Update;
-
-    // Resolve this before the swap. Once `updater.update()` succeeds, this
-    // path points at the newly installed executable even though this process
-    // is still running the old code.
-    let installed_binary = std::env::current_exe().context("resolve the running cas binary")?;
+    use self_update::update::ReleaseUpdate;
 
     let mut updater = Update::configure();
     updater
@@ -1560,6 +1556,10 @@ fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow
     }
 
     let updater = updater.build()?;
+    // self_update resolves its install destination before the replacement.
+    // Keep that stable path: after a Linux rename swap, current_exe() can
+    // report the old process image as `/path/cas (deleted)`.
+    let installed_binary = strip_deleted_suffix(updater.bin_install_path());
 
     // Check what we're updating to
     let latest = updater.get_latest_release()?;
@@ -1598,7 +1598,11 @@ fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow
     let status = updater.update()?;
 
     if matches!(&status, Status::Updated(_)) {
-        run_post_swap_hook(&installed_binary, current_version, cli.json)?;
+        if let Err(error) = run_post_swap_hook(&installed_binary, current_version, cli.json) {
+            eprintln!(
+                "Post-update hook unavailable ({error}); using in-process hub restart fallback"
+            );
+        }
     }
 
     if cli.json {
@@ -1670,6 +1674,16 @@ fn build_post_swap_command(
         command.arg("--json");
     }
     command
+}
+
+fn strip_deleted_suffix(path: std::path::PathBuf) -> std::path::PathBuf {
+    let Some(path_str) = path.to_str() else {
+        return path;
+    };
+    path_str
+        .strip_suffix(" (deleted)")
+        .map(std::path::PathBuf::from)
+        .unwrap_or(path)
 }
 
 fn run_post_swap_hook(

--- a/cas-cli/src/cli/update.rs
+++ b/cas-cli/src/cli/update.rs
@@ -8,6 +8,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use clap::Args;
 
 use crate::builtins::{
@@ -184,12 +185,27 @@ pub struct UpdateArgs {
     /// every cloud-linked project.
     #[arg(long)]
     pub all_projects: bool,
+
+    /// Run the post-swap hook from a freshly installed binary.
+    #[arg(long = "post-swap", hide = true)]
+    pub post_swap: bool,
+
+    /// Version replaced by the post-swap invocation.
+    #[arg(long = "from", hide = true, requires = "post_swap")]
+    pub from: Option<String>,
 }
 
 pub fn execute(args: &UpdateArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow::Result<()> {
     // Note: update command accepts Option<&Path> because it can run without an initialized Cassy
     // (e.g., binary update only, or checking for updates before init)
     let current_version = env!("CARGO_PKG_VERSION");
+
+    // A post-swap invocation is dispatched by the newly installed binary. It
+    // must terminate before any path that can download or install another
+    // binary, otherwise every update would recursively launch updates.
+    if args.post_swap {
+        return execute_post_swap(args, cli, current_version);
+    }
 
     // This is also the no-download entry point for a host which already has
     // the desired binary. It deliberately does the same complete sweep that a
@@ -1521,6 +1537,11 @@ fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow
     use self_update::Status;
     use self_update::backends::github::Update;
 
+    // Resolve this before the swap. Once `updater.update()` succeeds, this
+    // path points at the newly installed executable even though this process
+    // is still running the old code.
+    let installed_binary = std::env::current_exe().context("resolve the running cas binary")?;
+
     let mut updater = Update::configure();
     updater
         .repo_owner(REPO_OWNER)
@@ -1576,6 +1597,10 @@ fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow
     // Perform the update
     let status = updater.update()?;
 
+    if matches!(&status, Status::Updated(_)) {
+        run_post_swap_hook(&installed_binary, current_version, cli.json)?;
+    }
+
     if cli.json {
         let (updated, version) = match &status {
             Status::UpToDate(v) => (false, v.as_str()),
@@ -1620,6 +1645,53 @@ fn perform_update(args: &UpdateArgs, current_version: &str, cli: &Cli) -> anyhow
     };
 
     Ok(installed_version)
+}
+
+fn execute_post_swap(args: &UpdateArgs, cli: &Cli, current_version: &str) -> anyhow::Result<()> {
+    // Keep the old version available to the internal protocol and future
+    // diagnostics without rendering it into the normal update receipt.
+    let _previous_version = args
+        .from
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("post-swap mode requires --from"))?;
+    super::hub::restart_stale_hub(current_version, cli)?;
+    Ok(())
+}
+
+fn build_post_swap_command(
+    installed_binary: &Path,
+    previous_version: &str,
+    json: bool,
+) -> std::process::Command {
+    let mut command = std::process::Command::new(installed_binary);
+    command.args(["update", "--post-swap", "--from"]);
+    command.arg(previous_version);
+    if json {
+        command.arg("--json");
+    }
+    command
+}
+
+fn run_post_swap_hook(
+    installed_binary: &Path,
+    previous_version: &str,
+    json: bool,
+) -> anyhow::Result<()> {
+    let status = build_post_swap_command(installed_binary, previous_version, json)
+        .status()
+        .with_context(|| {
+            format!(
+                "run post-update hook from installed binary {}",
+                installed_binary.display()
+            )
+        })?;
+    if !status.success() {
+        anyhow::bail!(
+            "post-update hook from {} exited with {status}",
+            installed_binary.display()
+        );
+    }
+    Ok(())
 }
 
 /// Try to get a GitHub auth token from `gh auth token` or GITHUB_TOKEN env var.

--- a/cas-cli/src/cli/update_tests/tests.rs
+++ b/cas-cli/src/cli/update_tests/tests.rs
@@ -1,6 +1,6 @@
 use crate::cli::update::*;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::cli::Cli;
 
@@ -16,12 +16,25 @@ fn test_is_newer() {
 }
 
 #[test]
-fn post_swap_command_targets_installed_binary_and_passes_previous_version() {
-    let command = build_post_swap_command(Path::new("/tmp/cas-new"), "3.7.7", true);
+fn post_swap_command_targets_install_destination_path() {
+    let install_destination = Path::new("/usr/local/bin/cas");
+    let command = build_post_swap_command(install_destination, "3.7.7", true);
 
-    assert_eq!(command.get_program(), "/tmp/cas-new");
+    assert_eq!(command.get_program(), "/usr/local/bin/cas");
     let args: Vec<_> = command.get_args().collect();
     assert_eq!(args, ["update", "--post-swap", "--from", "3.7.7", "--json"]);
+}
+
+#[test]
+fn strip_deleted_suffix_from_linux_process_path() {
+    assert_eq!(
+        strip_deleted_suffix(PathBuf::from("/usr/local/bin/cas (deleted)")),
+        PathBuf::from("/usr/local/bin/cas")
+    );
+    assert_eq!(
+        strip_deleted_suffix(PathBuf::from("/usr/local/bin/cas")),
+        PathBuf::from("/usr/local/bin/cas")
+    );
 }
 
 #[test]

--- a/cas-cli/src/cli/update_tests/tests.rs
+++ b/cas-cli/src/cli/update_tests/tests.rs
@@ -1,5 +1,9 @@
 use crate::cli::update::*;
 
+use std::path::Path;
+
+use crate::cli::Cli;
+
 #[test]
 fn test_is_newer() {
     assert!(is_newer("0.3.0", "0.2.0"));
@@ -9,4 +13,84 @@ fn test_is_newer() {
     assert!(!is_newer("0.1.0", "0.2.0"));
     assert!(is_newer("v0.3.0", "0.2.0"));
     assert!(is_newer("0.3.0", "v0.2.0"));
+}
+
+#[test]
+fn post_swap_command_targets_installed_binary_and_passes_previous_version() {
+    let command = build_post_swap_command(Path::new("/tmp/cas-new"), "3.7.7", true);
+
+    assert_eq!(command.get_program(), "/tmp/cas-new");
+    let args: Vec<_> = command.get_args().collect();
+    assert_eq!(args, ["update", "--post-swap", "--from", "3.7.7", "--json"]);
+}
+
+#[test]
+#[cfg(unix)]
+fn post_swap_hook_invokes_the_installed_binary() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().expect("create post-swap test directory");
+    let installed_binary = temp_dir.path().join("cas-new");
+    fs::write(
+        &installed_binary,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$0.args\"\n",
+    )
+    .expect("write fake installed binary");
+    let mut permissions = fs::metadata(&installed_binary)
+        .expect("stat fake installed binary")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&installed_binary, permissions).expect("make fake binary executable");
+
+    run_post_swap_hook(&installed_binary, "3.7.7", true)
+        .expect("post-swap hook should run successfully");
+
+    let args = fs::read_to_string(installed_binary.with_extension("args"))
+        .expect("fake binary should receive the post-swap arguments");
+    assert_eq!(args, "update\n--post-swap\n--from\n3.7.7\n--json\n");
+}
+
+#[test]
+fn post_swap_flags_parse_as_a_hidden_terminal_mode() {
+    let parsed = crate::cli::try_parse_from_with_wordmark([
+        "cas",
+        "update",
+        "--post-swap",
+        "--from",
+        "3.7.7",
+    ])
+    .expect("post-swap flags must parse");
+
+    let Some(crate::cli::Commands::Update(args)) = parsed.command else {
+        panic!("expected update command");
+    };
+    assert!(args.post_swap);
+    assert_eq!(args.from.as_deref(), Some("3.7.7"));
+}
+
+#[test]
+fn post_swap_mode_is_a_terminal_update_path() {
+    let _guard = crate::test_support::TestEnvGuard::temp_home();
+    let args = UpdateArgs {
+        check: false,
+        version: None,
+        yes: false,
+        schema_only: false,
+        sync: false,
+        user: false,
+        dry_run: false,
+        keep_backup: false,
+        all_projects: false,
+        post_swap: true,
+        from: Some("3.7.7".to_owned()),
+    };
+    let cli = Cli {
+        json: true,
+        full: false,
+        verbose: false,
+        command: None,
+    };
+
+    execute(&args, &cli, None).expect("post-swap mode must not re-enter binary update");
 }

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -193,6 +193,24 @@ pub fn canonical_project_id_with_pin(value: &str, pinned_id: Option<&str>) -> Op
     }
 }
 
+/// Compare two project identities after normalization, accepting the legacy
+/// bare-repository-name alias in either direction. This is intentionally
+/// separate from [`canonical_project_id_with_pin`]: a pin determines which
+/// spelling to emit, while ownership checks must recognize both spellings
+/// without changing the current project's selected identity.
+pub fn project_ids_match(candidate: &str, current: &str) -> bool {
+    let Some(candidate) = canonical_project_id(candidate) else {
+        return false;
+    };
+    let Some(current) = canonical_project_id(current) else {
+        return false;
+    };
+
+    candidate == current
+        || project_id_aliases(&candidate, &current)
+        || project_id_aliases(&current, &candidate)
+}
+
 /// Backwards-compatible name retained for cloud callers outside this module.
 /// New identity code should call [`canonical_project_id`] directly.
 pub fn normalize_project_canonical_id(value: &str) -> Option<String> {
@@ -381,7 +399,7 @@ pub fn should_adopt_canonical_id(
     if local.is_empty() || resp_remote.is_empty() || canonical.is_empty() {
         return None;
     }
-    if !local.eq_ignore_ascii_case(resp_remote) {
+    if canonical_project_id(local) != canonical_project_id(resp_remote) {
         return None;
     }
     if current_pin.is_some() {
@@ -3029,6 +3047,20 @@ mod tests {
             .as_deref(),
             Some("github.com/someone-else/other-repo"),
         );
+    }
+
+    #[test]
+    fn canonical_identity_matches_bare_alias_to_explicit_remote_pin() {
+        for alias in ["gabber-studio", "GABBER-STUDIO"] {
+            assert_eq!(
+                project_ids_match(
+                    alias,
+                    "https://GitHub.com/Richards-LLC/gabber-studio.git",
+                ),
+                true,
+                "alias {alias} must match the explicit remote pin",
+            );
+        }
     }
 
     #[test]

--- a/cas-cli/src/cloud/config.rs
+++ b/cas-cli/src/cloud/config.rs
@@ -128,13 +128,12 @@ pub fn resolve_canonical_id_with_source(cas_root: &Path) -> Option<(String, Cano
         // from legacy bare-slug buckets because team pull matches verbatim.
         return Some((id, CanonicalIdSource::ConfigToml));
     }
-    if let Some(id) = derive_canonical_id_from_git_remote(cas_root)
-        .and_then(|id| normalize_project_canonical_id(&id))
+    if let Some(id) =
+        derive_canonical_id_from_git_remote(cas_root).and_then(|id| canonical_project_id(&id))
     {
         return Some((id, CanonicalIdSource::GitRemote));
     }
-    if let Some(id) =
-        canonical_id_from_cas_root(cas_root).and_then(|id| normalize_project_canonical_id(&id))
+    if let Some(id) = canonical_id_from_cas_root(cas_root).and_then(|id| canonical_project_id(&id))
     {
         return Some((id, CanonicalIdSource::FolderName));
     }
@@ -153,17 +152,19 @@ pub fn canonical_id_from_config_toml(cas_root: &Path) -> Option<String> {
         .get("project")?
         .get("canonical_id")?
         .as_str()
-        .and_then(normalize_project_canonical_id)
+        .and_then(canonical_project_id)
 }
 
-/// Normalize a project identity to the single wire form used by push and
-/// pull. Older releases preserved remote URL case in one path, lowercased it
-/// in another, and sometimes retained whitespace in a config pin. That made
-/// the same repository appear to be several cloud projects.
+/// Resolve one project identity to the single wire form used by registration,
+/// push, pull, and local ownership checks. Remote-shaped values are reduced to
+/// `host/owner/repository`; host, owner, and legacy bare slugs are folded to
+/// lowercase so URL, SSH, and server-slug spellings cannot fork a project.
 ///
-/// Bare server-assigned slugs remain valid pins; only their spelling is
-/// normalized. Remote-shaped values are first reduced to host/owner/repo.
-pub fn normalize_project_canonical_id(value: &str) -> Option<String> {
+/// This is deliberately the one-argument normalizer used at every cloud
+/// boundary. [`canonical_project_id_with_pin`] adds the explicit-pin alias
+/// rule for callers that are comparing a stored identity to the current
+/// project.
+pub fn canonical_project_id(value: &str) -> Option<String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         return None;
@@ -172,6 +173,40 @@ pub fn normalize_project_canonical_id(value: &str) -> Option<String> {
         .or_else(|| normalize_git_remote_url(&trimmed.to_ascii_lowercase()))
         .unwrap_or_else(|| trimmed.to_string());
     Some(normalized.trim_matches('/').to_ascii_lowercase())
+}
+
+/// Normalize an identity while treating an explicit project pin as the
+/// authoritative alias target. A remote form whose repository name is the
+/// pinned bare slug is therefore represented by the pin,
+/// preserving the legacy server bucket instead of creating a remote-shaped
+/// sibling bucket.
+pub fn canonical_project_id_with_pin(value: &str, pinned_id: Option<&str>) -> Option<String> {
+    let normalized = canonical_project_id(value)?;
+    let Some(pin) = pinned_id.and_then(canonical_project_id) else {
+        return Some(normalized);
+    };
+
+    if normalized == pin || project_id_aliases(&normalized, &pin) {
+        Some(pin)
+    } else {
+        Some(normalized)
+    }
+}
+
+/// Backwards-compatible name retained for cloud callers outside this module.
+/// New identity code should call [`canonical_project_id`] directly.
+pub fn normalize_project_canonical_id(value: &str) -> Option<String> {
+    canonical_project_id(value)
+}
+
+fn project_id_aliases(candidate: &str, pinned: &str) -> bool {
+    fn final_segment(value: &str) -> &str {
+        value.rsplit('/').next().unwrap_or(value)
+    }
+    let candidate_is_remote = candidate.matches('/').count() >= 2;
+    let pinned_is_remote = pinned.matches('/').count() >= 2;
+
+    candidate_is_remote && !pinned_is_remote && final_segment(candidate) == pinned
 }
 
 /// Write `[project] canonical_id = "<value>"` to `<cas_root>/config.toml`,
@@ -184,7 +219,7 @@ pub fn set_canonical_id_in_config_toml(
     cas_root: &Path,
     canonical_id: &str,
 ) -> Result<(), CasError> {
-    let canonical_id = normalize_project_canonical_id(canonical_id)
+    let canonical_id = canonical_project_id(canonical_id)
         .ok_or_else(|| CasError::Other("canonical project id must not be empty".to_string()))?;
     let toml_path = cas_root.join("config.toml");
 
@@ -264,8 +299,7 @@ pub fn derive_canonical_id_from_git_remote(cas_root: &Path) -> Option<String> {
 /// case for response comparison, while the cloud resolver treats remotes
 /// case-insensitively on the wire.
 pub fn normalized_git_remote_for_push(cas_root: &Path) -> Option<String> {
-    derive_canonical_id_from_git_remote(cas_root)
-        .and_then(|remote| normalize_project_canonical_id(&remote))
+    derive_canonical_id_from_git_remote(cas_root).and_then(|remote| canonical_project_id(&remote))
 }
 
 /// Normalize a git remote URL to `<host>/<owner>/<repo>` form.
@@ -303,11 +337,13 @@ pub fn normalize_git_remote_url(url: &str) -> Option<String> {
         return None;
     };
 
-    // Strip optional `.git` suffix.
-    let without_dot_git = without_ssh_user
+    // Strip optional trailing slash before `.git` so both `repo.git/` and
+    // `repo/` converge on the same identity. A second trim handles a slash
+    // after the suffix without making the accepted URL shapes order-sensitive.
+    let without_trailing_slash = without_ssh_user.trim_end_matches('/');
+    let without_dot_git = without_trailing_slash
         .strip_suffix(".git")
-        .unwrap_or(&without_ssh_user);
-    // Strip optional trailing slash for paranoia.
+        .unwrap_or(without_trailing_slash);
     let clean = without_dot_git.trim_end_matches('/');
 
     if clean.is_empty() {
@@ -351,7 +387,7 @@ pub fn should_adopt_canonical_id(
     if current_pin.is_some() {
         return None;
     }
-    normalize_project_canonical_id(canonical)
+    canonical_project_id(canonical)
 }
 
 /// Derive the canonical project ID from a `.cas` directory path.
@@ -2955,6 +2991,43 @@ mod tests {
         assert_eq!(
             normalize_project_canonical_id("github.com/Richards-LLC/gabber-studio").as_deref(),
             Some("github.com/richards-llc/gabber-studio"),
+        );
+    }
+
+    #[test]
+    fn canonical_identity_maps_remote_alias_to_explicit_slug_pin() {
+        for alias in [
+            "gabber-studio",
+            "git@GitHub.com:Richards-LLC/gabber-studio.git",
+            "https://github.com/richards-llc/gabber-studio/",
+        ] {
+            assert_eq!(
+                canonical_project_id_with_pin(alias, Some("gabber-studio")).as_deref(),
+                Some("gabber-studio"),
+                "alias {alias} must resolve to the explicit slug pin",
+            );
+        }
+        for alias in [
+            "pixel-hive",
+            "ssh://git@GitHub.com/Pixel-Hive/pixel-hive.git",
+        ] {
+            assert_eq!(
+                canonical_project_id_with_pin(alias, Some("pixel-hive")).as_deref(),
+                Some("pixel-hive"),
+                "alias {alias} must resolve to the explicit slug pin",
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_identity_keeps_different_repository_foreign_to_slug_pin() {
+        assert_eq!(
+            canonical_project_id_with_pin(
+                "git@github.com:someone-else/other-repo.git",
+                Some("gabber-studio"),
+            )
+            .as_deref(),
+            Some("github.com/someone-else/other-repo"),
         );
     }
 

--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -41,9 +41,10 @@ pub use config::{
     TeamInfo, TeamScopeAdoption, adopt_team_scope_for_configs, canonical_id_from_cas_root,
     canonical_id_from_config_toml, clear_login_credentials, derive_canonical_id_from_git_remote,
     detect_canonical_id_collisions, get_project_canonical_id, invalidate_cached_project_id,
-    maybe_adopt_team_scope, maybe_mark_personal_scope_notice, normalize_project_canonical_id,
-    normalized_git_remote_for_push, personal_scope_notice_for_configs, resolve_canonical_id,
-    resolve_canonical_id_with_source, set_canonical_id_in_config_toml, should_adopt_canonical_id,
+    maybe_adopt_team_scope, maybe_mark_personal_scope_notice, canonical_project_id,
+    canonical_project_id_with_pin, normalize_project_canonical_id, normalized_git_remote_for_push,
+    personal_scope_notice_for_configs, resolve_canonical_id, resolve_canonical_id_with_source,
+    set_canonical_id_in_config_toml, should_adopt_canonical_id,
     store_login_credentials,
 };
 pub(crate) use config::{

--- a/cas-cli/src/cloud/mod.rs
+++ b/cas-cli/src/cloud/mod.rs
@@ -43,6 +43,7 @@ pub use config::{
     detect_canonical_id_collisions, get_project_canonical_id, invalidate_cached_project_id,
     maybe_adopt_team_scope, maybe_mark_personal_scope_notice, canonical_project_id,
     canonical_project_id_with_pin, normalize_project_canonical_id, normalized_git_remote_for_push,
+    project_ids_match,
     personal_scope_notice_for_configs, resolve_canonical_id, resolve_canonical_id_with_source,
     set_canonical_id_in_config_toml, should_adopt_canonical_id,
     store_login_credentials,

--- a/cas-cli/src/cloud/sync_queue/maintenance.rs
+++ b/cas-cli/src/cloud/sync_queue/maintenance.rs
@@ -199,6 +199,31 @@ impl SyncQueue {
         Ok(reset)
     }
 
+    /// Requeue terminal rows whose last diagnostic contains a repaired reason.
+    /// Matching is case-insensitive and substring-based because push errors
+    /// retain structured reason text inside a user-readable diagnostic.
+    pub fn retry_failed_for_reason(
+        &self,
+        reason: &str,
+        max_retries: i32,
+    ) -> Result<usize, CasError> {
+        let reason = reason.trim();
+        if reason.is_empty() {
+            return Ok(0);
+        }
+
+        let conn = self.conn.lock().unwrap();
+        let reset = conn.execute(
+            "UPDATE sync_queue
+             SET retry_count = 0
+             WHERE retry_count >= ?1
+               AND last_error IS NOT NULL
+               AND instr(lower(last_error), lower(?2)) > 0",
+            params![max_retries, reason],
+        )?;
+        Ok(reset)
+    }
+
     /// Requeue terminal failures caused by an older client once this build
     /// meets the server's recorded minimum version. The diagnostic is cleared
     /// with the retry counter so the operation is idempotent: a second push

--- a/cas-cli/src/cloud/sync_queue/maintenance.rs
+++ b/cas-cli/src/cloud/sync_queue/maintenance.rs
@@ -4,6 +4,31 @@ use rusqlite::params;
 use crate::cloud::sync_queue::SyncQueue;
 use crate::error::CasError;
 
+fn parse_numeric_version(value: &str) -> Option<(u64, u64, u64)> {
+    let core = value.trim().strip_prefix('v').unwrap_or(value.trim());
+    let core = core.split(['-', '+']).next()?;
+    let mut components = core.split('.');
+    let major = components.next()?.parse().ok()?;
+    let minor = components.next()?.parse().ok()?;
+    let patch = components.next()?.parse().ok()?;
+    if components.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+fn minimum_version_from_gate_error(error: &str) -> Option<(u64, u64, u64)> {
+    let after_client = error.strip_prefix("Client version ").or_else(|| {
+        error
+            .find("Client version ")
+            .map(|index| &error[index..])
+            .and_then(|value| value.strip_prefix("Client version "))
+    })?;
+    let (client, minimum) = after_client.split_once(" is below minimum ")?;
+    parse_numeric_version(client)?;
+    parse_numeric_version(minimum.split_whitespace().next()?)
+}
+
 impl SyncQueue {
     /// Mark an item as successfully synced (removes from queue).
     pub fn mark_synced(&self, id: i64) -> Result<(), CasError> {
@@ -172,6 +197,53 @@ impl SyncQueue {
             params![max_retries],
         )?;
         Ok(reset)
+    }
+
+    /// Requeue terminal failures caused by an older client once this build
+    /// meets the server's recorded minimum version. The diagnostic is cleared
+    /// with the retry counter so the operation is idempotent: a second push
+    /// sees no matching gate error after the first reset.
+    pub fn requeue_version_gated_failures(
+        &self,
+        current_version: &str,
+        max_retries: i32,
+    ) -> Result<usize, CasError> {
+        let Some(current) = parse_numeric_version(current_version) else {
+            return Ok(0);
+        };
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let candidates = {
+            let mut stmt = tx.prepare(
+                r#"
+                SELECT id, last_error
+                FROM sync_queue
+                WHERE retry_count >= ?1
+                  AND last_error LIKE '%Client version % is below minimum %'
+                "#,
+            )?;
+            stmt.query_map(params![max_retries], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+        };
+
+        let mut requeued = 0;
+        for (id, error) in candidates {
+            let Some(minimum) = minimum_version_from_gate_error(&error) else {
+                continue;
+            };
+            if current < minimum {
+                continue;
+            }
+            requeued += tx.execute(
+                "UPDATE sync_queue SET retry_count = 0, last_error = NULL WHERE id = ?1 AND last_error = ?2",
+                params![id, error],
+            )?;
+        }
+        tx.commit()?;
+        Ok(requeued)
     }
 
     /// Clear all items from the queue.

--- a/cas-cli/src/cloud/sync_queue/queue_ops.rs
+++ b/cas-cli/src/cloud/sync_queue/queue_ops.rs
@@ -63,7 +63,32 @@ impl SyncQueue {
         payload: Option<&str>,
         team_id: &str,
     ) -> Result<(), CasError> {
-        self.enqueue_with_team_project(entity_type, entity_id, operation, payload, team_id, None)
+        self.enqueue_for_team_project(entity_type, entity_id, operation, payload, team_id, None)
+    }
+
+    /// Enqueue a team operation targeted at a specific project identity.
+    ///
+    /// Ordinary writes leave `project_id` unset so the pusher's project is
+    /// used. Foreign-owned task replicas and project-move replacements set it
+    /// to the destination owner so their envelopes cannot recreate the row
+    /// under the pusher's project key.
+    pub fn enqueue_for_team_project(
+        &self,
+        entity_type: EntityType,
+        entity_id: &str,
+        operation: SyncOperation,
+        payload: Option<&str>,
+        team_id: &str,
+        project_id: Option<&str>,
+    ) -> Result<(), CasError> {
+        self.enqueue_with_team_project(
+            entity_type,
+            entity_id,
+            operation,
+            payload,
+            team_id,
+            project_id,
+        )
     }
 
     fn enqueue_with_team(
@@ -123,6 +148,7 @@ impl SyncQueue {
         entity_type: EntityType,
         entity_id: &str,
         old_project_id: &str,
+        new_project_id: &str,
         payload: &str,
         team_id: &str,
     ) -> Result<(), CasError> {
@@ -155,16 +181,23 @@ impl SyncQueue {
         tx.execute(
             r#"
             INSERT INTO sync_queue (entity_type, entity_id, operation, payload, team_id, project_id, created_at, retry_count)
-            VALUES (?1, ?2, 'upsert', ?3, ?4, NULL, ?5, 0)
+            VALUES (?1, ?2, 'upsert', ?3, ?4, ?5, ?6, 0)
             ON CONFLICT DO UPDATE SET
                 operation = excluded.operation,
                 payload = excluded.payload,
-                project_id = NULL,
+                project_id = excluded.project_id,
                 created_at = excluded.created_at,
                 retry_count = 0,
                 last_error = NULL
             "#,
-            params![entity_type.as_str(), entity_id, payload, team_id, upsert_time],
+            params![
+                entity_type.as_str(),
+                entity_id,
+                payload,
+                team_id,
+                new_project_id,
+                upsert_time,
+            ],
         )?;
 
         tx.commit()?;

--- a/cas-cli/src/cloud/sync_queue/schema.rs
+++ b/cas-cli/src/cloud/sync_queue/schema.rs
@@ -68,7 +68,9 @@ impl SyncQueue {
         // team_id). SQLite cannot replace that constraint with an expression
         // index in place, so rebuild once when either identity column was
         // added. Existing rows retain NULL project_id and therefore continue
-        // to coalesce under COALESCE(project_id, '').
+        // to coalesce under COALESCE(project_id, ''). Do not create the new
+        // unique index inside this rebuild: old databases may already contain
+        // duplicate rows, and cleanup below must run before index creation.
         if !has_team_id || !has_project_id {
             conn.execute_batch(
                 r#"
@@ -91,19 +93,32 @@ impl SyncQueue {
                 CREATE INDEX IF NOT EXISTS idx_sync_queue_created ON sync_queue(created_at);
                 CREATE INDEX IF NOT EXISTS idx_sync_queue_retry ON sync_queue(retry_count);
                 CREATE INDEX IF NOT EXISTS idx_sync_queue_team ON sync_queue(team_id);
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_queue_entity_team_project
-                    ON sync_queue(entity_type, entity_id, team_id, COALESCE(project_id, ''));
                 "#,
             )?;
         }
 
-        // Normalize any pre-migration NULL team_ids to '' so the UNIQUE
-        // identity index properly deduplicates
-        // personal-queue items. In SQLite, NULL != NULL and NULL != '' under
-        // UNIQUE, so a row with team_id=NULL and a subsequent enqueue with
-        // team_id='' would create duplicates (defect C / cas-8dd8).
-        // This UPDATE is idempotent — a no-op when no NULLs remain.
+        // Normalize any pre-migration NULL team_ids to '' before creating the
+        // unique index. In SQLite, NULL != '' under UNIQUE, so a row with
+        // team_id=NULL and a subsequent enqueue with team_id='' would create
+        // duplicates (defect C / cas-8dd8).
         conn.execute_batch("UPDATE sync_queue SET team_id = '' WHERE team_id IS NULL;")?;
+
+        // Databases created before the identity index could contain several
+        // copies of one queue key. Retain the newest row (highest AUTOINCREMENT
+        // id, which is the latest enqueue) so its operation and payload are the
+        // values that the next push observes. This also makes index creation
+        // safe for a partially migrated database.
+        conn.execute_batch(
+            r#"
+            DELETE FROM sync_queue
+            WHERE id NOT IN (
+                SELECT MAX(id)
+                FROM sync_queue
+                GROUP BY entity_type, entity_id, team_id, COALESCE(project_id, '')
+            );
+            "#,
+        )?;
+
         conn.execute_batch(
             r#"
             CREATE INDEX IF NOT EXISTS idx_sync_queue_team ON sync_queue(team_id);

--- a/cas-cli/src/cloud/sync_queue/stats.rs
+++ b/cas-cli/src/cloud/sync_queue/stats.rs
@@ -225,6 +225,7 @@ impl SyncQueue {
                 EntityType::CommitLink => grouped.commit_links.push(item),
                 EntityType::Agent => grouped.agents.push(item),
                 EntityType::Worktree => grouped.worktrees.push(item),
+                EntityType::TaskDependency => grouped.task_dependencies.push(item),
                 EntityType::KnowledgePage => grouped.knowledge_pages.push(item),
             }
         }

--- a/cas-cli/src/cloud/sync_queue/tests.rs
+++ b/cas-cli/src/cloud/sync_queue/tests.rs
@@ -549,6 +549,85 @@ fn test_retry_failed_requeues_without_erasing_diagnostic() {
     );
 }
 
+/// GH #652: migration must repair duplicate rows created before the unique
+/// identity index existed, retaining the newest payload for the next push.
+#[test]
+fn queue_migration_collapses_legacy_duplicate_personal_rows() {
+    use rusqlite::Connection;
+
+    let temp = TempDir::new().unwrap();
+    let db_path = temp.path().join("cas.db");
+    {
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE sync_queue (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                operation TEXT NOT NULL,
+                payload TEXT,
+                team_id TEXT,
+                created_at TEXT NOT NULL,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT
+            );
+            INSERT INTO sync_queue
+                (entity_type, entity_id, operation, payload, team_id, created_at)
+            VALUES
+                ('entry', 'entry-duplicate', 'upsert', '{"v":1}', NULL, '2026-08-20T00:00:00Z'),
+                ('entry', 'entry-duplicate', 'upsert', '{"v":2}', '', '2026-08-21T00:00:00Z');
+            "#,
+        )
+        .unwrap();
+    }
+
+    let queue = SyncQueue::open(temp.path()).unwrap();
+    queue.init().unwrap();
+
+    let rows = queue.pending(10, 5).unwrap();
+    assert_eq!(rows.len(), 1, "legacy duplicate identities must collapse");
+    assert_eq!(rows[0].payload.as_deref(), Some(r#"{"v":2}"#));
+}
+
+/// GH #652: an operator can retry only the parked rows whose diagnostic names
+/// the repaired server reason, leaving unrelated terminal rows untouched.
+#[test]
+fn retry_failed_by_reason_requeues_only_matching_terminal_rows() {
+    let (_temp, queue) = create_test_queue();
+    const MAX_RETRIES: i32 = 5;
+
+    for (id, reason) in [
+        ("project-mismatch", "project_mismatch"),
+        ("scope-mismatch", "scope_mismatch"),
+    ] {
+        queue
+            .enqueue(EntityType::Task, id, SyncOperation::Upsert, Some("{}"))
+            .unwrap();
+        let row_id = queue.pending(10, MAX_RETRIES).unwrap()
+            .iter()
+            .find(|row| row.entity_id == id)
+            .unwrap()
+            .id;
+        for _ in 0..MAX_RETRIES {
+            queue
+                .mark_failed(row_id, &format!("server reason={reason}"))
+                .unwrap();
+        }
+    }
+
+    assert_eq!(
+        queue
+            .retry_failed_for_reason("project_mismatch", MAX_RETRIES)
+            .unwrap(),
+        1
+    );
+    let pending = queue.pending(10, MAX_RETRIES).unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].entity_id, "project-mismatch");
+    assert_eq!(queue.failed_for_entity_type(None, MAX_RETRIES, 10).unwrap().len(), 1);
+}
+
 /// AC4: A row with team_id=NULL (inserted by an older code path that did not
 /// normalise the personal-queue sentinel) must coalesce with a new personal-
 /// queue enqueue (team_id='') instead of creating a duplicate.

--- a/cas-cli/src/cloud/sync_queue/tests.rs
+++ b/cas-cli/src/cloud/sync_queue/tests.rs
@@ -613,7 +613,9 @@ fn retry_failed_by_reason_requeues_only_matching_terminal_rows() {
         queue
             .enqueue(EntityType::Task, id, SyncOperation::Upsert, Some("{}"))
             .unwrap();
-        let row_id = queue.pending(10, MAX_RETRIES).unwrap()
+        let row_id = queue
+            .pending(10, MAX_RETRIES)
+            .unwrap()
             .iter()
             .find(|row| row.entity_id == id)
             .unwrap()
@@ -634,7 +636,13 @@ fn retry_failed_by_reason_requeues_only_matching_terminal_rows() {
     let pending = queue.pending(10, MAX_RETRIES).unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].entity_id, "project-mismatch");
-    assert_eq!(queue.failed_for_entity_type(None, MAX_RETRIES, 10).unwrap().len(), 1);
+    assert_eq!(
+        queue
+            .failed_for_entity_type(None, MAX_RETRIES, 10)
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 /// AC4: A row with team_id=NULL (inserted by an older code path that did not

--- a/cas-cli/src/cloud/sync_queue/tests.rs
+++ b/cas-cli/src/cloud/sync_queue/tests.rs
@@ -670,6 +670,7 @@ fn project_id_migration_preserves_legacy_rows_and_allows_move_pair() {
             EntityType::Task,
             "move-after-migration",
             "project-a",
+            "project-b",
             r#"{"id":"move-after-migration","origin_project":"project-b"}"#,
             "team-123",
         )
@@ -679,6 +680,27 @@ fn project_id_migration_preserves_legacy_rows_and_allows_move_pair() {
     assert_eq!(moved[1].operation, SyncOperation::Delete);
     assert_eq!(moved[1].project_id.as_deref(), Some("project-a"));
     assert_eq!(moved[2].operation, SyncOperation::Upsert);
+    assert_eq!(moved[2].project_id.as_deref(), Some("project-b"));
+}
+
+#[test]
+fn enqueue_for_team_project_targets_a_foreign_owner() {
+    let (_temp, queue) = create_test_queue();
+
+    queue
+        .enqueue_for_team_project(
+            EntityType::Task,
+            "foreign-task",
+            SyncOperation::Upsert,
+            Some(r#"{"id":"foreign-task"}"#),
+            "team-123",
+            Some("destination-project"),
+        )
+        .unwrap();
+
+    let pending = queue.pending_for_team("team-123", 10, 5).unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].project_id.as_deref(), Some("destination-project"));
 }
 
 #[test]

--- a/cas-cli/src/cloud/sync_queue/tests.rs
+++ b/cas-cli/src/cloud/sync_queue/tests.rs
@@ -222,15 +222,24 @@ fn test_pending_by_type() {
         .enqueue(EntityType::Task, "t1", SyncOperation::Upsert, None)
         .unwrap();
     queue
+        .enqueue(
+            EntityType::TaskDependency,
+            "t1:t2:blocks",
+            SyncOperation::Upsert,
+            Some(r#"{"from_id":"t1","to_id":"t2","dep_type":"blocks"}"#),
+        )
+        .unwrap();
+    queue
         .enqueue(EntityType::Rule, "r1", SyncOperation::Delete, None)
         .unwrap();
 
     let by_type = queue.pending_by_type(10, 5).unwrap();
     assert_eq!(by_type.entries.len(), 2);
     assert_eq!(by_type.tasks.len(), 1);
+    assert_eq!(by_type.task_dependencies.len(), 1);
     assert_eq!(by_type.rules.len(), 1);
     assert_eq!(by_type.skills.len(), 0);
-    assert_eq!(by_type.total(), 4);
+    assert_eq!(by_type.total(), 5);
 }
 
 #[test]

--- a/cas-cli/src/cloud/sync_queue/types.rs
+++ b/cas-cli/src/cloud/sync_queue/types.rs
@@ -142,8 +142,10 @@ pub struct QueuedSync {
     pub payload: Option<String>,
     /// Team ID for team-scoped sync (None for personal sync)
     pub team_id: Option<String>,
-    /// Project identity targeted by a project-scoped delete. `None` preserves
-    /// the normal behavior of using the project performing the push.
+    /// Project identity targeted by a project-scoped operation. `None`
+    /// preserves the normal behavior of using the project performing the
+    /// push. Move deletes target the old owner; move upserts and later edits
+    /// to foreign-owned tasks target the new owner.
     pub project_id: Option<String>,
     /// When the item was queued
     pub created_at: DateTime<Utc>,

--- a/cas-cli/src/cloud/sync_queue/types.rs
+++ b/cas-cli/src/cloud/sync_queue/types.rs
@@ -19,6 +19,9 @@ pub enum EntityType {
     CommitLink,
     Agent,
     Worktree,
+    /// A task-to-task dependency edge. The cloud stores this as an opaque
+    /// blob because the local dependency table remains authoritative.
+    TaskDependency,
     /// A distilled project-knowledge page (T5). Local SQLite remains the
     /// source of truth; the cloud carries pages so teammates share them.
     KnowledgePage,
@@ -39,6 +42,7 @@ impl EntityType {
             EntityType::CommitLink => "commit_link",
             EntityType::Agent => "agent",
             EntityType::Worktree => "worktree",
+            EntityType::TaskDependency => "task_dependency",
             EntityType::KnowledgePage => "knowledge_page",
         }
     }
@@ -57,6 +61,7 @@ impl EntityType {
             "commit_link" => Some(EntityType::CommitLink),
             "agent" => Some(EntityType::Agent),
             "worktree" => Some(EntityType::Worktree),
+            "task_dependency" | "task_dependencies" => Some(EntityType::TaskDependency),
             "knowledge_page" => Some(EntityType::KnowledgePage),
             _ => None,
         }
@@ -77,6 +82,7 @@ impl EntityType {
             EntityType::CommitLink => "commit_links",
             EntityType::Agent => "agents",
             EntityType::Worktree => "worktrees",
+            EntityType::TaskDependency => "task_dependencies",
             EntityType::KnowledgePage => "knowledge_pages",
         }
     }
@@ -208,6 +214,7 @@ pub struct PendingByType {
     pub commit_links: Vec<QueuedSync>,
     pub agents: Vec<QueuedSync>,
     pub worktrees: Vec<QueuedSync>,
+    pub task_dependencies: Vec<QueuedSync>,
     pub knowledge_pages: Vec<QueuedSync>,
 }
 
@@ -225,6 +232,7 @@ impl PendingByType {
             && self.commit_links.is_empty()
             && self.agents.is_empty()
             && self.worktrees.is_empty()
+            && self.task_dependencies.is_empty()
             && self.knowledge_pages.is_empty()
     }
 
@@ -241,5 +249,6 @@ impl PendingByType {
             + self.commit_links.len()
             + self.agents.len()
             + self.worktrees.len()
+            + self.task_dependencies.len()
     }
 }

--- a/cas-cli/src/cloud/syncer/mod.rs
+++ b/cas-cli/src/cloud/syncer/mod.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::cloud::{CloudConfig, EntityType, SyncQueue};
+use crate::error::CasError;
 use crate::types::{Entry, Rule, Skill};
 
 mod knowledge;
@@ -437,6 +438,19 @@ impl CloudSyncer {
         self.cloud_config.is_logged_in()
     }
 
+    /// Requeue terminal cloud failures whose version gate is satisfied by the
+    /// current client before either personal or team push reads the queue.
+    pub(crate) fn requeue_version_gated_items(&self) -> Result<usize, CasError> {
+        let requeued = self.queue.requeue_version_gated_failures(
+            env!("CARGO_PKG_VERSION"),
+            self.config.max_retries,
+        )?;
+        if requeued > 0 {
+            eprintln!("requeued {requeued} version-gated item(s)");
+        }
+        Ok(requeued)
+    }
+
     /// Get the sync queue
     pub fn queue(&self) -> &SyncQueue {
         &self.queue
@@ -571,7 +585,13 @@ struct TeamPushResponse {
     /// returns `{inserted, updated, skipped}` objects instead. Keep the wire
     /// value raw so the team path can recognize both and fail closed on a
     /// malformed-but-present skip signal.
+    #[serde(default)]
     synced: serde_json::Value,
+    /// Newer cloud builds may return complete per-row outcomes at the top
+    /// level. Keep this alongside `synced` so the team path can consume both
+    /// response generations without changing the aggregate contract.
+    #[serde(default)]
+    rows: Option<Vec<PushRowResult>>,
     /// cas-8ca5 / contract §5: the canonical project id the server's resolver
     /// mapped this push to. `None` on older cloud builds that predate the
     /// resolver echo — the client then leaves its local pin untouched.
@@ -655,6 +675,93 @@ impl PushInvalidReason {
 pub(crate) enum PushItemizedFailure {
     Rejection(PushRejection),
     Invalid(PushInvalid),
+}
+
+/// Outcome for one row in a push response. The server may include these rows
+/// in addition to aggregate counts so the client can distinguish a benign LWW
+/// loss from a rejected write without retrying or parking neighboring rows.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PushRowOutcome {
+    Inserted,
+    Updated,
+    SkippedLww,
+    Rejected,
+}
+
+/// A complete per-row push result returned by newer cloud builds.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct PushRowResult {
+    pub id: String,
+    pub outcome: PushRowOutcome,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+impl PushRowResult {
+    pub(crate) fn acknowledges(&self) -> bool {
+        matches!(
+            self.outcome,
+            PushRowOutcome::Inserted | PushRowOutcome::Updated | PushRowOutcome::SkippedLww
+        )
+    }
+
+    /// Rejection reasons which describe a temporary server-side condition.
+    /// Unknown rejection reasons remain parked: losing a diagnostic row is
+    /// worse than requiring an operator to explicitly requeue it.
+    pub(crate) fn rejection_is_retryable(&self) -> bool {
+        let Some(reason) = self.reason.as_deref() else {
+            return false;
+        };
+        matches!(
+            reason.to_ascii_lowercase().as_str(),
+            "retryable"
+                | "temporary"
+                | "transient"
+                | "server_error"
+                | "internal_error"
+                | "service_unavailable"
+                | "rate_limited"
+                | "timeout"
+        )
+    }
+}
+
+/// Parse and validate a complete per-row result list for one entity response.
+/// A present list must cover exactly the submitted queue rows so an omitted
+/// result can never be mistaken for an acknowledgement.
+pub(crate) fn row_results_for(
+    entity: &serde_json::Value,
+    location: &str,
+    queued_ids: impl Iterator<Item = String>,
+) -> Result<Option<HashMap<String, PushRowResult>>, String> {
+    let Some(detail) = entity.as_object() else {
+        return Ok(None);
+    };
+    let Some(value) = detail.get("rows") else {
+        return Ok(None);
+    };
+    let rows: Vec<PushRowResult> = serde_json::from_value(value.clone())
+        .map_err(|error| format!("unrecognized {location}.rows: {error}"))?;
+    let queued_ids = queued_ids.collect::<std::collections::HashSet<_>>();
+    let mut by_id = HashMap::with_capacity(rows.len());
+    for row in rows {
+        if !queued_ids.contains(&row.id) {
+            return Err(format!(
+                "{location}.rows names row {} that was not in this sub-batch",
+                row.id
+            ));
+        }
+        if by_id.insert(row.id.clone(), row).is_some() {
+            return Err(format!("{location}.rows contains a duplicate id"));
+        }
+    }
+    for id in queued_ids {
+        if !by_id.contains_key(&id) {
+            return Err(format!("{location}.rows missing row {id}"));
+        }
+    }
+    Ok(Some(by_id))
 }
 
 impl PushItemizedFailure {
@@ -817,9 +924,9 @@ pub(crate) fn itemized_failures_for(
 /// excluded count per entity type and surfaces it here so the client can:
 ///
 /// 1. Emit a structured warning to ops/users.
-/// 2. Leave the affected local queue items un-marked-synced, record the raw
-///    response, and consume their bounded retry budget instead of silently
-///    dropping or retrying them forever.
+/// 2. Consume rows named by per-row rejection results and park or retry them
+///    according to the supplied reason; aggregate-only skips are acknowledged
+///    under the server's LWW semantics because their row identities are absent.
 ///
 /// Both the proposed top-level map and the live per-entity result objects are
 /// accepted so the wire format can evolve without silently losing skips.
@@ -848,7 +955,7 @@ impl PushResponse {
     /// Both the older proposed top-level map and the live nested entity shape
     /// are accepted. Absence remains backward-compatible (`Ok(0)`), but a
     /// present skip signal with an unknown type or contradictory counts is an
-    /// error. Callers must then retain the queue row/watermark for retry.
+    /// error. Callers must then retain the affected queue rows for retry.
     pub fn skipped_count_for(&self, entity_type: &str) -> Result<usize, String> {
         fn count(value: &serde_json::Value, location: &str) -> Result<usize, String> {
             value
@@ -897,6 +1004,28 @@ impl PushResponse {
             return Ok(None);
         };
         itemized_failures_for(entity, entity_type, skipped, queued_ids)
+    }
+
+    pub(crate) fn row_results_for(
+        &self,
+        entity_type: &str,
+        queued_ids: impl Iterator<Item = String>,
+    ) -> Result<Option<HashMap<String, PushRowResult>>, String> {
+        let queued_ids = queued_ids.collect::<Vec<_>>();
+        if let Some(entity) = self.fields.get(entity_type) {
+            if let Some(rows) = row_results_for(
+                entity,
+                entity_type,
+                queued_ids.iter().cloned(),
+            )? {
+                return Ok(Some(rows));
+            }
+        }
+        if let Some(rows) = self.fields.get("rows") {
+            let wrapped = serde_json::json!({"rows": rows});
+            return row_results_for(&wrapped, "rows", queued_ids.into_iter());
+        }
+        Ok(None)
     }
 }
 

--- a/cas-cli/src/cloud/syncer/mod.rs
+++ b/cas-cli/src/cloud/syncer/mod.rs
@@ -84,6 +84,12 @@ pub struct SyncResult {
     pub pulled_commit_links: usize,
     /// Number of task dependency edges pulled
     pub pulled_task_dependencies: usize,
+    /// Number of local task dependency edges queued for cloud healing.
+    pub healed_task_dependencies_to_cloud: usize,
+    /// Number of task dependency edges materialized from the cloud during
+    /// healing. This is separate from `pulled_task_dependencies` so callers
+    /// can distinguish ordinary pull application from reconciliation.
+    pub healed_task_dependencies_from_cloud: usize,
     /// Number of distilled knowledge pages pulled (T5)
     pub pulled_knowledge_pages: usize,
     /// Number of conflicts resolved
@@ -179,6 +185,20 @@ pub struct PushPlan {
 }
 
 impl SyncResult {
+    /// Render the one-line dependency healing receipt when reconciliation did
+    /// work. A quiet no-op is intentional for steady-state pulls.
+    pub fn dependency_heal_summary(&self) -> Option<String> {
+        (self.healed_task_dependencies_to_cloud > 0
+            || self.healed_task_dependencies_from_cloud > 0)
+            .then(|| {
+                format!(
+                    "healed {} edge(s) to cloud, {} from cloud",
+                    self.healed_task_dependencies_to_cloud,
+                    self.healed_task_dependencies_from_cloud
+                )
+            })
+    }
+
     pub fn total_pushed(&self) -> usize {
         self.pushed_entries
             + self.pushed_tasks

--- a/cas-cli/src/cloud/syncer/mod.rs
+++ b/cas-cli/src/cloud/syncer/mod.rs
@@ -59,6 +59,8 @@ pub struct SyncResult {
     pub pushed_agents: usize,
     /// Number of worktrees pushed
     pub pushed_worktrees: usize,
+    /// Number of task dependency edges pushed
+    pub pushed_task_dependencies: usize,
     /// Number of distilled knowledge pages pushed (T5)
     pub pushed_knowledge_pages: usize,
     /// Number of entries pulled
@@ -79,6 +81,8 @@ pub struct SyncResult {
     pub pulled_file_changes: usize,
     /// Number of commit links pulled
     pub pulled_commit_links: usize,
+    /// Number of task dependency edges pulled
+    pub pulled_task_dependencies: usize,
     /// Number of distilled knowledge pages pulled (T5)
     pub pulled_knowledge_pages: usize,
     /// Number of conflicts resolved
@@ -151,6 +155,7 @@ impl PushScope {
                 "commit_links",
                 "agents",
                 "worktrees",
+                "task_dependencies",
             ],
         }
     }
@@ -186,6 +191,7 @@ impl SyncResult {
             + self.pushed_commit_links
             + self.pushed_agents
             + self.pushed_worktrees
+            + self.pushed_task_dependencies
             + self.pushed_knowledge_pages
     }
 
@@ -199,6 +205,7 @@ impl SyncResult {
             + self.pulled_prompts
             + self.pulled_file_changes
             + self.pulled_commit_links
+            + self.pulled_task_dependencies
             + self.pulled_knowledge_pages
     }
 
@@ -525,6 +532,10 @@ struct PullResponse {
     #[serde(default)]
     #[allow(dead_code)]
     knowledge_pages: Option<Vec<serde_json::Value>>,
+    /// Task dependency edges are opaque cloud blobs but use a dedicated
+    /// envelope key so the pull path can materialize them after tasks.
+    #[serde(default)]
+    task_dependencies: Option<Vec<serde_json::Value>>,
     pulled_at: Option<String>,
 }
 
@@ -541,6 +552,8 @@ struct TeamPullResponse {
     rules: Option<Vec<serde_json::Value>>,
     #[serde(default)]
     skills: Option<Vec<serde_json::Value>>,
+    #[serde(default)]
+    task_dependencies: Option<Vec<serde_json::Value>>,
     pulled_at: Option<String>,
     #[allow(dead_code)]
     team_id: Option<String>,

--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Instant;
 
 use chrono::{DateTime, Utc};
@@ -9,7 +9,7 @@ use crate::cloud::syncer::{
     CloudSyncer, ConflictAction, ConflictResolution, PullResponse, SyncResult,
     TaskStatusTransition, TeamPullResponse, UpsertResult,
 };
-use crate::cloud::{EntityType, get_project_canonical_id};
+use crate::cloud::{EntityType, SyncOperation, get_project_canonical_id};
 use crate::error::CasError;
 use crate::store::{
     CommitLinkStore, EventStore, FileChangeStore, PromptStore, RuleStore, SkillStore, SpecStore,
@@ -52,11 +52,18 @@ struct TaskDependencyRecord {
     from_id: String,
     to_id: String,
     dep_type: DependencyType,
+    /// Older cloud tombstones omit this field. It is unused for deletes, but
+    /// defaulting it lets those records still protect the local edge.
+    #[serde(default = "default_dependency_created_at")]
     created_at: DateTime<Utc>,
     #[serde(default)]
     operation: Option<String>,
     #[serde(default)]
     deleted: bool,
+}
+
+fn default_dependency_created_at() -> DateTime<Utc> {
+    Utc::now()
 }
 
 impl TaskDependencyRecord {
@@ -106,14 +113,69 @@ fn task_dependency_matches_project(raw: &serde_json::Value, current_project_id: 
     }
 }
 
+fn dependency_entity_id(dependency: &Dependency) -> String {
+    format!(
+        "{}:{}:{}",
+        dependency.from_id, dependency.to_id, dependency.dep_type
+    )
+}
+
+#[derive(Debug, Default)]
+struct RemoteDependencyState {
+    live: BTreeMap<String, Dependency>,
+    deleted: BTreeSet<String>,
+}
+
+fn remote_dependency_state(
+    raw_dependencies: &[serde_json::Value],
+    current_project_id: &str,
+) -> RemoteDependencyState {
+    let mut state = RemoteDependencyState::default();
+    for raw in raw_dependencies {
+        let project_matches = raw
+            .get("project_canonical_id")
+            .or_else(|| raw.get("project_id"))
+            .or_else(|| raw.get("origin_project"))
+            .and_then(serde_json::Value::as_str)
+            == Some(current_project_id);
+        if !project_matches {
+            continue;
+        }
+        let Ok(record) = serde_json::from_value::<TaskDependencyRecord>(raw.clone()) else {
+            continue;
+        };
+        let is_delete = record.is_delete();
+        let dependency = record.dependency();
+        let entity_id = dependency_entity_id(&dependency);
+        if is_delete {
+            state.live.remove(&entity_id);
+            state.deleted.insert(entity_id);
+        } else if !state.deleted.contains(&entity_id) {
+            state.live.insert(entity_id, dependency);
+        }
+    }
+    state
+}
+
+fn local_dependency_map(
+    task_store: &dyn TaskStore,
+) -> Result<BTreeMap<String, Dependency>, CasError> {
+    Ok(task_store
+        .list_dependencies(None)?
+        .into_iter()
+        .map(|dependency| (dependency_entity_id(&dependency), dependency))
+        .collect())
+}
+
 fn apply_task_dependencies(
-    raw_dependencies: Vec<serde_json::Value>,
+    raw_dependencies: &[serde_json::Value],
     task_store: &dyn TaskStore,
     current_project_id: &str,
     result: &mut SyncResult,
+    deleted_dependency_ids: &BTreeSet<String>,
 ) {
     for raw in raw_dependencies {
-        if !task_dependency_matches_project(&raw, current_project_id) {
+        if !task_dependency_matches_project(raw, current_project_id) {
             continue;
         }
         let edge_id = raw
@@ -122,7 +184,7 @@ fn apply_task_dependencies(
             .and_then(serde_json::Value::as_str)
             .unwrap_or("<unknown>")
             .to_owned();
-        let record: TaskDependencyRecord = match serde_json::from_value(raw) {
+        let record: TaskDependencyRecord = match serde_json::from_value(raw.clone()) {
             Ok(record) => record,
             Err(error) => {
                 result.errors.push(format!(
@@ -133,6 +195,7 @@ fn apply_task_dependencies(
         };
         let is_delete = record.is_delete();
         let dependency = record.dependency();
+        let dependency_id = dependency_entity_id(&dependency);
         if is_delete {
             if let Err(error) = task_store.remove_dependency_of_type(
                 &dependency.from_id,
@@ -144,6 +207,13 @@ fn apply_task_dependencies(
                     dependency.from_id, dependency.to_id
                 ));
             }
+            continue;
+        }
+
+        // A delete tombstone wins for the whole response, regardless of wire
+        // ordering. This prevents a stale upsert in the same envelope from
+        // recreating an edge just removed by the user.
+        if deleted_dependency_ids.contains(&dependency_id) {
             continue;
         }
 
@@ -166,6 +236,120 @@ fn apply_task_dependencies(
             ));
         } else {
             result.pulled_task_dependencies += 1;
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct DependencyHealReport {
+    to_cloud: usize,
+    from_cloud: usize,
+}
+
+impl CloudSyncer {
+    /// Apply the endpoint's dependency envelope, then reconcile the complete
+    /// local edge set against it. An omitted field is handled by the caller as
+    /// an older endpoint response and intentionally skips healing.
+    fn apply_and_heal_task_dependencies(
+        &self,
+        raw_dependencies: Vec<serde_json::Value>,
+        task_store: &dyn TaskStore,
+        current_project_id: &str,
+        team_id: Option<&str>,
+        result: &mut SyncResult,
+    ) -> Result<DependencyHealReport, CasError> {
+        let local_before = local_dependency_map(task_store)?;
+        let remote = remote_dependency_state(&raw_dependencies, current_project_id);
+
+        apply_task_dependencies(
+            &raw_dependencies,
+            task_store,
+            current_project_id,
+            result,
+            &remote.deleted,
+        );
+
+        let local_after = local_dependency_map(task_store)?;
+        let from_cloud = remote
+            .live
+            .keys()
+            .filter(|entity_id| {
+                !local_before.contains_key(*entity_id) && local_after.contains_key(*entity_id)
+            })
+            .count();
+
+        // Existing queue state is authoritative for idempotency. In
+        // particular, a pending delete must never be replaced by this
+        // best-effort reconciliation when the deployed endpoint cannot yet
+        // provide deletion tombstones.
+        let pending = match team_id {
+            Some(team_id) => self.queue.pending_for_team(team_id, usize::MAX, i32::MAX)?,
+            None => self.queue.pending_for_entity_type(
+                Some(EntityType::TaskDependency),
+                usize::MAX,
+                i32::MAX,
+            )?,
+        };
+        let pending_operations = pending
+            .into_iter()
+            .map(|item| (item.entity_id, item.operation))
+            .collect::<BTreeMap<_, _>>();
+
+        let mut to_cloud = 0;
+        for (entity_id, dependency) in local_after {
+            // The currently deployed endpoint has no deletion tombstone feed,
+            // so an omitted edge is indistinguishable from a cloud-missing
+            // edge. Explicit tombstones (when supplied) and pending local
+            // deletes are protected above; until the feed ships, this is the
+            // documented safe degradation for that ambiguity.
+            if remote.live.contains_key(&entity_id) || remote.deleted.contains(&entity_id) {
+                continue;
+            }
+            if pending_operations.contains_key(&entity_id) {
+                continue;
+            }
+
+            let payload = serde_json::json!({
+                "from_id": dependency.from_id,
+                "to_id": dependency.to_id,
+                "dep_type": dependency.dep_type.to_string(),
+                "created_at": dependency.created_at,
+                "origin_project": current_project_id,
+            });
+            let payload = serde_json::to_string(&payload).map_err(|error| {
+                CasError::Other(format!(
+                    "Could not serialize healed task dependency: {error}"
+                ))
+            })?;
+            match team_id {
+                Some(team_id) => self.queue.enqueue_for_team(
+                    EntityType::TaskDependency,
+                    &entity_id,
+                    SyncOperation::Upsert,
+                    Some(&payload),
+                    team_id,
+                )?,
+                None => self.queue.enqueue(
+                    EntityType::TaskDependency,
+                    &entity_id,
+                    SyncOperation::Upsert,
+                    Some(&payload),
+                )?,
+            }
+            to_cloud += 1;
+        }
+
+        Ok(DependencyHealReport {
+            to_cloud,
+            from_cloud,
+        })
+    }
+
+    fn record_dependency_heal(result: &mut SyncResult, report: DependencyHealReport) {
+        result.healed_task_dependencies_to_cloud += report.to_cloud;
+        result.healed_task_dependencies_from_cloud += report.from_cloud;
+        if let Some(summary) = result.dependency_heal_summary() {
+            eprintln!("{summary}");
         }
     }
 }
@@ -1002,14 +1186,19 @@ impl CloudSyncer {
         }
 
         // Dependencies are applied after tasks so a fresh pull can materialize
-        // an edge whose endpoints arrived in the same envelope. Pull uses
-        // local stores, so these writes are intentionally not re-enqueued.
-        apply_task_dependencies(
-            body.task_dependencies.unwrap_or_default(),
-            task_store,
-            current_project_id,
-            &mut result,
-        );
+        // an edge whose endpoints arrived in the same envelope. A response
+        // without this optional field predates dependency healing, so it is
+        // left untouched until the endpoint supports the collection.
+        if let Some(raw_dependencies) = body.task_dependencies {
+            let report = self.apply_and_heal_task_dependencies(
+                raw_dependencies,
+                task_store,
+                current_project_id,
+                None,
+                &mut result,
+            )?;
+            Self::record_dependency_heal(&mut result, report);
+        }
 
         // Process rules
         for raw_rule in body.rules.unwrap_or_default() {
@@ -1203,7 +1392,10 @@ impl CloudSyncer {
         // fetched and rejected forever. Foreign/malformed rows never reach
         // `conflicts_resolved`, so the GH #192 empty/wrong-bucket safeguard
         // remains intact.
-        if (had_prior_watermark || result.total_pulled() > 0 || result.conflicts_resolved > 0)
+        if (had_prior_watermark
+            || result.total_pulled() > 0
+            || result.conflicts_resolved > 0
+            || result.healed_task_dependencies_to_cloud > 0)
             && let Some(pulled_at) = body.pulled_at
         {
             let _ = self.queue.set_metadata("last_pull_at", &pulled_at);
@@ -1694,6 +1886,8 @@ impl CloudSyncer {
             pulled_file_changes: pull_result.pulled_file_changes,
             pulled_commit_links: pull_result.pulled_commit_links,
             pulled_task_dependencies: pull_result.pulled_task_dependencies,
+            healed_task_dependencies_to_cloud: pull_result.healed_task_dependencies_to_cloud,
+            healed_task_dependencies_from_cloud: pull_result.healed_task_dependencies_from_cloud,
             task_status_transitions: pull_result.task_status_transitions,
             conflicts_resolved: pull_result.conflicts_resolved,
             errors: [
@@ -1889,13 +2083,19 @@ impl CloudSyncer {
         }
 
         // Dependencies are applied after tasks; missing endpoints are parked
-        // with a warning instead of creating dangling local rows.
-        apply_task_dependencies(
-            body.task_dependencies.unwrap_or_default(),
-            task_store,
-            current_project_id,
-            &mut result,
-        );
+        // with a warning instead of creating dangling local rows. A response
+        // without this optional field predates dependency healing, so it is
+        // left untouched until the endpoint supports the collection.
+        if let Some(raw_dependencies) = body.task_dependencies {
+            let report = self.apply_and_heal_task_dependencies(
+                raw_dependencies,
+                task_store,
+                current_project_id,
+                Some(team_id),
+                &mut result,
+            )?;
+            Self::record_dependency_heal(&mut result, report);
+        }
 
         // Process rules
         for raw_rule in body.rules.unwrap_or_default() {

--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -10,7 +10,7 @@ use crate::cloud::syncer::{
     TaskStatusTransition, TeamPullResponse, UpsertResult,
 };
 use crate::cloud::{
-    EntityType, canonical_project_id, canonical_project_id_with_pin, get_project_canonical_id,
+    EntityType, get_project_canonical_id, project_ids_match as canonical_project_ids_match,
 };
 use crate::error::CasError;
 use crate::store::{
@@ -92,7 +92,7 @@ fn task_dependency_matches_project(raw: &serde_json::Value, current_project_id: 
         .and_then(serde_json::Value::as_str)
         .unwrap_or("<unknown>");
     match project_field.and_then(serde_json::Value::as_str) {
-        Some(project) if project == current_project_id => true,
+        Some(project) if project_ids_match(project, current_project_id) => true,
         Some(project) => {
             eprintln!(
                 "[Cassy sync] WARNING: skipping task dependency '{edge_id}' from foreign project '{project}' (expected '{current_project_id}')"
@@ -394,11 +394,7 @@ pub(crate) fn entity_matches_project(
 }
 
 fn project_ids_match(candidate: &str, current: &str) -> bool {
-    let Some(current) = canonical_project_id(current) else {
-        return false;
-    };
-    canonical_project_id_with_pin(candidate, Some(&current))
-        .is_some_and(|candidate| candidate == current)
+    canonical_project_ids_match(candidate, current)
 }
 
 fn task_wire_id(raw: &serde_json::Value) -> Option<&str> {
@@ -1993,7 +1989,7 @@ mod tests {
     use super::{
         PROPOSAL_PROVENANCE_BEGIN, PROPOSAL_PROVENANCE_END, PULL_PATH,
         build_scoped_pull_url_with, deserialize_pulled_entity, entity_matches_project,
-        render_task_proposal_provenance,
+        render_task_proposal_provenance, task_dependency_matches_project,
     };
     use crate::types::{Entry, Task};
     use serde_json::json;
@@ -2301,6 +2297,19 @@ mod tests {
             &entity,
             "github.com/other/Ledger",
             "task"
+        ));
+    }
+
+    #[test]
+    fn canonical_identity_pull_accepts_bare_alias_for_remote_scope_dependency() {
+        let dependency = json!({
+            "id": "alias-edge",
+            "project_id": "gabber-studio",
+        });
+
+        assert!(task_dependency_matches_project(
+            &dependency,
+            "github.com/richards-llc/gabber-studio"
         ));
     }
 }

--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::time::Instant;
 
 use chrono::{DateTime, Utc};
+use serde::Deserialize;
 use serde::de::DeserializeOwned;
 
 use crate::cloud::syncer::{
@@ -15,7 +16,8 @@ use crate::store::{
     Store, TaskStore,
 };
 use crate::types::{
-    CommitLink, Entry, Event, FileChange, Prompt, Rule, Session, Skill, Spec, Task, TaskStatus,
+    CommitLink, Dependency, DependencyType, Entry, Event, FileChange, Prompt, Rule, Session, Skill,
+    Spec, Task, TaskStatus,
 };
 
 /// Path of the cloud sync pull endpoint.
@@ -43,6 +45,129 @@ fn deserialize_pulled_entity<T: DeserializeOwned>(
         .to_owned();
     serde_json::from_value(raw)
         .map_err(|error| format!("{entity_type} deserialize error (id={id}): {error}"))
+}
+
+#[derive(Debug, Deserialize)]
+struct TaskDependencyRecord {
+    from_id: String,
+    to_id: String,
+    dep_type: DependencyType,
+    created_at: DateTime<Utc>,
+    #[serde(default)]
+    operation: Option<String>,
+    #[serde(default)]
+    deleted: bool,
+}
+
+impl TaskDependencyRecord {
+    fn is_delete(&self) -> bool {
+        self.deleted
+            || self
+                .operation
+                .as_deref()
+                .is_some_and(|operation| operation.eq_ignore_ascii_case("delete"))
+    }
+
+    fn dependency(self) -> Dependency {
+        Dependency {
+            from_id: self.from_id,
+            to_id: self.to_id,
+            dep_type: self.dep_type,
+            created_at: self.created_at,
+            created_by: None,
+        }
+    }
+}
+
+fn task_dependency_matches_project(raw: &serde_json::Value, current_project_id: &str) -> bool {
+    let project_field = raw
+        .get("project_canonical_id")
+        .or_else(|| raw.get("project_id"))
+        .or_else(|| raw.get("origin_project"));
+    let edge_id = raw
+        .get("id")
+        .or_else(|| raw.get("entity_id"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("<unknown>");
+    match project_field.and_then(serde_json::Value::as_str) {
+        Some(project) if project == current_project_id => true,
+        Some(project) => {
+            eprintln!(
+                "[Cassy sync] WARNING: skipping task dependency '{edge_id}' from foreign project '{project}' (expected '{current_project_id}')"
+            );
+            false
+        }
+        None => {
+            eprintln!(
+                "[Cassy sync] WARNING: parking task dependency '{edge_id}' — no project identity (expected '{current_project_id}')"
+            );
+            false
+        }
+    }
+}
+
+fn apply_task_dependencies(
+    raw_dependencies: Vec<serde_json::Value>,
+    task_store: &dyn TaskStore,
+    current_project_id: &str,
+    result: &mut SyncResult,
+) {
+    for raw in raw_dependencies {
+        if !task_dependency_matches_project(&raw, current_project_id) {
+            continue;
+        }
+        let edge_id = raw
+            .get("id")
+            .or_else(|| raw.get("entity_id"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("<unknown>")
+            .to_owned();
+        let record: TaskDependencyRecord = match serde_json::from_value(raw) {
+            Ok(record) => record,
+            Err(error) => {
+                result.errors.push(format!(
+                    "task dependency deserialize error (id={edge_id}): {error}"
+                ));
+                continue;
+            }
+        };
+        let is_delete = record.is_delete();
+        let dependency = record.dependency();
+        if is_delete {
+            if let Err(error) = task_store.remove_dependency_of_type(
+                &dependency.from_id,
+                &dependency.to_id,
+                dependency.dep_type,
+            ) {
+                result.errors.push(format!(
+                    "Task dependency delete error ({}:{}): {error}",
+                    dependency.from_id, dependency.to_id
+                ));
+            }
+            continue;
+        }
+
+        let from_exists = task_store.get(&dependency.from_id).is_ok();
+        let to_exists = task_store.get(&dependency.to_id).is_ok();
+        if !from_exists || !to_exists {
+            tracing::warn!(
+                from_id = %dependency.from_id,
+                to_id = %dependency.to_id,
+                dep_type = %dependency.dep_type,
+                "Parking dangling task dependency from cloud pull because one or both tasks are absent locally"
+            );
+            continue;
+        }
+
+        if let Err(error) = task_store.add_dependency(&dependency) {
+            result.errors.push(format!(
+                "Task dependency upsert error ({}:{}): {error}",
+                dependency.from_id, dependency.to_id
+            ));
+        } else {
+            result.pulled_task_dependencies += 1;
+        }
+    }
 }
 
 /// Read the cloud mutation timestamp carried by a team-pull entry.
@@ -876,6 +1001,16 @@ impl CloudSyncer {
             }
         }
 
+        // Dependencies are applied after tasks so a fresh pull can materialize
+        // an edge whose endpoints arrived in the same envelope. Pull uses
+        // local stores, so these writes are intentionally not re-enqueued.
+        apply_task_dependencies(
+            body.task_dependencies.unwrap_or_default(),
+            task_store,
+            current_project_id,
+            &mut result,
+        );
+
         // Process rules
         for raw_rule in body.rules.unwrap_or_default() {
             if !entity_matches_project(&raw_rule, &current_project_id, "rule") {
@@ -1547,6 +1682,8 @@ impl CloudSyncer {
                 + team_push_result.pushed_commit_links,
             pushed_agents: push_result.pushed_agents + team_push_result.pushed_agents,
             pushed_worktrees: push_result.pushed_worktrees + team_push_result.pushed_worktrees,
+            pushed_task_dependencies: push_result.pushed_task_dependencies
+                + team_push_result.pushed_task_dependencies,
             pulled_entries: pull_result.pulled_entries,
             pulled_tasks: pull_result.pulled_tasks,
             pulled_rules: pull_result.pulled_rules,
@@ -1556,6 +1693,7 @@ impl CloudSyncer {
             pulled_prompts: pull_result.pulled_prompts,
             pulled_file_changes: pull_result.pulled_file_changes,
             pulled_commit_links: pull_result.pulled_commit_links,
+            pulled_task_dependencies: pull_result.pulled_task_dependencies,
             task_status_transitions: pull_result.task_status_transitions,
             conflicts_resolved: pull_result.conflicts_resolved,
             errors: [
@@ -1749,6 +1887,15 @@ impl CloudSyncer {
                 }
             }
         }
+
+        // Dependencies are applied after tasks; missing endpoints are parked
+        // with a warning instead of creating dangling local rows.
+        apply_task_dependencies(
+            body.task_dependencies.unwrap_or_default(),
+            task_store,
+            current_project_id,
+            &mut result,
+        );
 
         // Process rules
         for raw_rule in body.rules.unwrap_or_default() {

--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -8,7 +8,9 @@ use crate::cloud::syncer::{
     CloudSyncer, ConflictAction, ConflictResolution, PullResponse, SyncResult,
     TaskStatusTransition, TeamPullResponse, UpsertResult,
 };
-use crate::cloud::{EntityType, get_project_canonical_id};
+use crate::cloud::{
+    EntityType, canonical_project_id, canonical_project_id_with_pin, get_project_canonical_id,
+};
 use crate::error::CasError;
 use crate::store::{
     CommitLinkStore, EventStore, FileChangeStore, PromptStore, RuleStore, SkillStore, SpecStore,
@@ -209,9 +211,9 @@ pub(crate) fn build_scoped_pull_url_with(
 /// so both directions of the sync client apply *one* definition of "is this
 /// row mine", rather than a second implementation that can drift from this one.
 ///
-/// The equality is deliberately byte-exact — see the protocol invariant in
-/// `docs/`/ARCHITECTURE and `canonical_id_equality_is_byte_exact_by_protocol`
-/// below. Normalizing here would silently merge two distinct projects.
+/// Project identities are compared through the canonical cloud normalizer so
+/// a legacy remote-shaped row can match an explicit bare-slug pin. Values that
+/// normalize to different host/org/repository identities remain foreign.
 pub(crate) fn entity_matches_project(
     raw: &serde_json::Value,
     current_project_id: &str,
@@ -245,7 +247,7 @@ pub(crate) fn entity_matches_project(
             false
         }
         Some(serde_json::Value::String(s)) => {
-            if s == current_project_id {
+            if project_ids_match(s, current_project_id) {
                 true
             } else {
                 eprintln!(
@@ -264,6 +266,14 @@ pub(crate) fn entity_matches_project(
             false
         }
     }
+}
+
+fn project_ids_match(candidate: &str, current: &str) -> bool {
+    let Some(current) = canonical_project_id(current) else {
+        return false;
+    };
+    canonical_project_id_with_pin(candidate, Some(&current))
+        .is_some_and(|candidate| candidate == current)
 }
 
 fn task_wire_id(raw: &serde_json::Value) -> Option<&str> {
@@ -287,8 +297,9 @@ fn task_wire_cloud_project<'a>(raw: &'a serde_json::Value, requested_project: &'
 }
 
 fn task_wire_is_owner(raw: &serde_json::Value, requested_project: &str) -> bool {
-    task_wire_origin_project(raw)
-        .is_some_and(|origin| origin == task_wire_cloud_project(raw, requested_project))
+    task_wire_origin_project(raw).is_some_and(|origin| {
+        project_ids_match(origin, task_wire_cloud_project(raw, requested_project))
+    })
 }
 
 fn task_wire_updated_at(raw: &serde_json::Value) -> Option<DateTime<Utc>> {
@@ -598,7 +609,14 @@ impl CloudSyncer {
         source: &str,
     ) -> Result<UpsertResult, CasError> {
         if let Ok(local) = store.get(&task.id) {
-            let origins_differ = local.origin_project != task.origin_project;
+            let origins_differ = match (
+                local.origin_project.as_deref(),
+                task.origin_project.as_deref(),
+            ) {
+                (Some(local), Some(incoming)) => !project_ids_match(local, incoming),
+                (None, None) => false,
+                _ => true,
+            };
             if incoming_is_owner && origins_differ {
                 return self.upsert_owner_task(store, task, sync_id, source);
             }
@@ -834,8 +852,10 @@ impl CloudSyncer {
             if remote_task.origin_project.is_none() {
                 remote_task.origin_project = Some(current_project_id.to_string());
             }
-            let incoming_is_owner =
-                remote_task.origin_project.as_deref() == Some(current_project_id);
+            let incoming_is_owner = remote_task
+                .origin_project
+                .as_deref()
+                .is_some_and(|origin| project_ids_match(origin, &current_project_id));
             let previous_status = task_store.get(&remote_task.id).ok().map(|task| task.status);
             let task_outcome = if web_close {
                 reconcile_web_close(
@@ -1718,8 +1738,11 @@ impl CloudSyncer {
             if remote_task.origin_project.is_none() {
                 remote_task.origin_project = Some(current_project_id.to_string());
             }
-            let incoming_is_owner =
-                wire_is_owner || remote_task.origin_project.as_deref() == Some(current_project_id);
+            let incoming_is_owner = wire_is_owner
+                || remote_task
+                    .origin_project
+                    .as_deref()
+                    .is_some_and(|origin| project_ids_match(origin, current_project_id));
             let previous_status = task_store.get(&remote_task.id).ok().map(|task| task.status);
             match self.upsert_task_with_owner_preference(
                 task_store,
@@ -2111,58 +2134,27 @@ mod tests {
         ));
     }
 
-    /// PROTOCOL INVARIANT — do not "fix" this test by making the comparison
-    /// case-insensitive or otherwise normalizing.
-    ///
-    /// Canonical-id equality is byte-exact on BOTH sides of the wire, by
-    /// agreement with the server. Two consequences the next reader needs:
-    ///
-    /// 1. **Normalizing here would be a data-merge, not a convenience.**
-    ///    `Accounting` and `accounting` are two distinct projects as far as
-    ///    every stored row is concerned; folding them together would
-    ///    cross-contaminate them permanently and unattributably.
-    /// 2. **This is the SECOND line of defence, not the first.** The server
-    ///    filters on the id the client SENDS and echoes the stored column, so
-    ///    an id divergence does not present here as a rejected row — the
-    ///    client receives an *empty envelope*, indefinitely, with no warning
-    ///    on either side. Silent starvation, not contamination. If you are
-    ///    debugging "sync returns nothing", suspect an id mismatch upstream of
-    ///    this function rather than assuming this check is dropping rows.
-    ///
-    /// The remedy for divergence is client-side pinning of the canonical id;
-    /// the server deliberately refused to normalize for exactly the reason in
-    /// (1).
     #[test]
-    fn canonical_id_equality_is_byte_exact_by_protocol() {
+    fn canonical_identity_pull_accepts_remote_alias_spellings() {
         let entity = json!({ "id": "t-1", "project_canonical_id": "github.com/Acme/Ledger" });
 
-        assert!(
-            entity_matches_project(&entity, "github.com/Acme/Ledger", "task"),
-            "exact match must be accepted"
-        );
-        // Case variants are DIFFERENT projects. Each of these must be refused.
+        assert!(entity_matches_project(&entity, "github.com/Acme/Ledger", "task"));
         for variant in [
             "github.com/acme/ledger",
             "github.com/ACME/LEDGER",
             "github.com/Acme/ledger",
+            " https://github.com/Acme/Ledger.git/ ",
         ] {
             assert!(
-                !entity_matches_project(&entity, variant, "task"),
-                "case variant '{variant}' must not match — normalizing here would \
-                 silently merge two distinct projects"
+                entity_matches_project(&entity, variant, "task"),
+                "alias '{variant}' must match the canonical project"
             );
         }
-        // Whitespace and trailing-separator variants are likewise distinct.
-        for variant in [
-            "github.com/Acme/Ledger ",
-            " github.com/Acme/Ledger",
-            "github.com/Acme/Ledger/",
-        ] {
-            assert!(
-                !entity_matches_project(&entity, variant, "task"),
-                "variant '{variant:?}' must not match: equality is byte-exact"
-            );
-        }
+        assert!(!entity_matches_project(
+            &entity,
+            "github.com/other/Ledger",
+            "task"
+        ));
     }
 }
 

--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -2097,6 +2097,20 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn alias_project_row_is_owned_after_normalization() {
+        let entity = json!({
+            "id": "alias-row",
+            "project_canonical_id": "git@GitHub.com:Richards-LLC/gabber-studio.git"
+        });
+
+        assert!(entity_matches_project(
+            &entity,
+            "gabber-studio",
+            "task"
+        ));
+    }
+
     /// PROTOCOL INVARIANT — do not "fix" this test by making the comparison
     /// case-insensitive or otherwise normalizing.
     ///

--- a/cas-cli/src/cloud/syncer/push.rs
+++ b/cas-cli/src/cloud/syncer/push.rs
@@ -1,13 +1,15 @@
 use chrono::Utc;
 use flate2::Compression;
 use flate2::write::GzEncoder;
+use std::collections::HashMap;
 use std::io::Write;
 use std::time::Instant;
 use tracing::warn;
 
 use crate::cloud::sync_queue::PendingByType;
 use crate::cloud::syncer::{
-    CloudSyncer, PushBacklog, PushItemizedFailure, PushPlan, PushResponse, PushScope, SyncResult,
+    CloudSyncer, PushBacklog, PushItemizedFailure, PushPlan, PushResponse, PushRowResult,
+    PushScope, SyncResult,
 };
 use crate::cloud::{QueuedSync, SyncOperation};
 use crate::error::CasError;
@@ -88,6 +90,8 @@ impl CloudSyncer {
     ) -> Result<SyncResult, CasError> {
         let mut result = SyncResult::default();
         let start = Instant::now();
+
+        self.requeue_version_gated_items()?;
 
         if !self.is_available() {
             return Ok(result);
@@ -331,6 +335,51 @@ impl CloudSyncer {
         }
     }
 
+    fn settle_personal_row_results(
+        &self,
+        batch_items: &[&QueuedSync],
+        entity_type: &str,
+        raw_response: &str,
+        rows: HashMap<String, PushRowResult>,
+        synced_count: &mut usize,
+        skip_errors: &mut Vec<String>,
+    ) {
+        let mut rejected = Vec::new();
+        for item in batch_items {
+            let row = rows
+                .get(&item.entity_id)
+                .expect("row_results_for validates every queue identity");
+            if row.acknowledges() {
+                let _ = self.queue.mark_synced(item.id);
+                *synced_count += 1;
+                continue;
+            }
+
+            let reason = row.reason.as_deref().unwrap_or("unspecified");
+            let diagnostic = format!(
+                "cloud rejected {entity_type} {}: reason={reason}; server response: {raw_response}",
+                item.entity_id
+            );
+            if row.rejection_is_retryable() {
+                let _ = self.queue.mark_failed(item.id, &diagnostic);
+            } else {
+                let _ = self
+                    .queue
+                    .park_failed(item.id, &diagnostic, self.config.max_retries);
+            }
+            rejected.push(format!("{} ({reason})", item.entity_id));
+        }
+
+        if !rejected.is_empty() {
+            skip_errors.push(format!(
+                "cloud rejected {} of {} {entity_type} row(s): {}",
+                rejected.len(),
+                batch_items.len(),
+                rejected.join(", ")
+            ));
+        }
+    }
+
     fn push_batch(
         &self,
         items: &[QueuedSync],
@@ -404,6 +453,36 @@ impl CloudSyncer {
                         // Backward-compat: older cloud builds omit `skipped`
                         // entirely, in which case `skipped_count` is 0 and
                         // we fall through to the legacy mark-synced path.
+                        match response.row_results_for(
+                            entity_type,
+                            batch_items.iter().map(|item| item.entity_id.clone()),
+                        ) {
+                            Ok(Some(rows)) => {
+                                self.settle_personal_row_results(
+                                    &batch_items,
+                                    entity_type,
+                                    &response.raw_body,
+                                    rows,
+                                    &mut synced_count,
+                                    &mut skip_errors,
+                                );
+                                continue;
+                            }
+                            Err(error) => {
+                                let diagnostic = format!(
+                                    "cloud returned invalid per-row results for {entity_type}: {error}; marking {} row(s) failed; server response: {}",
+                                    batch_items.len(),
+                                    response.raw_body
+                                );
+                                for item in &batch_items {
+                                    let _ = self.queue.mark_failed(item.id, &diagnostic);
+                                }
+                                skip_errors.push(diagnostic);
+                                continue;
+                            }
+                            Ok(None) => {}
+                        }
+
                         let skipped_count = response.skipped_count_for(entity_type);
                         if let Err(error) = &skipped_count {
                             let diagnostic = format!(
@@ -425,6 +504,17 @@ impl CloudSyncer {
                         let skipped_count = skipped_count.unwrap_or_default();
                         if skipped_count > 0 {
                             let batch_size = batch_items.len();
+                            if skipped_count > batch_size {
+                                let diagnostic = format!(
+                                    "cloud reported {skipped_count} skipped {entity_type} row(s) for a {batch_size}-row sub-batch; marking sub-batch failed; server response: {}",
+                                    response.raw_body
+                                );
+                                for item in &batch_items {
+                                    let _ = self.queue.mark_failed(item.id, &diagnostic);
+                                }
+                                skip_errors.push(diagnostic);
+                                continue;
+                            }
                             let itemized = response.itemized_failures_for(
                                 entity_type,
                                 skipped_count,
@@ -433,16 +523,22 @@ impl CloudSyncer {
                             let itemized = match itemized {
                                 Ok(Some(failures)) => failures,
                                 Ok(None) => {
-                                    // Aggregate-only servers cannot identify individual rows.
-                                    // Preserve cas-607a's conservative whole-batch retry path.
+                                    // Aggregate-only responses count benign LWW losses as
+                                    // skipped but do not identify the row. Trust the server's
+                                    // LWW semantics and consume the local rows as acknowledgements.
                                     let diagnostic = format!(
-                                        "cloud skipped {skipped_count} of {batch_size} {entity_type} row(s); marking the indistinguishable sub-batch failed; server response: {}",
-                                        response.raw_body
+                                        "cloud skipped {skipped_count} of {batch_size} {entity_type} row(s); treating skips as LWW acknowledgements"
+                                    );
+                                    warn!(
+                                        entity_type = entity_type,
+                                        skipped = skipped_count,
+                                        batch_size,
+                                        "{diagnostic}"
                                     );
                                     for item in &batch_items {
-                                        let _ = self.queue.mark_failed(item.id, &diagnostic);
+                                        let _ = self.queue.mark_synced(item.id);
+                                        synced_count += 1;
                                     }
-                                    skip_errors.push(diagnostic);
                                     continue;
                                 }
                                 Err(error) => {
@@ -461,8 +557,21 @@ impl CloudSyncer {
                             // The server supplied a complete identity mapping: only named
                             // rows are terminal failures; owned neighbors in the same request
                             // are safely removed from the local queue.
+                            let mut failure_details = Vec::new();
                             for item in &batch_items {
                                 if let Some(failure) = itemized.get(&item.entity_id) {
+                                    let reason = match failure {
+                                        PushItemizedFailure::Rejection(rejection) => {
+                                            rejection.reason.as_str().to_string()
+                                        }
+                                        PushItemizedFailure::Invalid(invalid) => {
+                                            format!(
+                                                "{}: {}",
+                                                invalid.reason.as_str(),
+                                                invalid.detail
+                                            )
+                                        }
+                                    };
                                     let diagnostic = match failure {
                                         PushItemizedFailure::Rejection(rejection) => format!(
                                             "permanent cloud rejection: reason={}; entity={entity_type}; id={}; existing_project={}",
@@ -488,11 +597,19 @@ impl CloudSyncer {
                                     } else {
                                         let _ = self.queue.mark_failed(item.id, &diagnostic);
                                     }
-                                    skip_errors.push(diagnostic);
+                                    failure_details.push(format!("{} ({reason})", item.entity_id));
                                 } else {
                                     let _ = self.queue.mark_synced(item.id);
                                     synced_count += 1;
                                 }
+                            }
+                            if !failure_details.is_empty() {
+                                skip_errors.push(format!(
+                                    "cloud rejected {} of {} {entity_type} row(s): {}",
+                                    failure_details.len(),
+                                    batch_items.len(),
+                                    failure_details.join(", ")
+                                ));
                             }
                         } else {
                             for item in &batch_items {

--- a/cas-cli/src/cloud/syncer/push.rs
+++ b/cas-cli/src/cloud/syncer/push.rs
@@ -235,6 +235,12 @@ impl CloudSyncer {
             "worktrees",
             "Worktree push failed"
         );
+        push_type!(
+            pushed_task_dependencies,
+            &pending.task_dependencies,
+            "task_dependencies",
+            "Task dependency push failed"
+        );
 
         result
     }
@@ -252,6 +258,7 @@ impl CloudSyncer {
         target.pushed_commit_links += source.pushed_commit_links;
         target.pushed_agents += source.pushed_agents;
         target.pushed_worktrees += source.pushed_worktrees;
+        target.pushed_task_dependencies += source.pushed_task_dependencies;
         target.errors.extend(source.errors);
     }
 

--- a/cas-cli/src/cloud/syncer/team_push.rs
+++ b/cas-cli/src/cloud/syncer/team_push.rs
@@ -42,6 +42,22 @@ fn stamp_task_origin_project(value: &mut serde_json::Value, project_id: &str) {
     }
 }
 
+fn stamp_task_dependency_origin_project(value: &mut serde_json::Value, project_id: &str) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    let has_explicit_origin = object
+        .get("origin_project")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|origin| !origin.trim().is_empty());
+    if !has_explicit_origin {
+        object.insert(
+            "origin_project".to_string(),
+            serde_json::Value::String(project_id.to_string()),
+        );
+    }
+}
+
 impl CloudSyncer {
     pub fn push_team(&self, team_id: &str) -> Result<SyncResult, CasError> {
         let mut result = SyncResult::default();
@@ -171,6 +187,7 @@ impl CloudSyncer {
             (EntityType::CommitLink, "commit_links"),
             (EntityType::Agent, "agents"),
             (EntityType::Worktree, "worktrees"),
+            (EntityType::TaskDependency, "task_dependencies"),
         ] {
             let (synced, errors) = self.push_team_upserts_for_type(
                 team_id,
@@ -242,6 +259,9 @@ impl CloudSyncer {
                         // task consumers also rely on the row-level field.
                         if entity_type == EntityType::Task {
                             stamp_task_origin_project(&mut value, project_id);
+                        }
+                        if entity_type == EntityType::TaskDependency {
+                            stamp_task_dependency_origin_project(&mut value, project_id);
                         }
                         upserts.push((item, value));
                     }
@@ -559,6 +579,7 @@ impl CloudSyncer {
             "commit_links" => result.pushed_commit_links += count,
             "agents" => result.pushed_agents += count,
             "worktrees" => result.pushed_worktrees += count,
+            "task_dependencies" => result.pushed_task_dependencies += count,
             _ => {}
         }
     }

--- a/cas-cli/src/cloud/syncer/team_push.rs
+++ b/cas-cli/src/cloud/syncer/team_push.rs
@@ -1,8 +1,9 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use crate::cloud::syncer::{
-    CloudSyncer, PushItemizedFailure, SyncResult, TeamPushResponse, itemized_failures_for,
+    CloudSyncer, PushItemizedFailure, PushRowResult, SyncResult, TeamPushResponse,
+    itemized_failures_for, row_results_for,
 };
 use crate::cloud::{EntityType, QueuedSync, SyncOperation, get_project_canonical_id};
 use crate::error::CasError;
@@ -46,6 +47,8 @@ impl CloudSyncer {
     pub fn push_team(&self, team_id: &str) -> Result<SyncResult, CasError> {
         let mut result = SyncResult::default();
         let start = Instant::now();
+
+        self.requeue_version_gated_items()?;
 
         if !self.is_available() {
             return Ok(result);
@@ -276,6 +279,39 @@ impl CloudSyncer {
                     }
 
                     let raw_response = response.as_ref().map_or("", |body| body.raw_body.as_str());
+                    match response.as_ref() {
+                        Some(body) => match Self::team_row_results_for(
+                            body,
+                            entity_key,
+                            batch_items.iter().map(|item| item.entity_id.clone()),
+                        ) {
+                            Ok(Some(rows)) => {
+                                self.settle_team_row_results(
+                                    &batch_items,
+                                    entity_key,
+                                    raw_response,
+                                    rows,
+                                    &mut synced,
+                                    &mut errors,
+                                );
+                                continue;
+                            }
+                            Err(error) => {
+                                let diagnostic = format!(
+                                    "team {entity_key} push returned invalid per-row results: {error}; marking {} row(s) failed; server response: {raw_response}",
+                                    batch_items.len()
+                                );
+                                for item in &batch_items {
+                                    let _ = self.queue.mark_failed(item.id, &diagnostic);
+                                }
+                                errors.push(diagnostic);
+                                continue;
+                            }
+                            Ok(None) => {}
+                        },
+                        None => {}
+                    }
+
                     let (accepted, skipped) = match response.as_ref() {
                         Some(body) => match Self::team_counts_for(body, entity_key) {
                             Ok(Some(counts)) => counts,
@@ -296,6 +332,17 @@ impl CloudSyncer {
                         None => (sent_count, 0),
                     };
                     if skipped > 0 {
+                        if skipped > batch_items.len() {
+                            let diagnostic = format!(
+                                "cloud reported {skipped} skipped team {entity_key} row(s) for a {}-row sub-batch; marking sub-batch failed; server response: {raw_response}",
+                                batch_items.len()
+                            );
+                            for item in &batch_items {
+                                let _ = self.queue.mark_failed(item.id, &diagnostic);
+                            }
+                            errors.push(diagnostic);
+                            continue;
+                        }
                         let itemized = Self::team_itemized_failures_for(
                             response
                                 .as_ref()
@@ -308,14 +355,19 @@ impl CloudSyncer {
                             Ok(Some(rejections)) => rejections,
                             Ok(None) => {
                                 let diagnostic = format!(
-                                    "cloud skipped {skipped} of {} team {entity_key} row(s); marking the indistinguishable sub-batch failed; server response: {}",
+                                    "cloud skipped {skipped} of {} team {entity_key} row(s); treating skips as LWW acknowledgements",
                                     batch_items.len(),
-                                    raw_response
+                                );
+                                tracing::warn!(
+                                    entity_type = entity_key,
+                                    skipped,
+                                    batch_size = batch_items.len(),
+                                    "{diagnostic}"
                                 );
                                 for item in &batch_items {
-                                    let _ = self.queue.mark_failed(item.id, &diagnostic);
+                                    let _ = self.queue.mark_synced(item.id);
                                 }
-                                errors.push(diagnostic);
+                                synced += batch_items.len();
                                 continue;
                             }
                             Err(error) => {
@@ -332,8 +384,21 @@ impl CloudSyncer {
                             }
                         };
 
+                        let mut failure_details = Vec::new();
                         for item in &batch_items {
                             if let Some(failure) = itemized.get(&item.entity_id) {
+                                let reason = match failure {
+                                    PushItemizedFailure::Rejection(rejection) => {
+                                        rejection.reason.as_str().to_string()
+                                    }
+                                    PushItemizedFailure::Invalid(invalid) => {
+                                        format!(
+                                            "{}: {}",
+                                            invalid.reason.as_str(),
+                                            invalid.detail
+                                        )
+                                    }
+                                };
                                 let diagnostic = match failure {
                                     PushItemizedFailure::Rejection(rejection) => format!(
                                         "permanent cloud rejection: reason={}; entity={entity_key}; id={}; existing_project={}",
@@ -359,11 +424,19 @@ impl CloudSyncer {
                                 } else {
                                     let _ = self.queue.mark_failed(item.id, &diagnostic);
                                 }
-                                errors.push(diagnostic);
+                                failure_details.push(format!("{} ({reason})", item.entity_id));
                             } else {
                                 let _ = self.queue.mark_synced(item.id);
                                 synced += 1;
                             }
+                        }
+                        if !failure_details.is_empty() {
+                            errors.push(format!(
+                                "cloud rejected {} of {} team {entity_key} row(s): {}",
+                                failure_details.len(),
+                                batch_items.len(),
+                                failure_details.join(", ")
+                            ));
                         }
                         continue;
                     }
@@ -383,6 +456,51 @@ impl CloudSyncer {
         }
 
         (synced, errors)
+    }
+
+    fn settle_team_row_results(
+        &self,
+        batch_items: &[&QueuedSync],
+        entity_key: &str,
+        raw_response: &str,
+        rows: HashMap<String, PushRowResult>,
+        synced: &mut usize,
+        errors: &mut Vec<String>,
+    ) {
+        let mut rejected = Vec::new();
+        for item in batch_items {
+            let row = rows
+                .get(&item.entity_id)
+                .expect("row_results_for validates every queue identity");
+            if row.acknowledges() {
+                let _ = self.queue.mark_synced(item.id);
+                *synced += 1;
+                continue;
+            }
+
+            let reason = row.reason.as_deref().unwrap_or("unspecified");
+            let diagnostic = format!(
+                "cloud rejected team {entity_key} {}: reason={reason}; server response: {raw_response}",
+                item.entity_id
+            );
+            if row.rejection_is_retryable() {
+                let _ = self.queue.mark_failed(item.id, &diagnostic);
+            } else {
+                let _ = self
+                    .queue
+                    .park_failed(item.id, &diagnostic, self.config.max_retries);
+            }
+            rejected.push(format!("{} ({reason})", item.entity_id));
+        }
+
+        if !rejected.is_empty() {
+            errors.push(format!(
+                "cloud rejected {} of {} team {entity_key} row(s): {}",
+                rejected.len(),
+                batch_items.len(),
+                rejected.join(", ")
+            ));
+        }
     }
 
     fn push_team_sub_batch(
@@ -524,6 +642,30 @@ impl CloudSyncer {
         }
 
         Ok(Some((inserted.saturating_add(updated), skipped)))
+    }
+
+    fn team_row_results_for(
+        response: &TeamPushResponse,
+        entity_key: &str,
+        queued_ids: impl Iterator<Item = String>,
+    ) -> Result<Option<HashMap<String, PushRowResult>>, String> {
+        let queued_ids = queued_ids.collect::<Vec<_>>();
+        if let Some(rows) = response.rows.as_ref() {
+            let wrapped = serde_json::json!({"rows": rows});
+            return row_results_for(&wrapped, "rows", queued_ids.into_iter());
+        }
+
+        let Some(synced) = response.synced.as_object() else {
+            return Ok(None);
+        };
+        let Some(entity) = synced.get(entity_key) else {
+            return Ok(None);
+        };
+        row_results_for(
+            entity,
+            &format!("synced.{entity_key}"),
+            queued_ids.into_iter(),
+        )
     }
 
     fn team_itemized_failures_for(

--- a/cas-cli/src/cloud/syncer/team_push.rs
+++ b/cas-cli/src/cloud/syncer/team_push.rs
@@ -60,14 +60,25 @@ fn stamp_task_dependency_origin_project(value: &mut serde_json::Value, project_i
     let Some(object) = value.as_object_mut() else {
         return;
     };
-    let has_explicit_origin = object
+    let explicit_origin = object
         .get("origin_project")
         .and_then(serde_json::Value::as_str)
-        .is_some_and(|origin| !origin.trim().is_empty());
-    if !has_explicit_origin {
+        .map(str::trim)
+        .filter(|origin| !origin.is_empty());
+    if let Some(origin) = explicit_origin {
+        if let Some(canonical) = canonical_project_id_with_pin(origin, Some(project_id)) {
+            object.insert(
+                "origin_project".to_string(),
+                serde_json::Value::String(canonical),
+            );
+        }
+    } else {
         object.insert(
             "origin_project".to_string(),
-            serde_json::Value::String(project_id.to_string()),
+            serde_json::Value::String(
+                canonical_project_id_with_pin(project_id, Some(project_id))
+                    .unwrap_or_else(|| project_id.to_string()),
+            ),
         );
     }
 }
@@ -949,6 +960,21 @@ mod tests {
         assert_eq!(
             value.get("origin_project").and_then(|value| value.as_str()),
             Some("github.com/richards-llc/gabber-studio")
+        );
+    }
+
+    #[test]
+    fn canonical_identity_team_push_stamps_dependency_alias_as_canonical() {
+        let mut value = serde_json::json!({
+            "id": "edge-alias",
+            "origin_project": "git@GitHub.com:Richards-LLC/gabber-studio.git",
+        });
+
+        super::stamp_task_dependency_origin_project(&mut value, "gabber-studio");
+
+        assert_eq!(
+            value.get("origin_project").and_then(|value| value.as_str()),
+            Some("gabber-studio")
         );
     }
 }

--- a/cas-cli/src/cloud/syncer/team_push.rs
+++ b/cas-cli/src/cloud/syncer/team_push.rs
@@ -246,7 +246,12 @@ impl CloudSyncer {
         git_remote: Option<&str>,
         blocked_upserts: &HashSet<i64>,
     ) -> (usize, Vec<String>) {
-        let mut upserts = Vec::new();
+        // A move replacement (and every later edit to a moved task) carries
+        // its destination in the queue row. Keep those rows out of the
+        // pusher's envelope: the cloud keys the upsert by this envelope's
+        // project_canonical_id, not by the row's origin_project field.
+        let mut upserts_by_project: HashMap<String, Vec<(&QueuedSync, serde_json::Value)>> =
+            HashMap::new();
 
         for item in queued.iter().filter(|item| {
             item.operation == SyncOperation::Upsert
@@ -256,17 +261,21 @@ impl CloudSyncer {
             match item.payload.as_deref() {
                 Some(payload) => match serde_json::from_str::<serde_json::Value>(payload) {
                     Ok(mut value) => {
+                        let target_project = item.project_id.as_deref().unwrap_or(project_id);
                         // Rows queued before origin_project existed still need
-                        // the current scoped identity when they are retried.
-                        // The outer project_canonical_id is not a substitute:
-                        // task consumers also rely on the row-level field.
+                        // the target scoped identity when they are retried. The
+                        // outer project_canonical_id is not a substitute: task
+                        // consumers also rely on the row-level field.
                         if entity_type == EntityType::Task {
-                            stamp_task_origin_project(&mut value, project_id);
+                            stamp_task_origin_project(&mut value, target_project);
                         }
                         if entity_type == EntityType::TaskDependency {
-                            stamp_task_dependency_origin_project(&mut value, project_id);
+                            stamp_task_dependency_origin_project(&mut value, target_project);
                         }
-                        upserts.push((item, value));
+                        upserts_by_project
+                            .entry(target_project.to_string())
+                            .or_default()
+                            .push((item, value));
                     }
                     Err(_) => {
                         let _ = self
@@ -285,13 +294,29 @@ impl CloudSyncer {
         let mut synced = 0;
         let mut errors = Vec::new();
 
-        for sub_batch in self.split_into_sub_batches(upserts) {
+        let sub_batches: Vec<_> = upserts_by_project
+            .into_iter()
+            .flat_map(|(target_project, upserts)| {
+                self.split_into_sub_batches(upserts)
+                    .into_iter()
+                    .map(move |sub_batch| (target_project.clone(), sub_batch))
+            })
+            .collect();
+
+        for (target_project, sub_batch) in sub_batches {
             let (batch_items, values): (Vec<&QueuedSync>, Vec<serde_json::Value>) =
                 sub_batch.into_iter().unzip();
             let sent_count = values.len();
 
             match self
-                .push_team_sub_batch(team_id, entity_key, values, token, project_id, git_remote)
+                .push_team_sub_batch(
+                    team_id,
+                    entity_key,
+                    values,
+                    token,
+                    &target_project,
+                    git_remote,
+                )
             {
                 Ok(response) => {
                     if let Some(body) = response.as_ref() {

--- a/cas-cli/src/cloud/syncer/team_push.rs
+++ b/cas-cli/src/cloud/syncer/team_push.rs
@@ -754,7 +754,25 @@ mod tests {
         assert!(
             value
                 .get("origin_project")
-                .is_some_and(serde_json::Value::is_null)
+            .is_some_and(serde_json::Value::is_null)
+        );
+    }
+
+    #[test]
+    fn canonical_identity_team_push_stamps_remote_alias_as_canonical() {
+        let mut value = serde_json::json!({
+            "id": "cas-alias",
+            "scope": "project",
+        });
+
+        super::stamp_task_origin_project(
+            &mut value,
+            "git@GitHub.com:Richards-LLC/gabber-studio.git",
+        );
+
+        assert_eq!(
+            value.get("origin_project").and_then(|value| value.as_str()),
+            Some("github.com/richards-llc/gabber-studio")
         );
     }
 }

--- a/cas-cli/src/cloud/syncer/team_push.rs
+++ b/cas-cli/src/cloud/syncer/team_push.rs
@@ -4,7 +4,9 @@ use std::time::Instant;
 use crate::cloud::syncer::{
     CloudSyncer, PushItemizedFailure, SyncResult, TeamPushResponse, itemized_failures_for,
 };
-use crate::cloud::{EntityType, QueuedSync, SyncOperation, get_project_canonical_id};
+use crate::cloud::{
+    EntityType, QueuedSync, SyncOperation, canonical_project_id_with_pin, get_project_canonical_id,
+};
 use crate::error::CasError;
 use chrono::Utc;
 
@@ -29,14 +31,25 @@ fn stamp_task_origin_project(value: &mut serde_json::Value, project_id: &str) {
         // Supervisor reassignment is carried by a non-empty origin_project in
         // the queued payload. Only legacy rows without a usable identity need
         // to inherit the project performing the push.
-        let has_explicit_origin = task
+        let explicit_origin = task
             .get("origin_project")
             .and_then(serde_json::Value::as_str)
-            .is_some_and(|origin| !origin.trim().is_empty());
-        if !has_explicit_origin {
+            .map(str::trim)
+            .filter(|origin| !origin.is_empty());
+        if let Some(origin) = explicit_origin {
+            if let Some(canonical) = canonical_project_id_with_pin(origin, Some(project_id)) {
+                task.insert(
+                    "origin_project".to_string(),
+                    serde_json::Value::String(canonical),
+                );
+            }
+        } else {
             task.insert(
                 "origin_project".to_string(),
-                serde_json::Value::String(project_id.to_string()),
+                serde_json::Value::String(
+                    canonical_project_id_with_pin(project_id, Some(project_id))
+                        .unwrap_or_else(|| project_id.to_string()),
+                ),
             );
         }
     }
@@ -754,7 +767,7 @@ mod tests {
         assert!(
             value
                 .get("origin_project")
-            .is_some_and(serde_json::Value::is_null)
+                .is_some_and(serde_json::Value::is_null)
         );
     }
 

--- a/cas-cli/src/cloud/syncer/tests.rs
+++ b/cas-cli/src/cloud/syncer/tests.rs
@@ -457,6 +457,74 @@ async fn personal_push_keeps_itemized_invalid_revision_visible_in_queue_health()
     assert_eq!(remaining[0].retry_count, 1);
 }
 
+#[tokio::test]
+async fn team_push_serializes_task_dependency_collection() {
+    use crate::cloud::{CloudConfig, CloudSyncer, CloudSyncerConfig, EntityType, SyncOperation};
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+    use tempfile::tempdir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    let team_id = "team-cas-616e";
+    Mock::given(method("POST"))
+        .and(path(format!("/api/teams/{team_id}/sync/push")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "synced": {
+                "task_dependencies": {
+                    "inserted": 1,
+                    "updated": 0,
+                    "skipped": 0
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let temp = tempdir().unwrap();
+    let queue = Arc::new(SyncQueue::open(temp.path()).unwrap());
+    queue.init().unwrap();
+    queue
+        .enqueue_for_team(
+            EntityType::TaskDependency,
+            "cas-616e-from:cas-616e-to:blocks",
+            SyncOperation::Upsert,
+            Some(
+                r#"{"from_id":"cas-616e-from","to_id":"cas-616e-to","dep_type":"blocks","created_at":"2026-09-01T12:00:00Z"}"#,
+            ),
+            team_id,
+        )
+        .unwrap();
+
+    let syncer = CloudSyncer::new(
+        queue.clone(),
+        CloudConfig {
+            endpoint: server.uri(),
+            token: Some("test-token".to_string()),
+            ..Default::default()
+        },
+        CloudSyncerConfig::default(),
+    );
+    let result = tokio::task::spawn_blocking(move || syncer.push_team(team_id))
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.pushed_task_dependencies, 1);
+    assert!(queue.pending_for_team(team_id, 10, 5).unwrap().is_empty());
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let mut decoder = GzDecoder::new(requests[0].body.as_slice());
+    let mut decoded = Vec::new();
+    decoder.read_to_end(&mut decoded).unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&decoded).unwrap();
+    assert_eq!(payload["task_dependencies"][0]["from_id"], "cas-616e-from");
+    assert_eq!(payload["task_dependencies"][0]["dep_type"], "blocks");
+}
+
 #[test]
 fn push_response_is_backward_compatible_with_legacy_payload() {
     // Older cloud builds may return shapes like {"synced": {...}} or just
@@ -523,10 +591,49 @@ fn team_task_fixture(
     raw
 }
 
+fn team_dependency_fixture(
+    dependency: &crate::types::Dependency,
+    project_id: &str,
+    operation: Option<&str>,
+) -> serde_json::Value {
+    let mut raw = serde_json::to_value(dependency).unwrap();
+    raw["id"] = serde_json::json!(format!(
+        "{}:{}:{}",
+        dependency.from_id, dependency.to_id, dependency.dep_type
+    ));
+    raw["project_id"] = serde_json::json!(project_id);
+    if let Some(operation) = operation {
+        raw["operation"] = serde_json::json!(operation);
+    }
+    raw
+}
+
 async fn pull_team_task_fixtures(
     project_id: &str,
     tasks: Vec<serde_json::Value>,
     local_task: Option<Task>,
+) -> (
+    tempfile::TempDir,
+    SyncResult,
+    Arc<dyn TaskStore>,
+    Arc<SyncQueue>,
+) {
+    pull_team_task_and_dependency_fixtures(
+        project_id,
+        tasks,
+        local_task.into_iter().collect(),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await
+}
+
+async fn pull_team_task_and_dependency_fixtures(
+    project_id: &str,
+    tasks: Vec<serde_json::Value>,
+    local_tasks: Vec<Task>,
+    local_dependencies: Vec<crate::types::Dependency>,
+    task_dependencies: Vec<serde_json::Value>,
 ) -> (
     tempfile::TempDir,
     SyncResult,
@@ -551,6 +658,7 @@ async fn pull_team_task_fixtures(
             "tasks": tasks,
             "rules": [],
             "skills": [],
+            "task_dependencies": task_dependencies,
             "pulled_at": "2026-09-01T12:00:00Z",
             "team_id": team_id,
             "status": "ok",
@@ -564,8 +672,11 @@ async fn pull_team_task_fixtures(
     queue.init().unwrap();
     let store = open_store_local(temp.path()).unwrap();
     let task_store = open_task_store_local(temp.path()).unwrap();
-    if let Some(local_task) = local_task {
+    for local_task in local_tasks {
         task_store.add(&local_task).unwrap();
+    }
+    for dependency in local_dependencies {
+        task_store.add_dependency(&dependency).unwrap();
     }
     let rule_store = open_rule_store_local(temp.path()).unwrap();
     let skill_store = open_skill_store_local(temp.path()).unwrap();
@@ -589,6 +700,73 @@ async fn pull_team_task_fixtures(
         )
         .unwrap();
     (temp, result, task_store, queue)
+}
+
+#[tokio::test]
+async fn team_pull_applies_and_deletes_task_dependencies_without_requeue() {
+    use crate::types::{Dependency, DependencyType};
+
+    let project_id = "dependency-project";
+    let from = Task::new("cas-616e-from".to_string(), "from".to_string());
+    let to = Task::new("cas-616e-to".to_string(), "to".to_string());
+    let existing = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::Related);
+    let pulled = Dependency::new(to.id.clone(), from.id.clone(), DependencyType::Blocks);
+    let delete = team_dependency_fixture(&existing, project_id, Some("delete"));
+    let upsert = team_dependency_fixture(&pulled, project_id, None);
+
+    let (_temp, result, task_store, queue) = pull_team_task_and_dependency_fixtures(
+        project_id,
+        Vec::new(),
+        vec![from.clone(), to.clone()],
+        vec![existing],
+        vec![delete, upsert],
+    )
+    .await;
+
+    assert!(
+        result.errors.is_empty(),
+        "unexpected dependency pull errors: {:?}",
+        result.errors
+    );
+    assert_eq!(result.pulled_task_dependencies, 1);
+    assert!(task_store.get_dependencies(&from.id).unwrap().is_empty());
+    assert_eq!(task_store.get_dependencies(&to.id).unwrap().len(), 1);
+    assert_eq!(
+        task_store.get_dependencies(&to.id).unwrap()[0].dep_type,
+        DependencyType::Blocks
+    );
+    assert!(queue.pending(10, 5).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn team_pull_parks_dangling_task_dependency_without_error() {
+    use crate::types::{Dependency, DependencyType};
+
+    let project_id = "dependency-project";
+    let from = Task::new("cas-616e-dangling-from".to_string(), "from".to_string());
+    let missing = Dependency::new(
+        from.id.clone(),
+        "cas-616e-missing".to_string(),
+        DependencyType::Blocks,
+    );
+    let dangling = team_dependency_fixture(&missing, project_id, None);
+
+    let (_temp, result, task_store, _queue) = pull_team_task_and_dependency_fixtures(
+        project_id,
+        Vec::new(),
+        vec![from.clone()],
+        Vec::new(),
+        vec![dangling],
+    )
+    .await;
+
+    assert!(
+        result.errors.is_empty(),
+        "dangling dependency should be parked: {:?}",
+        result.errors
+    );
+    assert_eq!(result.pulled_task_dependencies, 0);
+    assert!(task_store.get_dependencies(&from.id).unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/cas-cli/src/cloud/syncer/tests.rs
+++ b/cas-cli/src/cloud/syncer/tests.rs
@@ -1092,6 +1092,113 @@ async fn team_pull_parks_dangling_task_dependency_without_error() {
 }
 
 #[tokio::test]
+async fn heal_local_task_dependency_enqueues_team_upsert() {
+    use crate::types::{Dependency, DependencyType};
+
+    let project_id = "dependency-heal-project";
+    let from = Task::new("cas-heal-local-from".to_string(), "from".to_string());
+    let to = Task::new("cas-heal-local-to".to_string(), "to".to_string());
+    let local = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::Blocks);
+
+    let (_temp, _result, _task_store, queue) = pull_team_task_and_dependency_fixtures(
+        project_id,
+        Vec::new(),
+        vec![from, to],
+        vec![local],
+        Vec::new(),
+    )
+    .await;
+
+    let pending = queue
+        .pending_for_team("team-cas-2125", 10, 5)
+        .unwrap();
+    assert_eq!(pending.len(), 1, "a local-only edge must be queued for team push");
+    assert_eq!(pending[0].entity_id, "cas-heal-local-from:cas-heal-local-to:blocks");
+    assert_eq!(pending[0].operation, crate::cloud::SyncOperation::Upsert);
+}
+
+#[tokio::test]
+async fn heal_cloud_task_dependency_materializes_local_edge() {
+    use crate::types::{Dependency, DependencyType};
+
+    let project_id = "dependency-heal-project";
+    let from = Task::new("cas-heal-cloud-from".to_string(), "from".to_string());
+    let to = Task::new("cas-heal-cloud-to".to_string(), "to".to_string());
+    let remote = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::Related);
+    let remote_wire = team_dependency_fixture(&remote, project_id, None);
+
+    let (_temp, _result, task_store, queue) = pull_team_task_and_dependency_fixtures(
+        project_id,
+        Vec::new(),
+        vec![from, to],
+        Vec::new(),
+        vec![remote_wire],
+    )
+    .await;
+
+    let dependencies = task_store
+        .get_dependencies("cas-heal-cloud-from")
+        .unwrap();
+    assert_eq!(dependencies.len(), 1);
+    assert_eq!(dependencies[0].from_id, remote.from_id);
+    assert_eq!(dependencies[0].to_id, remote.to_id);
+    assert_eq!(dependencies[0].dep_type, remote.dep_type);
+    assert!(queue.pending_for_team("team-cas-2125", 10, 5).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn heal_task_dependencies_with_matching_sets_is_quiet() {
+    use crate::types::{Dependency, DependencyType};
+
+    let project_id = "dependency-heal-project";
+    let from = Task::new("cas-heal-match-from".to_string(), "from".to_string());
+    let to = Task::new("cas-heal-match-to".to_string(), "to".to_string());
+    let matching = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::ParentChild);
+    let remote_wire = team_dependency_fixture(&matching, project_id, None);
+
+    let (_temp, _result, task_store, queue) = pull_team_task_and_dependency_fixtures(
+        project_id,
+        Vec::new(),
+        vec![from, to],
+        vec![matching.clone()],
+        vec![remote_wire],
+    )
+    .await;
+
+    let dependencies = task_store
+        .get_dependencies("cas-heal-match-from")
+        .unwrap();
+    assert_eq!(dependencies.len(), 1);
+    assert_eq!(dependencies[0].from_id, matching.from_id);
+    assert_eq!(dependencies[0].to_id, matching.to_id);
+    assert_eq!(dependencies[0].dep_type, matching.dep_type);
+    assert!(queue.pending_for_team("team-cas-2125", 10, 5).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn heal_deleted_task_dependency_does_not_requeue_edge() {
+    use crate::types::{Dependency, DependencyType};
+
+    let project_id = "dependency-heal-project";
+    let from = Task::new("cas-heal-delete-from".to_string(), "from".to_string());
+    let to = Task::new("cas-heal-delete-to".to_string(), "to".to_string());
+    let local = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::Blocks);
+    let delete_wire = team_dependency_fixture(&local, project_id, Some("delete"));
+
+    let (_temp, _result, task_store, queue) = pull_team_task_and_dependency_fixtures(
+        project_id,
+        Vec::new(),
+        vec![from, to],
+        vec![local],
+        vec![delete_wire],
+    )
+    .await;
+
+    assert!(task_store.get_dependencies("cas-heal-delete-from").unwrap().is_empty());
+    assert!(queue.pending_for_team("team-cas-2125", 10, 5).unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn team_pull_duplicate_task_id_prefers_owner_closed_row() {
     let now = chrono::Utc::now();
     let tasks = vec![

--- a/cas-cli/src/cloud/syncer/tests.rs
+++ b/cas-cli/src/cloud/syncer/tests.rs
@@ -47,6 +47,21 @@ fn test_sync_result_has_errors() {
 }
 
 #[test]
+fn heal_summary_is_quiet_for_noop_and_exact_when_edges_change() {
+    assert_eq!(SyncResult::default().dependency_heal_summary(), None);
+
+    let result = SyncResult {
+        healed_task_dependencies_to_cloud: 2,
+        healed_task_dependencies_from_cloud: 3,
+        ..Default::default()
+    };
+    assert_eq!(
+        result.dependency_heal_summary().as_deref(),
+        Some("healed 2 edge(s) to cloud, 3 from cloud")
+    );
+}
+
+#[test]
 fn concise_errors_groups_parked_rejections_without_server_json() {
     let result = SyncResult {
         errors: vec![
@@ -962,6 +977,30 @@ async fn pull_team_task_and_dependency_fixtures(
     Arc<dyn TaskStore>,
     Arc<SyncQueue>,
 ) {
+    pull_team_task_and_dependency_fixtures_with_pull_count(
+        project_id,
+        tasks,
+        local_tasks,
+        local_dependencies,
+        task_dependencies,
+        1,
+    )
+    .await
+}
+
+async fn pull_team_task_and_dependency_fixtures_with_pull_count(
+    project_id: &str,
+    tasks: Vec<serde_json::Value>,
+    local_tasks: Vec<Task>,
+    local_dependencies: Vec<crate::types::Dependency>,
+    task_dependencies: Vec<serde_json::Value>,
+    pull_count: usize,
+) -> (
+    tempfile::TempDir,
+    SyncResult,
+    Arc<dyn TaskStore>,
+    Arc<SyncQueue>,
+) {
     use crate::cloud::{CloudConfig, CloudSyncer, CloudSyncerConfig};
     use crate::store::{
         open_rule_store_local, open_skill_store_local, open_store_local, open_task_store_local,
@@ -985,7 +1024,7 @@ async fn pull_team_task_and_dependency_fixtures(
             "team_id": team_id,
             "status": "ok",
         })))
-        .expect(1)
+        .expect(pull_count as u64)
         .mount(&server)
         .await;
 
@@ -1011,16 +1050,19 @@ async fn pull_team_task_and_dependency_fixtures(
         },
         CloudSyncerConfig::default(),
     );
-    let result = syncer
-        .pull_team(
-            team_id,
-            project_id,
-            store.as_ref(),
-            task_store.as_ref(),
-            rule_store.as_ref(),
-            skill_store.as_ref(),
-        )
-        .unwrap();
+    let mut result = SyncResult::default();
+    for _ in 0..pull_count {
+        result = syncer
+            .pull_team(
+                team_id,
+                project_id,
+                store.as_ref(),
+                task_store.as_ref(),
+                rule_store.as_ref(),
+                skill_store.as_ref(),
+            )
+            .unwrap();
+    }
     (temp, result, task_store, queue)
 }
 
@@ -1100,7 +1142,7 @@ async fn heal_local_task_dependency_enqueues_team_upsert() {
     let to = Task::new("cas-heal-local-to".to_string(), "to".to_string());
     let local = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::Blocks);
 
-    let (_temp, _result, _task_store, queue) = pull_team_task_and_dependency_fixtures(
+    let (_temp, result, _task_store, queue) = pull_team_task_and_dependency_fixtures(
         project_id,
         Vec::new(),
         vec![from, to],
@@ -1109,6 +1151,8 @@ async fn heal_local_task_dependency_enqueues_team_upsert() {
     )
     .await;
 
+    assert_eq!(result.healed_task_dependencies_to_cloud, 1);
+    assert_eq!(result.healed_task_dependencies_from_cloud, 0);
     let pending = queue
         .pending_for_team("team-cas-2125", 10, 5)
         .unwrap();
@@ -1127,7 +1171,7 @@ async fn heal_cloud_task_dependency_materializes_local_edge() {
     let remote = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::Related);
     let remote_wire = team_dependency_fixture(&remote, project_id, None);
 
-    let (_temp, _result, task_store, queue) = pull_team_task_and_dependency_fixtures(
+    let (_temp, result, task_store, queue) = pull_team_task_and_dependency_fixtures(
         project_id,
         Vec::new(),
         vec![from, to],
@@ -1136,6 +1180,8 @@ async fn heal_cloud_task_dependency_materializes_local_edge() {
     )
     .await;
 
+    assert_eq!(result.healed_task_dependencies_to_cloud, 0);
+    assert_eq!(result.healed_task_dependencies_from_cloud, 1);
     let dependencies = task_store
         .get_dependencies("cas-heal-cloud-from")
         .unwrap();
@@ -1156,7 +1202,7 @@ async fn heal_task_dependencies_with_matching_sets_is_quiet() {
     let matching = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::ParentChild);
     let remote_wire = team_dependency_fixture(&matching, project_id, None);
 
-    let (_temp, _result, task_store, queue) = pull_team_task_and_dependency_fixtures(
+    let (_temp, result, task_store, queue) = pull_team_task_and_dependency_fixtures(
         project_id,
         Vec::new(),
         vec![from, to],
@@ -1165,6 +1211,8 @@ async fn heal_task_dependencies_with_matching_sets_is_quiet() {
     )
     .await;
 
+    assert_eq!(result.healed_task_dependencies_to_cloud, 0);
+    assert_eq!(result.healed_task_dependencies_from_cloud, 0);
     let dependencies = task_store
         .get_dependencies("cas-heal-match-from")
         .unwrap();
@@ -1183,19 +1231,52 @@ async fn heal_deleted_task_dependency_does_not_requeue_edge() {
     let from = Task::new("cas-heal-delete-from".to_string(), "from".to_string());
     let to = Task::new("cas-heal-delete-to".to_string(), "to".to_string());
     let local = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::Blocks);
-    let delete_wire = team_dependency_fixture(&local, project_id, Some("delete"));
+    let mut delete_wire = team_dependency_fixture(&local, project_id, Some("delete"));
+    delete_wire
+        .as_object_mut()
+        .expect("dependency fixture is an object")
+        .remove("created_at");
+    let stale_upsert = team_dependency_fixture(&local, project_id, None);
 
-    let (_temp, _result, task_store, queue) = pull_team_task_and_dependency_fixtures(
+    let (_temp, result, task_store, queue) = pull_team_task_and_dependency_fixtures(
         project_id,
         Vec::new(),
         vec![from, to],
         vec![local],
-        vec![delete_wire],
+        vec![delete_wire, stale_upsert],
     )
     .await;
 
+    assert_eq!(result.healed_task_dependencies_to_cloud, 0);
+    assert_eq!(result.healed_task_dependencies_from_cloud, 0);
     assert!(task_store.get_dependencies("cas-heal-delete-from").unwrap().is_empty());
     assert!(queue.pending_for_team("team-cas-2125", 10, 5).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn heal_local_task_dependency_is_idempotent_across_pulls() {
+    use crate::types::{Dependency, DependencyType};
+
+    let project_id = "dependency-heal-project";
+    let from = Task::new("cas-heal-repeat-from".to_string(), "from".to_string());
+    let to = Task::new("cas-heal-repeat-to".to_string(), "to".to_string());
+    let local = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::Blocks);
+
+    let (_temp, result, _task_store, queue) =
+        pull_team_task_and_dependency_fixtures_with_pull_count(
+            project_id,
+            Vec::new(),
+            vec![from, to],
+            vec![local],
+            Vec::new(),
+            2,
+        )
+        .await;
+
+    assert_eq!(result.healed_task_dependencies_to_cloud, 0);
+    assert_eq!(result.healed_task_dependencies_from_cloud, 0);
+    let pending = queue.pending_for_team("team-cas-2125", 10, 5).unwrap();
+    assert_eq!(pending.len(), 1, "repeated pulls must not duplicate the queue row");
 }
 
 #[tokio::test]

--- a/cas-cli/src/cloud/syncer/tests.rs
+++ b/cas-cli/src/cloud/syncer/tests.rs
@@ -499,6 +499,328 @@ fn push_response_skipped_count_threshold_drives_warn_path() {
     );
 }
 
+#[test]
+fn push_response_parses_complete_per_row_outcomes() {
+    let body = r#"{
+        "tasks": {
+            "inserted": 1,
+            "updated": 1,
+            "skipped": 1,
+            "rows": [
+                {"id": "task-inserted", "outcome": "inserted"},
+                {"id": "task-updated", "outcome": "updated"},
+                {"id": "task-skipped", "outcome": "skipped_lww"},
+                {"id": "task-rejected", "outcome": "rejected", "reason": "project_mismatch"}
+            ]
+        }
+    }"#;
+    let response: PushResponse = serde_json::from_str(body).expect("per-row response parses");
+    let rows = response
+        .row_results_for(
+            "tasks",
+            [
+                "task-inserted".to_string(),
+                "task-updated".to_string(),
+                "task-skipped".to_string(),
+                "task-rejected".to_string(),
+            ]
+            .into_iter(),
+        )
+        .expect("row response validates")
+        .expect("rows are present");
+
+    assert!(matches!(
+        rows["task-inserted"].outcome,
+        PushRowOutcome::Inserted
+    ));
+    assert!(matches!(
+        rows["task-updated"].outcome,
+        PushRowOutcome::Updated
+    ));
+    assert!(matches!(
+        rows["task-skipped"].outcome,
+        PushRowOutcome::SkippedLww
+    ));
+    assert_eq!(
+        rows["task-rejected"].reason.as_deref(),
+        Some("project_mismatch")
+    );
+}
+
+#[test]
+fn push_response_rejects_incomplete_or_duplicate_per_row_outcomes() {
+    let incomplete: PushResponse = serde_json::from_str(
+        r#"{"entries":{"rows":[{"id":"entry-one","outcome":"inserted"}]}}"#,
+    )
+    .unwrap();
+    let error = incomplete
+        .row_results_for(
+            "entries",
+            ["entry-one".to_string(), "entry-two".to_string()].into_iter(),
+        )
+        .unwrap_err();
+    assert!(error.contains("missing row entry-two"));
+
+    let duplicate: PushResponse = serde_json::from_str(
+        r#"{"entries":{"rows":[
+            {"id":"entry-one","outcome":"inserted"},
+            {"id":"entry-one","outcome":"updated"}
+        ]}}"#,
+    )
+    .unwrap();
+    assert!(duplicate
+        .row_results_for("entries", ["entry-one".to_string()].into_iter())
+        .unwrap_err()
+        .contains("duplicate id"));
+}
+
+#[tokio::test]
+async fn push_response_aggregate_skip_acknowledges_the_whole_personal_batch() {
+    use crate::cloud::{CloudConfig, EntityType, SyncOperation, SyncQueue};
+    use tempfile::tempdir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/push"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": {"inserted": 1, "updated": 0, "skipped": 1}
+        })))
+        .mount(&server)
+        .await;
+
+    let temp = tempdir().unwrap();
+    let queue = Arc::new(SyncQueue::open(temp.path()).unwrap());
+    queue.init().unwrap();
+    queue
+        .enqueue(
+            EntityType::Entry,
+            "entry-accepted",
+            SyncOperation::Upsert,
+            Some(r#"{"id":"entry-accepted"}"#),
+        )
+        .unwrap();
+    queue
+        .enqueue(
+            EntityType::Entry,
+            "entry-lww-skipped",
+            SyncOperation::Upsert,
+            Some(r#"{"id":"entry-lww-skipped"}"#),
+        )
+        .unwrap();
+
+    let syncer = CloudSyncer::new_for_project(
+        queue.clone(),
+        CloudConfig {
+            endpoint: server.uri(),
+            token: Some("test-token".to_string()),
+            ..Default::default()
+        },
+        CloudSyncerConfig::default(),
+        "test-project".to_string(),
+        temp.path(),
+    );
+    let result = syncer.push_scoped(PushScope::EntriesOnly).unwrap();
+
+    assert!(result.errors.is_empty(), "LWW skips are acknowledgements");
+    assert_eq!(result.pushed_entries, 2);
+    assert!(queue.list_all(10).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn push_response_per_row_rejection_is_parked_without_poisoning_neighbors() {
+    use crate::cloud::{CloudConfig, EntityType, SyncOperation, SyncQueue};
+    use tempfile::tempdir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/push"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": {
+                "inserted": 1,
+                "updated": 0,
+                "skipped": 1,
+                "rows": [
+                    {"id": "entry-good", "outcome": "updated"},
+                    {"id": "entry-rejected", "outcome": "rejected", "reason": "project_mismatch"}
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let temp = tempdir().unwrap();
+    let queue = Arc::new(SyncQueue::open(temp.path()).unwrap());
+    queue.init().unwrap();
+    for id in ["entry-good", "entry-rejected"] {
+        queue
+            .enqueue(
+                EntityType::Entry,
+                id,
+                SyncOperation::Upsert,
+                Some(&format!(r#"{{"id":"{id}"}}"#)),
+            )
+            .unwrap();
+    }
+
+    let syncer = CloudSyncer::new_for_project(
+        queue.clone(),
+        CloudConfig {
+            endpoint: server.uri(),
+            token: Some("test-token".to_string()),
+            ..Default::default()
+        },
+        CloudSyncerConfig::default(),
+        "test-project".to_string(),
+        temp.path(),
+    );
+    let result = syncer.push_scoped(PushScope::EntriesOnly).unwrap();
+
+    assert_eq!(result.pushed_entries, 0, "the batch reports its queue error");
+    assert_eq!(result.errors.len(), 1);
+    let remaining = queue.list_all(10).unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].entity_id, "entry-rejected");
+    assert_eq!(remaining[0].retry_count, 5);
+    assert!(remaining[0]
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.contains("project_mismatch")));
+}
+
+#[test]
+fn version_gate_requeues_only_after_minimum_and_is_idempotent() {
+    let (_temp, queue) = {
+        let temp = tempfile::tempdir().unwrap();
+        let queue = SyncQueue::open(temp.path()).unwrap();
+        queue.init().unwrap();
+        queue
+            .enqueue(
+                crate::cloud::EntityType::Task,
+                "task-old-client",
+                crate::cloud::SyncOperation::Upsert,
+                Some(r#"{"id":"task-old-client"}"#),
+            )
+            .unwrap();
+        queue
+            .enqueue(
+                crate::cloud::EntityType::Task,
+                "task-new-enough",
+                crate::cloud::SyncOperation::Upsert,
+                Some(r#"{"id":"task-new-enough"}"#),
+            )
+            .unwrap();
+        let ids = queue
+            .pending(10, 5)
+            .unwrap()
+            .into_iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>();
+        for _ in 0..5 {
+            queue
+                .mark_failed(
+                    ids[0],
+                    "Team push failed with status 400: Client version 3.4.2 is below minimum 3.5.0",
+                )
+                .unwrap();
+            queue
+                .mark_failed(
+                    ids[1],
+                    "Team push failed with status 400: Client version 3.4.2 is below minimum 3.4.9",
+                )
+                .unwrap();
+        }
+        (temp, queue)
+    };
+
+    assert_eq!(
+        queue
+            .requeue_version_gated_failures("3.4.8", 5)
+            .unwrap(),
+        0
+    );
+    assert!(queue
+        .list_all(10)
+        .unwrap()
+        .iter()
+        .all(|item| item.retry_count == 5 && item.last_error.is_some()));
+
+    assert_eq!(
+        queue
+            .requeue_version_gated_failures("3.5.0", 5)
+            .unwrap(),
+        2
+    );
+    let requeued = queue.list_all(10).unwrap();
+    assert!(requeued.iter().all(|item| {
+        item.retry_count == 0 && item.last_error.is_none()
+    }));
+    assert_eq!(
+        queue
+            .requeue_version_gated_failures("3.5.0", 5)
+            .unwrap(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn version_gate_push_requeues_terminal_items_before_reading_pending_queue() {
+    use crate::cloud::{CloudConfig, EntityType, SyncOperation, SyncQueue};
+    use tempfile::tempdir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/sync/push"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": {"inserted": 1, "updated": 0, "skipped": 0}
+        })))
+        .mount(&server)
+        .await;
+
+    let temp = tempdir().unwrap();
+    let queue = Arc::new(SyncQueue::open(temp.path()).unwrap());
+    queue.init().unwrap();
+    queue
+        .enqueue(
+            EntityType::Entry,
+            "entry-version-gated",
+            SyncOperation::Upsert,
+            Some(r#"{"id":"entry-version-gated"}"#),
+        )
+        .unwrap();
+    let id = queue.pending(10, 5).unwrap()[0].id;
+    for _ in 0..5 {
+        queue
+            .mark_failed(
+                id,
+                "Push failed with status 400: Client version 3.4.2 is below minimum 3.5.0",
+            )
+            .unwrap();
+    }
+
+    let syncer = CloudSyncer::new_for_project(
+        queue.clone(),
+        CloudConfig {
+            endpoint: server.uri(),
+            token: Some("test-token".to_string()),
+            ..Default::default()
+        },
+        CloudSyncerConfig::default(),
+        "test-project".to_string(),
+        temp.path(),
+    );
+    let result = syncer.push_scoped(PushScope::EntriesOnly).unwrap();
+
+    assert!(result.errors.is_empty());
+    assert_eq!(result.pushed_entries, 1);
+    assert!(queue.list_all(10).unwrap().is_empty());
+}
+
 // ---------------------------------------------------------------------------
 // Cross-project team-task ownership (cas-2125).
 // ---------------------------------------------------------------------------

--- a/cas-cli/src/cloud/team_registration.rs
+++ b/cas-cli/src/cloud/team_registration.rs
@@ -38,7 +38,7 @@
 use std::fmt;
 use std::time::Duration;
 
-use crate::cloud::{CloudSyncer, TeamProjectsResponse};
+use crate::cloud::{CloudSyncer, TeamProjectsResponse, canonical_project_id_with_pin};
 
 /// Timeout for both the lookup and the registration request. Matches the
 /// 30 s used by the other interactive team endpoints in `cli/cloud.rs`.
@@ -130,6 +130,7 @@ pub struct TeamRegistration<'a> {
     team_id: &'a str,
     canonical_id: &'a str,
     git_remote: Option<&'a str>,
+    pinned_canonical_id: Option<&'a str>,
     timeout: Duration,
 }
 
@@ -142,6 +143,7 @@ impl<'a> TeamRegistration<'a> {
             team_id,
             canonical_id,
             git_remote: None,
+            pinned_canonical_id: None,
             timeout: REGISTRATION_TIMEOUT,
         }
     }
@@ -151,6 +153,13 @@ impl<'a> TeamRegistration<'a> {
     /// instead of creating a second one.
     pub fn with_git_remote(mut self, git_remote: Option<&'a str>) -> Self {
         self.git_remote = git_remote;
+        self
+    }
+
+    /// Treat an explicit local pin as the authoritative target when a
+    /// project list contains a remote-shaped alias.
+    pub fn with_pinned_canonical_id(mut self, pinned: Option<&'a str>) -> Self {
+        self.pinned_canonical_id = pinned;
         self
     }
 
@@ -195,15 +204,19 @@ impl<'a> TeamRegistration<'a> {
     /// Returns `Ok` only when the *server* lists the project — a 2xx on the
     /// registration write is not treated as proof on its own.
     pub fn ensure(&self) -> Result<RegistrationOutcome, RegistrationFailure> {
-        if let Some(project_uuid) = self.lookup(self.canonical_id)? {
+        let canonical_id = self.wire_canonical_id();
+        if let Some(project_uuid) = self.lookup(&canonical_id)? {
             return Ok(RegistrationOutcome::AlreadyRegistered { project_uuid });
         }
 
         let (register_status, resolved_id) = self.register()?;
-        let expected_id = resolved_id.as_deref().unwrap_or(self.canonical_id);
+        let expected_id = resolved_id
+            .as_deref()
+            .and_then(|id| canonical_project_id_with_pin(id, self.pinned_canonical_id))
+            .unwrap_or_else(|| canonical_id.clone());
 
-        match self.lookup(expected_id)? {
-            Some(project_uuid) if expected_id == self.canonical_id => {
+        match self.lookup(&expected_id)? {
+            Some(project_uuid) if expected_id == canonical_id => {
                 Ok(RegistrationOutcome::Registered { project_uuid })
             }
             Some(project_uuid) => Ok(RegistrationOutcome::AdoptedExisting {
@@ -211,20 +224,20 @@ impl<'a> TeamRegistration<'a> {
                 canonical_id: expected_id.to_string(),
             }),
             None => Err(RegistrationFailure {
-                reason: if expected_id == self.canonical_id {
+                reason: if expected_id == canonical_id {
                     format!(
                         "Project '{}' is still not registered with team {} on {} after the \
                          registration request succeeded. The server accepted the write but does \
                          not list the project, so team memories and team pushes for this project \
                          cannot work. This is a server-side defect — report the interaction below.",
-                        self.canonical_id, self.team_id, self.endpoint
+                        canonical_id, self.team_id, self.endpoint
                     )
                 } else {
                     format!(
                         "The server resolved project '{}' to '{}' during registration, but \
                          team {} on {} did not list the resolved project afterward. The client \
                          will not adopt '{}' until that verification succeeds.",
-                        self.canonical_id, expected_id, self.team_id, self.endpoint, expected_id,
+                        canonical_id, expected_id, self.team_id, self.endpoint, expected_id,
                     )
                 },
                 interaction: format!(
@@ -232,7 +245,7 @@ impl<'a> TeamRegistration<'a> {
                      (resolved canonical_id: {}); \
                      GET {} -> 200 but no project with canonical_id \"{}\"",
                     self.push_url(),
-                    self.canonical_id,
+                    canonical_id,
                     match self.git_remote {
                         Some(remote) => format!(",\"git_remote\":\"{remote}\""),
                         None => String::new(),
@@ -311,10 +324,15 @@ impl<'a> TeamRegistration<'a> {
                 interaction: format!("GET {url} -> 200 {}", body_excerpt(&body)),
             })?;
 
+        let expected = canonical_project_id_with_pin(canonical_id, self.pinned_canonical_id)
+            .unwrap_or_else(|| canonical_id.to_string());
         Ok(parsed
             .projects
             .into_iter()
-            .find(|p| p.canonical_id == canonical_id)
+            .find(|p| {
+                canonical_project_id_with_pin(&p.canonical_id, self.pinned_canonical_id)
+                    .is_some_and(|id| id == expected)
+            })
             .map(|p| p.id))
     }
 
@@ -331,7 +349,7 @@ impl<'a> TeamRegistration<'a> {
         payload.insert("entries".to_string(), serde_json::json!([]));
         payload.insert(
             "project_canonical_id".to_string(),
-            serde_json::json!(self.canonical_id),
+            serde_json::json!(self.wire_canonical_id()),
         );
         if let Some(remote) = self.git_remote {
             payload.insert("git_remote".to_string(), serde_json::json!(remote));
@@ -400,7 +418,9 @@ impl<'a> TeamRegistration<'a> {
             _ => format!(
                 "Could not register project '{}' with team {} on {}: the server returned \
                  HTTP {status}.",
-                self.canonical_id, self.team_id, self.endpoint
+                self.wire_canonical_id(),
+                self.team_id,
+                self.endpoint
             ),
         };
         RegistrationFailure {
@@ -408,10 +428,15 @@ impl<'a> TeamRegistration<'a> {
             interaction: format!(
                 "POST {url} (body: {{\"entries\":[],\"project_canonical_id\":\"{}\"}}) -> \
                  {status} {}",
-                self.canonical_id,
+                self.wire_canonical_id(),
                 body_excerpt(body)
             ),
         }
+    }
+
+    fn wire_canonical_id(&self) -> String {
+        canonical_project_id_with_pin(self.canonical_id, self.pinned_canonical_id)
+            .unwrap_or_else(|| self.canonical_id.trim().to_string())
     }
 }
 

--- a/cas-cli/src/factory_preflight.rs
+++ b/cas-cli/src/factory_preflight.rs
@@ -112,6 +112,8 @@ pub struct OptionalUpstreamPreflight {
     pub name: String,
     pub transport: String,
     pub state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executable: Option<String>,
     pub attempts: u32,
     pub consecutive_failures: u32,
     pub tool_count: usize,
@@ -202,7 +204,13 @@ impl From<cmcp_core::ProxyHealthSnapshot> for ProxySnapshotInput {
                 .map(|server| OptionalUpstreamPreflight {
                     name: server.name,
                     transport: server.transport,
-                    state: format!("{:?}", server.state).to_ascii_lowercase(),
+                    state: match server.state {
+                        cmcp_core::UpstreamState::ExecutableMissing => {
+                            "executable_missing".to_string()
+                        }
+                        state => format!("{:?}", state).to_ascii_lowercase(),
+                    },
+                    executable: server.executable,
                     attempts: server.attempts,
                     consecutive_failures: server.consecutive_failures,
                     tool_count: server.tool_count,
@@ -1758,6 +1766,7 @@ mod tests {
                     name: "optional".to_string(),
                     transport: "http".to_string(),
                     state: "backoff".to_string(),
+                    executable: None,
                     attempts: 2,
                     consecutive_failures: 2,
                     tool_count: 0,
@@ -1805,6 +1814,7 @@ mod tests {
                     name: first_name.to_string(),
                     transport: "Bearer cache-secret".to_string(),
                     state: cmcp_core::UpstreamState::Backoff,
+                    executable: None,
                     attempts: 1,
                     consecutive_failures: 1,
                     tool_count: 0,
@@ -1816,6 +1826,7 @@ mod tests {
                     name: second_name.to_string(),
                     transport: "http".to_string(),
                     state: cmcp_core::UpstreamState::Backoff,
+                    executable: None,
                     attempts: 1,
                     consecutive_failures: 1,
                     tool_count: 0,

--- a/cas-cli/src/mcp/server/runtime.rs
+++ b/cas-cli/src/mcp/server/runtime.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -1009,6 +1009,27 @@ pub fn proxy_config_fingerprint(config: &cmcp_core::config::Config) -> String {
             }
         }
     }
+    for route in config
+        .allowlist
+        .iter()
+        .map(|route| route.canonical_entry())
+        .collect::<BTreeSet<_>>()
+    {
+        field(&mut hasher, b"allowlist", route.as_bytes());
+    }
+    if let Some(gateway) = config.delegation.external_production_verification.as_ref() {
+        field(&mut hasher, b"delegation-server", gateway.server.as_bytes());
+        field(
+            &mut hasher,
+            b"delegation-start",
+            gateway.start_tool.as_bytes(),
+        );
+        field(
+            &mut hasher,
+            b"delegation-wait",
+            gateway.wait_tool.as_bytes(),
+        );
+    }
     format!("sha256:{:x}", hasher.finalize())
 }
 
@@ -1750,6 +1771,19 @@ mod tests {
         assert_eq!(first_fingerprint.len(), 71);
         assert!(first_fingerprint.starts_with("sha256:"));
         assert_ne!(first_fingerprint, super::proxy_config_fingerprint(&second));
+
+        let mut policy_changed = first.clone();
+        policy_changed
+            .allowlist
+            .push(cmcp_core::config::ExternalToolConfig {
+                server: "github".to_string(),
+                tool: "list_issues".to_string(),
+            });
+        assert_ne!(
+            first_fingerprint,
+            super::proxy_config_fingerprint(&policy_changed),
+            "policy-only config changes must invalidate cached proxy state"
+        );
         for forbidden in ["unsafe/name", "example.invalid", "first-secret"] {
             assert!(!first_fingerprint.contains(forbidden));
         }

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -4557,6 +4557,41 @@ impl CasCore {
                         let dep_title = dependent_task.title.clone();
                         let occurrence =
                             super::supervisor_push::occurrence_from_updated_at(persisted_at);
+                        // GH #673: task_ready is also a worker wake. A lifecycle
+                        // relay to the supervisor is not enough for an idle PTY
+                        // worker, whose message delivery is the turn trigger.
+                        match super::supervisor_push::queue_auto_unblock_worker_wake(
+                            &self.cas_root,
+                            &dependent_task,
+                            &req.id,
+                            &occurrence,
+                        ) {
+                            Ok(super::supervisor_push::AutoUnblockWakeResult::Queued {
+                                worker_name,
+                                prompt_id,
+                                ..
+                            }) => tracing::info!(
+                                task_id = %dep_id,
+                                worker = %worker_name,
+                                prompt_id,
+                                blocker = %req.id,
+                                "cas-673: queued synthetic auto-unblock wake for worker"
+                            ),
+                            Ok(super::supervisor_push::AutoUnblockWakeResult::Skipped {
+                                reason,
+                            }) => tracing::debug!(
+                                task_id = %dep_id,
+                                blocker = %req.id,
+                                %reason,
+                                "cas-673: skipped synthetic auto-unblock wake"
+                            ),
+                            Err(error) => tracing::warn!(
+                                task_id = %dep_id,
+                                blocker = %req.id,
+                                %error,
+                                "cas-673: synthetic auto-unblock wake failed after task_ready"
+                            ),
+                        }
                         let actor = self
                             .get_agent_id()
                             .ok()

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/supervisor_push.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/supervisor_push.rs
@@ -17,6 +17,7 @@ use cas_store::{
     SupervisorNotification, SupervisorQueueStore,
 };
 use cas_types::{AgentRole, TaskStatus};
+use std::path::Path;
 
 use super::TaskLifecycleGateError;
 use crate::mcp::server::CasCore;
@@ -213,6 +214,192 @@ pub fn prepare_task_lifecycle_outbox(
 /// Stable prompt_queue dedupe key for one durable lifecycle notification (cas-ecff).
 pub fn lifecycle_prompt_dedupe_key(notification_id: i64) -> String {
     format!("lifecycle-outbox:{notification_id}")
+}
+
+const AUTO_UNBLOCK_ASSIGNEE_STALE_SECS: i64 = 300;
+const AUTO_UNBLOCK_SPAWN_RECEIPT_LIMIT: usize = 100;
+
+/// Result of trying to wake the worker that owns an automatically unblocked
+/// task. The worker prompt uses the normal, non-urgent coordination-message
+/// queue path, while the idempotent key keeps one unblock occurrence from
+/// producing duplicate turns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AutoUnblockWakeResult {
+    Queued {
+        worker_name: String,
+        prompt_id: i64,
+        dedupe_key: String,
+    },
+    Skipped {
+        reason: String,
+    },
+}
+
+enum AutoUnblockWorkerTarget {
+    Worker(String),
+    Skipped(String),
+}
+
+fn append_auto_unblock_wake_note(
+    cas_root: &Path,
+    task_id: &str,
+    marker: &str,
+    note: &str,
+) -> Result<(), String> {
+    let task_store = crate::store::open_task_store(cas_root).map_err(|error| {
+        format!("task store open failed while recording auto-unblock wake: {error}")
+    })?;
+    let mut task = task_store
+        .get(task_id)
+        .map_err(|error| format!("task read failed while recording auto-unblock wake: {error}"))?;
+    if task.notes.contains(marker) {
+        return Ok(());
+    }
+    task.notes = if task.notes.is_empty() {
+        note.to_string()
+    } else {
+        format!("{}\n\n{note}", task.notes)
+    };
+    task.updated_at = Utc::now();
+    task_store.update(&task).map(|_| ()).map_err(|error| {
+        format!("task note update failed while recording auto-unblock wake: {error}")
+    })
+}
+
+fn auto_unblock_worker_target(
+    cas_root: &Path,
+    task: &cas_types::Task,
+) -> Result<AutoUnblockWorkerTarget, String> {
+    let factory_session = std::env::var("CAS_FACTORY_SESSION")
+        .ok()
+        .filter(|session| !session.trim().is_empty());
+
+    if let Some(assignee) = task.assignee.as_deref() {
+        let agent_store = crate::store::open_agent_store(cas_root).map_err(|error| {
+            format!("agent store open failed while resolving assignee: {error}")
+        })?;
+        let agents = agent_store
+            .list(None)
+            .map_err(|error| format!("agent list failed while resolving assignee: {error}"))?;
+        let live_assignee = agents.into_iter().find(|agent| {
+            agent.role == AgentRole::Worker
+                && agent.visible_to_factory_session(factory_session.as_deref())
+                && (agent.name == assignee || agent.id == assignee)
+                && agent.is_alive()
+                && !agent.is_heartbeat_expired(AUTO_UNBLOCK_ASSIGNEE_STALE_SECS)
+        });
+        return Ok(match live_assignee {
+            Some(agent) => AutoUnblockWorkerTarget::Worker(agent.name),
+            None => AutoUnblockWorkerTarget::Skipped(format!(
+                "assignee '{assignee}' has no registered worker with a fresh heartbeat"
+            )),
+        });
+    }
+
+    let Some(factory_session) = factory_session.as_deref() else {
+        return Ok(AutoUnblockWorkerTarget::Skipped(
+            "no live assignee or matching pre-assignment receipt".to_string(),
+        ));
+    };
+    let spawn_queue = crate::store::open_spawn_queue_store(cas_root).map_err(|error| {
+        format!("spawn queue open failed while resolving pre-assignment: {error}")
+    })?;
+    let worker_name = spawn_queue
+        .recent_spawn_lifecycle(factory_session, AUTO_UNBLOCK_SPAWN_RECEIPT_LIMIT)
+        .map_err(|error| {
+            format!("spawn receipt lookup failed while resolving pre-assignment: {error}")
+        })?
+        .into_iter()
+        .filter(|receipt| receipt.task_id.as_deref() == Some(task.id.as_str()))
+        .filter(|receipt| !receipt.state.is_terminal())
+        .find_map(|receipt| {
+            receipt
+                .worker_name
+                .filter(|name| !name.trim().is_empty())
+                .or_else(|| {
+                    (receipt.requested_names.len() == 1).then(|| receipt.requested_names[0].clone())
+                })
+        });
+    Ok(match worker_name {
+        Some(worker_name) => AutoUnblockWorkerTarget::Worker(worker_name),
+        None => AutoUnblockWorkerTarget::Skipped(
+            "no live assignee or matching pre-assignment receipt".to_string(),
+        ),
+    })
+}
+
+/// Queue the synthetic worker wake emitted by the blocked→open transition.
+///
+/// This deliberately uses the same prompt queue consumed by
+/// `coordination action=message`, with `urgent = false`; the daemon therefore
+/// applies its ordinary idle-gate PTY nudge. The dedupe key is scoped to the
+/// task, worker, blocker, and post-update occurrence, so a replay cannot add a
+/// second prompt while a later unblock cycle can still wake the same worker.
+pub(crate) fn queue_auto_unblock_worker_wake(
+    cas_root: &Path,
+    task: &cas_types::Task,
+    blocker_id: &str,
+    occurrence_id: &str,
+) -> Result<AutoUnblockWakeResult, String> {
+    let target = auto_unblock_worker_target(cas_root, task)?;
+    let base_key = format!(
+        "task-unblocked:{}:{}:{}",
+        task.id, blocker_id, occurrence_id
+    );
+    let (worker_name, prompt_id, dedupe_key) = match target {
+        AutoUnblockWorkerTarget::Skipped(reason) => {
+            let marker = format!("auto-unblock-wake-skip:{base_key}");
+            let timestamp = Utc::now().format("%Y-%m-%d %H:%M");
+            let note =
+                format!("[{timestamp}] Auto-unblock wake skipped: {reason}. (marker={marker})");
+            append_auto_unblock_wake_note(cas_root, &task.id, &marker, &note)?;
+            return Ok(AutoUnblockWakeResult::Skipped { reason });
+        }
+        AutoUnblockWorkerTarget::Worker(worker_name) => {
+            let dedupe_key = format!("{base_key}:worker:{worker_name}");
+            let prompt = format!(
+                "Task {} is now unblocked (blocker {} closed): run task start id={}",
+                task.id, blocker_id, task.id
+            );
+            let summary = format!("Task unblocked: {}", task.id);
+            let factory_session = std::env::var("CAS_FACTORY_SESSION")
+                .ok()
+                .filter(|session| !session.trim().is_empty());
+            let queue = crate::store::open_prompt_queue_store(cas_root).map_err(|error| {
+                format!("prompt queue open failed for auto-unblock wake: {error}")
+            })?;
+            let result = queue
+                .enqueue_idempotent(
+                    "supervisor",
+                    &worker_name,
+                    &prompt,
+                    factory_session.as_deref(),
+                    Some(&summary),
+                    Some(cas_store::NotificationPriority::Normal),
+                    &dedupe_key,
+                )
+                .map_err(|error| format!("auto-unblock worker wake enqueue failed: {error}"))?;
+            let prompt_id = match result {
+                cas_store::EnqueueIdempotentResult::Created(id)
+                | cas_store::EnqueueIdempotentResult::AlreadyExists(id) => id,
+            };
+            crate::ui::factory::daemon::runtime::delivery::wake_daemon_after_enqueue(cas_root);
+            (worker_name, prompt_id, dedupe_key)
+        }
+    };
+
+    let marker = format!("auto-unblock-wake:{dedupe_key}");
+    let timestamp = Utc::now().format("%Y-%m-%d %H:%M");
+    let note = format!(
+        "[{timestamp}] Auto-unblock wake queued for worker '{worker_name}' (prompt_id={prompt_id}): Task {} is now unblocked (blocker {blocker_id} closed): run task start id={} (dedupe_key={dedupe_key}; marker={marker}).",
+        task.id, task.id
+    );
+    append_auto_unblock_wake_note(cas_root, &task.id, &marker, &note)?;
+    Ok(AutoUnblockWakeResult::Queued {
+        worker_name,
+        prompt_id,
+        dedupe_key,
+    })
 }
 
 /// Truthful repair guidance after task mutation succeeded but lifecycle push failed.
@@ -819,10 +1006,10 @@ mod tests {
     use crate::mcp::tools::core::workflow::verification_tools::VERIFICATION_REJECTED_REOPEN_RECOVERY;
     use crate::test_support::TestEnvGuard;
     use cas_store::{
-        PromptQueueStore, SqliteAgentStore, SqlitePromptQueueStore, SqliteSupervisorQueueStore,
-        SupervisorQueueStore,
+        PromptQueueStore, SpawnQueueStore, SqliteAgentStore, SqlitePromptQueueStore,
+        SqliteSpawnQueueStore, SqliteSupervisorQueueStore, SupervisorQueueStore, TaskStore,
     };
-    use cas_types::{Agent, AgentRole, AgentStatus};
+    use cas_types::{Agent, AgentRole, AgentStatus, Task, TaskStatus};
     use tempfile::TempDir;
 
     // cas-acb4: `CAS_FACTORY_SESSION` mutations here go through `TestEnvGuard`,
@@ -957,6 +1144,166 @@ mod tests {
         assert!(!is_lifecycle_wake_source(&fyi));
         // The non-waking form must not be a prefix-match false positive.
         assert!(!is_lifecycle_wake_source("lifecycle:70"));
+    }
+
+    #[test]
+    fn auto_unblock_wakes_fresh_idle_assignee_once_and_records_note() {
+        let _env = TestEnvGuard::with_vars(&[("CAS_FACTORY_SESSION", "sess-auto-wake")]);
+        let temp = TempDir::new().unwrap();
+        let agents = SqliteAgentStore::open(temp.path()).unwrap();
+        agents.init().unwrap();
+        let mut worker = agent_in_session(
+            "worker-auto-id",
+            "quiet-worker",
+            AgentRole::Worker,
+            "sess-auto-wake",
+        );
+        worker.status = AgentStatus::Idle;
+        agents.register(&worker).unwrap();
+
+        let task_store = cas_store::SqliteTaskStore::open(temp.path()).unwrap();
+        task_store.init().unwrap();
+        let mut task = Task::new("cas-auto-wake".into(), "Wake me after blocker close".into());
+        task.status = TaskStatus::Blocked;
+        task.assignee = Some("quiet-worker".into());
+        task_store.add(&task).unwrap();
+
+        let result = queue_auto_unblock_worker_wake(
+            temp.path(),
+            &task,
+            "cas-blocker",
+            "unblock-occurrence-1",
+        )
+        .unwrap();
+        assert!(matches!(result, AutoUnblockWakeResult::Queued { .. }));
+
+        // A repeated attempt represents a replay of the same unblock event;
+        // the idempotent queue row is the only prompt.
+        queue_auto_unblock_worker_wake(temp.path(), &task, "cas-blocker", "unblock-occurrence-1")
+            .unwrap();
+        let queue = SqlitePromptQueueStore::open(temp.path()).unwrap();
+        queue.init().unwrap();
+        let rows = queue.peek_all(10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].source, "supervisor");
+        assert_eq!(rows[0].target, "quiet-worker");
+        assert!(!rows[0].urgent);
+        assert_eq!(
+            rows[0].prompt,
+            "Task cas-auto-wake is now unblocked (blocker cas-blocker closed): run task start id=cas-auto-wake"
+        );
+        assert!(
+            task_store
+                .get("cas-auto-wake")
+                .unwrap()
+                .notes
+                .contains("Auto-unblock wake queued for worker 'quiet-worker'")
+        );
+    }
+
+    #[test]
+    fn auto_unblock_without_assignee_does_not_queue_a_message() {
+        let _env = TestEnvGuard::with_vars(&[("CAS_FACTORY_SESSION", "sess-auto-none")]);
+        let temp = TempDir::new().unwrap();
+        let task_store = cas_store::SqliteTaskStore::open(temp.path()).unwrap();
+        task_store.init().unwrap();
+        let mut task = Task::new("cas-auto-none".into(), "No worker yet".into());
+        task.status = TaskStatus::Blocked;
+        task_store.add(&task).unwrap();
+
+        let result = queue_auto_unblock_worker_wake(
+            temp.path(),
+            &task,
+            "cas-blocker",
+            "unblock-occurrence-none",
+        )
+        .unwrap();
+        assert!(matches!(result, AutoUnblockWakeResult::Skipped { .. }));
+        let queue = SqlitePromptQueueStore::open(temp.path()).unwrap();
+        queue.init().unwrap();
+        assert_eq!(queue.pending_count().unwrap(), 0);
+        assert!(task_store.get("cas-auto-none").unwrap().notes.contains(
+            "Auto-unblock wake skipped: no live assignee or matching pre-assignment receipt"
+        ));
+    }
+
+    #[test]
+    fn auto_unblock_stale_assignee_does_not_queue_a_message_and_records_note() {
+        let _env = TestEnvGuard::with_vars(&[("CAS_FACTORY_SESSION", "sess-auto-stale")]);
+        let temp = TempDir::new().unwrap();
+        let agents = SqliteAgentStore::open(temp.path()).unwrap();
+        agents.init().unwrap();
+        let mut worker = agent_in_session(
+            "worker-stale-id",
+            "stale-worker",
+            AgentRole::Worker,
+            "sess-auto-stale",
+        );
+        worker.status = AgentStatus::Idle;
+        worker.last_heartbeat = chrono::Utc::now() - chrono::Duration::seconds(301);
+        agents.register(&worker).unwrap();
+
+        let task_store = cas_store::SqliteTaskStore::open(temp.path()).unwrap();
+        task_store.init().unwrap();
+        let mut task = Task::new("cas-auto-stale".into(), "Stale worker".into());
+        task.status = TaskStatus::Blocked;
+        task.assignee = Some("stale-worker".into());
+        task_store.add(&task).unwrap();
+
+        let result = queue_auto_unblock_worker_wake(
+            temp.path(),
+            &task,
+            "cas-blocker",
+            "unblock-occurrence-stale",
+        )
+        .unwrap();
+        assert!(matches!(result, AutoUnblockWakeResult::Skipped { .. }));
+        let queue = SqlitePromptQueueStore::open(temp.path()).unwrap();
+        queue.init().unwrap();
+        assert_eq!(queue.pending_count().unwrap(), 0);
+        let notes = task_store.get("cas-auto-stale").unwrap().notes;
+        assert!(
+            notes.contains("stale-worker")
+                && notes.contains("no registered worker with a fresh heartbeat")
+        );
+    }
+
+    #[test]
+    fn auto_unblock_uses_named_spawn_receipt_when_task_is_unassigned() {
+        let _env = TestEnvGuard::with_vars(&[("CAS_FACTORY_SESSION", "sess-auto-preassign")]);
+        let temp = TempDir::new().unwrap();
+        let task_store = cas_store::SqliteTaskStore::open(temp.path()).unwrap();
+        task_store.init().unwrap();
+        let mut task = Task::new("cas-auto-preassign".into(), "Spawn receipt target".into());
+        task.status = TaskStatus::Blocked;
+        task_store.add(&task).unwrap();
+
+        let spawn_queue = SqliteSpawnQueueStore::open(temp.path()).unwrap();
+        spawn_queue.init().unwrap();
+        spawn_queue
+            .enqueue_spawn(
+                1,
+                &["spawned-worker".into()],
+                false,
+                None,
+                Some("sess-auto-preassign"),
+                Some("cas-auto-preassign"),
+            )
+            .unwrap();
+
+        let result = queue_auto_unblock_worker_wake(
+            temp.path(),
+            &task,
+            "cas-blocker",
+            "unblock-occurrence-preassign",
+        )
+        .unwrap();
+        assert!(matches!(result, AutoUnblockWakeResult::Queued { .. }));
+        let queue = SqlitePromptQueueStore::open(temp.path()).unwrap();
+        queue.init().unwrap();
+        let rows = queue.peek_all(10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].target, "spawned-worker");
     }
 
     /// cas-f02b end to end: parking a task as AwaitingMerge enqueues a

--- a/cas-cli/src/mcp/tools/service/agent_search_system/system.rs
+++ b/cas-cli/src/mcp/tools/service/agent_search_system/system.rs
@@ -770,6 +770,7 @@ mod tests {
                 name: raw_name.to_string(),
                 transport: "Bearer cache-secret".to_string(),
                 state: cmcp_core::UpstreamState::Backoff,
+                executable: None,
                 attempts: 1,
                 consecutive_failures: 1,
                 tool_count: 0,

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -6739,7 +6739,7 @@ fn format_assigned_unstarted_status(
     threshold_secs: i64,
 ) -> String {
     format!(
-        "\n    ⚠ ASSIGNED BUT UNSTARTED: {task_id} was assigned {elapsed_secs}s ago and remains unstarted with no recent activity (threshold: {threshold_secs}s)"
+        "\n    ⚠ ASSIGNED BUT UNSTARTED: {task_id} was assigned {elapsed_secs}s ago and remains unstarted with no recent activity (threshold: {threshold_secs}s; possible missed wake — inspect the queued task message)"
     )
 }
 
@@ -10572,6 +10572,7 @@ effort = "high"
         assert!(rendered.contains("cas-unstarted was assigned 310s ago"));
         assert!(rendered.contains("remains unstarted with no recent activity"));
         assert!(rendered.contains("threshold: 300s"));
+        assert!(rendered.contains("possible missed wake"));
     }
 
     #[test]

--- a/cas-cli/src/store/syncing_task.rs
+++ b/cas-cli/src/store/syncing_task.rs
@@ -710,6 +710,30 @@ mod tests {
                 .as_deref()
                 .is_some_and(|payload| payload.contains("\"origin_project\":\"project-b\""))
         );
+        assert_eq!(pending[1].project_id.as_deref(), Some("project-b"));
+    }
+
+    #[test]
+    fn task_origin_project_move_later_edit_stays_on_new_owner_key() {
+        let (temp, store) = create_team_store(None);
+        let queue = SyncQueue::open(temp.path()).unwrap();
+
+        let mut task = Task::new("p-task-move-002".to_string(), "move me".to_string());
+        task.origin_project = Some("project-a".to_string());
+        store.add(&task).unwrap();
+        queue.clear().unwrap();
+
+        task.origin_project = Some("project-b".to_string());
+        store.update(&task).unwrap();
+        queue.clear().unwrap();
+
+        task.title = "edited after move".to_string();
+        store.update(&task).unwrap();
+
+        let pending = queue.pending_for_team(TEST_TEAM, 10, 5).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].operation, SyncOperation::Upsert);
+        assert_eq!(pending[0].project_id.as_deref(), Some("project-b"));
     }
 
     #[test]

--- a/cas-cli/src/store/syncing_task.rs
+++ b/cas-cli/src/store/syncing_task.rs
@@ -61,12 +61,17 @@ impl SyncingTaskStore {
         if let Some(team_id) = self.team_id.as_deref()
             && eligible_for_team_task(task)
         {
-            let _ = self.queue.enqueue_for_team(
+            let destination_project = task
+                .origin_project
+                .as_deref()
+                .filter(|project_id| !project_id.trim().is_empty());
+            let _ = self.queue.enqueue_for_team_project(
                 EntityType::Task,
                 &task.id,
                 SyncOperation::Upsert,
                 Some(&payload),
                 team_id,
+                destination_project,
             );
         }
     }
@@ -90,10 +95,14 @@ impl SyncingTaskStore {
         if let Some(team_id) = self.team_id.as_deref()
             && eligible_for_team_task(task)
         {
+            let Some(new_project_id) = task.origin_project.as_deref() else {
+                return;
+            };
             let _ = self.queue.enqueue_team_move(
                 EntityType::Task,
                 &task.id,
                 old_project_id,
+                new_project_id,
                 &payload,
                 team_id,
             );
@@ -703,14 +712,13 @@ mod tests {
         assert_eq!(pending[0].project_id.as_deref(), Some("project-a"));
         assert_eq!(pending[1].operation, SyncOperation::Upsert);
         assert_eq!(pending[1].entity_id, task.id);
-        assert_eq!(pending[1].project_id, None);
+        assert_eq!(pending[1].project_id.as_deref(), Some("project-b"));
         assert!(
             pending[1]
                 .payload
                 .as_deref()
                 .is_some_and(|payload| payload.contains("\"origin_project\":\"project-b\""))
         );
-        assert_eq!(pending[1].project_id.as_deref(), Some("project-b"));
     }
 
     #[test]

--- a/cas-cli/src/store/syncing_task.rs
+++ b/cas-cli/src/store/syncing_task.rs
@@ -13,6 +13,15 @@ use crate::types::{Dependency, DependencyType, Scope, Task, TaskStatus};
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 
+#[derive(serde::Serialize)]
+struct TaskDependencyPayload<'a> {
+    from_id: &'a str,
+    to_id: &'a str,
+    dep_type: String,
+    created_at: DateTime<Utc>,
+    origin_project: Option<&'a str>,
+}
+
 /// A task store wrapper that queues changes for cloud sync
 pub struct SyncingTaskStore {
     inner: Arc<dyn TaskStore>,
@@ -125,6 +134,73 @@ impl SyncingTaskStore {
             );
         }
     }
+
+    fn queue_dependency_upsert(&self, dep: &Dependency, from_task: &Task) {
+        let origin_project = match from_task.scope {
+            Scope::Global => None,
+            Scope::Project => from_task
+                .origin_project
+                .as_deref()
+                .or(self.inner.project_id()),
+        };
+        let payload = TaskDependencyPayload {
+            from_id: &dep.from_id,
+            to_id: &dep.to_id,
+            dep_type: dep.dep_type.to_string(),
+            created_at: dep.created_at,
+            origin_project,
+        };
+        let Ok(payload) = serde_json::to_string(&payload) else {
+            return;
+        };
+        let entity_id = dependency_entity_id(dep);
+        let _ = self.queue.enqueue(
+            EntityType::TaskDependency,
+            &entity_id,
+            SyncOperation::Upsert,
+            Some(&payload),
+        );
+
+        if let Some(team_id) = self.team_id.as_deref()
+            && eligible_for_team_task(from_task)
+        {
+            let _ = self.queue.enqueue_for_team(
+                EntityType::TaskDependency,
+                &entity_id,
+                SyncOperation::Upsert,
+                Some(&payload),
+                team_id,
+            );
+        }
+    }
+
+    fn queue_dependency_delete(&self, dep: &Dependency) {
+        let entity_id = dependency_entity_id(dep);
+        let _ = self.queue.enqueue(
+            EntityType::TaskDependency,
+            &entity_id,
+            SyncOperation::Delete,
+            None,
+        );
+
+        // A delete must fan out when a team is configured, even when the
+        // source task is no longer available to evaluate the promotion
+        // predicate. This prevents stale cloud edges from surviving local
+        // task/dependency deletion.
+        if let Some(team_id) = self.team_id.as_deref() {
+            let _ = self.queue.enqueue_for_team(
+                EntityType::TaskDependency,
+                &entity_id,
+                SyncOperation::Delete,
+                None,
+                team_id,
+            );
+        }
+    }
+}
+
+fn dependency_entity_id(dep: &Dependency) -> String {
+    format!("{}:{}:{}", dep.from_id, dep.to_id, dep.dep_type)
 }
 
 impl TaskStore for SyncingTaskStore {
@@ -158,6 +234,9 @@ impl TaskStore for SyncingTaskStore {
             .create_atomic(task, blocked_by, epic_id, created_by)?;
         let persisted = self.persisted_for_queue(task)?;
         self.queue_upsert(&persisted);
+        for dep in self.inner.get_dependencies(&task.id)? {
+            self.queue_dependency_upsert(&dep, &persisted);
+        }
         Ok(())
     }
 
@@ -199,8 +278,21 @@ impl TaskStore for SyncingTaskStore {
     }
 
     fn delete(&self, id: &str) -> Result<()> {
+        let mut dependencies = self.inner.get_dependencies(id)?;
+        for dep in self.inner.get_dependents(id)? {
+            if !dependencies.iter().any(|existing| {
+                existing.from_id == dep.from_id
+                    && existing.to_id == dep.to_id
+                    && existing.dep_type == dep.dep_type
+            }) {
+                dependencies.push(dep);
+            }
+        }
         self.inner.delete(id)?;
         self.queue_delete(id);
+        for dep in &dependencies {
+            self.queue_dependency_delete(dep);
+        }
         Ok(())
     }
 
@@ -228,13 +320,36 @@ impl TaskStore for SyncingTaskStore {
         self.inner.close()
     }
 
-    // Dependency operations - don't sync these as they're derived from task relationships
+    // Dependency operations are first-class cloud entities. The local
+    // dependency table remains authoritative; queue writes mirror successful
+    // local mutations without routing pulled rows back through this wrapper.
     fn add_dependency(&self, dep: &Dependency) -> Result<()> {
-        self.inner.add_dependency(dep)
+        let previous = self
+            .inner
+            .get_dependencies(&dep.from_id)?
+            .into_iter()
+            .find(|existing| existing.to_id == dep.to_id);
+        self.inner.add_dependency(dep)?;
+        if let Some(previous) = previous.filter(|previous| previous.dep_type != dep.dep_type) {
+            self.queue_dependency_delete(&previous);
+        }
+        let from_task = self.inner.get(&dep.from_id)?;
+        self.queue_dependency_upsert(dep, &from_task);
+        Ok(())
     }
 
     fn remove_dependency(&self, from_id: &str, to_id: &str) -> Result<()> {
-        self.inner.remove_dependency(from_id, to_id)
+        let dependencies: Vec<Dependency> = self
+            .inner
+            .get_dependencies(from_id)?
+            .into_iter()
+            .filter(|dep| dep.to_id == to_id)
+            .collect();
+        self.inner.remove_dependency(from_id, to_id)?;
+        for dep in &dependencies {
+            self.queue_dependency_delete(dep);
+        }
+        Ok(())
     }
 
     fn remove_dependency_of_type(
@@ -243,8 +358,19 @@ impl TaskStore for SyncingTaskStore {
         to_id: &str,
         dep_type: DependencyType,
     ) -> Result<bool> {
-        self.inner
-            .remove_dependency_of_type(from_id, to_id, dep_type)
+        let removed = self
+            .inner
+            .remove_dependency_of_type(from_id, to_id, dep_type)?;
+        if removed {
+            self.queue_dependency_delete(&Dependency {
+                from_id: from_id.to_string(),
+                to_id: to_id.to_string(),
+                dep_type,
+                created_at: Utc::now(),
+                created_by: None,
+            });
+        }
+        Ok(removed)
     }
 
     fn get_dependencies(&self, task_id: &str) -> Result<Vec<Dependency>> {
@@ -444,6 +570,33 @@ mod tests {
         assert_eq!(pending[0].entity_id, "task-remove-from:task-remove-to:related");
         assert_eq!(pending[0].operation, SyncOperation::Delete);
         assert!(pending[0].payload.is_none());
+    }
+
+    #[test]
+    fn create_atomic_queues_all_created_task_dependencies() {
+        let (temp, store) = create_test_store();
+        let queue = SyncQueue::open(temp.path()).unwrap();
+
+        let mut epic = Task::new("task-dep-epic".to_string(), "epic".to_string());
+        epic.task_type = crate::types::TaskType::Epic;
+        store.add(&epic).unwrap();
+        let blocker = Task::new("task-dep-blocker".to_string(), "blocker".to_string());
+        store.add(&blocker).unwrap();
+        queue.clear().unwrap();
+
+        let child = Task::new("task-dep-child".to_string(), "child".to_string());
+        store
+            .create_atomic(&child, &[blocker.id.clone()], Some(&epic.id), Some("test"))
+            .unwrap();
+
+        let pending = queue
+            .pending_for_entity_type(Some(EntityType::TaskDependency), 10, 5)
+            .unwrap();
+        let ids: std::collections::HashSet<_> =
+            pending.iter().map(|item| item.entity_id.as_str()).collect();
+        assert_eq!(pending.len(), 2);
+        assert!(ids.contains("task-dep-child:task-dep-blocker:blocks"));
+        assert!(ids.contains("task-dep-child:task-dep-epic:parent-child"));
     }
 
     // ── Dual-enqueue behaviour (cas-82a1) ────────────────────────────────

--- a/cas-cli/src/store/syncing_task.rs
+++ b/cas-cli/src/store/syncing_task.rs
@@ -398,6 +398,54 @@ mod tests {
         assert_eq!(pending[0].operation, SyncOperation::Delete);
     }
 
+    #[test]
+    fn dependency_add_queues_task_dependency_upsert() {
+        let (temp, store) = create_test_store();
+        let queue = SyncQueue::open(temp.path()).unwrap();
+        let from = Task::new("task-dep-from".to_string(), "from".to_string());
+        let to = Task::new("task-dep-to".to_string(), "to".to_string());
+        store.add(&from).unwrap();
+        store.add(&to).unwrap();
+        queue.clear().unwrap();
+
+        let dep = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::Blocks);
+        store.add_dependency(&dep).unwrap();
+
+        let pending = queue.pending_for_entity_type(Some(EntityType::TaskDependency), 10, 5).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].entity_id, "task-dep-from:task-dep-to:blocks");
+        assert_eq!(pending[0].operation, SyncOperation::Upsert);
+        let payload: serde_json::Value = serde_json::from_str(pending[0].payload.as_deref().unwrap()).unwrap();
+        assert_eq!(payload["from_id"], "task-dep-from");
+        assert_eq!(payload["to_id"], "task-dep-to");
+        assert_eq!(payload["dep_type"], "blocks");
+        assert!(payload["created_at"].is_string());
+        assert!(payload.get("origin_project").is_some());
+    }
+
+    #[test]
+    fn dependency_remove_queues_task_dependency_delete() {
+        let (temp, store) = create_test_store();
+        let queue = SyncQueue::open(temp.path()).unwrap();
+        let from = Task::new("task-remove-from".to_string(), "from".to_string());
+        let to = Task::new("task-remove-to".to_string(), "to".to_string());
+        store.add(&from).unwrap();
+        store.add(&to).unwrap();
+        let dep = Dependency::new(from.id.clone(), to.id.clone(), DependencyType::Related);
+        store.add_dependency(&dep).unwrap();
+        queue.clear().unwrap();
+
+        assert!(store
+            .remove_dependency_of_type(&from.id, &to.id, DependencyType::Related)
+            .unwrap());
+
+        let pending = queue.pending_for_entity_type(Some(EntityType::TaskDependency), 10, 5).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].entity_id, "task-remove-from:task-remove-to:related");
+        assert_eq!(pending[0].operation, SyncOperation::Delete);
+        assert!(pending[0].payload.is_none());
+    }
+
     // ── Dual-enqueue behaviour (cas-82a1) ────────────────────────────────
 
     use cas_types::Scope;

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -383,7 +383,13 @@ impl WorkerSpawnPrep {
             git.create_worktree(&wt.worktree_path, &wt.branch_name, Some(&checkout_from))?;
 
             if std::env::var("CAS_FACTORY_DISABLE_TARGET_SEED").as_deref() != Ok("1") {
-                match seed_worker_target_from_baseline(&wt.cas_dir, &wt.worktree_path) {
+                // A cross-repository worker keeps the session store as
+                // `CAS_ROOT`, but its Cargo target must come from the target
+                // repository's cache. Seeding the session cache here could
+                // copy artifacts built for an unrelated project into the
+                // target worktree.
+                let build_cache_cas_dir = wt.repo_root.join(".cas");
+                match seed_worker_target_from_baseline(&build_cache_cas_dir, &wt.worktree_path) {
                     Ok(Some(stats)) => tracing::info!(
                         worker = %self.worker_name,
                         files = stats.files,

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -118,6 +118,10 @@ pub(crate) struct TaskEpicBase {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SpawnWorkTarget {
     pub task_id: String,
+    /// Portable selector for the repository whose target branch owns this
+    /// spawn. A task's store remains in the factory session repository, but
+    /// the worker's Git worktree may live in this sibling checkout.
+    pub repo_selector: String,
     pub target_branch: String,
     pub owner: WorkTargetOwner,
 }
@@ -420,6 +424,77 @@ pub(crate) fn base_diverges_from_focus(
     ) && focused_epic_branch.is_some_and(|focus| focus != base)
 }
 
+/// Resolve the repository in which an isolated worker worktree must be
+/// provisioned.
+///
+/// The task store is deliberately not moved: `cas_dir` remains the spawning
+/// session's `.cas` directory and is passed to the worker as `CAS_ROOT`. A
+/// declared WorkTarget can, however, identify a sibling checkout. Resolve
+/// that selector through the host repository bindings before any branch or
+/// worktree operation so a branch that exists only there is never looked up in
+/// the session repository.
+pub(crate) fn resolve_spawn_worktree_repo(
+    cas_dir: &std::path::Path,
+    session_repo_root: &std::path::Path,
+    target: Option<&SpawnWorkTarget>,
+) -> anyhow::Result<std::path::PathBuf> {
+    let Some(target) = target else {
+        return Ok(session_repo_root.to_path_buf());
+    };
+
+    if crate::mcp::tools::core::task::repo_context::repo_answers_to(
+        session_repo_root,
+        &target.repo_selector,
+    ) {
+        return Ok(session_repo_root.to_path_buf());
+    }
+
+    let work_target = cas_types::WorkTarget {
+        repo_selector: target.repo_selector.clone(),
+        target_branch: target.target_branch.clone(),
+    };
+    let context = crate::mcp::tools::core::task::repo_context::resolve_repo_context(
+        cas_dir,
+        &work_target,
+    )
+    .map_err(|reason| {
+        anyhow::anyhow!(
+            "cross-repo spawn: target_repo {} — {}",
+            target.repo_selector,
+            reason
+        )
+    })?;
+    let target_root = context.repo_root;
+    let target_git = crate::worktree::GitOperations::new(target_root.clone());
+    if !target_git.has_commits().unwrap_or(false) {
+        anyhow::bail!(
+            "cross-repo spawn: target_repo {} — repository has no commits",
+            target_root.display()
+        );
+    }
+    if !ref_exists(&target_root, &target.target_branch) {
+        anyhow::bail!(
+            "cross-repo spawn: target_repo {} — target branch '{}' does not resolve to a commit",
+            target_root.display(),
+            target.target_branch
+        );
+    }
+    Ok(target_root)
+}
+
+/// Human-readable provision receipt. Keep the session store implicit in this
+/// line: `Worktree repository` is the Git venue, while the worker's `CAS_ROOT`
+/// continues to be the spawning session's store.
+pub(crate) fn spawn_provision_receipt(prep: &crate::ui::factory::app::WorkerSpawnPrep) -> String {
+    match prep.worktree_info.as_ref() {
+        Some(worktree) => format!(
+            "Preparing worker filesystem and worktree. Worktree repository: {} (CAS_ROOT remains the factory session store).",
+            worktree.repo_root.display()
+        ),
+        None => "Preparing worker filesystem (no isolated worktree).".to_string(),
+    }
+}
+
 /// cas-7587: resolve `task_id` → its epic → that epic's branch.
 ///
 /// A task that *is* an epic resolves to itself. The branch is the one persisted
@@ -465,6 +540,7 @@ pub(crate) fn task_epic_base(
         .as_ref()
         .map(|target| SpawnWorkTarget {
             task_id: task_id.to_string(),
+            repo_selector: target.repo_selector.clone(),
             target_branch: target.target_branch.clone(),
             owner: if task.task_type == cas_types::TaskType::Epic {
                 WorkTargetOwner::Epic {
@@ -539,6 +615,7 @@ pub(crate) fn task_epic_base(
                     .as_ref()
                     .map(|target| SpawnWorkTarget {
                         task_id: task_id.to_string(),
+                        repo_selector: target.repo_selector.clone(),
                         target_branch: target.target_branch.clone(),
                         owner: WorkTargetOwner::Epic {
                             epic_id: epic.id.clone(),
@@ -551,24 +628,23 @@ pub(crate) fn task_epic_base(
 /// Return a supervisor-visible warning when a resolved spawn base cannot be
 /// proven to contain the focused epic's current tip.
 fn worker_base_mismatch_notice(
-    manager: &WorktreeManager,
+    repo_root: &std::path::Path,
     worker_base: &str,
     epic_branch: &str,
 ) -> Option<String> {
     let output = std::process::Command::new("git")
         .args(["merge-base", "--is-ancestor", epic_branch, worker_base])
-        .current_dir(manager.repo_root())
+        .current_dir(repo_root)
         .output();
 
     match output {
         Ok(output) if output.status.success() => None,
         Ok(_) => {
-            let epic_tip = manager
-                .git()
+            let git = crate::worktree::GitOperations::new(repo_root.to_path_buf());
+            let epic_tip = git
                 .ref_sha(epic_branch)
                 .unwrap_or_else(|_| "unknown".to_string());
-            let base_tip = manager
-                .git()
+            let base_tip = git
                 .ref_sha(worker_base)
                 .unwrap_or_else(|_| "unknown".to_string());
             Some(format!(
@@ -1699,18 +1775,29 @@ impl FactoryApp {
                     );
                 }
 
-                let worktree_path = manager.worktree_path_for_worker(&worker_name);
+                let session_repo_root = manager.repo_root().to_path_buf();
+                let task_base = task_id
+                    .map(|tid| task_epic_base(&self.cas_dir, &session_repo_root, tid))
+                    .unwrap_or(TaskBase::Unresolved);
+                let repo_root = resolve_spawn_worktree_repo(
+                    &self.cas_dir,
+                    &session_repo_root,
+                    task_base.work_target(),
+                )?;
+                let cross_repo = repo_root != session_repo_root;
+                let spawn_git = crate::worktree::GitOperations::new(repo_root.clone());
+                let worktree_path = if cross_repo {
+                    repo_root.join(".cas/worktrees").join(&worker_name)
+                } else {
+                    manager.worktree_path_for_worker(&worker_name)
+                };
                 let branch_name = manager.branch_name_for_worker(&worker_name);
-                let repo_root = manager.repo_root().to_path_buf();
                 // Dynamic spawns must match startup spawns: never the
                 // supervisor's incidental HEAD. cas-7587 (GH #122): precedence
                 // is the pre-assigned task's epic branch first, pinned epic
                 // focus second, trunk last.
-                let configured_trunk = Config::configured_epic_base_branch(manager.repo_root())
-                    .unwrap_or_else(|| manager.git().detect_default_branch());
-                let task_base = task_id
-                    .map(|tid| task_epic_base(&self.cas_dir, manager.repo_root(), tid))
-                    .unwrap_or(TaskBase::Unresolved);
+                let configured_trunk = Config::configured_epic_base_branch(&repo_root)
+                    .unwrap_or_else(|| spawn_git.detect_default_branch());
                 // An epic's declared delivery target is authoritative for both
                 // a no-epic child fallback and stale-base comparison. Falling
                 // back to factory configuration keeps legacy/taskless spawns.
@@ -1742,7 +1829,7 @@ impl FactoryApp {
                     });
                 if let Some((epic_branch, recorded_parent)) = recorded_base_parent {
                     let refresh = fast_forward_epic_base_from_parent(
-                        manager.repo_root(),
+                        &repo_root,
                         &epic_branch,
                         &recorded_parent,
                     )
@@ -1755,7 +1842,7 @@ impl FactoryApp {
                 // resolved to the fresher of its local and origin refs — a
                 // stale local ref silently backdates every worker cut from it.
                 let (base_ref, freshness_notice, checkout_ref) =
-                    checkout_ref_for_spawn_base(manager.repo_root(), &parent_branch, &base_source);
+                    checkout_ref_for_spawn_base(&repo_root, &parent_branch, &base_source);
                 if let Some(notice) = freshness_notice {
                     notices.push(notice);
                 }
@@ -1769,7 +1856,7 @@ impl FactoryApp {
                     &base_source,
                     self.epic_branch.as_deref(),
                 );
-                let checkout_sha = short_sha(manager.repo_root(), effective_base);
+                let checkout_sha = short_sha(&repo_root, effective_base);
                 provenance.push_str(&format!(
                     " CHECKOUT BASE: '{checkout_ref}' @ {checkout_sha}."
                 ));
@@ -1790,7 +1877,7 @@ impl FactoryApp {
                     _ => self.epic_branch.clone(),
                 };
                 if let Some(notice) = epic_to_contain.as_deref().and_then(|epic_branch| {
-                    worker_base_mismatch_notice(manager, effective_base, epic_branch)
+                    worker_base_mismatch_notice(&repo_root, effective_base, epic_branch)
                 }) {
                     notices.push(notice);
                 }
@@ -1818,7 +1905,7 @@ impl FactoryApp {
                 // spawn time instead of leaving it to whoever happens to read
                 // `behind:` in worker_status.
                 if let Some(notice) =
-                    stale_spawn_base_notice(manager.repo_root(), effective_base, &trunk)
+                    stale_spawn_base_notice(&repo_root, effective_base, &trunk)
                 {
                     notices.push(notice);
                 }
@@ -2511,6 +2598,7 @@ impl FactoryApp {
 #[cfg(test)]
 mod spawn_base_tests {
     use super::*;
+    use crate::test_support::TestEnvGuard;
     use std::process::Command;
     use tempfile::TempDir;
 
@@ -2567,6 +2655,14 @@ mod spawn_base_tests {
             .unwrap();
     }
 
+    fn add_origin(repo: &std::path::Path, url: &str) {
+        Command::new("git")
+            .args(["remote", "add", "origin", url])
+            .current_dir(repo)
+            .output()
+            .expect("git remote add origin");
+    }
+
     fn seed_epic(cas_dir: &std::path::Path, epic_id: &str, title: &str, branch: Option<&str>) {
         let store = crate::store::open_task_store(cas_dir).unwrap();
         let mut epic = cas_types::Task::new(epic_id.to_string(), title.to_string());
@@ -2588,6 +2684,173 @@ mod spawn_base_tests {
                 created_by: None,
             })
             .unwrap();
+    }
+
+    /// GH #670: a task's durable WorkTarget selector may resolve to a sibling
+    /// checkout. The worker worktree must be cut from that checkout, where its
+    /// target-only branch exists, rather than from the session repository.
+    #[test]
+    fn cross_repo_spawn_resolves_target_only_branch_and_worktree_repo_cas_052a() {
+        TestEnvGuard::run_with_temp_home(|_| {
+            crate::store::known_repos::ensure_host_schema().unwrap();
+
+            let tmp = TempDir::new().unwrap();
+            let session_repo = tmp.path().join("session-repo");
+            let target_repo = tmp.path().join("target-repo");
+            std::fs::create_dir(&session_repo).unwrap();
+            std::fs::create_dir(&target_repo).unwrap();
+            init_repo(&session_repo);
+            init_repo(&target_repo);
+            let session_cas = crate::store::init_cas_dir(&session_repo).unwrap();
+            let _target_cas = crate::store::init_cas_dir(&target_repo).unwrap();
+            add_origin(&session_repo, "https://github.com/example/session.git");
+            add_origin(&target_repo, "https://github.com/example/target.git");
+            branch_at(&target_repo, "cursor/target-only", "main");
+            Command::new("git")
+                .args(["checkout", "-q", "cursor/target-only"])
+                .current_dir(&target_repo)
+                .output()
+                .unwrap();
+            commit_file(&target_repo, "target-only.txt", "target");
+            Command::new("git")
+                .args(["checkout", "-q", "main"])
+                .current_dir(&target_repo)
+                .output()
+                .unwrap();
+            crate::store::known_repos::register_repo_strict(&target_repo).unwrap();
+
+            let target = SpawnWorkTarget {
+                task_id: "cas-target-only".into(),
+                repo_selector: "remote:github.com/example/target".into(),
+                target_branch: "cursor/target-only".into(),
+                owner: WorkTargetOwner::Task,
+            };
+            let target_root = resolve_spawn_worktree_repo(
+                &session_cas,
+                &session_repo,
+                Some(&target),
+            )
+            .expect("target selector must resolve in the sibling checkout");
+            assert_eq!(target_root, target_repo);
+
+            let worker_path = target_root.join(".cas/worktrees/cross-repo-worker");
+            WorkerSpawnPrep {
+                worker_name: "cross-repo-worker".into(),
+                worktree_info: Some(WorktreePrep {
+                    worktree_path: worker_path.clone(),
+                    branch_name: "factory/cross-repo-worker".into(),
+                    parent_branch: target.target_branch.clone(),
+                    base_ref: None,
+                    repo_root: target_root,
+                    cas_dir: session_cas.clone(),
+                }),
+                warnings: Vec::new(),
+                base_provenance: None,
+            }
+            .run()
+            .expect("target repository should provision the worker worktree");
+            assert!(worker_path.join("target-only.txt").is_file());
+            assert!(worker_path.join(".git").is_file());
+            assert_eq!(
+                std::process::Command::new("git")
+                    .args(["-C", worker_path.to_str().unwrap(), "branch", "--show-current"])
+                    .output()
+                    .unwrap()
+                    .stdout,
+                b"factory/cross-repo-worker\n"
+            );
+
+            let mut manager = WorktreeManager::new(
+                &session_repo,
+                WorktreeConfig {
+                    enabled: true,
+                    base_path: session_repo
+                        .join(".cas/worktrees")
+                        .to_string_lossy()
+                        .to_string(),
+                    branch_prefix: "factory/".into(),
+                    auto_merge: false,
+                    cleanup_on_close: false,
+                    promote_entries_on_merge: false,
+                },
+            )
+            .unwrap();
+            manager.register_worktree(
+                "cross-repo-worker",
+                Worktree::new(
+                    Worktree::generate_id(),
+                    "factory/cross-repo-worker".into(),
+                    target.target_branch,
+                    worker_path.clone(),
+                ),
+            );
+            manager
+                .remove_worker("cross-repo-worker", false)
+                .expect("manager should clean up the target-repository worktree");
+            assert!(!worker_path.exists());
+        });
+    }
+
+    /// GH #670: a target selector that resolves to a real sibling repository
+    /// must still fail with an explicit cross-repo message when its branch is
+    /// absent there (and the session repo does not have it either).
+    #[test]
+    fn cross_repo_spawn_missing_target_branch_has_explicit_failure_cas_052a() {
+        TestEnvGuard::run_with_temp_home(|_| {
+            crate::store::known_repos::ensure_host_schema().unwrap();
+            let tmp = TempDir::new().unwrap();
+            let session_repo = tmp.path().join("session-repo");
+            let target_repo = tmp.path().join("target-repo");
+            std::fs::create_dir(&session_repo).unwrap();
+            std::fs::create_dir(&target_repo).unwrap();
+            init_repo(&session_repo);
+            init_repo(&target_repo);
+            let session_cas = crate::store::init_cas_dir(&session_repo).unwrap();
+            let _target_cas = crate::store::init_cas_dir(&target_repo).unwrap();
+            add_origin(&target_repo, "https://github.com/example/target-missing.git");
+            crate::store::known_repos::register_repo_strict(&target_repo).unwrap();
+
+            let target = SpawnWorkTarget {
+                task_id: "cas-target-missing".into(),
+                repo_selector: "remote:github.com/example/target-missing".into(),
+                target_branch: "cursor/exists-nowhere".into(),
+                owner: WorkTargetOwner::Task,
+            };
+            let error = resolve_spawn_worktree_repo(
+                &session_cas,
+                &session_repo,
+                Some(&target),
+            )
+            .expect_err("missing target branch must fail before git worktree add");
+            let text = error.to_string();
+            assert!(
+                text.starts_with("cross-repo spawn: target_repo "),
+                "{text}"
+            );
+            assert!(text.contains(target_repo.to_str().unwrap()), "{text}");
+            assert!(text.contains("cursor/exists-nowhere"), "{text}");
+            assert!(!text.contains("Refusing to create worktree branch"), "{text}");
+        });
+    }
+
+    #[test]
+    fn cross_repo_spawn_receipt_names_target_repository_cas_052a() {
+        let target_repo = std::path::Path::new("/workspace/target-repo");
+        let prep = WorkerSpawnPrep {
+            worker_name: "receipt-worker".into(),
+            worktree_info: Some(WorktreePrep {
+                worktree_path: target_repo.join(".cas/worktrees/receipt-worker"),
+                branch_name: "factory/receipt-worker".into(),
+                parent_branch: "main".into(),
+                base_ref: None,
+                repo_root: target_repo.to_path_buf(),
+                cas_dir: std::path::PathBuf::from("/workspace/session/.cas"),
+            }),
+            warnings: Vec::new(),
+            base_provenance: None,
+        };
+        let receipt = spawn_provision_receipt(&prep);
+        assert!(receipt.contains("Worktree repository: /workspace/target-repo"), "{receipt}");
     }
 
     /// GH #122 repro, end to end: focus pinned to epic A, spawn requested with
@@ -3523,7 +3786,7 @@ mod spawn_base_tests {
         )
         .unwrap();
         let worker_base = worker_base_for_spawn(Some("epic/stacked"), &manager);
-        assert!(worker_base_mismatch_notice(&manager, &worker_base, "epic/stacked").is_none());
+        assert!(worker_base_mismatch_notice(manager.repo_root(), &worker_base, "epic/stacked").is_none());
 
         let worker_path = worktree_root.join("stacked-worker");
         let result = WorkerSpawnPrep {
@@ -3586,7 +3849,7 @@ mod spawn_base_tests {
             },
         )
         .unwrap();
-        let notice = worker_base_mismatch_notice(&manager, "main", "epic/ahead").unwrap();
+        let notice = worker_base_mismatch_notice(manager.repo_root(), "main", "epic/ahead").unwrap();
         assert!(notice.contains("WORKER BASE MISMATCH"));
         assert!(notice.contains("does not contain"));
         assert!(notice.contains("epic/ahead"));
@@ -4230,6 +4493,7 @@ mod spawn_base_tests {
         let repo = tmp.path().join("repo");
         std::fs::create_dir(&repo).unwrap();
         init_repo(&repo);
+        add_origin(&repo, "https://github.com/example/test.git");
 
         Command::new("git")
             .args(["checkout", "-q", "-b", "epic/diverged-support"])
@@ -4250,7 +4514,7 @@ mod spawn_base_tests {
         epic.task_type = cas_types::TaskType::Epic;
         epic.branch = Some("epic/diverged-support".into());
         epic.deliverables.work_target = Some(cas_types::WorkTarget {
-            repo_selector: "project:test".into(),
+            repo_selector: "remote:github.com/example/test".into(),
             target_branch: "main".into(),
         });
         store.add(&epic).unwrap();

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -5224,7 +5224,7 @@ impl FactoryDaemon {
                             Some(&worker_name),
                             "provision",
                             "started",
-                            "Preparing worker filesystem and worktree.",
+                            &crate::ui::factory::app::render_and_ops::epic_workers::spawn_provision_receipt(&prep),
                         );
                         // cas-7587 (GH #122): record which branch this worker
                         // was cut from and why (task's epic / pinned focus /
@@ -5282,12 +5282,17 @@ impl FactoryDaemon {
                         );
                         self.app.set_error(format!("Failed to prepare spawn: {e}"));
                         let detail = e.to_string();
+                        let stage = if detail.starts_with("cross-repo spawn:") {
+                            "provision"
+                        } else {
+                            "prepare"
+                        };
                         append_spawn_audit(
                             self.app.cas_dir(),
                             &self.session_name,
                             request_id,
                             None,
-                            "prepare",
+                            stage,
                             "failed",
                             &detail,
                         );
@@ -5297,7 +5302,7 @@ impl FactoryDaemon {
                             &self.session_name,
                             request_id,
                             "unresolved",
-                            "prepare",
+                            stage,
                             false,
                             &detail,
                         );
@@ -5327,7 +5332,7 @@ impl FactoryDaemon {
                             Some(&worker_name),
                             "provision",
                             "started",
-                            "Preparing worker filesystem and worktree.",
+                            &crate::ui::factory::app::render_and_ops::epic_workers::spawn_provision_receipt(&prep),
                         );
                         // cas-7587 (GH #122): record which branch this worker
                         // was cut from and why (task's epic / pinned focus /
@@ -5381,12 +5386,17 @@ impl FactoryDaemon {
                         self.app
                             .set_error(format!("Failed to prepare spawn '{name}': {e}"));
                         let detail = e.to_string();
+                        let stage = if detail.starts_with("cross-repo spawn:") {
+                            "provision"
+                        } else {
+                            "prepare"
+                        };
                         append_spawn_audit(
                             self.app.cas_dir(),
                             &self.session_name,
                             request_id,
                             Some(&name),
-                            "prepare",
+                            stage,
                             "failed",
                             &detail,
                         );
@@ -5396,7 +5406,7 @@ impl FactoryDaemon {
                             &self.session_name,
                             request_id,
                             &name,
-                            "prepare",
+                            stage,
                             false,
                             &detail,
                         );

--- a/cas-cli/src/worktree/manager/mod.rs
+++ b/cas-cli/src/worktree/manager/mod.rs
@@ -111,6 +111,11 @@ pub struct WorktreeManager {
 
     /// Factory worker worktrees (worker_name -> worktree)
     workers: HashMap<String, Worktree>,
+
+    /// Git roots for worker worktrees. Most workers use `repo_root`, but a
+    /// pre-assigned WorkTarget may place one in a sibling repository while the
+    /// task store remains in the factory session repository.
+    pub(crate) worker_repo_roots: HashMap<String, PathBuf>,
 }
 
 mod epic_ops;
@@ -210,8 +215,13 @@ impl WorktreeManager {
     /// the worktree directory (merge_and_cleanup with cleanup=true,
     /// abandon, remove_worker); pass `false` only when the worktree is
     /// merged but preserved (cleanup=false).
-    fn reject_or_warn_on_dirty(&self, path: &Path, will_remove: bool) -> WorktreeResult<()> {
-        let dirty = self.git.classify_dirty_status(path)?;
+    fn reject_or_warn_on_dirty(
+        &self,
+        git: &GitOperations,
+        path: &Path,
+        will_remove: bool,
+    ) -> WorktreeResult<()> {
+        let dirty = git.classify_dirty_status(path)?;
 
         if will_remove && !dirty.warnings.is_empty() {
             let mut message = dirty.describe_blocking();
@@ -263,6 +273,7 @@ impl WorktreeManager {
             repo_root,
             context,
             workers: HashMap::new(),
+            worker_repo_roots: HashMap::new(),
         })
     }
 
@@ -492,7 +503,7 @@ impl WorktreeManager {
         // must block too (removal destroys them outright); when the
         // worktree survives (cleanup=false) they only warn.
         if !force {
-            self.reject_or_warn_on_dirty(&worktree.path, will_cleanup)?;
+            self.reject_or_warn_on_dirty(&self.git, &worktree.path, will_cleanup)?;
         }
 
         let merge_commit = if self.config.auto_merge {
@@ -589,7 +600,7 @@ impl WorktreeManager {
         // abandon unconditionally deletes the worktree directory, so
         // untracked files must block exactly like tracked ones.
         if !force {
-            self.reject_or_warn_on_dirty(&worktree.path, true)?;
+            self.reject_or_warn_on_dirty(&self.git, &worktree.path, true)?;
         }
 
         // Remove the worktree. cas-006c: pass force=true unconditionally —

--- a/cas-cli/src/worktree/manager/worker_ops.rs
+++ b/cas-cli/src/worktree/manager/worker_ops.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::types::Worktree;
 use crate::worktree::external_symlinks::{
@@ -58,16 +58,49 @@ pub struct CleanupReport {
 }
 
 impl WorktreeManager {
+    fn worker_repo_root(&self, worker_name: &str) -> PathBuf {
+        self.worker_repo_roots
+            .get(worker_name)
+            .cloned()
+            .unwrap_or_else(|| self.repo_root.clone())
+    }
+
+    fn worker_git(&self, worker_name: &str) -> GitOperations {
+        GitOperations::new(self.worker_repo_root(worker_name))
+    }
+
     /// External-link guard shared by every manager-owned worktree deletion.
     /// `$HOME` links and primary-checkout `node_modules` links have different
     /// roots, so keep their scans separate and combine their named evidence.
-    fn inbound_symlinks(&self, worktree_path: &std::path::Path) -> Vec<ExternalSymlink> {
+    fn inbound_symlinks(
+        &self,
+        worktree_path: &std::path::Path,
+        repo_root: &std::path::Path,
+    ) -> Vec<ExternalSymlink> {
         let mut links = scan_external_symlinks_into(worktree_path);
         links.extend(scan_project_node_modules_symlinks_into(
             worktree_path,
-            &self.repo_root,
+            repo_root,
         ));
         links
+    }
+
+    fn repo_root_for_worktree(path: &std::path::Path) -> Option<PathBuf> {
+        let output = std::process::Command::new("git")
+            .args(["-C", path.to_str()?, "rev-parse", "--git-common-dir"])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())?;
+        let common = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim().to_string());
+        let common = if common.is_absolute() {
+            common
+        } else {
+            path.join(common)
+        };
+        common
+            .canonicalize()
+            .ok()
+            .and_then(|common| common.parent().map(Path::to_path_buf))
     }
 
     /// Calculate the worktree path for a factory worker
@@ -119,6 +152,8 @@ impl WorktreeManager {
 
         self.workers
             .insert(worker_name.to_string(), worktree.clone());
+        self.worker_repo_roots
+            .insert(worker_name.to_string(), self.repo_root.clone());
 
         Ok(worktree)
     }
@@ -159,6 +194,8 @@ impl WorktreeManager {
 
         self.workers
             .insert(worker_name.to_string(), worktree.clone());
+        self.worker_repo_roots
+            .insert(worker_name.to_string(), self.repo_root.clone());
 
         Ok(worktree)
     }
@@ -189,6 +226,8 @@ impl WorktreeManager {
                 worktree_path,
             );
             self.workers.insert(worker_name.to_string(), worktree);
+            self.worker_repo_roots
+                .insert(worker_name.to_string(), self.repo_root.clone());
             return self.worker_ref(worker_name);
         }
 
@@ -221,6 +260,8 @@ impl WorktreeManager {
                 worktree_path,
             );
             self.workers.insert(worker_name.to_string(), worktree);
+            self.worker_repo_roots
+                .insert(worker_name.to_string(), self.repo_root.clone());
             return self.worker_ref(worker_name);
         }
 
@@ -244,7 +285,11 @@ impl WorktreeManager {
 
     /// Register a worktree that was created externally.
     pub fn register_worktree(&mut self, worker_name: &str, worktree: Worktree) {
+        let repo_root = Self::repo_root_for_worktree(&worktree.path)
+            .unwrap_or_else(|| self.repo_root.clone());
         self.workers.insert(worker_name.to_string(), worktree);
+        self.worker_repo_roots
+            .insert(worker_name.to_string(), repo_root);
     }
 
     /// Get a reference to the git operations wrapper
@@ -266,11 +311,13 @@ impl WorktreeManager {
 
         for name in worker_names {
             if let Some(mut worktree) = self.workers.remove(&name) {
+                let repo_root = self.worker_repo_root(&name);
+                let git = self.worker_git(&name);
                 // cas-df97: live external symlinks block regardless of
                 // `force` — force means "bypass git dirty-tree protection",
                 // not "I'm aware this will orphan $HOME symlinks".
                 if worktree.path.exists() {
-                    let links = self.inbound_symlinks(&worktree.path);
+                    let links = self.inbound_symlinks(&worktree.path, &repo_root);
                     if !links.is_empty() {
                         report
                             .external_symlinks_blocked
@@ -285,7 +332,7 @@ impl WorktreeManager {
                 }
 
                 if !force && worktree.path.exists() {
-                    let file_count = self.git.uncommitted_file_count(&worktree.path).unwrap_or(0);
+                    let file_count = git.uncommitted_file_count(&worktree.path).unwrap_or(0);
                     if file_count > 0 {
                         report.dirty_deferred.push(DirtyWorktreeWarning {
                             worker_name: name.clone(),
@@ -298,15 +345,16 @@ impl WorktreeManager {
                 }
 
                 if worktree.path.exists() {
-                    let _ = self.git.remove_worktree(&worktree.path, force);
+                    let _ = git.remove_worktree(&worktree.path, force);
                 }
 
-                let _ = self.git.delete_branch(&worktree.branch, true);
+                let _ = git.delete_branch(&worktree.branch, true);
 
                 worktree.mark_abandoned();
                 worktree.mark_removed();
 
-                report.cleaned.push(name);
+                report.cleaned.push(name.clone());
+                self.worker_repo_roots.remove(&name);
             }
         }
 
@@ -316,10 +364,12 @@ impl WorktreeManager {
     /// Remove a single worker's worktree
     pub fn remove_worker(&mut self, worker_name: &str, force: bool) -> WorktreeResult<()> {
         if let Some(mut worktree) = self.workers.remove(worker_name) {
+            let repo_root = self.worker_repo_root(worker_name);
+            let git = self.worker_git(worker_name);
             // cas-df97: live external symlinks block regardless of `force`
             // — see the identical guard in cleanup_workers.
             if worktree.path.exists() {
-                let links = self.inbound_symlinks(&worktree.path);
+                let links = self.inbound_symlinks(&worktree.path, &repo_root);
                 if !links.is_empty() {
                     let warning = ExternalSymlinkWarning {
                         worker_name: worker_name.to_string(),
@@ -339,7 +389,7 @@ impl WorktreeManager {
             // finding cas-006c — untracked-only debris is destroyed, not
             // preserved, by an actual removal).
             if !force && worktree.path.exists() {
-                if let Err(e) = self.reject_or_warn_on_dirty(&worktree.path, true) {
+                if let Err(e) = self.reject_or_warn_on_dirty(&git, &worktree.path, true) {
                     self.workers.insert(worker_name.to_string(), worktree);
                     return Err(e);
                 }
@@ -351,13 +401,14 @@ impl WorktreeManager {
             // the tree as safe to remove (blocking on untracked too, not
             // just tracked changes).
             if worktree.path.exists() {
-                self.git.remove_worktree(&worktree.path, true)?;
+                git.remove_worktree(&worktree.path, true)?;
             }
 
-            let _ = self.git.delete_branch(&worktree.branch, true);
+            let _ = git.delete_branch(&worktree.branch, true);
 
             worktree.mark_abandoned();
             worktree.mark_removed();
+            self.worker_repo_roots.remove(worker_name);
         }
 
         Ok(())
@@ -375,13 +426,15 @@ impl WorktreeManager {
             Some(wt) => wt,
             None => return Ok(RemoveOutcome::NotTracked),
         };
+        let repo_root = self.worker_repo_root(worker_name);
+        let git = self.worker_git(worker_name);
 
         if worktree.path.exists() {
             // cas-df97: live external symlinks block regardless of dirty
             // state — this is the actual production path
             // (finalize_worker_worktree) that the reported incident went
             // through.
-            let links = self.inbound_symlinks(&worktree.path);
+            let links = self.inbound_symlinks(&worktree.path, &repo_root);
             if !links.is_empty() {
                 let warning = ExternalSymlinkWarning {
                     worker_name: worker_name.to_string(),
@@ -392,7 +445,7 @@ impl WorktreeManager {
                 return Ok(RemoveOutcome::ExternalSymlinksBlocked(warning));
             }
 
-            let file_count = self.git.uncommitted_file_count(&worktree.path).unwrap_or(0);
+            let file_count = git.uncommitted_file_count(&worktree.path).unwrap_or(0);
             if file_count > 0 {
                 let warning = DirtyWorktreeWarning {
                     worker_name: worker_name.to_string(),
@@ -403,13 +456,14 @@ impl WorktreeManager {
                 return Ok(RemoveOutcome::DirtyDeferred(warning));
             }
 
-            self.git.remove_worktree(&worktree.path, false)?;
+            git.remove_worktree(&worktree.path, false)?;
         }
 
-        let _ = self.git.delete_branch(&worktree.branch, true);
+        let _ = git.delete_branch(&worktree.branch, true);
 
         worktree.mark_abandoned();
         worktree.mark_removed();
+        self.worker_repo_roots.remove(worker_name);
 
         Ok(RemoveOutcome::Removed)
     }

--- a/cas-cli/tests/mcp_proxy_test.rs
+++ b/cas-cli/tests/mcp_proxy_test.rs
@@ -166,16 +166,18 @@ fn cas_serve_boot_installs_fail_closed_exact_allowlist_policy() {
     std::fs::write(
         sandbox.cas_root().join("proxy.toml"),
         r#"
+allowlist = ["github.list_issues"]
+
 [servers.github]
 transport = "stdio"
 command = "cas-f7ac-intentionally-missing-upstream"
-
-[[allowlist]]
-server = "github"
-tool = "list_issues"
 "#,
     )
     .unwrap();
+    let parsed = cmcp_core::config::Config::load_from(&sandbox.cas_root().join("proxy.toml"))
+        .expect("canonical string allowlist should parse");
+    assert_eq!(parsed.allowlist.len(), 1);
+    assert_eq!(parsed.allowlist[0].canonical_entry(), "github.list_issues");
     let mut client = McpClient::spawn(&sandbox);
     client.initialize();
     let listed = client.request("tools/list", json!({}));
@@ -221,7 +223,10 @@ tool = "list_issues"
         }),
     );
     let admitted_message = admitted["error"]["message"].as_str().unwrap();
-    assert!(admitted_message.contains("MCP upstream 'github' is absent: it is configured but not connected"));
+    assert!(
+        admitted_message.contains("MCP upstream 'github' is absent: it is configured but not connected"),
+        "unexpected admitted response: {admitted}"
+    );
     assert!(!admitted_message.contains("proxy policy denied"));
 }
 

--- a/cas-cli/tests/mcp_tools_test/system_tools.rs
+++ b/cas-cli/tests/mcp_tools_test/system_tools.rs
@@ -766,6 +766,7 @@ async fn system_proxy_health_cache_fallback_is_sanitized() {
             name: raw_name.to_string(),
             transport: "Bearer cache-secret".to_string(),
             state: cmcp_core::UpstreamState::Backoff,
+            executable: None,
             attempts: 1,
             consecutive_failures: 1,
             tool_count: 0,

--- a/cas-cli/tests/push_skipped_test.rs
+++ b/cas-cli/tests/push_skipped_test.rs
@@ -1,16 +1,8 @@
-//! Integration test for the cas-f645 client-side defense.
+//! Integration tests for the cas-2cce push response contract.
 //!
-//! When the cloud server's push route silently skips rows due to a
-//! cross-project `project_canonical_id` conflict (via Postgres
-//! `ON CONFLICT DO UPDATE ... WHERE false ... RETURNING`), the response
-//! carries a per-entity-type `skipped` count. The client must inspect that
-//! count, surface it as a push error, and advance the corresponding local
-//! queue rows toward the visible failed state instead of retrying them
-//! silently forever.
-//!
-//! This test exercises the full `CloudSyncer::push` path through a
-//! wiremock-backed `/api/sync/push` endpoint to lock that behavior in.
-//! Companion server-side change is tracked under cas-d656 / cas-0bdc.
+//! Aggregate-only `skipped` counts acknowledge local rows under the server's
+//! last-write-wins semantics. A response that identifies a row-level
+//! `rejected` outcome still parks that row with its actionable reason.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -38,12 +30,11 @@ fn entry_payload(id: &str) -> String {
     .to_string()
 }
 
-/// When the server reports `skipped > 0` for an entity type, the affected
-/// queue items must not be marked synced. Each explicit rejection consumes a
-/// retry, so a persistent refusal becomes a visible failed row instead of
-/// remaining pending forever.
+/// Aggregate-only skips are last-write-wins acknowledgements: the row is
+/// removed from the local queue, counted as pushed, and does not become an
+/// error or visible failed item.
 #[tokio::test]
-async fn skipped_response_becomes_visible_failed_queue_item() {
+async fn skipped_response_is_acknowledged_as_lww() {
     let server = MockServer::start().await;
 
     // Live server shape: counts are nested under the entity key rather than
@@ -53,7 +44,7 @@ async fn skipped_response_becomes_visible_failed_queue_item() {
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "entries": { "inserted": 0, "updated": 0, "skipped": 1 }
         })))
-        .expect(1..)
+        .expect(1)
         .mount(&server)
         .await;
 
@@ -97,55 +88,98 @@ async fn skipped_response_becomes_visible_failed_queue_item() {
 
     // `push` is sync + blocking ureq; the wiremock runtime needs us off
     // the executor thread to serve the POST.
-    let (push_results, syncer) = tokio::task::spawn_blocking(move || {
-        let results = (0..5)
-            .map(|_| syncer.push().expect("push() returned Err"))
-            .collect::<Vec<_>>();
-        (results, syncer)
-    })
-    .await
-    .expect("spawn_blocking join");
-    let push_result = &push_results[0];
+    let (push_result, syncer) =
+        tokio::task::spawn_blocking(move || (syncer.push().expect("push() returned Err"), syncer))
+            .await
+            .expect("spawn_blocking join");
 
-    // Server reported 1 skipped → the client must NOT count this as
-    // pushed. The legacy "trust the 200" path would have set pushed_entries
-    // to 1; this assertion locks in the new behavior.
     assert_eq!(
-        push_result.pushed_entries, 0,
-        "client must not count server-skipped rows as pushed",
+        push_result.pushed_entries, 1,
+        "aggregate skips must count as acknowledged pushes",
     );
-
     assert!(
-        push_result
-            .errors
-            .iter()
-            .any(|error| error.contains("cloud skipped 1 of 1 entries")),
-        "server skips must make the overall push incomplete: {push_result:?}"
+        push_result.errors.is_empty(),
+        "aggregate skips are acknowledged without an error: {push_result:?}"
     );
-
-    // Critical AC: the queue item is neither silently discarded nor retried
-    // indefinitely. It becomes a failed row with an operator-visible reason.
     let queue_after = syncer.queue();
     assert_eq!(
         queue_after.pending_count(5).unwrap(),
         0,
-        "persistent server skips must leave the pending queue after max retries",
+        "acknowledged aggregate skips must be removed from the pending queue",
     );
+    assert_eq!(queue_after.stats(5).unwrap().failed, 0);
+    assert!(queue_after.list_all(10).unwrap().is_empty());
+}
+
+/// A row-level rejection is different from an aggregate skip: it identifies
+/// the exact queue item and must remain visible with its server-provided
+/// reason for operator repair.
+#[tokio::test]
+async fn per_row_rejected_outcome_stays_visible_with_reason() {
+    let server = MockServer::start().await;
+    let entry_id = "rejected-outcome-entry-001";
+    Mock::given(method("POST"))
+        .and(path("/api/sync/push"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": {
+                "inserted": 0,
+                "updated": 0,
+                "skipped": 1,
+                "rows": [{
+                    "id": entry_id,
+                    "outcome": "rejected",
+                    "reason": "project_mismatch"
+                }]
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let queue = SyncQueue::open(tmp.path()).unwrap();
+    queue.init().unwrap();
+    queue
+        .enqueue(
+            EntityType::Entry,
+            entry_id,
+            SyncOperation::Upsert,
+            Some(&entry_payload(entry_id)),
+        )
+        .unwrap();
+
+    let mut cfg = make_cloud_config(server.uri());
+    cfg.team_id = None;
+    let syncer = CloudSyncer::new(
+        Arc::new(queue),
+        cfg,
+        CloudSyncerConfig {
+            timeout: Duration::from_secs(5),
+            max_retries: 5,
+            ..Default::default()
+        },
+    );
+
+    let (push_result, syncer) =
+        tokio::task::spawn_blocking(move || (syncer.push().expect("push() returned Err"), syncer))
+            .await
+            .expect("spawn_blocking join");
+
+    assert_eq!(push_result.pushed_entries, 0);
+    assert_eq!(push_result.errors.len(), 1);
+    assert!(push_result.errors[0].contains("cloud rejected 1 of 1 entries"));
+    let queue_after = syncer.queue();
+    assert_eq!(queue_after.pending_count(5).unwrap(), 0);
     assert_eq!(queue_after.stats(5).unwrap().failed, 1);
     let items = queue_after.list_all(10).unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].entity_id, entry_id);
     assert!(
         items[0]
             .last_error
             .as_deref()
-            .is_some_and(|diagnostic| diagnostic.contains("cloud skipped 1 of 1 entries")),
-        "queue output must expose why this row failed: {items:?}"
-    );
-    assert!(
-        items[0]
-            .last_error
-            .as_deref()
-            .is_some_and(|diagnostic| diagnostic.contains("server response: {\"entries\"")),
-        "queue output must preserve the raw server response: {items:?}"
+            .is_some_and(|diagnostic| diagnostic.contains("reason=project_mismatch")),
+        "queue output must expose the rejection reason: {items:?}"
     );
 }
 

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -17,6 +17,7 @@ cas doctor
 [OK] embedding drain: no cloud embedding capability (not logged in); nothing is queued
 [WARN] code history index: cannot check code history index: not a git repository: [TEMP_PATH] ([GIT_NOT_REPOSITORY])
 [OK] configuration: Loaded (sync: enabled)
+[OK] MCP stdio upstreams: [N] registered command(s) resolve to executable files
 [OK] sync target: Will sync to .claude/rules/cas (not yet created)
 [OK] memory stats: [N] total () | tiers:  | compressed: [N] | helpful: [N] | harmful: [N]
 [OK] memory decay: Memory decay (last cycle): unavailable (no completed decay cycle recorded)

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -26,6 +26,7 @@ cas doctor
 [OK] mcp config: MCP configured in .mcp.json
 [OK] integrations: no integrations configured
 [OK] canonical id: Cloud bucket `[BUCKET]` (from folder name)
+[OK] cloud sync queue: [N] queued content change(s) block purge-foreign; Run `cas cloud queue --retry`, then `cas cloud push`, then `cas cloud purge-foreign --dry-run`; repeat the push until this count reaches 0.
 [OK] cross-project rows: [N] project DB(s) compared (0 local task row(s), 0 DB(s) unreadable) — task replication was not checked; 0 foreign knowledge page(s): [N] attributed page(s) checked
 
 [WARN] All critical checks passed with some warnings.

--- a/cas-cli/tests/team_registration_test.rs
+++ b/cas-cli/tests/team_registration_test.rs
@@ -384,6 +384,41 @@ async fn registration_adopts_the_server_resolved_existing_bucket() {
     );
 }
 
+/// A previously registered project may be returned in its git-remote spelling
+/// while this checkout has the server's short slug pinned. Registration must
+/// recognize the existing row without issuing a duplicate registration push.
+#[tokio::test]
+async fn alias_registration_project_list_remote_alias_is_owned() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(projects_path()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(project_list_body(
+            "https://GitHub.com/Richards-LLC/gabber-studio.git/",
+        )))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(team_push_path()))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let endpoint = server.uri();
+    let outcome = tokio::task::spawn_blocking(move || {
+        cas::cloud::TeamRegistration::new(&endpoint, "test-token", TEST_TEAM, "gabber-studio")
+            .with_pinned_canonical_id(Some("gabber-studio"))
+            .ensure()
+    })
+    .await
+    .unwrap()
+    .expect("a remote alias in the team project list must count as registered");
+
+    assert_eq!(outcome.project_uuid(), "project-uuid-1");
+    assert!(!outcome.newly_registered());
+}
+
 /// A divergent server response is an identity-resolution result, not evidence
 /// of a server-side defect. If its listed bucket disappears between the push
 /// and the verification GET, name the resolved id honestly for recovery.

--- a/cas-cli/tests/team_sync_test.rs
+++ b/cas-cli/tests/team_sync_test.rs
@@ -273,7 +273,7 @@ async fn team_push_drains_queue_when_team_configured() {
 }
 
 #[tokio::test]
-async fn team_push_nested_skip_response_becomes_visible_failed_queue_item() {
+async fn team_push_nested_skip_response_acknowledges_lww_row() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path(format!("/api/teams/{TEST_TEAM}/sync/push")))
@@ -284,7 +284,7 @@ async fn team_push_nested_skip_response_becomes_visible_failed_queue_item() {
             "canonical_id": "cas-src",
             "git_remote": "github.com/pippenz/cas"
         })))
-        .expect(5)
+        .expect(1)
         .mount(&server)
         .await;
 
@@ -307,31 +307,15 @@ async fn team_push_nested_skip_response_becomes_visible_failed_queue_item() {
     .unwrap();
     let result = &results[0];
 
-    assert_eq!(result.pushed_entries, 0);
+    assert_eq!(result.pushed_entries, 1);
     assert!(
-        result
-            .errors
-            .iter()
-            .any(|error| error.contains("skipped 1")),
-        "skip must be surfaced: {:?}",
+        result.errors.is_empty(),
+        "aggregate LWW skip is an acknowledgement: {:?}",
         result.errors
     );
     assert_eq!(queue.pending_for_team(TEST_TEAM, 10, 5).unwrap().len(), 0);
-    assert_eq!(queue.stats(5).unwrap().failed, 1);
-    let items = queue.list_all(10).unwrap();
-    assert!(
-        items[0]
-            .last_error
-            .as_deref()
-            .is_some_and(|diagnostic| diagnostic.contains("cloud skipped 1 of 1 team entries")),
-        "queue output must expose why this team row failed: {items:?}"
-    );
-    assert!(
-        items[0].last_error.as_deref().is_some_and(|diagnostic| {
-            diagnostic.contains("server response:") && diagnostic.contains("\"synced\"")
-        }),
-        "queue output must preserve the raw team server response: {items:?}"
-    );
+    assert_eq!(queue.stats(5).unwrap().failed, 0);
+    assert!(queue.list_all(10).unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/cas-cli/tests/team_sync_test.rs
+++ b/cas-cli/tests/team_sync_test.rs
@@ -72,6 +72,7 @@ fn seed_team_task_move(queue: &SyncQueue, task_id: &str) {
             EntityType::Task,
             task_id,
             "project-a",
+            "project-b",
             &format!(
                 r#"{{"id":"{task_id}","title":"moved","scope":"project","origin_project":"project-b"}}"#
             ),
@@ -120,6 +121,9 @@ async fn team_task_move_deletes_old_project_before_upserting_new_owner() {
     assert_eq!(requests.len(), 2);
     assert_eq!(requests[0].method.as_str(), "DELETE");
     assert_eq!(requests[1].method.as_str(), "POST");
+    let payload = decode_gzip_json(&requests[1].body);
+    assert_eq!(payload["project_canonical_id"], "project-b");
+    assert_eq!(payload["tasks"][0]["origin_project"], "project-b");
     assert!(queue.pending_for_team(TEST_TEAM, 10, 5).unwrap().is_empty());
 }
 

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp-proxy/README.md
+++ b/crates/cas-mcp-proxy/README.md
@@ -64,15 +64,25 @@ url = "https://example.com/sse"
 
 ### External dispatch policy
 
-`cas serve` installs an exact `(server, tool)` allowlist at startup and on hot
+`cas serve` installs a parsed `(server, tool)` allowlist at startup and on hot
 reload. The default is fail-closed: configuring a server makes its catalog
 searchable, but an empty or omitted `allowlist` forwards no external calls.
+Catalog results include `policy = "denied by policy"` for tools that are
+visible but not admitted, so discovery cannot be mistaken for authorization.
 
 ```toml
-[[allowlist]]
-server = "github"
-tool = "list_issues"
+allowlist = ["github.list_issues", "github.*"]
 ```
+
+`allowlist` is a top-level key, so place it before any `[servers.<name>]`
+tables in a combined file.
+
+The canonical spelling is `server.tool`. `server:tool`, `server/tool`,
+`mcp__server__tool`, bare tool names (matching any server), and the historical
+`[[allowlist]]` tables remain accepted as compatibility input. A `server.*`
+entry admits every tool from one server; `*.tool` admits one tool from every
+server. Serialized configuration uses canonical strings. Denials identify the
+exact canonical entry to add, for example `neon.run_sql`.
 
 When `.cas/proxy.toml` exists its allowlist and delegation sections replace the
 user-scoped values rather than unioning them. This prevents a broader personal
@@ -86,16 +96,10 @@ epic plus a non-secret local proof reference, and writes a budget reservation
 to the project's `cas.db` before starting the upstream run. A timed-out run is
 resumed by its recorded run ID; the gateway never starts a replacement run.
 
-Both gateway tools must also appear in the exact allowlist:
+Both gateway tools must also appear in the allowlist:
 
 ```toml
-[[allowlist]]
-server = "viktor"
-tool = "ask_viktor"
-
-[[allowlist]]
-server = "viktor"
-tool = "wait_for_run"
+allowlist = ["viktor.ask_viktor", "viktor.wait_for_run"]
 
 [delegation.external_production_verification]
 server = "viktor"
@@ -124,6 +128,12 @@ configuration and is never copied into tool arguments or model context.
 An explicit `server:<name>` query for a configured upstream that is disconnected returns an
 `upstream ... is absent` error instead of an empty catalog. Inspect `proxy_health` and repair the
 credential or connection before retrying a run-starting call.
+
+When a stdio command or interpreter path no longer exists, `proxy_health` reports
+`state = "executable_missing"`, `last_error_code = "executable_missing"`, and the
+configured executable. This is terminal for the current daemon session and does
+not enter retry backoff. `cas doctor` checks configured stdio commands before a
+restart and names the registrations that need repair.
 
 ## Execute
 

--- a/crates/cas-mcp-proxy/src/config.rs
+++ b/crates/cas-mcp-proxy/src/config.rs
@@ -405,6 +405,59 @@ tool = "ask_viktor"
     }
 
     #[test]
+    fn allowlist_accepts_canonical_and_legacy_string_route_spellings() {
+        let config: Config = toml::from_str(
+            r#"
+allowlist = ["neon.run_sql", "neon:write", "neon/read", "run_sql", "neon.*"]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.allowlist,
+            vec![
+                ExternalToolConfig {
+                    server: "neon".to_string(),
+                    tool: "run_sql".to_string(),
+                },
+                ExternalToolConfig {
+                    server: "neon".to_string(),
+                    tool: "write".to_string(),
+                },
+                ExternalToolConfig {
+                    server: "neon".to_string(),
+                    tool: "read".to_string(),
+                },
+                ExternalToolConfig {
+                    server: "*".to_string(),
+                    tool: "run_sql".to_string(),
+                },
+                ExternalToolConfig {
+                    server: "neon".to_string(),
+                    tool: "*".to_string(),
+                },
+            ]
+        );
+
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(serialized.contains("allowlist = ["));
+        assert!(serialized.contains("neon.run_sql"));
+    }
+
+    #[test]
+    fn allowlist_rejects_empty_or_malformed_string_route_spellings() {
+        for source in [
+            "allowlist = [\"\"]",
+            "allowlist = [\"neon.\"]",
+            "allowlist = [\"neon:*:run_sql\"]",
+            "allowlist = [\"*\"]",
+        ] {
+            let error = toml::from_str::<Config>(source).unwrap_err();
+            assert!(error.to_string().contains("allowlist entry"), "{source}: {error}");
+        }
+    }
+
+    #[test]
     fn add_and_remove_server() {
         let mut config = Config::default();
         config.add_server(

--- a/crates/cas-mcp-proxy/src/config.rs
+++ b/crates/cas-mcp-proxy/src/config.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Canonical Viktor streamable-HTTP upstream. The credential is resolved at
 /// connection time so it is safe to place this managed default on disk.
@@ -38,10 +39,93 @@ pub struct Config {
     pub delegation: DelegationConfig,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExternalToolConfig {
     pub server: String,
     pub tool: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ExternalToolConfigInput {
+    Structured { server: String, tool: String },
+    Entry(String),
+}
+
+impl ExternalToolConfig {
+    /// Parse the canonical `server.tool` spelling and the historical
+    /// separator aliases accepted in project proxy files. A bare tool is
+    /// retained as a tool-only route (`*.tool`) for compatibility; new files
+    /// should use an explicit server or `server.*` wildcard.
+    pub fn parse_allowlist_entry(entry: &str) -> Result<Self, String> {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            return Err("allowlist entry must not be empty".to_string());
+        }
+
+        if let Some(encoded) = entry.strip_prefix("mcp__") {
+            let Some((server, tool)) = encoded.split_once("__") else {
+                return Err(format!("invalid allowlist entry {entry:?}"));
+            };
+            return Self::from_parts(server, tool, entry);
+        }
+
+        let Some(separator) = entry.find(|character| matches!(character, '.' | ':' | '/')) else {
+            return Self::from_parts("*", entry, entry);
+        };
+        let (server, tool) = entry.split_at(separator);
+        let tool = &tool[1..];
+        Self::from_parts(server, tool, entry)
+    }
+
+    fn from_parts(server: &str, tool: &str, original: &str) -> Result<Self, String> {
+        if server.is_empty()
+            || tool.is_empty()
+            || server
+                .chars()
+                .any(|character| matches!(character, '.' | ':' | '/'))
+            || tool
+                .chars()
+                .any(|character| matches!(character, '.' | ':' | '/'))
+            || (server == "*" && tool == "*")
+        {
+            return Err(format!("invalid allowlist entry {original:?}"));
+        }
+        Ok(Self {
+            server: server.to_string(),
+            tool: tool.to_string(),
+        })
+    }
+
+    pub fn canonical_entry(&self) -> String {
+        format!("{}.{}", self.server, self.tool)
+    }
+}
+
+impl<'de> Deserialize<'de> for ExternalToolConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match ExternalToolConfigInput::deserialize(deserializer)? {
+            ExternalToolConfigInput::Structured { server, tool } => {
+                Self::from_parts(&server, &tool, &format!("{server}.{tool}"))
+                    .map_err(D::Error::custom)
+            }
+            ExternalToolConfigInput::Entry(entry) => {
+                Self::parse_allowlist_entry(&entry).map_err(D::Error::custom)
+            }
+        }
+    }
+}
+
+impl Serialize for ExternalToolConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.canonical_entry())
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/cas-mcp-proxy/src/lib.rs
+++ b/crates/cas-mcp-proxy/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 
 use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -144,6 +145,21 @@ impl ExternalToolRoute {
         Some(Self::new(server, tool))
     }
 
+    /// Parse a proxy configuration allowlist entry into its canonical route.
+    /// The canonical spelling is `server.tool`; `server:tool`, `server/tool`,
+    /// MCP's `mcp__server__tool`, and a bare tool name remain accepted as
+    /// compatibility aliases.
+    pub fn parse_allowlist_entry(entry: &str) -> Result<Self> {
+        let route =
+            config::ExternalToolConfig::parse_allowlist_entry(entry).map_err(anyhow::Error::msg)?;
+        Ok(Self::new(route.server, route.tool))
+    }
+
+    /// Canonical configuration spelling for this route.
+    pub fn canonical_entry(&self) -> String {
+        format!("{}.{}", self.server, self.tool)
+    }
+
     /// Upstream server component.
     pub fn server(&self) -> &str {
         &self.server
@@ -162,6 +178,13 @@ impl ExternalToolRoute {
 /// can use this hook to deny a call before `ProxyEngine` forwards it.
 pub trait ProxyPolicy: Send + Sync {
     fn decide(&self, request: &ProxyPolicyRequest<'_>) -> ProxyPolicyDecision;
+
+    /// Return the policy's catalog visibility decision without inventing a
+    /// caller identity. Policies that do not filter discovery retain the
+    /// default, while the configured external allowlist marks denied tools.
+    fn catalog_decision(&self, _server: &str, _tool: &str) -> ProxyPolicyDecision {
+        ProxyPolicyDecision::Allow
+    }
 }
 
 /// Default policy for installations that have not opted into protected tools.
@@ -209,6 +232,20 @@ impl ExternalToolAllowlistPolicy {
     pub fn allows(&self, server: &str, tool: &str) -> bool {
         self.allowed_routes
             .contains(&ExternalToolRoute::new(server, tool))
+            || self
+                .allowed_routes
+                .contains(&ExternalToolRoute::new(server, "*"))
+            || self
+                .allowed_routes
+                .contains(&ExternalToolRoute::new("*", tool))
+    }
+
+    fn denial_reason(server: &str, tool: &str) -> String {
+        format!(
+            "external tool is not explicitly allowlisted; add \"{}.{}\" to [proxy].allowlist",
+            public_upstream_id(server),
+            public_tool_id(tool)
+        )
     }
 }
 
@@ -216,7 +253,7 @@ impl ProxyPolicy for ExternalToolAllowlistPolicy {
     fn decide(&self, request: &ProxyPolicyRequest<'_>) -> ProxyPolicyDecision {
         if !self.allows(request.server, request.tool) {
             return ProxyPolicyDecision::Deny {
-                reason: "external tool is not explicitly allowlisted".to_string(),
+                reason: Self::denial_reason(request.server, request.tool),
             };
         }
         let route = ExternalToolRoute::new(request.server, request.tool);
@@ -230,6 +267,16 @@ impl ProxyPolicy for ExternalToolAllowlistPolicy {
             };
         }
         ProxyPolicyDecision::Allow
+    }
+
+    fn catalog_decision(&self, server: &str, tool: &str) -> ProxyPolicyDecision {
+        if self.allows(server, tool) {
+            ProxyPolicyDecision::Allow
+        } else {
+            ProxyPolicyDecision::Deny {
+                reason: Self::denial_reason(server, tool),
+            }
+        }
     }
 }
 
@@ -267,6 +314,10 @@ pub struct UpstreamHealth {
     pub name: String,
     pub transport: String,
     pub state: UpstreamState,
+    /// The configured stdio executable, only populated when it is missing.
+    /// HTTP/SSE endpoints and working commands remain absent from health.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executable: Option<String>,
     pub attempts: u32,
     pub consecutive_failures: u32,
     pub tool_count: usize,
@@ -282,6 +333,7 @@ pub enum UpstreamState {
     Healthy,
     Degraded,
     Backoff,
+    ExecutableMissing,
 }
 
 /// Per-engine (therefore per MCP session) health snapshot.
@@ -306,7 +358,14 @@ impl ProxyHealthSnapshot {
                 .get(&server.name)
                 .cloned()
                 .unwrap_or_else(|| public_upstream_id(&server.name));
+            let expose_executable =
+                server.state == UpstreamState::ExecutableMissing && server.transport == "stdio";
             server.transport = safe_transport(&server.transport).to_string();
+            server.executable = expose_executable
+                .then(|| server.executable.take())
+                .flatten()
+                .as_deref()
+                .map(safe_executable);
             server.last_error_code = server
                 .last_error_code
                 .as_deref()
@@ -509,9 +568,20 @@ impl ProxyEngine {
                     let record = health
                         .entry(name.to_string())
                         .or_insert_with(|| initial_health(name, config));
+                    if code == "executable_missing"
+                        && let ServerConfig::Stdio { command, .. } = config
+                    {
+                        record.executable = Some(command.trim().to_string());
+                    }
                     record_failure(record, code, now)
                 };
                 match visibility {
+                    FailureVisibility::Error if code == "executable_missing" => tracing::error!(
+                        upstream = %public_name,
+                        error_code = code,
+                        proxy_session = %self.session_id,
+                        "Optional MCP upstream executable is missing; CAS will continue without retry"
+                    ),
                     FailureVisibility::Error => tracing::error!(
                         upstream = %public_name,
                         error_code = code,
@@ -589,8 +659,13 @@ impl ProxyEngine {
 
             let public_tools =
                 public_tool_ids(connected.tools.iter().map(|tool| tool.name.as_ref()));
+            let policy = self.policy.read().await.clone();
             for tool in &connected.tools {
                 if matches_keywords(tool, &keywords) {
+                    let policy = match policy.catalog_decision(server_name, tool.name.as_ref()) {
+                        ProxyPolicyDecision::Allow => None,
+                        ProxyPolicyDecision::Deny { .. } => Some("denied by policy".to_string()),
+                    };
                     results.push(SearchResult {
                         server: public_server.clone(),
                         name: public_tools
@@ -599,6 +674,7 @@ impl ProxyEngine {
                             .unwrap_or_else(|| public_tool_id(tool.name.as_ref())),
                         description: tool.description.as_ref().map(|d| d.to_string()),
                         input_schema: serde_json::to_value(&*tool.input_schema).unwrap_or_default(),
+                        policy,
                     });
                 }
             }
@@ -1147,6 +1223,7 @@ fn initial_health(name: &str, config: &ServerConfig) -> UpstreamHealth {
         name: name.to_string(),
         transport: transport_name(config).to_string(),
         state: UpstreamState::Degraded,
+        executable: None,
         attempts: 0,
         consecutive_failures: 0,
         tool_count: 0,
@@ -1169,6 +1246,7 @@ fn record_success(record: &mut UpstreamHealth, tool_count: usize, now: u64) {
     record.consecutive_failures = 0;
     record.tool_count = tool_count;
     record.state = UpstreamState::Healthy;
+    record.executable = None;
     record.last_error_code = None;
     record.last_attempt_at_ms = Some(now);
     record.next_retry_at_ms = None;
@@ -1180,6 +1258,11 @@ fn record_failure(record: &mut UpstreamHealth, error_code: &str, now: u64) -> Fa
     record.tool_count = 0;
     record.last_error_code = Some(error_code.to_string());
     record.last_attempt_at_ms = Some(now);
+    if error_code == "executable_missing" {
+        record.state = UpstreamState::ExecutableMissing;
+        record.next_retry_at_ms = None;
+        return FailureVisibility::Error;
+    }
     let shift = record.consecutive_failures.saturating_sub(1).min(6);
     let delay_secs = RETRY_BASE_SECS
         .saturating_mul(1_u64 << shift)
@@ -1211,6 +1294,13 @@ fn classify_error(error: &anyhow::Error) -> &'static str {
         "invalid_url"
     } else if message.contains("timed out") || message.contains("timeout") {
         "timeout"
+    } else if message.contains("no such file or directory")
+        || message.contains("os error 2")
+        || message.contains("exit status: 127")
+        || message.contains("status 127")
+        || message.contains("code 127")
+    {
+        "executable_missing"
     } else {
         "connection_failed"
     }
@@ -1278,6 +1368,7 @@ fn safe_error_code(code: &str) -> &'static str {
         "invalid_url" => "invalid_url",
         "timeout" => "timeout",
         "connection_failed" => "connection_failed",
+        "executable_missing" => "executable_missing",
         _ => "unknown",
     }
 }
@@ -1289,6 +1380,93 @@ fn live_failure_applies(
     failure_completion: u64,
 ) -> bool {
     installed_generation == failed_generation && last_successful_call <= failure_completion
+}
+
+/// Resolve a stdio command using the same PATH semantics as process launch.
+/// Absolute and relative paths must point at executable files; bare commands
+/// are searched through the current process PATH.
+pub fn resolve_stdio_executable(command: &str) -> Option<PathBuf> {
+    resolve_stdio_executable_at_depth(command, 0)
+}
+
+fn resolve_stdio_executable_at_depth(command: &str, depth: u8) -> Option<PathBuf> {
+    if depth > 8 {
+        return None;
+    }
+    let command = command.trim();
+    if command.is_empty() {
+        return None;
+    }
+    let path = Path::new(command);
+    let has_path = path.is_absolute()
+        || path
+            .parent()
+            .is_some_and(|parent| !parent.as_os_str().is_empty());
+    if has_path {
+        return is_executable(path, depth).then(|| path.to_path_buf());
+    }
+
+    std::env::split_paths(&std::env::var_os("PATH")?)
+        .map(|directory| directory.join(command))
+        .find(|candidate| is_executable(candidate, depth))
+}
+
+fn is_executable(path: &Path, depth: u8) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return false;
+        }
+
+        // `Command::new` asks the kernel to resolve a script's `#!`
+        // interpreter. A script can therefore be executable while still
+        // failing with ENOENT when its interpreter was removed; validate that
+        // second hop so doctor reports the same stale-path failure.
+        let Ok(contents) = std::fs::read(path) else {
+            return true;
+        };
+        let Some(first_line) = contents.split(|byte| *byte == b'\n').next() else {
+            return true;
+        };
+        let Ok(first_line) = std::str::from_utf8(first_line) else {
+            return true;
+        };
+        let Some(shebang) = first_line.strip_prefix("#!") else {
+            return true;
+        };
+        let mut words = shebang.split_whitespace();
+        let Some(interpreter) = words.next() else {
+            return false;
+        };
+        let interpreter = if interpreter.ends_with("/env") {
+            words.find(|word| !word.starts_with('-'))
+        } else {
+            Some(interpreter)
+        };
+        interpreter.is_some_and(|interpreter| {
+            resolve_stdio_executable_at_depth(interpreter, depth + 1).is_some()
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = depth;
+        true
+    }
+}
+
+fn safe_executable(executable: &str) -> String {
+    if executable.len() <= 4096 && executable.chars().all(|character| !character.is_control()) {
+        executable.to_string()
+    } else {
+        "unknown".to_string()
+    }
 }
 
 /// Connect to a single upstream MCP server and discover its tools.
@@ -1402,6 +1580,8 @@ struct SearchResult {
     name: String,
     description: Option<String>,
     input_schema: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    policy: Option<String>,
 }
 
 /// Parse a search query into an optional server filter and keyword tokens.
@@ -1649,7 +1829,7 @@ mod tests {
             assert_eq!(
                 decision(server, tool),
                 ProxyPolicyDecision::Deny {
-                    reason: "external tool is not explicitly allowlisted".to_string()
+                    reason: ExternalToolAllowlistPolicy::denial_reason(server, tool)
                 },
                 "allowlist must compare parsed components exactly for {server}.{tool}"
             );
@@ -1659,10 +1839,10 @@ mod tests {
     #[test]
     fn external_tool_allowlist_normalizes_aliases_and_supports_server_wildcards() {
         let routes = ["neon.run_sql", "neon:write", "neon/read", "run_sql", "github.*"]
-            .into_iter()
-            .map(ExternalToolRoute::parse_allowlist_entry)
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
+        .into_iter()
+        .map(ExternalToolRoute::parse_allowlist_entry)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
         let policy = ExternalToolAllowlistPolicy::new(routes);
 
         assert!(policy.allows("neon", "run_sql"));
@@ -1803,7 +1983,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "proxy policy denied tool 'ask_viktor' on 'viktor-shadow': external tool is not explicitly allowlisted"
+            "proxy policy denied tool 'ask_viktor' on 'viktor-shadow': external tool is not explicitly allowlisted; add \"viktor-shadow.ask_viktor\" to [proxy].allowlist"
         );
         let audit = engine.policy_audit();
         assert_eq!(audit.len(), 1);
@@ -2229,6 +2409,7 @@ mod tests {
                     name: first_raw.to_string(),
                     transport: "Bearer private".to_string(),
                     state: UpstreamState::Backoff,
+                    executable: None,
                     attempts: 1,
                     consecutive_failures: 1,
                     tool_count: 0,
@@ -2240,6 +2421,7 @@ mod tests {
                     name: second_raw.to_string(),
                     transport: "http".to_string(),
                     state: UpstreamState::Backoff,
+                    executable: None,
                     attempts: 1,
                     consecutive_failures: 1,
                     tool_count: 0,
@@ -2300,6 +2482,7 @@ mod tests {
                     name: name.to_string(),
                     transport: "http".to_string(),
                     state: UpstreamState::Healthy,
+                    executable: None,
                     attempts: 1,
                     consecutive_failures: 0,
                     tool_count: 1,
@@ -2364,6 +2547,98 @@ mod tests {
         assert_eq!(first.executable.as_deref(), Some("cas-command-that-does-not-exist-for-proxy-test"));
         assert_eq!(engine.retry_unhealthy().await, 0);
         assert_eq!(engine.health_snapshot().await.servers[0].attempts, 1);
+    }
+
+    #[test]
+    fn health_sanitization_only_exposes_missing_stdio_executables() {
+        let snapshot = ProxyHealthSnapshot {
+            session_id: "proxy-test".to_string(),
+            generated_at_ms: 1,
+            healthy: 1,
+            degraded: 2,
+            servers: vec![
+                UpstreamHealth {
+                    name: "missing-stdio".to_string(),
+                    transport: "stdio".to_string(),
+                    state: UpstreamState::ExecutableMissing,
+                    executable: Some("/opt/stale/mcp-server".to_string()),
+                    attempts: 1,
+                    consecutive_failures: 1,
+                    tool_count: 0,
+                    last_error_code: Some("executable_missing".to_string()),
+                    last_attempt_at_ms: Some(1),
+                    next_retry_at_ms: None,
+                },
+                UpstreamHealth {
+                    name: "forged-http".to_string(),
+                    transport: "http".to_string(),
+                    state: UpstreamState::ExecutableMissing,
+                    executable: Some("/should/not/escape".to_string()),
+                    attempts: 1,
+                    consecutive_failures: 1,
+                    tool_count: 0,
+                    last_error_code: Some("executable_missing".to_string()),
+                    last_attempt_at_ms: Some(1),
+                    next_retry_at_ms: None,
+                },
+                UpstreamHealth {
+                    name: "healthy-stdio".to_string(),
+                    transport: "stdio".to_string(),
+                    state: UpstreamState::Healthy,
+                    executable: Some("/should/not/escape".to_string()),
+                    attempts: 1,
+                    consecutive_failures: 0,
+                    tool_count: 1,
+                    last_error_code: None,
+                    last_attempt_at_ms: Some(1),
+                    next_retry_at_ms: None,
+                },
+            ],
+        }
+        .sanitized();
+
+        assert_eq!(
+            snapshot.servers[0].executable.as_deref(),
+            Some("/opt/stale/mcp-server")
+        );
+        assert_eq!(snapshot.servers[1].executable, None);
+        assert_eq!(snapshot.servers[2].executable, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_stdio_executable_checks_relative_paths_and_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp.path().join("nested").join("stdio-server");
+        std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
+        std::fs::write(&executable, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions).unwrap();
+
+        let path_with_parent = executable
+            .parent()
+            .unwrap()
+            .join("..")
+            .join("nested")
+            .join("stdio-server");
+        assert_eq!(
+            resolve_stdio_executable(&path_with_parent.to_string_lossy()),
+            Some(path_with_parent)
+        );
+
+        let non_executable = temp.path().join("not-executable");
+        std::fs::write(&non_executable, "not executable").unwrap();
+        assert!(resolve_stdio_executable(&non_executable.to_string_lossy()).is_none());
+
+        let stale_interpreter = temp.path().join("stale-interpreter");
+        std::fs::write(&stale_interpreter, "#!/missing/interpreter\nexit 0\n").unwrap();
+        let mut permissions = std::fs::metadata(&stale_interpreter).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&stale_interpreter, permissions).unwrap();
+        assert!(resolve_stdio_executable(&stale_interpreter.to_string_lossy()).is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -2434,6 +2709,7 @@ mod tests {
                 name: "github".to_string(),
                 transport: "http".to_string(),
                 state: UpstreamState::Backoff,
+                executable: None,
                 attempts: 1,
                 consecutive_failures: 1,
                 tool_count: 0,

--- a/crates/cas-mcp-proxy/src/lib.rs
+++ b/crates/cas-mcp-proxy/src/lib.rs
@@ -1657,6 +1657,54 @@ mod tests {
     }
 
     #[test]
+    fn external_tool_allowlist_normalizes_aliases_and_supports_server_wildcards() {
+        let routes = ["neon.run_sql", "neon:write", "neon/read", "run_sql", "github.*"]
+            .into_iter()
+            .map(ExternalToolRoute::parse_allowlist_entry)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let policy = ExternalToolAllowlistPolicy::new(routes);
+
+        assert!(policy.allows("neon", "run_sql"));
+        assert!(policy.allows("neon", "write"));
+        assert!(policy.allows("neon", "read"));
+        assert!(policy.allows("other", "run_sql"));
+        assert!(policy.allows("github", "list_issues"));
+        assert!(!policy.allows("github-shadow", "list_issues"));
+        assert!(!policy.allows("neon", "run_sql_with_full_context"));
+    }
+
+    #[test]
+    fn external_tool_allowlist_denial_names_canonical_entry_to_add() {
+        let policy = ExternalToolAllowlistPolicy::default();
+        let caller = registered_worker_caller();
+        let arguments = None;
+        assert_eq!(
+            policy.decide(&ProxyPolicyRequest {
+                caller: &caller,
+                server: "neon",
+                tool: "run_sql",
+                arguments: &arguments,
+                dispatch_kind: ProxyDispatchKind::Direct,
+            }),
+            ProxyPolicyDecision::Deny {
+                reason: "external tool is not explicitly allowlisted; add \"neon.run_sql\" to [proxy].allowlist".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn external_tool_allowlist_catalog_decision_marks_denied_tools() {
+        let policy = ExternalToolAllowlistPolicy::default();
+        assert_eq!(
+            policy.catalog_decision("neon", "run_sql"),
+            ProxyPolicyDecision::Deny {
+                reason: "external tool is not explicitly allowlisted; add \"neon.run_sql\" to [proxy].allowlist".to_string(),
+            }
+        );
+    }
+
+    #[test]
     fn delegation_routes_require_internal_supervisor_dispatch_kind() {
         let policy = ExternalToolAllowlistPolicy::new([
             ExternalToolRoute::new("viktor", "ask_viktor"),
@@ -2297,7 +2345,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn retries_only_when_backoff_is_due_and_suppresses_repeated_error_visibility() {
+    async fn missing_stdio_executable_is_terminal_and_visible_without_retry() {
         let config = ServerConfig::Stdio {
             command: "cas-command-that-does-not-exist-for-proxy-test".to_string(),
             args: Vec::new(),
@@ -2310,25 +2358,12 @@ mod tests {
         let first = engine.health_snapshot().await.servers.remove(0);
         assert_eq!(first.attempts, 1);
         assert_eq!(first.consecutive_failures, 1);
-        let due = first
-            .next_retry_at_ms
-            .expect("failed upstream must back off");
-
-        assert_eq!(engine.retry_unhealthy_at(due - 1).await, 0);
-        assert_eq!(
-            engine.health_snapshot().await.servers[0].attempts,
-            1,
-            "retry before the deadline must be suppressed"
-        );
-
-        assert_eq!(engine.retry_unhealthy_at(due).await, 1);
-        let repeated = engine.health_snapshot().await.servers.remove(0);
-        assert_eq!(repeated.attempts, 2);
-        assert_eq!(repeated.consecutive_failures, 2);
-        assert!(
-            repeated.next_retry_at_ms.unwrap() >= due + 10_000,
-            "the second production-path failure must advance exponential backoff"
-        );
+        assert_eq!(first.state, UpstreamState::ExecutableMissing);
+        assert_eq!(first.last_error_code.as_deref(), Some("executable_missing"));
+        assert_eq!(first.next_retry_at_ms, None);
+        assert_eq!(first.executable.as_deref(), Some("cas-command-that-does-not-exist-for-proxy-test"));
+        assert_eq!(engine.retry_unhealthy().await, 0);
+        assert_eq!(engine.health_snapshot().await.servers[0].attempts, 1);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-pty/src/pty.rs
+++ b/crates/cas-pty/src/pty.rs
@@ -4415,12 +4415,24 @@ mod tests {
     // is sent at the Pane/Mux layer (`Pane::break_turn`). These tests lock the
     // byte values against a real PTY so we never regress the payload.
 
-    // Run 32067496804 exhausted the former 20s ceiling in 20.061s while its
-    // saturated runner completed the full suite in 128.862s. Keep one shared,
-    // event-driven ceiling for both sides of this behavioral contrast: healthy
-    // runs still return on the first event, while runner starvation gets nearly
-    // a full suite's scheduling slack without introducing polling or retries.
-    const PTY_CONTROL_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+    const PTY_CONTROL_EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+    const PTY_EVENT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+
+    async fn next_pty_event_until(
+        pty: &mut Pty,
+        deadline: tokio::time::Instant,
+    ) -> Option<PtyEvent> {
+        loop {
+            if let Some(event) = pty.try_recv() {
+                return Some(event);
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return None;
+            }
+            tokio::time::sleep((deadline - now).min(PTY_EVENT_POLL_INTERVAL)).await;
+        }
+    }
 
     /// Esc (0x1b) is NOT a signal-generating control char (unlike 0x03 = INTR),
     /// so it traverses the PTY rather than killing the child. We send Esc then a
@@ -4450,32 +4462,31 @@ mod tests {
         // canonical-mode cat flushes the line back to us.
         pty.write(&[0x1b]).await.expect("write esc");
         pty.write(b"\r").await.expect("write newline");
+        // The PTY reader retains four trailing bytes while checking for a
+        // cursor-position response. A second, ordinary line makes the
+        // expected short echo observable without sleeping or closing cat.
+        pty.write(b"flush\r").await.expect("write reader flush");
 
-        // Wait for output events until a generous absolute deadline. This has
-        // no wall-clock SLA: loaded CI runners have exhausted both the former
-        // polling deadline and the first event-driven ceiling even though the
-        // PTY behavior was correct.
-        // Keep the ceiling large enough for runner contention, while returning
-        // immediately once the expected echo event arrives. Accept raw 0x1b OR
-        // the ECHOCTL rendering "^[". Also assert the child stays ALIVE (no
-        // Exited event) — Esc must not behave like Ctrl+C.
+        // Poll events to a bounded deadline, returning immediately once the
+        // expected echo arrives. Accept raw 0x1b OR the ECHOCTL rendering
+        // "^[". Also assert the child stays ALIVE (no Exited event) — Esc must
+        // not behave like Ctrl+C.
         let mut saw_esc = false;
         let mut exited = false;
         let deadline = tokio::time::Instant::now() + PTY_CONTROL_EVENT_TIMEOUT;
         while !saw_esc {
-            match tokio::time::timeout_at(deadline, pty.recv()).await {
-                Ok(Some(PtyEvent::Output(data))) => {
+            match next_pty_event_until(&mut pty, deadline).await {
+                Some(PtyEvent::Output(data)) => {
                     let rendered_caret = data.windows(2).any(|w| w == [0x5e, 0x5b]); // "^["
                     if data.contains(&0x1b) || rendered_caret {
                         saw_esc = true;
                     }
                 }
-                Ok(Some(PtyEvent::Exited(_))) | Ok(Some(PtyEvent::Error(_))) => {
+                Some(PtyEvent::Exited(_)) | Some(PtyEvent::Error(_)) => {
                     exited = true;
                     break;
                 }
-                Ok(None) => break,
-                Err(_) => break, // absolute deadline elapsed
+                None => break, // absolute deadline elapsed
             }
         }
         pty.kill();
@@ -4511,24 +4522,19 @@ mod tests {
         pty.interrupt().await.expect("interrupt"); // writes 0x03
 
         // 0x03 = INTR → SIGINT → cat exits. Wait on events with the same
-        // generous ceiling as the Esc test: CI runner load is not a PTY
-        // behavior contract, and an event ends the test immediately.
-        let mut exited = false;
+        // bounded ceiling as the Esc test: an event ends the test immediately.
         let deadline = tokio::time::Instant::now() + PTY_CONTROL_EVENT_TIMEOUT;
-        loop {
-            match tokio::time::timeout_at(deadline, pty.recv()).await {
-                Ok(Some(PtyEvent::Exited(_))) | Ok(Some(PtyEvent::Error(_))) => {
-                    exited = true;
-                    break;
+        let exited = loop {
+            match next_pty_event_until(&mut pty, deadline).await {
+                Some(PtyEvent::Exited(_)) | Some(PtyEvent::Error(_)) => {
+                    break true;
                 }
-                Ok(Some(_)) => {}
-                Ok(None) => {
-                    exited = true; // channel closed = process gone
-                    break;
+                Some(_) => {}
+                None => {
+                    break false; // no exit event before the deadline
                 }
-                Err(_) => break, // absolute deadline elapsed
             }
-        }
+        };
         pty.kill();
         assert!(
             exited,

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-tui-test/src/async_runner.rs
+++ b/crates/cas-tui-test/src/async_runner.rs
@@ -506,9 +506,6 @@ mod tests {
         let mut runner = AsyncPtyRunner::new();
         runner.spawn("cat", &[]).await.expect("spawn failed");
 
-        // Give cat time to start
-        runner.wait(Duration::from_millis(100)).await;
-
         // Send input
         runner
             .send_input("test input\n")
@@ -628,9 +625,6 @@ mod tests {
             .spawn("sh", &["-c", "exit 0"])
             .await
             .expect("spawn failed");
-
-        // Wait for process to exit
-        runner.wait(Duration::from_millis(200)).await;
 
         // Now waiting for text should fail with ProcessExited
         let result = runner

--- a/crates/cas-tui-test/src/input.rs
+++ b/crates/cas-tui-test/src/input.rs
@@ -138,7 +138,7 @@ pub fn input() -> InputSequence {
 
 #[cfg(test)]
 mod tests {
-    use crate::input::*;
+    use crate::{WaitExt, input::*};
 
     #[test]
     fn test_input_sequence_builder() {
@@ -177,9 +177,9 @@ mod tests {
         let seq = input().text("test").enter();
         seq.execute(&mut runner).expect("execute failed");
 
-        std::thread::sleep(Duration::from_millis(50));
-        let output = runner.read_available().expect("read failed");
-        assert!(output.contains("test"), "output: {}", output.as_str());
+        runner
+            .wait_for_text_timeout("test", Duration::from_secs(2))
+            .expect("input echo should arrive before the deadline");
 
         runner.send_key(Key::CtrlD).expect("ctrl-d failed");
     }

--- a/crates/cas-tui-test/src/pty_runner_tests/tests.rs
+++ b/crates/cas-tui-test/src/pty_runner_tests/tests.rs
@@ -1,4 +1,4 @@
-use crate::pty_runner::*;
+use crate::{WaitExt, pty_runner::*};
 
 #[test]
 fn test_config_default() {
@@ -52,11 +52,9 @@ fn test_spawn_echo() {
         .spawn("sh", &["-c", "sleep 0.2; echo hello"])
         .expect("spawn failed");
 
-    // Give the process time to complete
-    std::thread::sleep(std::time::Duration::from_millis(100));
-
-    let output = runner.read_available().expect("read failed");
-    assert!(output.contains("hello"), "output was: {}", output.as_str());
+    runner
+        .wait_for_text_timeout("hello", std::time::Duration::from_secs(2))
+        .expect("echo output should arrive before the deadline");
 }
 
 #[test]
@@ -68,14 +66,9 @@ fn test_spawn_with_env() {
         .spawn("sh", &["-c", "echo $TEST_VAR"])
         .expect("spawn failed");
 
-    std::thread::sleep(std::time::Duration::from_millis(100));
-
-    let output = runner.read_available().expect("read failed");
-    assert!(
-        output.contains("test_value"),
-        "output was: {}",
-        output.as_str()
-    );
+    runner
+        .wait_for_text_timeout("test_value", std::time::Duration::from_secs(2))
+        .expect("environment output should arrive before the deadline");
 }
 
 #[test]
@@ -84,14 +77,9 @@ fn test_send_input() {
     runner.spawn("cat", &[]).expect("spawn failed");
 
     runner.send_input("test input\n").expect("send failed");
-    std::thread::sleep(std::time::Duration::from_millis(100));
-
-    let output = runner.read_available().expect("read failed");
-    assert!(
-        output.contains("test input"),
-        "output was: {}",
-        output.as_str()
-    );
+    runner
+        .wait_for_text_timeout("test input", std::time::Duration::from_secs(2))
+        .expect("cat echo should arrive before the deadline");
 
     runner.send_key(Key::CtrlD).expect("send key failed");
 }

--- a/crates/cas-tui-test/src/pty_runner_tests/tests.rs
+++ b/crates/cas-tui-test/src/pty_runner_tests/tests.rs
@@ -48,7 +48,9 @@ fn test_key_bytes() {
 #[test]
 fn test_spawn_echo() {
     let mut runner = PtyRunner::new();
-    runner.spawn("echo", &["hello"]).expect("spawn failed");
+    runner
+        .spawn("sh", &["-c", "sleep 0.2; echo hello"])
+        .expect("spawn failed");
 
     // Give the process time to complete
     std::thread::sleep(std::time::Duration::from_millis(100));

--- a/crates/cas-tui-test/tests/tui_e2e_test.rs
+++ b/crates/cas-tui-test/tests/tui_e2e_test.rs
@@ -99,15 +99,14 @@ fn test_menu_navigation() {
         .wait_for_text_timeout("Menu", Duration::from_secs(3))
         .unwrap();
 
-    // Navigate down through menu items
+    // Navigate down through menu items. PTY writes preserve order, so no
+    // fixed delay is needed between input events.
     for _ in 0..3 {
         runner.send_key(Key::Down).unwrap();
-        std::thread::sleep(Duration::from_millis(100));
     }
 
     // Navigate back up
     runner.send_key(Key::Up).unwrap();
-    std::thread::sleep(Duration::from_millis(100));
 
     // Clean exit
     runner.send_input("q").unwrap();
@@ -145,12 +144,10 @@ fn test_counter_screen() {
     // Increment counter multiple times
     for _ in 0..3 {
         runner.send_input("+").unwrap();
-        std::thread::sleep(Duration::from_millis(150));
     }
 
     // Decrement once
     runner.send_input("-").unwrap();
-    std::thread::sleep(Duration::from_millis(150));
 
     // Go back to menu
     runner.send_key(Key::Escape).unwrap();
@@ -177,9 +174,7 @@ fn test_about_screen() {
 
     // Navigate to About (third item)
     runner.send_key(Key::Down).unwrap();
-    std::thread::sleep(Duration::from_millis(100));
     runner.send_key(Key::Down).unwrap();
-    std::thread::sleep(Duration::from_millis(100));
     runner.send_key(Key::Enter).unwrap();
     wait_for_render(&mut runner);
 
@@ -225,7 +220,6 @@ fn test_input_screen() {
 
     // Navigate to Input (second item)
     runner.send_key(Key::Down).unwrap();
-    std::thread::sleep(Duration::from_millis(100));
     runner.send_key(Key::Enter).unwrap();
     wait_for_render(&mut runner);
 
@@ -236,7 +230,6 @@ fn test_input_screen() {
 
     // Type some text
     input().text("Hello").execute(&mut runner).unwrap();
-    std::thread::sleep(Duration::from_millis(200));
 
     // Verify text appears
     wait_for_screen_text(&runner, "Hello", Duration::from_secs(3), 80, 24)
@@ -244,7 +237,6 @@ fn test_input_screen() {
 
     // Submit with Enter
     runner.send_key(Key::Enter).unwrap();
-    std::thread::sleep(Duration::from_millis(200));
 
     // Go back
     runner.send_key(Key::Escape).unwrap();
@@ -302,11 +294,8 @@ fn test_vim_navigation() {
 
     // Use j/k for navigation
     runner.send_input("j").unwrap();
-    std::thread::sleep(Duration::from_millis(100));
     runner.send_input("j").unwrap();
-    std::thread::sleep(Duration::from_millis(100));
     runner.send_input("k").unwrap();
-    std::thread::sleep(Duration::from_millis(100));
 
     // Select (should be on Input now)
     runner.send_key(Key::Enter).unwrap();
@@ -319,7 +308,6 @@ fn test_vim_navigation() {
 
     // Go back and exit
     runner.send_key(Key::Escape).unwrap();
-    std::thread::sleep(Duration::from_millis(200));
     runner.send_input("q").unwrap();
 }
 

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-09-01-v3.8.0-slack.md
+++ b/docs/release-notes/2026-09-01-v3.8.0-slack.md
@@ -2,8 +2,8 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** DRAFT — digests and timestamps are filled by
-`release-published-receipt.sh --write-draft` after the tag publishes.
+**Status:** Posted 2026-09-01 to #cas-internal. Both User and Dev threads have
+exactly one Was → Now reply; the receipt below records all four messages.
 
 ## User thread
 
@@ -16,8 +16,8 @@ Live on production — **User** — Your Cassy board now shows only your project
 - Was: cleaning foreign data out of a project could have wiped everything, and the guard was the only thing stopping it. Now: only data explicitly owned by another project is eligible, and Cassy refuses to remove more than half of your tasks or any proven rule.
 - Was: `cas hub authorize` needed the exact `https://` Commander URL every time and pointed you at a restart that failed because the hub was already running; a hub left over from an older install stayed running after updates. Now: it remembers the Commander origin, accepts a bare hostname, explains the real fix, `cas hub` shows status, and `cas update` restarts a stale hub.
 - Install: use `cas update` for an existing installation, or download the
-  v3.8.0 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
-  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+  v3.8.0 archive for Linux x86_64 (SHA-256 `07130086a07e580c29820b4ecb69eb11a27f1908a1d1eb612969a530719b37e1`) or macOS ARM64
+  (SHA-256 `581deba6aefd33279c495f4fe02a2e3337dde36d3f0af8008d303bd597771424`) from the GitHub release.
 
 ## Dev thread
 
@@ -32,8 +32,8 @@ Live on production — **Dev** — Team task identity is now (owner project, id)
 - Was: `resolve_hub_url` accepted only the tailscale-serve record or `--hub-url`; bare hosts failed `Url::parse`; `cas hub` defaulted to `start` and bailed on a live record regardless of version/flags; `cas update` never touched the hub. Now: explicit → record → `[hub].public_url` → remembered origin, `https://` auto-prefix, state-aware error, `cas hub` = status with both versions, drift-aware restart, post-update stale-hub restart.
 - Was: `cas list` counted `metadata.workers`, which the MCP spawn path never wrote. Now: live registry count.
 - Validation and artifact: `cargo check --workspace --tests`, scoped suites on the merged tree (`mcp_tools_test` + `team_sync_test` 378 passed), merge-queue validation of the single integration PR. The published archives are
-  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
-  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`).
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `07130086a07e580c29820b4ecb69eb11a27f1908a1d1eb612969a530719b37e1`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `581deba6aefd33279c495f4fe02a2e3337dde36d3f0af8008d303bd597771424`).
 
 ## Posting sequence
 
@@ -43,4 +43,11 @@ Live on production — **Dev** — Team task identity is now (owner project, id)
 
 ## POSTED
 
-(pending)
+Channel: `#cas-internal` (`C0B44GUKDK2`). Release published 2026-09-01T13:43:05Z (tag→publish 169s).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level | 2026-09-01T13:44:21.293259Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788270261293259) |
+| User reply (Was → Now) | 2026-09-01T13:46:14.650359Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788270374650359?thread_ts=1788270261.293259&cid=C0B44GUKDK2) |
+| Dev top-level | 2026-09-01T13:44:22.752649Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788270262752649) |
+| Dev reply (Was → Now) | 2026-09-01T13:46:24.463649Z | [message](https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788270384463649?thread_ts=1788270262.752649&cid=C0B44GUKDK2) |

--- a/docs/release-notes/2026-09-01-v3.9.0-slack.md
+++ b/docs/release-notes/2026-09-01-v3.9.0-slack.md
@@ -1,0 +1,53 @@
+# Slack draft — Cassy v3.9.0 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** DRAFT — digests and timestamps are filled by
+`release-published-receipt.sh --write-draft` after the tag publishes.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Epics now show their child work in Cassy Cloud, stuck cloud syncs clear themselves, one project is one project again, and workers can be sent to work in a sibling repo.
+
+**Reply (Was → Now):**
+- Was: the relationship between an epic and its tasks never left your machine, so the cloud could not show what work sat under an epic. Now: every sync carries those links, and any machine that still has links the cloud lacks heals them automatically — no backfill step.
+- Was: a sync could park items forever after a harmless "the cloud already had a newer copy" outcome, or after an old-client rejection you had long since upgraded past. Now: those are acknowledged or requeued on their own, only genuine rejections are parked, and `cas doctor` prints the exact counts and the commands that clear them.
+- Was: the same project could exist in the cloud under several spellings, so rows were misattributed and cleanup tools were unsafe. Now: git-remote and case variants resolve to one project, `cas doctor` reports rows still on an alias, and `cas cloud project --adopt-aliases` folds them in.
+- Was: a task moved to another project kept a stale copy under the old project. Now: the move rewrites the cloud ownership so only the owner's row remains.
+- Was: spawning a worker on a branch in a sibling repository failed with a raw git error. Now: the worker is provisioned inside that repository, or you get a clear "cross-repo spawn" reason.
+- Was: after an upgrade the old hub kept running until a second `cas update`. Now: a single `cas update` restarts it on the new version.
+- Was: a task that got unblocked could sit unstarted until someone noticed. Now: the assigned worker is woken and told to start.
+- Was: allowlisting an external tool for workers never worked, and a broken tool path just looked like a network failure. Now: one documented allowlist format that reloads live, denials say exactly what to add, and a missing executable is named as such.
+- Install: use `cas update` for an existing installation, or download the
+  v3.9.0 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — `task_dependencies` sync + self-heal, honest push outcomes with version-gate requeue, canonical project identity, cross-repo worker provisioning, and the move/unblock/proxy fixes from the 2026-09-01 issue sweep.
+
+**Reply (Was → Now):**
+- Was: `dependencies` rows never left SQLite. Now: `task_dependencies` entity (`{from}:{to}:{dep_type}`) enqueued on add/remove/`create --epic`, pushed in both envelopes, applied/deleted on pull with dangling edges parked; a post-pull heal step diffs local vs cloud edge sets, re-pushes local-only edges, materializes cloud-only ones, honors same-envelope deletes, and is idempotent (second sync heals 0). Cross-client delete tombstones await the cloud feed.
+- Was: aggregate `{inserted, updated, skipped}` made an LWW skip look like a rejection and the client failed the whole sub-batch; `Client version X is below minimum Y` rejections stayed terminal after upgrading. Now: per-row outcomes/reasons are consumed when present (`skipped_lww` acks, `rejected` parks by reason without poisoning neighbors), aggregate-only responses treat skips as acks, and version-gated items are requeued transactionally once `CARGO_PKG_VERSION` satisfies the minimum. Queue migration collapses legacy duplicates and installs the identity unique index; `cas cloud queue --retry --retry-reason <r>`; doctor prints blocking counts + runnable remediation.
+- Was: identity derived inconsistently from slug/remote/case. Now: a directional normalizer maps alias/remote/case forms to the pinned slug (never the reverse), `project_ids_match` governs pull ownership, dependency ownership, purge-foreign, team memories and ambiguity checks; doctor alias report; `cas cloud project --adopt-aliases` rewrites rows and enqueues canonical upserts.
+- Was: a project move re-created the old `(project, id)` key because the replacement upsert rode the pusher's envelope. Now: the move upsert is keyed to the destination project.
+- Was: `spawn_workers` resolved `target_branch` in the session repo. Now: `resolve_spawn_worktree_repo` provisions under `<target_repo>/.cas/worktrees/<name>` from the start point resolved there, with explicit `cross-repo spawn: target_repo … — <reason>` failures and a receipt naming the repo.
+- Was: the `cas update` restart hook ran only in the new binary. Now: after the swap the installer execs `<installed> update --post-swap --from <old>` (destination path, `(deleted)`-suffix guard, in-process fallback).
+- Was: `task_ready` emitted no delivery. Now: a deduped wake message to the live assignee; stall detector is the fallback.
+- Was: proxy allowlist entries never matched and a missing stdio executable looked like backoff. Now: canonical `<server>.<tool>` / `<server>.*` with alias normalization and hot reload, denial names the exact entry, `executable_missing` state + doctor check.
+- Was: PTY tests used fixed sleeps. Now: bounded deadline polling (20/20 under load).
+- Validation and artifact: `cargo check --workspace --tests`, `cargo nextest run -p cas`, doctests, merge-queue validation of the single integration PR. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`).
+
+## Posting sequence
+
+1. Tag the fetched `origin/main` landing and run `./scripts/release.sh --publish-tag`.
+2. Run `release-published-receipt.sh v3.9.0 --write-draft` against this draft.
+3. Post the User top-level and its only reply, then the Dev top-level and its only reply; append the receipt.
+
+## POSTED
+
+(pending)


### PR DESCRIPTION
## Summary
- `task_dependencies` sync entity (push on change, pull apply/delete, dangling edges parked) + post-pull self-heal (local-only edges re-pushed, cloud-only edges materialized, idempotent). GH #639, #640.
- Push honesty: LWW skips acknowledged, per-row outcomes/reasons consumed, version-gated terminal failures auto-requeued; queue migration collapses legacy duplicates, `queue --retry --retry-reason`, doctor prints exact purge-blocking counts + runnable remediation. GH #668, #652.
- Canonical project identity: alias/remote/case forms resolve to the pinned slug for registration/push/pull/purge; doctor alias report; `cas cloud project --adopt-aliases`. GH #669.
- Task move keys the replacement upsert to the destination project (fixes the re-created old key found live during v3.8.0 verification).
- `spawn_workers` provisions in the task's `target_repo` or fails fast with an explicit cross-repo message. GH #670.
- Auto-unblock wakes the assigned idle worker. GH #673.
- Worker MCP proxy: canonical allowlist format + aliases + hot reload + denial guidance; `executable_missing` health state; doctor stdio check. GH #672.
- `cas update` runs the installed binary's post-swap hook (stale hub restarts on the same run across a version boundary).
- PTY test family deflaked (bounded deadline polling).
- Release prep v3.9.0 + posted v3.8.0 Slack receipt carried as the final commit — tag the merge commit after landing.

## Validation (local, final tree)
- `cargo check --workspace --tests`: ok
- `cargo nextest run -p cas`: 6285 passed, 76 skipped, 0 failed
- `cargo nextest run -p code-mode-mcp`: 51/51
- `cargo test -p cas --doc`: ok
- `cargo metadata --locked`: consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)