### PR TITLE
Epic cas-71ad: purge-foreign and doctor tell one story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.10.1] - 2026-09-02
+
+### Fixed
+- Project-scope cloud pull reconciles entries that exist locally as archived
+  rows through the same last-writer-wins path as team pull, instead of
+  failing every one of them with "entry already exists" (347 per pull on
+  one contaminated store); duplicate-key races resolve the same way and
+  unrelated store errors still surface.
+- `cas cloud purge-foreign` no longer trusts a backfilled `origin_project`
+  alone: rows the doctor's cross-database (id, title) and activity evidence
+  attribute to another project are now purgeable, id collisions and
+  unattributed replicas are never deleted, task deletes match on (id, title),
+  safety lookups fail closed, and the dry-run labels each row with the
+  evidence that selected it.
+- `cas doctor` reports the doctor's foreign-row evidence count next to the
+  purge delete-set count, names every retained row with its reason, and stops
+  prescribing `purge-foreign` as complete remediation when the two disagree.
+- `cas doctor` names the configuration file that registered an unresolvable
+  MCP stdio command (the user-scope `code-mode-mcp/config.toml` or the project
+  `proxy.toml`) instead of always saying "repair proxy.toml".
+
 ## [3.10.0] - 2026-09-01
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.10.0"
+version = "3.10.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -5941,6 +5941,76 @@ mod purge_foreign_safety_tests {
     }
 
     #[test]
+    fn backfilled_current_origin_rows_use_doctor_peer_evidence_and_label_the_source() {
+        use crate::cli::foreign_rows::{ForeignRow, ForeignRowReport};
+
+        let conn = Connection::open_in_memory().unwrap();
+        seed_project_scoped_db(&conn);
+        let report = ForeignRowReport {
+            local_project: "cas-src".to_string(),
+            local_task_count: 5,
+            peers_compared: vec!["accounting".to_string()],
+            foreign: vec![ForeignRow {
+                id: "own-1".to_string(),
+                title: "own task 1".to_string(),
+                closed: false,
+                origin_project: Some("cas-src".to_string()),
+                home_project: "accounting".to_string(),
+                also_present_in: Vec::new(),
+            }],
+            ..Default::default()
+        };
+
+        let analysis = collect_purge_delete_set_with_report(&conn, "cas-src", &report).unwrap();
+        let row = analysis
+            .delete_set
+            .tasks
+            .iter()
+            .find(|row| row.id == "own-1")
+            .expect("doctor peer evidence must add the backfilled row");
+        assert_eq!(row.evidence.source, "peer-evidence");
+        assert_eq!(row.evidence.project, "accounting");
+        assert_eq!(
+            analysis.delete_set.to_json()["tasks"][0]["evidence"]["source"],
+            "origin_project"
+        );
+        assert_eq!(
+            row_to_json(&analysis.delete_set, "own-1")["evidence"]["project"],
+            "accounting"
+        );
+    }
+
+    #[test]
+    fn accepted_proposal_tasks_with_foreign_origin_are_never_purge_candidates() {
+        let conn = Connection::open_in_memory().unwrap();
+        seed_project_scoped_db(&conn);
+        conn.execute("ALTER TABLE tasks ADD COLUMN notes TEXT", [])
+            .unwrap();
+        conn.execute(
+            "UPDATE tasks SET notes = ?1 WHERE id = 'foreign-1'",
+            ["--- BEGIN SERVER-ATTESTED PROPOSAL PROVENANCE ---\n  target_project_canonical_id: cas-src\n--- END SERVER-ATTESTED PROPOSAL PROVENANCE ---"],
+        )
+        .unwrap();
+
+        let set = collect_purge_delete_set(&conn, "cas-src").unwrap();
+
+        assert!(
+            set.tasks.iter().all(|task| task.id != "foreign-1"),
+            "an accepted proposal materialized in this project must be retained"
+        );
+    }
+
+    fn row_to_json(set: &PurgeDeleteSet, id: &str) -> serde_json::Value {
+        set.to_json()["tasks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["id"] == id)
+            .cloned()
+            .unwrap()
+    }
+
+    #[test]
     fn alias_rows_are_not_classified_as_foreign() {
         let conn = Connection::open_in_memory().unwrap();
         seed_project_scoped_db(&conn);

--- a/cas-cli/src/cli/cloud.rs
+++ b/cas-cli/src/cli/cloud.rs
@@ -4295,6 +4295,48 @@ pub struct PurgeEntity {
     pub id: String,
     /// Human label (title/name/first content line) — may be empty.
     pub label: String,
+    /// Evidence that made this row purgeable. This is rendered in dry-run
+    /// output so a destructive preview names the classifier it relied on.
+    pub evidence: PurgeEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PurgeEvidence {
+    /// `origin_project` for the persisted project field, or `peer-evidence`
+    /// when the doctor's cross-database activity classifier overrode a
+    /// backfilled current-project value.
+    pub source: &'static str,
+    /// Stored origin project, or the peer project whose activity proves the
+    /// row's home.
+    pub project: String,
+}
+
+impl PurgeEntity {
+    pub fn with_evidence(
+        kind: &'static str,
+        id: impl Into<String>,
+        label: impl Into<String>,
+        source: &'static str,
+        project: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            id: id.into(),
+            label: label.into(),
+            evidence: PurgeEvidence {
+                source,
+                project: project.into(),
+            },
+        }
+    }
+
+    fn evidence_label(&self) -> String {
+        if self.evidence.source == "peer-evidence" {
+            format!("peer-evidence + home project: {}", self.evidence.project)
+        } else {
+            format!("origin_project: {}", self.evidence.project)
+        }
+    }
 }
 
 /// The concrete set of rows a purge would delete.
@@ -4323,10 +4365,19 @@ impl PurgeDeleteSet {
         ]
     }
 
-    fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         let render = |rows: &Vec<PurgeEntity>| {
             rows.iter()
-                .map(|e| serde_json::json!({"id": e.id, "label": e.label}))
+                .map(|e| {
+                    serde_json::json!({
+                        "id": e.id,
+                        "label": e.label,
+                        "evidence": {
+                            "source": e.evidence.source,
+                            "project": e.evidence.project,
+                        },
+                    })
+                })
                 .collect::<Vec<_>>()
         };
         serde_json::json!({
@@ -4338,6 +4389,27 @@ impl PurgeDeleteSet {
             "total": self.total(),
         })
     }
+}
+
+/// A foreign row found by doctor but intentionally retained by purge. These
+/// are cross-project proposal materializations, not accidental replicas.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PurgeRetainedTask {
+    pub id: String,
+    pub title: String,
+    pub reason: String,
+}
+
+/// The shared result consumed by purge and doctor's cross-project check. The
+/// report count is the doctor's peer/evidence count; the delete set is the
+/// concrete, safety-filtered set purge can actually reach.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PurgeForeignAnalysis {
+    pub delete_set: PurgeDeleteSet,
+    pub foreign_task_count: usize,
+    pub retained_foreign_tasks: Vec<PurgeRetainedTask>,
+    pub unattributed_task_count: usize,
+    pub collision_count: usize,
 }
 
 /// Canonical attribution fields that have existed in cloud payloads. The local
@@ -4403,11 +4475,10 @@ fn attributed_rows(
     let mut stmt = conn.prepare(&sql)?;
     let mapped = stmt.query_map([], |row| {
         Ok((
-            PurgeEntity {
-                kind,
-                id: row.get::<_, String>(0)?,
-                label: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
-            },
+            (
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+            ),
             row.get::<_, String>(2)?,
         ))
     })?;
@@ -4415,16 +4486,100 @@ fn attributed_rows(
     Ok(rows
         .into_iter()
         .filter(|(_, stored_project)| !project_ids_match(stored_project, current_project))
-        .map(|(row, _)| row)
+        .map(|((id, label), stored_project)| {
+            PurgeEntity::with_evidence(kind, id, label, "origin_project", stored_project)
+        })
         .collect())
+}
+
+const PROPOSAL_PROVENANCE_BEGIN: &str = "--- BEGIN SERVER-ATTESTED PROPOSAL PROVENANCE ---";
+const PROPOSAL_PROVENANCE_END: &str = "--- END CLIENT-ASSERTED PROPOSAL PROVENANCE ---";
+const PROPOSAL_PROVENANCE_SERVER_END: &str = "--- END SERVER-ATTESTED PROPOSAL PROVENANCE ---";
+
+/// A task materialized by an accepted cross-project proposal is intentionally
+/// retained in the target project even though its origin belongs to a peer.
+/// Pull persists the server-attested target project in the task notes; only a
+/// complete marker block targeting this project qualifies.
+fn is_accepted_proposal_task(
+    conn: &rusqlite::Connection,
+    task_id: &str,
+    current_project: &str,
+) -> anyhow::Result<bool> {
+    let has_notes = conn
+        .prepare("PRAGMA table_info(tasks)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?
+        .iter()
+        .any(|column| column == "notes");
+    if !has_notes {
+        return Ok(false);
+    }
+
+    let notes: Option<String> = conn.query_row(
+        "SELECT notes FROM tasks WHERE id = ?1",
+        [task_id],
+        |row| row.get(0),
+    )?;
+    let Some(notes) = notes else {
+        return Ok(false);
+    };
+    let Some(start) = notes.find(PROPOSAL_PROVENANCE_BEGIN) else {
+        return Ok(false);
+    };
+    let Some((end_offset, end_marker)) = [
+        PROPOSAL_PROVENANCE_END,
+        PROPOSAL_PROVENANCE_SERVER_END,
+    ]
+    .iter()
+    .filter_map(|marker| notes[start..].find(marker).map(|offset| (offset, *marker)))
+    .min_by_key(|(offset, _)| *offset)
+    else {
+        return Ok(false);
+    };
+    let end = start + end_offset + end_marker.len();
+    let block = &notes[start..end];
+    let target = block.lines().find_map(|line| {
+        line.trim()
+            .strip_prefix("target_project_canonical_id:")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    });
+    Ok(target.is_some_and(|target| project_ids_match(target, current_project)))
+}
+
+/// A task with a local external-blocker projection is deliberately retained:
+/// `blocks_origin_task_id` created this origin-side row and the projection is
+/// the local model for that cross-project handoff.
+fn has_external_task_dependency(
+    conn: &rusqlite::Connection,
+    task_id: &str,
+) -> anyhow::Result<bool> {
+    let result = conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM sqlite_master
+             WHERE type = 'table' AND name = 'external_task_dependencies'
+         )",
+        [],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if !result {
+        return Ok(false);
+    }
+    Ok(conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM external_task_dependencies
+             WHERE origin_task_id = ?1
+         )",
+        [task_id],
+        |row| row.get(0),
+    )?)
 }
 
 fn count_proven_attributed_rules(
     conn: &rusqlite::Connection,
     current_project: &str,
 ) -> anyhow::Result<usize> {
-    let Some(project_column) =
-        first_existing_project_column(conn, "rules", PURGE_PROJECT_COLUMNS)?
+    let Some(project_column) = first_existing_project_column(conn, "rules", PURGE_PROJECT_COLUMNS)?
     else {
         return Ok(0);
     };
@@ -4486,7 +4641,16 @@ fn collect_purge_delete_set(
     conn: &rusqlite::Connection,
     current_project: &str,
 ) -> anyhow::Result<PurgeDeleteSet> {
-    let tasks = attributed_rows(conn, "task", "tasks", "title", current_project)?;
+    let mut tasks = Vec::new();
+    for task in attributed_rows(conn, "task", "tasks", "title", current_project)? {
+        // Fail closed if a safety lookup cannot be completed. The caller gets
+        // the database error rather than a misleadingly smaller delete set.
+        if !is_accepted_proposal_task(conn, &task.id, current_project)?
+            && !has_external_task_dependency(conn, &task.id)?
+        {
+            tasks.push(task);
+        }
+    }
     Ok(PurgeDeleteSet {
         entries: attributed_rows(
             conn,
@@ -4506,6 +4670,125 @@ fn collect_purge_delete_set(
         skills: attributed_rows(conn, "skill", "skills", "name", current_project)?,
         dependencies: count_purge_dependencies(conn, &tasks)?,
     })
+}
+
+/// Combine the explicit project-column classifier with doctor's read-only
+/// cross-database activity evidence. Peer evidence may only expand the task
+/// set for rows whose persisted `origin_project` says this is the current
+/// project; missing provenance, id collisions, and unattributed replicas are
+/// never promoted to deletions.
+pub(crate) fn collect_purge_delete_set_with_report(
+    conn: &rusqlite::Connection,
+    current_project: &str,
+    report: &crate::cli::foreign_rows::ForeignRowReport,
+) -> anyhow::Result<PurgeForeignAnalysis> {
+    let mut delete_set = collect_purge_delete_set(conn, current_project)?;
+    let collision_ids = report
+        .collisions
+        .iter()
+        .map(|collision| collision.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let unattributed_ids = report
+        .unattributed
+        .iter()
+        .map(|row| row.id.as_str())
+        .collect::<BTreeSet<_>>();
+    // An explicit origin value cannot override the doctor's safety verdict for
+    // a collision or an unattributed replica. Both categories are retained.
+    delete_set.tasks.retain(|task| {
+        !collision_ids.contains(task.id.as_str())
+            && !unattributed_ids.contains(task.id.as_str())
+    });
+    let mut known_task_ids = delete_set
+        .tasks
+        .iter()
+        .map(|task| task.id.clone())
+        .collect::<BTreeSet<_>>();
+
+    for foreign in &report.foreign {
+        if known_task_ids.contains(&foreign.id) {
+            continue;
+        }
+        if collision_ids.contains(foreign.id.as_str())
+            || unattributed_ids.contains(foreign.id.as_str())
+        {
+            continue;
+        }
+        let origin_is_current = foreign
+            .origin_project
+            .as_deref()
+            .is_some_and(|origin| project_ids_match(origin, current_project));
+        if !origin_is_current {
+            continue;
+        }
+        if is_accepted_proposal_task(conn, &foreign.id, current_project)?
+            || has_external_task_dependency(conn, &foreign.id)?
+        {
+            continue;
+        }
+        delete_set.tasks.push(PurgeEntity::with_evidence(
+            "task",
+            foreign.id.clone(),
+            foreign.title.clone(),
+            "peer-evidence",
+            foreign.home_project.clone(),
+        ));
+        known_task_ids.insert(foreign.id.clone());
+    }
+    delete_set.tasks.sort_by(|left, right| left.id.cmp(&right.id));
+    delete_set.dependencies = count_purge_dependencies(conn, &delete_set.tasks)?;
+
+    let mut retained_foreign_tasks = Vec::new();
+    for foreign in &report.foreign {
+        if delete_set.tasks.iter().any(|task| {
+            task.id == foreign.id && task.label.trim() == foreign.title.trim()
+        }) {
+            continue;
+        }
+        let reason = if collision_ids.contains(foreign.id.as_str()) {
+            "id collision across peer rows; purge fails closed".to_string()
+        } else if unattributed_ids.contains(foreign.id.as_str()) {
+            "unattributed replica; purge fails closed".to_string()
+        } else if is_accepted_proposal_task(conn, &foreign.id, current_project)? {
+            "accepted proposal materialized for this project".to_string()
+        } else if has_external_task_dependency(conn, &foreign.id)? {
+            "blocks_origin external dependency is retained locally".to_string()
+        } else if foreign.origin_project.is_none() {
+            "origin_project is missing; peer evidence is advisory and purge fails closed"
+                .to_string()
+        } else {
+            "row is not explicitly attributed to the current project".to_string()
+        };
+        retained_foreign_tasks.push(PurgeRetainedTask {
+            id: foreign.id.clone(),
+            title: foreign.title.clone(),
+            reason,
+        });
+    }
+
+    Ok(PurgeForeignAnalysis {
+        delete_set,
+        foreign_task_count: report.foreign.len(),
+        retained_foreign_tasks,
+        unattributed_task_count: report.unattributed.len(),
+        collision_count: report.collisions.len(),
+    })
+}
+
+/// Build the same purge analysis used by the destructive command from an
+/// already-collected doctor report. The database remains read-only.
+pub fn purge_analysis_for_report(
+    cas_root: &Path,
+    current_project: &str,
+    report: &crate::cli::foreign_rows::ForeignRowReport,
+) -> anyhow::Result<PurgeForeignAnalysis> {
+    let db_path = cas_root.join("cas.db");
+    let conn = rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+            | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    collect_purge_delete_set_with_report(&conn, current_project, report)
 }
 
 /// A named reason the purge refuses to run destructively.
@@ -4628,8 +4911,17 @@ fn delete_purge_rows(
         ("skills", &delete_set.skills),
     ] {
         for row in rows {
-            let sql = format!("DELETE FROM {table} WHERE id = ?1");
-            match tx.execute(&sql, [&row.id]) {
+            let sql = if table == "tasks" {
+                format!("DELETE FROM {table} WHERE id = ?1 AND trim(title) = trim(?2)")
+            } else {
+                format!("DELETE FROM {table} WHERE id = ?1")
+            };
+            let result = if table == "tasks" {
+                tx.execute(&sql, rusqlite::params![&row.id, &row.label])
+            } else {
+                tx.execute(&sql, [&row.id])
+            };
+            match result {
                 Ok(_) => {}
                 Err(error) if error.to_string().contains("no such table") => break,
                 Err(error) => return Err(error.into()),
@@ -4833,9 +5125,19 @@ fn execute_purge_foreign(
     // cas-a034 / GH #132: resolve the concrete delete set and the safety state
     // BEFORE anything destructive happens, so --dry-run can show exactly what
     // would be lost and a real run can refuse when losing it is unrecoverable.
-    let (delete_set, refusals) = {
+    let (analysis, refusals) = {
         let conn = rusqlite::Connection::open(&db_path)?;
-        let delete_set = collect_purge_delete_set(&conn, &project_id)?;
+        // Use doctor's cross-DB classifier so a legacy backfill that stamped
+        // foreign rows with this project cannot make purge under-delete them.
+        // A failed read is fatal to the purge preview: an incomplete peer scan
+        // must not be presented as a complete delete set.
+        let doctor_report = crate::cli::foreign_rows::scan(cas_root)?;
+        let analysis = collect_purge_delete_set_with_report(
+            &conn,
+            &project_id,
+            &doctor_report,
+        )?;
+        let delete_set = &analysis.delete_set;
         let proven_rule_count = count_proven_attributed_rules(&conn, &project_id)?;
         let last_pull_at: Option<String> = conn
             .query_row(
@@ -4852,12 +5154,13 @@ fn execute_purge_foreign(
             args.stale_days,
         );
         refusals.extend(evaluate_purge_hard_guards(
-            &delete_set,
+            delete_set,
             tasks_before,
             proven_rule_count,
         ));
-        (delete_set, refusals)
+        (analysis, refusals)
     };
+    let delete_set = &analysis.delete_set;
 
     if cli.json {
         if args.dry_run {
@@ -4874,6 +5177,21 @@ fn execute_purge_foreign(
                         "total": total_before,
                     },
                     "delete_set": delete_set.to_json(),
+                    "foreign_task_evidence_count": analysis.foreign_task_count,
+                    "doctor_exclusions": {
+                        "unattributed_tasks": analysis.unattributed_task_count,
+                        "id_collisions": analysis.collision_count,
+                        "retained_foreign_tasks": analysis.retained_foreign_tasks.len(),
+                    },
+                    "retained_foreign_tasks": analysis
+                        .retained_foreign_tasks
+                        .iter()
+                        .map(|row| serde_json::json!({
+                            "id": row.id,
+                            "title": row.title,
+                            "reason": row.reason,
+                        }))
+                        .collect::<Vec<_>>(),
                     "refusals": refusals.iter()
                         .map(|r| serde_json::json!({"code": r.code(), "reason": r.reason()}))
                         .collect::<Vec<_>>(),
@@ -4912,7 +5230,12 @@ fn execute_purge_foreign(
                 fmt.newline()?;
                 for row in rows.iter().take(PURGE_DRY_RUN_PRINT_LIMIT) {
                     fmt.write_muted("      - ")?;
-                    fmt.write_raw(&format!("{}  {}", row.id, row.label))?;
+                    fmt.write_raw(&format!(
+                        "{}  {} [{}]",
+                        row.id,
+                        row.label,
+                        row.evidence_label()
+                    ))?;
                     fmt.newline()?;
                 }
                 if rows.len() > PURGE_DRY_RUN_PRINT_LIMIT {
@@ -4922,6 +5245,22 @@ fn execute_purge_foreign(
                     ))?;
                     fmt.newline()?;
                 }
+            }
+            if analysis.foreign_task_count != delete_set.tasks.len() {
+                fmt.write_muted(&format!(
+                    "    doctor evidence: {} foreign task row(s); purge delete set: {} task row(s)",
+                    analysis.foreign_task_count,
+                    delete_set.tasks.len()
+                ))?;
+                fmt.newline()?;
+            }
+            if analysis.unattributed_task_count > 0 || analysis.collision_count > 0 {
+                fmt.write_muted(&format!(
+                    "    doctor exclusions: {} unattributed task row(s), {} id collision(s) (never deleted)",
+                    analysis.unattributed_task_count,
+                    analysis.collision_count
+                ))?;
+                fmt.newline()?;
             }
             fmt.write_raw(&format!("    {} dependency edges", delete_set.dependencies))?;
             fmt.newline()?;
@@ -5998,6 +6337,71 @@ mod purge_foreign_safety_tests {
             set.tasks.iter().all(|task| task.id != "foreign-1"),
             "an accepted proposal materialized in this project must be retained"
         );
+    }
+
+    #[test]
+    fn blocks_origin_and_doctor_safety_categories_are_never_purged() {
+        use crate::cli::foreign_rows::{ForeignRow, ForeignRowReport, IdCollision, UnattributedRow};
+
+        let conn = Connection::open_in_memory().unwrap();
+        seed_project_scoped_db(&conn);
+        conn.execute_batch(
+            "CREATE TABLE external_task_dependencies (
+                 origin_task_id TEXT NOT NULL,
+                 target_task_id TEXT NOT NULL
+             );
+             INSERT INTO external_task_dependencies (origin_task_id, target_task_id)
+             VALUES ('own-2', 'remote-1');",
+        )
+        .unwrap();
+        let report = ForeignRowReport {
+            local_project: "cas-src".to_string(),
+            local_task_count: 5,
+            peers_compared: vec!["accounting".to_string()],
+            foreign: vec![
+                ForeignRow {
+                    id: "own-2".to_string(),
+                    title: "own task 2".to_string(),
+                    closed: false,
+                    origin_project: Some("cas-src".to_string()),
+                    home_project: "accounting".to_string(),
+                    also_present_in: Vec::new(),
+                },
+                ForeignRow {
+                    id: "foreign-1".to_string(),
+                    title: "foreign task 1".to_string(),
+                    closed: false,
+                    origin_project: Some("other-project".to_string()),
+                    home_project: "accounting".to_string(),
+                    also_present_in: Vec::new(),
+                },
+            ],
+            unattributed: vec![UnattributedRow {
+                id: "foreign-1".to_string(),
+                title: "foreign task 1".to_string(),
+                closed: false,
+                present_in: vec!["accounting".to_string()],
+            }],
+            collisions: vec![IdCollision {
+                id: "foreign-2".to_string(),
+                local_title: "foreign task 2".to_string(),
+                other_project: "accounting".to_string(),
+                other_title: "different task".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        let analysis = collect_purge_delete_set_with_report(&conn, "cas-src", &report).unwrap();
+
+        assert!(analysis.delete_set.tasks.iter().all(|task| {
+            !matches!(task.id.as_str(), "own-2" | "foreign-1" | "foreign-2")
+        }));
+        assert_eq!(analysis.unattributed_task_count, 1);
+        assert_eq!(analysis.collision_count, 1);
+        assert!(analysis
+            .retained_foreign_tasks
+            .iter()
+            .any(|task| task.id == "own-2" && task.reason.contains("blocks_origin")));
     }
 
     fn row_to_json(set: &PurgeDeleteSet, id: &str) -> serde_json::Value {

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -2441,6 +2441,62 @@ mod tests {
     }
 
     #[test]
+    fn foreign_rows_check_explains_when_purge_cannot_reach_evidence_rows() {
+        use crate::cli::cloud::{PurgeDeleteSet, PurgeEntity, PurgeForeignAnalysis};
+        use crate::cli::foreign_rows::{ForeignRow, ForeignRowReport};
+
+        let report = ForeignRowReport {
+            local_project: "cas-src".to_string(),
+            local_task_count: 3,
+            peers_compared: vec!["accounting".to_string()],
+            foreign: vec![
+                ForeignRow {
+                    id: "cas-0001".to_string(),
+                    title: "Backfilled foreign task".to_string(),
+                    closed: false,
+                    origin_project: Some("cas-src".to_string()),
+                    home_project: "accounting".to_string(),
+                    also_present_in: Vec::new(),
+                },
+                ForeignRow {
+                    id: "cas-0002".to_string(),
+                    title: "Accepted proposal".to_string(),
+                    closed: false,
+                    origin_project: Some("accounting".to_string()),
+                    home_project: "accounting".to_string(),
+                    also_present_in: Vec::new(),
+                },
+            ],
+            ..Default::default()
+        };
+        let analysis = PurgeForeignAnalysis {
+            delete_set: PurgeDeleteSet {
+                tasks: vec![PurgeEntity::with_evidence(
+                    "task",
+                    "cas-0001",
+                    "Backfilled foreign task",
+                    "peer-evidence",
+                    "accounting",
+                )],
+                ..Default::default()
+            },
+            foreign_task_count: 2,
+            retained_foreign_tasks: vec![crate::cli::cloud::PurgeRetainedTask {
+                id: "cas-0002".to_string(),
+                title: "Accepted proposal".to_string(),
+                reason: "accepted proposal materialized for this project".to_string(),
+            }],
+        };
+
+        let check = foreign_rows_check(Ok(&report), Some(&analysis));
+
+        assert!(check.message.contains("foreign evidence: 2"), "{}", check.message);
+        assert!(check.message.contains("purge delete set: 1"), "{}", check.message);
+        assert!(check.message.contains("cannot reach 1"), "{}", check.message);
+        assert!(check.message.contains("accepted proposal"), "{}", check.message);
+    }
+
+    #[test]
     fn foreign_rows_check_zero_states_its_coverage_never_a_bare_clean_cas_fc6fa() {
         use crate::cli::foreign_rows::ForeignRowReport;
 

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -836,11 +836,44 @@ pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
     // `(id, title)`.
     if cas_root.join("cas.db").is_file() {
         let report = crate::cli::foreign_rows::scan(&cas_root);
+        let (purge_analysis, purge_analysis_error) = match (
+            report.as_ref(),
+            crate::cloud::resolve_canonical_id(&cas_root),
+        ) {
+            (Ok(report), Some(current_project)) => {
+                match crate::cli::cloud::purge_analysis_for_report(
+                    &cas_root,
+                    &current_project,
+                    report,
+                ) {
+                    Ok(analysis) => (Some(analysis), None),
+                    Err(error) => (None, Some(error.to_string())),
+                }
+            }
+            (Ok(_), None) => (
+                None,
+                Some("current project canonical id could not be resolved".to_string()),
+            ),
+            (Err(_), _) => (None, None),
+        };
         if args.foreign_rows {
-            return output_foreign_rows_detail(report, cli);
+            return output_foreign_rows_detail(
+                report,
+                purge_analysis.as_ref(),
+                purge_analysis_error.as_deref(),
+                cli,
+            );
         }
         checks.push(cloud_queue_check(&cas_root));
-        checks.push(foreign_rows_check(report.as_ref()));
+        let foreign_check = match purge_analysis_error.as_deref() {
+            Some(error) => foreign_rows_check_with_classifier_error(
+                report.as_ref(),
+                purge_analysis.as_ref(),
+                Some(error),
+            ),
+            None => foreign_rows_check(report.as_ref(), purge_analysis.as_ref()),
+        };
+        checks.push(foreign_check);
     } else if args.foreign_rows {
         anyhow::bail!(
             "`cas doctor --foreign-rows` needs a SQLite database at {}; this project uses legacy \
@@ -978,6 +1011,15 @@ fn legacy_versioned_search_index_check(cas_root: &Path) -> Option<Check> {
 /// wrong answer for the user consulting doctor because they suspect it.
 fn foreign_rows_check(
     report: Result<&crate::cli::foreign_rows::ForeignRowReport, &anyhow::Error>,
+    purge_analysis: Option<&crate::cli::cloud::PurgeForeignAnalysis>,
+) -> Check {
+    foreign_rows_check_with_classifier_error(report, purge_analysis, None)
+}
+
+fn foreign_rows_check_with_classifier_error(
+    report: Result<&crate::cli::foreign_rows::ForeignRowReport, &anyhow::Error>,
+    purge_analysis: Option<&crate::cli::cloud::PurgeForeignAnalysis>,
+    purge_analysis_error: Option<&str>,
 ) -> Check {
     let report = match report {
         Ok(report) => report,
@@ -995,6 +1037,45 @@ fn foreign_rows_check(
     };
 
     let mut message = report.summary();
+    if let Some(analysis) = purge_analysis {
+        let evidence_count = analysis.foreign_task_count;
+        let purge_count = analysis.delete_set.tasks.len();
+        message.push_str(&format!(
+            ". foreign evidence: {evidence_count} task row(s); purge delete set: {purge_count} task row(s)"
+        ));
+        if evidence_count == purge_count {
+            message.push_str(" — counts agree");
+        } else if evidence_count > purge_count {
+            let gap = evidence_count - purge_count;
+            message.push_str(&format!(" — purge cannot reach {gap} evidence row(s)"));
+            if !analysis.retained_foreign_tasks.is_empty() {
+                let retained = analysis
+                    .retained_foreign_tasks
+                    .iter()
+                    .map(|row| format!("{} ({})", row.id, row.reason))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                message.push_str(&format!(": {retained}"));
+            }
+        } else {
+            message.push_str(&format!(
+                " — purge includes {} task row(s) attributed by origin_project but absent from peer evidence",
+                purge_count - evidence_count
+            ));
+        }
+        if analysis.unattributed_task_count > 0 || analysis.collision_count > 0 {
+            message.push_str(&format!(
+                ". purge excludes {} unattributed task row(s) and {} id collision(s); neither category is deletable",
+                analysis.unattributed_task_count,
+                analysis.collision_count
+            ));
+        }
+    }
+    if let Some(error) = purge_analysis_error {
+        message.push_str(&format!(
+            ". purge delete-set classifier unavailable: {error}; foreign-count comparison is incomplete"
+        ));
+    }
     if !report.peers_unreadable.is_empty() {
         let named = report
             .peers_unreadable
@@ -1008,12 +1089,22 @@ fn foreign_rows_check(
         ));
     }
 
-    let status = if report.is_clean() && report.peers_unreadable.is_empty() {
+    let purge_counts_disagree = purge_analysis
+        .is_some_and(|analysis| analysis.foreign_task_count != analysis.delete_set.tasks.len());
+    let status = if report.is_clean()
+        && report.peers_unreadable.is_empty()
+        && purge_analysis_error.is_none()
+        && !purge_counts_disagree
+    {
         CheckStatus::Ok
     } else {
         CheckStatus::Warning
     };
-    if !report.is_clean() {
+    if purge_counts_disagree {
+        message.push_str(
+            ". Do not treat purge-foreign as complete remediation: inspect the retained evidence rows and their stated reasons before taking action.",
+        );
+    } else if !report.is_clean() {
         message.push_str(&format!(". {}", report.remediation()));
     }
 
@@ -1027,12 +1118,37 @@ fn foreign_rows_check(
 /// `cas doctor --foreign-rows`: the full read-only contamination listing.
 fn output_foreign_rows_detail(
     report: anyhow::Result<crate::cli::foreign_rows::ForeignRowReport>,
+    purge_analysis: Option<&crate::cli::cloud::PurgeForeignAnalysis>,
+    purge_analysis_error: Option<&str>,
     cli: &Cli,
 ) -> anyhow::Result<()> {
     let report = report?;
 
     if cli.json {
-        println!("{}", serde_json::to_string_pretty(&report.to_json())?);
+        let mut output = report.to_json();
+        if let Some(analysis) = purge_analysis {
+            output["purge_foreign"] = serde_json::json!({
+                "foreign_task_evidence_count": analysis.foreign_task_count,
+                "delete_set": analysis.delete_set.to_json(),
+                "retained_foreign_tasks": analysis.retained_foreign_tasks.iter().map(|row| {
+                    serde_json::json!({
+                        "id": row.id,
+                        "title": row.title,
+                        "reason": row.reason,
+                    })
+                }).collect::<Vec<_>>(),
+                "unattributed_task_count": analysis.unattributed_task_count,
+                "id_collision_count": analysis.collision_count,
+            });
+        }
+        if let Some(error) = purge_analysis_error {
+            output["purge_foreign_error"] = serde_json::json!({
+                "message": format!(
+                    "purge delete-set classifier unavailable: {error}; foreign-count comparison is incomplete"
+                ),
+            });
+        }
+        println!("{}", serde_json::to_string_pretty(&output)?);
         return Ok(());
     }
 
@@ -1057,6 +1173,38 @@ fn output_foreign_rows_detail(
             peer.project,
             peer.db_path.display(),
             peer.error
+        ))?;
+    }
+
+    if let Some(analysis) = purge_analysis {
+        fmt.write_muted(&format!(
+            "doctor evidence: {} foreign task row(s); purge delete set: {} task row(s)",
+            analysis.foreign_task_count,
+            analysis.delete_set.tasks.len()
+        ))?;
+        fmt.newline()?;
+        if analysis.foreign_task_count == analysis.delete_set.tasks.len() {
+            fmt.success("doctor evidence and purge delete-set counts agree")?;
+        } else {
+            fmt.warning(&format!(
+                "purge cannot reach {} doctor evidence row(s) — see retained proposal rows below",
+                analysis
+                    .foreign_task_count
+                    .saturating_sub(analysis.delete_set.tasks.len())
+            ))?;
+        }
+        for row in &analysis.retained_foreign_tasks {
+            fmt.warning(&format!(
+                "    retained [{}] {} — {}",
+                row.id,
+                truncate(&row.title, 55),
+                row.reason
+            ))?;
+        }
+    }
+    if let Some(error) = purge_analysis_error {
+        fmt.warning(&format!(
+            "purge delete-set classifier unavailable: {error}; foreign-count comparison is incomplete"
         ))?;
     }
 
@@ -1163,8 +1311,14 @@ fn output_foreign_rows_detail(
     }
 
     fmt.newline()?;
-    if report.is_clean() {
+    let purge_counts_disagree = purge_analysis
+        .is_some_and(|analysis| analysis.foreign_task_count != analysis.delete_set.tasks.len());
+    if report.is_clean() && purge_analysis_error.is_none() && !purge_counts_disagree {
         fmt.success("no cross-project contamination detected")?;
+    } else if purge_counts_disagree {
+        fmt.warning(
+            "Do not treat purge-foreign as complete remediation: inspect retained evidence rows above.",
+        )?;
     } else {
         fmt.warning(&report.remediation())?;
     }
@@ -2394,6 +2548,7 @@ mod tests {
                     id: "cas-0001".to_string(),
                     title: "Reconcile Q3 payroll".to_string(),
                     closed: false,
+                    origin_project: None,
                     home_project: "accounting".to_string(),
                     also_present_in: Vec::new(),
                 },
@@ -2401,6 +2556,7 @@ mod tests {
                     id: "cas-0002".to_string(),
                     title: "Finished months ago".to_string(),
                     closed: true,
+                    origin_project: None,
                     home_project: "accounting".to_string(),
                     also_present_in: Vec::new(),
                 },
@@ -2415,7 +2571,7 @@ mod tests {
         };
         let _ = DbSnapshot::default(); // keep the public snapshot type exercised
 
-        let check = foreign_rows_check(Ok(&report));
+        let check = foreign_rows_check(Ok(&report), None);
 
         assert!(matches!(check.status, CheckStatus::Warning));
         assert!(
@@ -2486,6 +2642,8 @@ mod tests {
                 title: "Accepted proposal".to_string(),
                 reason: "accepted proposal materialized for this project".to_string(),
             }],
+            unattributed_task_count: 0,
+            collision_count: 0,
         };
 
         let check = foreign_rows_check(Ok(&report), Some(&analysis));
@@ -2507,7 +2665,7 @@ mod tests {
             ..Default::default()
         };
 
-        let check = foreign_rows_check(Ok(&report));
+        let check = foreign_rows_check(Ok(&report), None);
 
         assert!(matches!(check.status, CheckStatus::Ok));
         // An Ok row that just said "clean" would be indistinguishable from a
@@ -2539,7 +2697,7 @@ mod tests {
         // Same reassuring-zero failure mode as the canonical-id registry row:
         // a scan that could not run must not render as "no contamination".
         let err = anyhow::anyhow!("disk I/O error");
-        let check = foreign_rows_check(Err(&err));
+        let check = foreign_rows_check(Err(&err), None);
 
         assert!(matches!(check.status, CheckStatus::Warning));
         assert!(check.message.contains("SKIPPED"), "{}", check.message);
@@ -2687,7 +2845,7 @@ mod tests {
             ..Default::default()
         };
 
-        let check = foreign_rows_check(Ok(&report));
+        let check = foreign_rows_check(Ok(&report), None);
 
         // Clean against what could be read, but partial coverage is not a
         // clean bill of health.

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -2615,6 +2615,98 @@ mod tests {
         });
     }
 
+    #[cfg(feature = "mcp-proxy")]
+    #[test]
+    fn doctor_proxy_stdio_check_names_user_config_source_for_missing_command() {
+        let mut env = crate::test_support::TestEnvGuard::temp_home();
+        let xdg_config_home = env.home().join("xdg");
+        env.set("XDG_CONFIG_HOME", &xdg_config_home);
+        let user_path = xdg_config_home.join("code-mode-mcp/config.toml");
+        let temp = TempDir::new().unwrap();
+        let cas_root = temp.path().join(".cas");
+        fs::create_dir_all(&cas_root).unwrap();
+
+        let mut config = cmcp_core::config::Config::default();
+        config.add_server(
+            "user-missing".to_string(),
+            cmcp_core::config::ServerConfig::Stdio {
+                command: "/definitely/missing-user-command".to_string(),
+                args: Vec::new(),
+                env: BTreeMap::new().into_iter().collect(),
+            },
+        );
+        config.save_to(&user_path).unwrap();
+
+        let check = proxy_stdio_commands_check(&cas_root);
+        assert!(matches!(check.status, CheckStatus::Warning));
+        assert!(
+            check
+                .message
+                .contains(&format!("from {}", user_path.display())),
+            "{}",
+            check.message
+        );
+        assert!(
+            check
+                .message
+                .contains(&format!("repair {}", user_path.display())),
+            "{}",
+            check.message
+        );
+    }
+
+    #[cfg(feature = "mcp-proxy")]
+    #[test]
+    fn doctor_proxy_stdio_check_names_project_source_for_overridden_command() {
+        let mut env = crate::test_support::TestEnvGuard::temp_home();
+        let xdg_config_home = env.home().join("xdg");
+        env.set("XDG_CONFIG_HOME", &xdg_config_home);
+        let user_path = xdg_config_home.join("code-mode-mcp/config.toml");
+        let temp = TempDir::new().unwrap();
+        let cas_root = temp.path().join(".cas");
+        fs::create_dir_all(&cas_root).unwrap();
+        let project_path = cas_root.join("proxy.toml");
+
+        let mut user_config = cmcp_core::config::Config::default();
+        user_config.add_server(
+            "shared".to_string(),
+            cmcp_core::config::ServerConfig::Stdio {
+                command: "/definitely/missing-user-command".to_string(),
+                args: Vec::new(),
+                env: BTreeMap::new().into_iter().collect(),
+            },
+        );
+        user_config.save_to(&user_path).unwrap();
+
+        let mut project_config = cmcp_core::config::Config::default();
+        project_config.add_server(
+            "shared".to_string(),
+            cmcp_core::config::ServerConfig::Stdio {
+                command: "/definitely/missing-project-command".to_string(),
+                args: Vec::new(),
+                env: BTreeMap::new().into_iter().collect(),
+            },
+        );
+        project_config.save_to(&project_path).unwrap();
+
+        let check = proxy_stdio_commands_check(&cas_root);
+        assert!(matches!(check.status, CheckStatus::Warning));
+        assert!(
+            check
+                .message
+                .contains(&format!("from {}", project_path.display())),
+            "{}",
+            check.message
+        );
+        assert!(
+            !check
+                .message
+                .contains(&format!("from {}", user_path.display())),
+            "{}",
+            check.message
+        );
+    }
+
     #[test]
     fn foreign_rows_check_warns_when_a_peer_db_could_not_be_read_cas_fc6fa() {
         use crate::cli::foreign_rows::{ForeignRowReport, UnreadablePeer};

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -2107,10 +2107,10 @@ fn cloud_queue_check(cas_root: &Path) -> Check {
 #[cfg(feature = "mcp-proxy")]
 fn proxy_stdio_commands_check(cas_root: &Path) -> Check {
     let proxy_path = cas_root.join("proxy.toml");
-    let config = match cmcp_core::config::Config::load_merged(
+    let (config, sources) = match cmcp_core::config::Config::load_merged_with_sources(
         proxy_path.exists().then_some(proxy_path.as_path()),
     ) {
-        Ok(config) => config,
+        Ok(loaded) => loaded,
         Err(error) => {
             return Check {
                 name: "MCP stdio upstreams".to_string(),
@@ -2134,7 +2134,13 @@ fn proxy_stdio_commands_check(cas_root: &Path) -> Check {
     let missing = commands
         .iter()
         .filter(|(_, command)| cmcp_core::resolve_stdio_executable(command).is_none())
-        .map(|(name, command)| format!("{name} = {command}"))
+        .map(|(name, command)| {
+            let source = sources
+                .get(*name)
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "unknown configuration source".to_string());
+            format!("{name} = {command} (from {source})")
+        })
         .collect::<Vec<_>>();
 
     if missing.is_empty() {
@@ -2147,11 +2153,24 @@ fn proxy_stdio_commands_check(cas_root: &Path) -> Check {
             ),
         }
     } else {
+        let mut source_paths = commands
+            .iter()
+            .filter(|(_, command)| cmcp_core::resolve_stdio_executable(command).is_none())
+            .filter_map(|(name, _)| sources.get(*name))
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>();
+        source_paths.sort();
+        source_paths.dedup();
+        let remediation = if source_paths.is_empty() {
+            "repair the registering configuration file".to_string()
+        } else {
+            format!("repair {}", source_paths.join(", "))
+        };
         Check {
             name: "MCP stdio upstreams".to_string(),
             status: CheckStatus::Warning,
             message: format!(
-                "{} of {} registered command(s) do not resolve: {}; repair proxy.toml before restarting cas serve",
+                "{} of {} registered command(s) do not resolve: {}; {remediation} before restarting cas serve",
                 missing.len(),
                 commands.len(),
                 missing.join(", ")

--- a/cas-cli/src/cli/foreign_rows.rs
+++ b/cas-cli/src/cli/foreign_rows.rs
@@ -72,6 +72,9 @@ const LOCAL_ACTIVITY_TABLES: &[&str] = &[
 pub struct TaskRow {
     pub id: String,
     pub title: String,
+    /// Persisted owner identity, when the local schema has it. Legacy rows
+    /// without this field are not safe purge candidates even with peer proof.
+    pub origin_project: Option<String>,
     /// `status == "closed"`. Split out because closed replicas are noise while
     /// non-closed replicas actively lie in ready queues (AC3).
     pub closed: bool,
@@ -133,6 +136,9 @@ pub struct ForeignRow {
     pub id: String,
     pub title: String,
     pub closed: bool,
+    /// The local row's persisted owner identity. A backfilled current-project
+    /// value is the signal that peer evidence must override.
+    pub origin_project: Option<String>,
     /// Project whose database carries local-activity evidence for this row.
     pub home_project: String,
     /// Every other project database holding the same `(id, title)`.
@@ -339,6 +345,7 @@ origin_project_id before removing a page, then re-run a scoped pull and this aud
                     "id": r.id,
                     "title": r.title,
                     "closed": r.closed,
+                    "origin_project": r.origin_project,
                     "home_project": r.home_project,
                     "also_present_in": r.also_present_in,
                 })
@@ -510,6 +517,7 @@ pub fn classify(local: &DbSnapshot, peers: &[DbSnapshot]) -> ForeignRowReport {
                 id: row.id.clone(),
                 title: row.title.clone(),
                 closed: row.closed,
+                origin_project: row.origin_project.clone(),
                 home_project: peers[home_idx].project.clone(),
                 also_present_in: present_in
                     .iter()
@@ -597,12 +605,23 @@ pub fn read_snapshot(db_path: &Path, project: &str) -> anyhow::Result<DbSnapshot
     )?;
     conn.busy_timeout(Duration::from_millis(250))?;
 
-    let mut stmt = conn.prepare("SELECT id, title, status FROM tasks")?;
+    let task_columns = conn
+        .prepare("PRAGMA table_info(tasks)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?;
+    let origin_column = task_columns.iter().any(|column| column == "origin_project");
+    let task_sql = if origin_column {
+        "SELECT id, title, status, origin_project FROM tasks"
+    } else {
+        "SELECT id, title, status, NULL FROM tasks"
+    };
+    let mut stmt = conn.prepare(task_sql)?;
     let mut tasks = Vec::new();
     let rows = stmt.query_map([], |row| {
         Ok(TaskRow {
             id: row.get::<_, String>(0)?,
             title: row.get::<_, String>(1)?,
+            origin_project: row.get::<_, Option<String>>(3)?,
             closed: row.get::<_, String>(2)?.eq_ignore_ascii_case("closed"),
         })
     })?;
@@ -804,6 +823,7 @@ mod tests {
         TaskRow {
             id: id.to_string(),
             title: title.to_string(),
+            origin_project: None,
             closed,
         }
     }

--- a/cas-cli/src/cloud/syncer/pull.rs
+++ b/cas-cli/src/cloud/syncer/pull.rs
@@ -357,7 +357,7 @@ impl CloudSyncer {
     }
 }
 
-/// Read the cloud mutation timestamp carried by a team-pull entry.
+/// Read the cloud mutation timestamp carried by a pulled entry.
 ///
 /// The local `Entry` model predates the wire-level `updated_at` field, so
 /// retain the timestamp as pull metadata instead of changing that public
@@ -1105,6 +1105,7 @@ impl CloudSyncer {
             if !entity_matches_project(&raw_entry, &current_project_id, "entry") {
                 continue;
             }
+            let remote_updated_at = pulled_entry_updated_at(&raw_entry);
             let remote_entry: Entry = match deserialize_pulled_entity(raw_entry, "entry") {
                 Ok(e) => e,
                 Err(e) => {
@@ -1112,7 +1113,9 @@ impl CloudSyncer {
                     continue;
                 }
             };
-            match self.upsert_entry(store, remote_entry) {
+            let remote_updated_at = remote_updated_at
+                .unwrap_or_else(|| remote_entry.last_accessed.unwrap_or(remote_entry.created));
+            match self.upsert_entry_lww(store, remote_entry, remote_updated_at) {
                 Ok(UpsertResult::Created) | Ok(UpsertResult::Updated) => {
                     result.pulled_entries += 1;
                 }
@@ -1411,35 +1414,6 @@ impl CloudSyncer {
 
         result.duration_ms = start.elapsed().as_millis() as u64;
         Ok(result)
-    }
-
-    fn upsert_entry(&self, store: &dyn Store, entry: Entry) -> Result<UpsertResult, CasError> {
-        match store.get(&entry.id) {
-            Ok(local) => {
-                // Compare timestamps for conflict resolution (last-write-wins)
-                let local_time = local.last_accessed.unwrap_or(local.created);
-                let remote_time = entry.last_accessed.unwrap_or(entry.created);
-
-                if remote_time > local_time {
-                    self.journal_local_overwrite(
-                        EntityType::Entry,
-                        &entry.id,
-                        &local,
-                        "remote",
-                        "timestamp_lww",
-                    )?;
-                    store.update(&entry)?;
-                    Ok(UpsertResult::Updated)
-                } else {
-                    Ok(UpsertResult::Skipped)
-                }
-            }
-            Err(cas_store::StoreError::EntryNotFound(_)) => {
-                store.add(&entry)?;
-                Ok(UpsertResult::Created)
-            }
-            Err(e) => Err(e.into()),
-        }
     }
 
     fn upsert_task(

--- a/cas-cli/tests/project_pull_archived_test.rs
+++ b/cas-cli/tests/project_pull_archived_test.rs
@@ -2,6 +2,7 @@
 //! local entries instead of trying to insert the same primary key again.
 
 use std::path::Path;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/cas-cli/tests/project_pull_archived_test.rs
+++ b/cas-cli/tests/project_pull_archived_test.rs
@@ -2,7 +2,6 @@
 //! local entries instead of trying to insert the same primary key again.
 
 use std::path::Path;
-use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/cas-cli/tests/project_pull_archived_test.rs
+++ b/cas-cli/tests/project_pull_archived_test.rs
@@ -1,0 +1,377 @@
+//! Regression coverage for cas-c9a4: project pulls must reconcile archived
+//! local entries instead of trying to insert the same primary key again.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use cas::cloud::{
+    CloudConfig, CloudSyncer, CloudSyncerConfig, SyncQueue, get_project_canonical_id,
+};
+use cas::store::{
+    Store, open_commit_link_store, open_event_store, open_file_change_store, open_prompt_store,
+    open_rule_store_local, open_skill_store_local, open_spec_store, open_store_local,
+    open_task_store_local,
+};
+use cas::types::{Entry, EntryType, Scope};
+use chrono::{DateTime, Duration, Utc};
+use rusqlite::Connection;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+struct PullHarness {
+    _tmp: TempDir,
+    syncer: CloudSyncer,
+    store: Arc<dyn Store>,
+    task_store: Arc<dyn cas::store::TaskStore>,
+    rule_store: Arc<dyn cas::store::RuleStore>,
+    skill_store: Arc<dyn cas::store::SkillStore>,
+    spec_store: Arc<dyn cas::store::SpecStore>,
+    event_store: Arc<dyn cas::store::EventStore>,
+    prompt_store: Arc<dyn cas::store::PromptStore>,
+    file_change_store: Arc<dyn cas::store::FileChangeStore>,
+    commit_link_store: Arc<dyn cas::store::CommitLinkStore>,
+}
+
+impl PullHarness {
+    fn new(endpoint: &str) -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let store = open_store_local(root).unwrap();
+        let task_store = open_task_store_local(root).unwrap();
+        let rule_store = open_rule_store_local(root).unwrap();
+        let skill_store = open_skill_store_local(root).unwrap();
+        let spec_store = open_spec_store(root).unwrap();
+        let event_store = open_event_store(root).unwrap();
+        let prompt_store = open_prompt_store(root).unwrap();
+        let file_change_store = open_file_change_store(root).unwrap();
+        let commit_link_store = open_commit_link_store(root).unwrap();
+        let queue = Arc::new(SyncQueue::open(root).unwrap());
+        queue.init().unwrap();
+
+        let syncer = CloudSyncer::new(
+            queue,
+            CloudConfig {
+                endpoint: endpoint.to_string(),
+                token: Some("test-token".to_string()),
+                ..Default::default()
+            },
+            CloudSyncerConfig::default(),
+        );
+
+        Self {
+            _tmp: tmp,
+            syncer,
+            store,
+            task_store,
+            rule_store,
+            skill_store,
+            spec_store,
+            event_store,
+            prompt_store,
+            file_change_store,
+            commit_link_store,
+        }
+    }
+
+    fn pull(&self) -> Result<cas::cloud::SyncResult, cas::error::CasError> {
+        self.syncer.pull(
+            self.store.as_ref(),
+            self.task_store.as_ref(),
+            self.rule_store.as_ref(),
+            self.skill_store.as_ref(),
+            self.spec_store.as_ref(),
+            self.event_store.as_ref(),
+            self.prompt_store.as_ref(),
+            self.file_change_store.as_ref(),
+            self.commit_link_store.as_ref(),
+        )
+    }
+}
+
+fn entry(id: &str, content: &str, created: DateTime<Utc>) -> Entry {
+    Entry {
+        id: id.to_string(),
+        scope: Scope::Project,
+        entry_type: EntryType::Context,
+        content: content.to_string(),
+        created,
+        ..Default::default()
+    }
+}
+
+fn remote_entry(entry: Entry, project_id: &str, updated_at: DateTime<Utc>) -> serde_json::Value {
+    let mut raw = serde_json::to_value(entry).unwrap();
+    raw["project_id"] = serde_json::json!(project_id);
+    raw["project_canonical_id"] = serde_json::json!(project_id);
+    raw["updated_at"] = serde_json::json!(updated_at.to_rfc3339());
+    raw
+}
+
+async fn mount_pull(server: &MockServer, project_id: &str, entries: Vec<serde_json::Value>) {
+    Mock::given(method("GET"))
+        .and(path("/api/sync/pull"))
+        .and(query_param("project_id", project_id))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "entries": entries,
+            "tasks": [],
+            "rules": [],
+            "skills": [],
+            "specs": [],
+            "events": [],
+            "prompts": [],
+            "file_changes": [],
+            "commit_links": [],
+            "pulled_at": "2026-09-01T00:00:00Z",
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
+}
+
+fn assert_no_pull_errors(result: &cas::cloud::SyncResult) {
+    assert!(
+        result.errors.is_empty(),
+        "unexpected pull errors: {:?}",
+        result.errors
+    );
+}
+
+#[tokio::test]
+async fn archived_local_newer_remote_updates_and_unarchives() {
+    let server = MockServer::start().await;
+    let project_id = get_project_canonical_id().expect("test runs inside a CAS project");
+    let now = Utc::now();
+    mount_pull(
+        &server,
+        &project_id,
+        vec![remote_entry(
+            entry("project-archived-newer", "remote", now - Duration::hours(2)),
+            &project_id,
+            now + Duration::hours(1),
+        )],
+    )
+    .await;
+
+    let harness = PullHarness::new(&server.uri());
+    harness
+        .store
+        .add(&entry(
+            "project-archived-newer",
+            "local archived",
+            now - Duration::hours(3),
+        ))
+        .unwrap();
+    harness.store.archive("project-archived-newer").unwrap();
+
+    let store = Arc::clone(&harness.store);
+    let result = tokio::task::spawn_blocking(move || harness.pull())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_no_pull_errors(&result);
+    assert_eq!(result.pulled_entries, 1);
+    assert_eq!(
+        store.get("project-archived-newer").unwrap().content,
+        "remote"
+    );
+    assert!(store.get_archived("project-archived-newer").is_err());
+}
+
+#[tokio::test]
+async fn archived_local_older_remote_skips_and_stays_archived() {
+    let server = MockServer::start().await;
+    let project_id = get_project_canonical_id().expect("test runs inside a CAS project");
+    let now = Utc::now();
+    mount_pull(
+        &server,
+        &project_id,
+        vec![remote_entry(
+            entry("project-archived-older", "remote", now - Duration::hours(2)),
+            &project_id,
+            now - Duration::hours(1),
+        )],
+    )
+    .await;
+
+    let harness = PullHarness::new(&server.uri());
+    harness
+        .store
+        .add(&entry(
+            "project-archived-older",
+            "local archived",
+            now - Duration::hours(3),
+        ))
+        .unwrap();
+    harness.store.archive("project-archived-older").unwrap();
+
+    let store = Arc::clone(&harness.store);
+    let result = tokio::task::spawn_blocking(move || harness.pull())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_no_pull_errors(&result);
+    assert_eq!(result.pulled_entries, 0);
+    assert_eq!(result.conflicts_resolved, 1);
+    assert_eq!(
+        store
+            .get_archived("project-archived-older")
+            .unwrap()
+            .content,
+        "local archived"
+    );
+}
+
+#[tokio::test]
+async fn active_local_lww_behavior_remains_unchanged() {
+    let server = MockServer::start().await;
+    let project_id = get_project_canonical_id().expect("test runs inside a CAS project");
+    let now = Utc::now();
+    mount_pull(
+        &server,
+        &project_id,
+        vec![
+            remote_entry(
+                entry(
+                    "project-active-newer",
+                    "remote newer",
+                    now - Duration::hours(2),
+                ),
+                &project_id,
+                now + Duration::hours(1),
+            ),
+            remote_entry(
+                entry(
+                    "project-active-older",
+                    "remote older",
+                    now - Duration::hours(2),
+                ),
+                &project_id,
+                now - Duration::hours(1),
+            ),
+        ],
+    )
+    .await;
+
+    let harness = PullHarness::new(&server.uri());
+    harness
+        .store
+        .add(&entry(
+            "project-active-newer",
+            "local",
+            now - Duration::hours(3),
+        ))
+        .unwrap();
+    harness
+        .store
+        .add(&entry(
+            "project-active-older",
+            "local",
+            now - Duration::hours(3),
+        ))
+        .unwrap();
+
+    let store = Arc::clone(&harness.store);
+    let result = tokio::task::spawn_blocking(move || harness.pull())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_no_pull_errors(&result);
+    assert_eq!(result.pulled_entries, 1);
+    assert_eq!(result.conflicts_resolved, 1);
+    assert_eq!(
+        store.get("project-active-newer").unwrap().content,
+        "remote newer"
+    );
+    assert_eq!(store.get("project-active-older").unwrap().content, "local");
+}
+
+#[tokio::test]
+async fn duplicate_race_reconciles_through_lww() {
+    let server = MockServer::start().await;
+    let project_id = get_project_canonical_id().expect("test runs inside a CAS project");
+    let now = Utc::now();
+    mount_pull(
+        &server,
+        &project_id,
+        vec![remote_entry(
+            entry("project-duplicate-race", "remote", now - Duration::hours(2)),
+            &project_id,
+            now + Duration::hours(1),
+        )],
+    )
+    .await;
+
+    let harness = PullHarness::new(&server.uri());
+    let trigger_conn = Connection::open(harness._tmp.path().join("cas.db")).unwrap();
+    trigger_conn
+        .execute_batch(
+            "CREATE TRIGGER insert_duplicate_race
+             BEFORE INSERT ON entries
+             WHEN NEW.id = 'project-duplicate-race'
+             BEGIN
+               INSERT INTO entries (id, type, created, content, scope, updated_at)
+               VALUES (NEW.id, 'context', '2026-08-01T00:00:00Z', 'concurrent local', 'project', '2026-08-01T00:00:00Z');
+             END;",
+        )
+        .unwrap();
+
+    let store = Arc::clone(&harness.store);
+    let result = tokio::task::spawn_blocking(move || harness.pull())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_no_pull_errors(&result);
+    assert_eq!(result.pulled_entries, 1);
+    assert_eq!(
+        store.get("project-duplicate-race").unwrap().content,
+        "remote"
+    );
+}
+
+#[tokio::test]
+async fn unrelated_store_error_is_reported() {
+    let server = MockServer::start().await;
+    let project_id = get_project_canonical_id().expect("test runs inside a CAS project");
+    let now = Utc::now();
+    mount_pull(
+        &server,
+        &project_id,
+        vec![remote_entry(
+            entry("project-store-error", "remote", now),
+            &project_id,
+            now + Duration::hours(1),
+        )],
+    )
+    .await;
+
+    let harness = PullHarness::new(&server.uri());
+    drop_entries_table(harness._tmp.path());
+
+    let result = tokio::task::spawn_blocking(move || harness.pull())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.pulled_entries, 0);
+    assert_eq!(result.errors.len(), 1);
+    assert!(
+        result.errors[0].contains("Entry error:"),
+        "{}",
+        result.errors[0]
+    );
+    assert!(
+        result.errors[0].contains("no such table"),
+        "{}",
+        result.errors[0]
+    );
+}
+
+fn drop_entries_table(root: &Path) {
+    let connection = Connection::open(root.join("cas.db")).unwrap();
+    connection.execute_batch("DROP TABLE entries").unwrap();
+}

--- a/cas-cli/tests/project_pull_archived_test.rs
+++ b/cas-cli/tests/project_pull_archived_test.rs
@@ -3,21 +3,153 @@
 
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use cas::cloud::{
     CloudConfig, CloudSyncer, CloudSyncerConfig, SyncQueue, get_project_canonical_id,
 };
 use cas::store::{
-    Store, open_commit_link_store, open_event_store, open_file_change_store, open_prompt_store,
-    open_rule_store_local, open_skill_store_local, open_spec_store, open_store_local,
-    open_task_store_local,
+    SqliteStore, Store, StoreError, open_commit_link_store, open_event_store,
+    open_file_change_store, open_prompt_store, open_rule_store_local, open_skill_store_local,
+    open_spec_store, open_store_local, open_task_store_local,
 };
 use cas::types::{Entry, EntryType, Scope};
 use chrono::{DateTime, Duration, Utc};
-use rusqlite::Connection;
 use tempfile::TempDir;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+struct RaceStore {
+    inner: SqliteStore,
+    race_id: String,
+    concurrent_entry: Entry,
+    raced: AtomicBool,
+}
+
+impl RaceStore {
+    fn new(inner: SqliteStore, concurrent_entry: Entry) -> Self {
+        Self {
+            inner,
+            race_id: concurrent_entry.id.clone(),
+            concurrent_entry,
+            raced: AtomicBool::new(false),
+        }
+    }
+}
+
+impl Store for RaceStore {
+    fn init(&self) -> cas::store::Result<()> {
+        self.inner.init()
+    }
+
+    fn generate_id(&self) -> cas::store::Result<String> {
+        self.inner.generate_id()
+    }
+
+    fn add(&self, entry: &Entry) -> cas::store::Result<()> {
+        if entry.id == self.race_id && !self.raced.swap(true, Ordering::SeqCst) {
+            self.inner.add(&self.concurrent_entry)?;
+            return Err(StoreError::EntryExists(entry.id.clone()));
+        }
+        self.inner.add(entry)
+    }
+
+    fn get(&self, id: &str) -> cas::store::Result<Entry> {
+        self.inner.get(id)
+    }
+
+    fn get_archived(&self, id: &str) -> cas::store::Result<Entry> {
+        self.inner.get_archived(id)
+    }
+
+    fn update(&self, entry: &Entry) -> cas::store::Result<()> {
+        self.inner.update(entry)
+    }
+
+    fn delete(&self, id: &str) -> cas::store::Result<()> {
+        self.inner.delete(id)
+    }
+
+    fn list(&self) -> cas::store::Result<Vec<Entry>> {
+        self.inner.list()
+    }
+
+    fn recent(&self, n: usize) -> cas::store::Result<Vec<Entry>> {
+        self.inner.recent(n)
+    }
+
+    fn recent_timestamp(&self, entry: &Entry) -> cas::store::Result<DateTime<Utc>> {
+        self.inner.recent_timestamp(entry)
+    }
+
+    fn archive(&self, id: &str) -> cas::store::Result<()> {
+        self.inner.archive(id)
+    }
+
+    fn unarchive(&self, id: &str) -> cas::store::Result<()> {
+        self.inner.unarchive(id)
+    }
+
+    fn list_archived(&self) -> cas::store::Result<Vec<Entry>> {
+        self.inner.list_archived()
+    }
+
+    fn list_by_branch(&self, branch: &str) -> cas::store::Result<Vec<Entry>> {
+        self.inner.list_by_branch(branch)
+    }
+
+    fn list_pending(&self, limit: usize) -> cas::store::Result<Vec<Entry>> {
+        self.inner.list_pending(limit)
+    }
+
+    fn mark_extracted(&self, id: &str) -> cas::store::Result<()> {
+        self.inner.mark_extracted(id)
+    }
+
+    fn list_pinned(&self) -> cas::store::Result<Vec<Entry>> {
+        self.inner.list_pinned()
+    }
+
+    fn list_helpful(&self, limit: usize) -> cas::store::Result<Vec<Entry>> {
+        self.inner.list_helpful(limit)
+    }
+
+    fn list_by_session(&self, session_id: &str) -> cas::store::Result<Vec<Entry>> {
+        self.inner.list_by_session(session_id)
+    }
+
+    fn list_unreviewed_learnings(&self, limit: usize) -> cas::store::Result<Vec<Entry>> {
+        self.inner.list_unreviewed_learnings(limit)
+    }
+
+    fn mark_reviewed(&self, id: &str) -> cas::store::Result<()> {
+        self.inner.mark_reviewed(id)
+    }
+
+    fn list_pending_index(&self, limit: usize) -> cas::store::Result<Vec<Entry>> {
+        self.inner.list_pending_index(limit)
+    }
+
+    fn mark_indexed(&self, id: &str) -> cas::store::Result<()> {
+        self.inner.mark_indexed(id)
+    }
+
+    fn mark_indexed_batch(&self, ids: &[&str]) -> cas::store::Result<()> {
+        self.inner.mark_indexed_batch(ids)
+    }
+
+    fn mark_index_pending_batch(&self, ids: &[&str]) -> cas::store::Result<()> {
+        self.inner.mark_index_pending_batch(ids)
+    }
+
+    fn cas_dir(&self) -> &Path {
+        self.inner.cas_dir()
+    }
+
+    fn close(&self) -> cas::store::Result<()> {
+        self.inner.close()
+    }
+}
 
 struct PullHarness {
     _tmp: TempDir,
@@ -38,6 +170,20 @@ impl PullHarness {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         let store = open_store_local(root).unwrap();
+        Self::from_store(tmp, endpoint, store)
+    }
+
+    fn with_duplicate_race(endpoint: &str, concurrent_entry: Entry) -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let inner = SqliteStore::open(root).unwrap();
+        inner.init().unwrap();
+        let store: Arc<dyn Store> = Arc::new(RaceStore::new(inner, concurrent_entry));
+        Self::from_store(tmp, endpoint, store)
+    }
+
+    fn from_store(tmp: TempDir, endpoint: &str, store: Arc<dyn Store>) -> Self {
+        let root = tmp.path();
         let task_store = open_task_store_local(root).unwrap();
         let rule_store = open_rule_store_local(root).unwrap();
         let skill_store = open_skill_store_local(root).unwrap();
@@ -305,19 +451,14 @@ async fn duplicate_race_reconciles_through_lww() {
     )
     .await;
 
-    let harness = PullHarness::new(&server.uri());
-    let trigger_conn = Connection::open(harness._tmp.path().join("cas.db")).unwrap();
-    trigger_conn
-        .execute_batch(
-            "CREATE TRIGGER insert_duplicate_race
-             BEFORE INSERT ON entries
-             WHEN NEW.id = 'project-duplicate-race'
-             BEGIN
-               INSERT INTO entries (id, type, created, content, scope, updated_at)
-               VALUES (NEW.id, 'context', '2026-08-01T00:00:00Z', 'concurrent local', 'project', '2026-08-01T00:00:00Z');
-             END;",
-        )
-        .unwrap();
+    let harness = PullHarness::with_duplicate_race(
+        &server.uri(),
+        entry(
+            "project-duplicate-race",
+            "concurrent local",
+            now - Duration::hours(3),
+        ),
+    );
 
     let store = Arc::clone(&harness.store);
     let result = tokio::task::spawn_blocking(move || harness.pull())
@@ -371,7 +512,7 @@ async fn unrelated_store_error_is_reported() {
     );
 }
 
-fn drop_entries_table(root: &Path) {
-    let connection = Connection::open(root.join("cas.db")).unwrap();
+fn drop_entries_table(root: &std::path::Path) {
+    let connection = rusqlite::Connection::open(root.join("cas.db")).unwrap();
     connection.execute_batch("DROP TABLE entries").unwrap();
 }

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -28,6 +28,6 @@ cas doctor
 [OK] integrations: no integrations configured
 [OK] canonical id: Cloud bucket `[BUCKET]` (from folder name)
 [OK] cloud sync queue: [N] queued content change(s) block purge-foreign; Run `cas cloud queue --retry`, then `cas cloud push`, then `cas cloud purge-foreign --dry-run`; repeat the push until this count reaches 0.
-[OK] cross-project rows: [N] project DB(s) compared (0 local task row(s), 0 DB(s) unreadable) — task replication was not checked; 0 foreign knowledge page(s): [N] attributed page(s) checked
+[OK] cross-project rows: [N] project DB(s) compared (0 local task row(s), 0 DB(s) unreadable) — task replication was not checked; 0 foreign knowledge page(s): [N] attributed page(s) checked. foreign evidence: [N] task row(s); purge delete set: [N] task row(s) — counts agree
 
 [WARN] All critical checks passed with some warnings.

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.10.0"
+version = "3.10.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp-proxy/src/config.rs
+++ b/crates/cas-mcp-proxy/src/config.rs
@@ -451,6 +451,61 @@ mod tests {
     }
 
     #[test]
+    fn load_merged_with_sources_tracks_user_and_project_server_origins() {
+        let dir = tempfile::tempdir().unwrap();
+        let user = dir.path().join("user.toml");
+        let project = dir.path().join("project.toml");
+
+        let mut user_config = Config::default();
+        user_config.add_server(
+            "user-only".to_string(),
+            ServerConfig::Stdio {
+                command: "/user-only".to_string(),
+                args: Vec::new(),
+                env: HashMap::new(),
+            },
+        );
+        user_config.add_server(
+            "shared".to_string(),
+            ServerConfig::Stdio {
+                command: "/user-shared".to_string(),
+                args: Vec::new(),
+                env: HashMap::new(),
+            },
+        );
+        user_config.save_to(&user).unwrap();
+
+        let mut project_config = Config::default();
+        project_config.add_server(
+            "shared".to_string(),
+            ServerConfig::Stdio {
+                command: "/project-shared".to_string(),
+                args: Vec::new(),
+                env: HashMap::new(),
+            },
+        );
+        project_config.add_server(
+            "project-only".to_string(),
+            ServerConfig::Stdio {
+                command: "/project-only".to_string(),
+                args: Vec::new(),
+                env: HashMap::new(),
+            },
+        );
+        project_config.save_to(&project).unwrap();
+
+        let (merged, sources) =
+            Config::load_merged_with_sources_from(Some(&user), Some(&project)).unwrap();
+        assert!(matches!(
+            merged.servers.get("shared"),
+            Some(ServerConfig::Stdio { command, .. }) if command == "/project-shared"
+        ));
+        assert_eq!(sources.get("user-only"), Some(&user));
+        assert_eq!(sources.get("shared"), Some(&project));
+        assert_eq!(sources.get("project-only"), Some(&project));
+    }
+
+    #[test]
     fn project_security_policy_replaces_instead_of_widens_user_policy() {
         let dir = tempfile::tempdir().unwrap();
         let user = dir.path().join("user.toml");

--- a/crates/cas-mcp-proxy/src/config.rs
+++ b/crates/cas-mcp-proxy/src/config.rs
@@ -264,19 +264,42 @@ impl Config {
     /// Load and merge project config with user config (~/.config/code-mode-mcp/config.toml).
     /// Project config takes precedence over user config.
     pub fn load_merged(project_path: Option<&Path>) -> Result<Config> {
-        let user_path = Scope::User.config_path().ok();
-        Self::load_merged_from(user_path.as_deref(), project_path)
+        let (config, _) = Self::load_merged_with_sources(project_path)?;
+        Ok(config)
     }
 
-    fn load_merged_from(user_path: Option<&Path>, project_path: Option<&Path>) -> Result<Config> {
-        let mut merged = match user_path {
-            Some(path) => Config::load_from(path)?,
-            None => Config::default(),
+    /// Load and merge project config with user config, retaining the source
+    /// path that supplied each final server definition. Project config takes
+    /// precedence over user config, so an overridden server is attributed to
+    /// the project file.
+    pub fn load_merged_with_sources(
+        project_path: Option<&Path>,
+    ) -> Result<(Config, HashMap<String, PathBuf>)> {
+        let user_path = Scope::User.config_path().ok();
+        Self::load_merged_with_sources_from(user_path.as_deref(), project_path)
+    }
+
+    fn load_merged_with_sources_from(
+        user_path: Option<&Path>,
+        project_path: Option<&Path>,
+    ) -> Result<(Config, HashMap<String, PathBuf>)> {
+        let (mut merged, mut sources) = match user_path {
+            Some(path) => {
+                let config = Config::load_from(path)?;
+                let sources = config
+                    .servers
+                    .keys()
+                    .map(|name| (name.clone(), path.to_path_buf()))
+                    .collect();
+                (config, sources)
+            }
+            None => (Config::default(), HashMap::new()),
         };
         if let Some(path) = project_path {
             let project = Config::load_from(path)?;
             for (name, server) in project.servers {
-                merged.servers.insert(name, server);
+                merged.servers.insert(name.clone(), server);
+                sources.insert(name, path.to_path_buf());
             }
             // Security policy is not union-merged. When a project config is
             // present it is authoritative, including an omitted/empty list;
@@ -285,7 +308,7 @@ impl Config {
             merged.delegation = project.delegation;
         }
 
-        Ok(merged)
+        Ok((merged, sources))
     }
 
     /// Save config to a TOML file.
@@ -438,15 +461,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let malformed = dir.path().join("malformed.toml");
         std::fs::write(&malformed, "[[not valid").unwrap();
-        let error = Config::load_merged_from(None, Some(&malformed)).unwrap_err();
+        let error = Config::load_merged_with_sources_from(None, Some(&malformed)).unwrap_err();
         assert!(error.to_string().contains("failed to parse"));
 
         let unreadable = dir.path().join("directory-not-file");
         std::fs::create_dir(&unreadable).unwrap();
-        let error = Config::load_merged_from(None, Some(&unreadable)).unwrap_err();
+        let error = Config::load_merged_with_sources_from(None, Some(&unreadable)).unwrap_err();
         assert!(error.to_string().contains("failed to read"));
 
-        let error = Config::load_merged_from(Some(&malformed), None).unwrap_err();
+        let error = Config::load_merged_with_sources_from(Some(&malformed), None).unwrap_err();
         assert!(error.to_string().contains("failed to parse"));
     }
 
@@ -532,7 +555,8 @@ tool = "ask_viktor"
         )
         .unwrap();
 
-        let merged = Config::load_merged_from(Some(&user), Some(&project)).unwrap();
+        let (merged, _) =
+            Config::load_merged_with_sources_from(Some(&user), Some(&project)).unwrap();
         assert_eq!(
             merged.allowlist,
             vec![ExternalToolConfig {

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.10.0"
+version = "3.10.1"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.10.0"
+version = "3.10.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.10.0"
+version = "3.10.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.10.0"
+version = "3.10.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-09-02-v3.10.1-slack.md
+++ b/docs/release-notes/2026-09-02-v3.10.1-slack.md
@@ -1,0 +1,54 @@
+# Slack draft — Cassy v3.10.1 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Cleaning another project's leftover tasks out of your Cassy store now actually works, and the doctor tells you exactly what it can and cannot clean.
+
+**Reply (Was → Now):**
+- Was: running the foreign-row cleanup removed nothing while the doctor kept reporting hundreds of tasks that belong to other projects, and every cloud pull printed a wall of "entry already exists" warnings for memories you had archived. Now: the cleanup finds the same rows the doctor finds, refuses anything ambiguous (same id with a different task, or a copy no project can be shown to own), previews each row with the reason it was selected, and cloud pulls reconcile archived memories quietly.
+- Was: when an MCP server command stopped resolving, the doctor told you to repair a project file that did not exist. Now: it names the exact configuration file that registered the command.
+- Install: use `cas update` for an existing installation, or download the
+  v3.10.1 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — purge-foreign and doctor now share one foreign-row classifier; project-scope pull reuses the team LWW entry path; doctor names MCP config provenance.
+
+**Reply (Was → Now):**
+- Was: `purge-foreign` classified by `tasks.origin_project` alone, which the m241 backfill had stamped with the current project on every legacy row, so its delete set was 3 rows against the doctor's 573; `CloudSyncer::upsert_entry` did get-then-add and collided on archived rows (347 errors per pull); `proxy_stdio_commands_check` always said "repair proxy.toml". Now: `collect_purge_delete_set_with_report` merges the origin column with `foreign_rows::classify` evidence (peer-evidence expansion only for rows whose origin equals the current project; collisions and unattributed replicas never deleted; task deletes match on (id, title); accepted-proposal and blocks_origin rows retained; safety lookups fail closed), the dry-run and doctor JSON carry per-row evidence and the retained set with reasons, doctor warns when evidence and delete-set counts disagree; project pull calls `upsert_entry_lww` (archived lookup, KeepRecent LWW, duplicate-race recovery); `Config::load_merged_with_sources` keeps per-server source paths so doctor names the user-scope or project file.
+- Validation and artifact: `cargo check --workspace --tests`, `cargo nextest run -p cas`, doctests on the assembled tree; new targets project_pull_archived_test (5), purge_foreign_safety_tests (28), foreign_rows_check (5), proxy config provenance (11); live `purge-foreign --dry-run` receipt on cas-src: 571-row delete set, 2 retained on id collision, 651 unattributed and 107 collisions excluded; Fast Validation + macOS Check green on the single integration PR. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |


### PR DESCRIPTION
## Summary
- Project-scope cloud pull reconciles archived local entries through the shared LWW helper instead of colliding on insert (347 "entry already exists" errors per pull on cas-src → 0).
- `cas cloud purge-foreign` combines the origin_project column with the doctor's cross-DB (id,title)+activity evidence, so rows whose origin was backfilled to the current project are reachable; id collisions and unattributed replicas are never deleted; task deletes match on (id,title); safety lookups fail closed; dry-run labels each row's evidence source.
- `cas doctor` prints the doctor evidence count next to the purge delete-set count, names every retained row and why, and stops prescribing purge-foreign as complete remediation when they disagree.
- `cas doctor` MCP stdio upstream check names the config file that registered an unresolvable command (user-scope `code-mode-mcp/config.toml` vs project `proxy.toml`).

## Verification
- cas-c9a4: project_pull_archived_test 5/5; team_pull_lww_test + team_pull_wiring_test 10/10; cargo check clean.
- cas-4bb5: purge_foreign_safety_tests 28/28; foreign_rows_check 5/5; doctor_snapshot 2/2; live dry-run receipt on cas-src: 571-row delete set (569 peer-evidence, 2 origin_project), 2 retained on id collision, 651 unattributed + 107 collisions excluded, no live deletion.
- cas-24a1: proxy config 11/11; doctor slice 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ax7RdpnoH5TkDHxYNSWTW