### PR TITLE
release: v3.13.1 — cas-cut-release publish-boundary hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.13.1] - 2026-09-03
+
+### Changed
+- The built-in `cas-cut-release` skill (Claude, Codex, and Grok mirrors) now
+  gives one exact publish procedure: release credentials come from a
+  configurable user-level `release.env` and are proven by name only, release
+  log/PID/done receipts live under the durable artifacts root instead of the
+  clean tag worktree, `release.sh --publish-tag` alone owns annotated-tag
+  creation and local preflight, a PID-safe wrapper always records a numeric
+  exit receipt, and publication may only be announced with tag, workflow,
+  asset, latency, Slack, and host receipts in hand.
+- MechaCassy release posts default to the rubric channel name `cas-internal`
+  and fall back to the directly configured Slack transport when a live Cassy
+  proxy lacks the registration.
+
 ## [3.13.0] - 2026-09-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.13.0"
+version = "3.13.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.13.0"
+version = "3.13.1"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.13.0"
+version = "3.13.1"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.13.0"
+version = "3.13.1"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.13.0"
+version = "3.13.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.13.0"
+version = "3.13.1"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.13.0"
+version = "3.13.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.13.0"
+version = "3.13.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.13.0"
+version = "3.13.1"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.13.0"
+version = "3.13.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.13.0"
+version = "3.13.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.13.0"
+version = "3.13.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-09-03-v3.13.0-slack.md
+++ b/docs/release-notes/2026-09-03-v3.13.0-slack.md
@@ -2,7 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+**Status:** Posted 2026-09-03 (see POSTED). Original guard: do not post until the tagged GitHub workflow publishes both
 assets and `release-published-receipt.sh --write-draft` has replaced both
 checksum placeholders below.
 
@@ -20,8 +20,8 @@ Live on production — **User** — Cassy now keeps factory work visible through
   timing. Now: every harness can use one checked, paced Slack transport with a
   durable receipt and no credentials in project files.
 - Install: use `cas update` for an existing installation, or download the
-  v3.13.0 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
-  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+  v3.13.0 archive for Linux x86_64 (SHA-256 `f8c144dea43df5a59dac0cb5db22d1d5c959dbb0e1a18f45f0b44d17b4ee2665`) or macOS ARM64
+  (SHA-256 `a212bc2a604acd91a91a02b267257bfee7029d9c40760886aff1ac805943b3b9`) from the GitHub release.
 
 ## Dev thread
 
@@ -43,8 +43,8 @@ Live on production — **Dev** — Cassy now reconciles factory identity and del
 - Validation and artifact: the assembled tree passes the full `cas` nextest
   and doctest suites, projection and ledger checks, and the release gate. The
   published archives are `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256
-  `{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (SHA-256
-  `{{MACOS_SHA256}}`). Linux and macOS are both available from CI, regardless
+  `f8c144dea43df5a59dac0cb5db22d1d5c959dbb0e1a18f45f0b44d17b4ee2665`) and `cas-aarch64-apple-darwin.tar.gz` (SHA-256
+  `a212bc2a604acd91a91a02b267257bfee7029d9c40760886aff1ac805943b3b9`). Linux and macOS are both available from CI, regardless
   of the tagger's host.
 
 ## Posting sequence
@@ -65,7 +65,13 @@ Channel: `#cas-internal` (`C0B44GUKDK2`).
 
 | Message | UTC timestamp | Permalink |
 | --- | --- | --- |
-| User top-level |  |  |
-| User reply (Was → Now) |  |  |
-| Dev top-level |  |  |
-| Dev reply (Was → Now) |  |  |
+| User top-level | 2026-09-03T16:19:01Z (ts 1788452341.825039) | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788452341825039 |
+| User reply (Was → Now) | 2026-09-03T16:19:12Z (ts 1788452352.630429) | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788452352630429?thread_ts=1788452341.825039&cid=C0B44GUKDK2 |
+| Dev top-level | 2026-09-03T16:19:17Z (ts 1788452357.456989) | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788452357456989 |
+| Dev reply (Was → Now) | 2026-09-03T16:19:28Z (ts 1788452368.530639) | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788452368530639?thread_ts=1788452357.456989&cid=C0B44GUKDK2 |
+
+Published 2026-09-03T16:13:28Z (Release run 33777004019 started 16:10:13Z; landed main ee619bef).
+Linux SHA-256 f8c144dea43df5a59dac0cb5db22d1d5c959dbb0e1a18f45f0b44d17b4ee2665;
+macOS SHA-256 a212bc2a604acd91a91a02b267257bfee7029d9c40760886aff1ac805943b3b9.
+Host verified: `cas --version` → cas 3.13.0 (ee619be); `cas hub` serving 3.13.0.
+Posted via MechaCassy (authenticated hub transport) to #cas-internal.

--- a/docs/release-notes/2026-09-03-v3.13.1-slack.md
+++ b/docs/release-notes/2026-09-03-v3.13.1-slack.md
@@ -1,0 +1,53 @@
+# Slack draft — Cassy v3.13.1 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Cassy’s built-in release checklist now walks a release from tag to announcement without the setup mistakes that slowed the last one.
+
+**Reply (Was → Now):**
+- Was: the release procedure assumed host-specific credential files, could leave stray logs that failed its own clean-tree check, and could report success without proof. Now: credentials come from one configurable user-level file (proved by name only), all runtime logs live under the artifacts folder, the tag step has one owner, and publication is only announced with the full set of receipts.
+- Install: use `cas update` for an existing installation, or download the
+  v3.13.1 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — `cas-cut-release` (Claude/Codex/Grok mirrors) now has one executable steps 7–8 publish boundary with fail-closed receipts and a MechaCassy channel fallback.
+
+**Reply (Was → Now):**
+- Was: the skill called `check-release-preflight.sh --local` before any tag existed, redirected release logs into the tag worktree, sourced a host-specific env path, and had no durable exit receipt or post-publication checklist. Now: `release.sh --publish-tag` alone creates the annotated tag and runs local preflight; a PID-safe non-errexit wrapper writes log/PID/done under `${CAS_RELEASE_ARTIFACTS_ROOT:-~/.cas/artifacts}/release/<tag>`; `${CAS_RELEASE_ENV_FILE:-~/.cas/release.env}` is sourced with `set -a` and proven set/unset by name; step 9 requires tag, workflow, asset, latency, Slack, and host receipts and posts to MechaCassy’s `cas-internal` channel name with the direct `mecha-cassy` MCP as fallback. Six new failure-log entries feed the self-learning gate.
+- Validation and artifact: the tree passes `scripts/release-gate.sh 3.13.1`, builtin flavor-drift, release-gate fixture (17), and publication-policy (8) guards. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |


### PR DESCRIPTION
Bump all crates to 3.13.1, add the CHANGELOG section, seed the v3.13.1
runtime-release Slack draft, and carry the v3.13.0 POSTED receipt and
published digests into its draft.
