### PR TITLE
fix(cas-8a55): report a worker killed by its harness account, and refuse the spawn that would create one

### DIFF
--- a/cas-cli/src/capability.rs
+++ b/cas-cli/src/capability.rs
@@ -189,6 +189,33 @@ pub fn probe_key_presence(
     }
 }
 
+/// Account-only probe for one harness, with no binary-version or model
+/// context (cas-8a55).
+///
+/// `probe_harness` answers "can this route run", which needs a version probe
+/// and a lane receipt. Spawn asks a narrower question — is the account this
+/// worker would use logged in — and asking it before cutting a worktree is
+/// what turns a half-hour of silent, assigned-but-dead workers into a refusal
+/// the operator can act on. Harnesses without account plumbing return
+/// `Unknown` rather than a verdict, because absence of a probe is not evidence
+/// of a bad account.
+pub(crate) fn probe_account_auth(
+    cli: cas_mux::SupervisorCli,
+    account_dir: Option<&str>,
+    deadline: Deadline,
+) -> CapabilityEvidence {
+    let now_ms = cas_factory::CapabilitySnapshot::now_ms();
+    match cli {
+        cas_mux::SupervisorCli::Claude => probe_claude_auth(account_dir, now_ms, deadline),
+        cas_mux::SupervisorCli::Codex => probe_codex_auth(account_dir, now_ms, deadline),
+        _ => unknown(
+            now_ms,
+            "harness has no account probe",
+            "No account preflight is defined for this harness.",
+        ),
+    }
+}
+
 fn probe_claude_auth(
     account_dir: Option<&str>,
     now_ms: u64,

--- a/cas-cli/src/factory_auth_health.rs
+++ b/cas-cli/src/factory_auth_health.rs
@@ -1,0 +1,331 @@
+//! Harness account-health evidence read from a worker's own transcript.
+//!
+//! A worker whose harness refuses its very first turn for an account reason —
+//! a revoked Codex refresh token, an expired Claude OAuth session — is not a
+//! slow worker. It is a dead one that will heartbeat forever: the harness
+//! process stays up, the MCP child stays registered, and the only trace is one
+//! line in a rollout file. In the incident this module exists for, four Codex
+//! workers each ended their first turn in ~1.2s with
+//! `codex_error_info: "unauthorized"` and were still listed as live, assigned
+//! and unstarted 34 minutes later.
+//!
+//! The scanners here are deliberately pure over transcript text so the
+//! incident's own rollout can be replayed as a fixture, and deliberately
+//! "latest terminal turn wins" so a transient failure the harness itself
+//! retried past cannot kill a working worker.
+
+/// What a transcript says about the account behind a harness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthFailureEvidence {
+    /// The most recent terminal turn failed for an account reason.
+    Failed {
+        /// The harness's own message, already free of secrets.
+        message: String,
+        /// Durable identity for this episode (timestamp when available), so a
+        /// relay is sent once per failure rather than once per scan.
+        occurrence: String,
+    },
+    /// A terminal turn completed without an account error, or the transcript
+    /// belongs to a harness this scanner does not read.
+    Healthy,
+    /// Nothing could be read. Explicitly not "healthy": an unreadable
+    /// transcript must never be used to close an open episode.
+    Unavailable,
+}
+
+impl AuthFailureEvidence {
+    pub fn failed(&self) -> bool {
+        matches!(self, Self::Failed { .. })
+    }
+}
+
+/// Codex writes one JSON object per line; the fields we need live under
+/// `payload` on `event_msg` records.
+///
+/// A turn is an account failure when its `task_complete` carries an `error`
+/// whose `codex_error_info` names an authorization problem. `last_agent_message`
+/// being null is what distinguishes "died before saying anything" from "worked,
+/// then hit a wall", and it is recorded in the message so the supervisor can
+/// tell the two apart.
+pub fn codex_rollout_auth_failure(tail: &str) -> AuthFailureEvidence {
+    let mut latest: Option<AuthFailureEvidence> = None;
+    for (index, line) in tail.lines().enumerate() {
+        let Ok(record) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let payload = record.get("payload").unwrap_or(&serde_json::Value::Null);
+        if payload.get("type").and_then(serde_json::Value::as_str) != Some("task_complete") {
+            continue;
+        }
+        let error = payload.get("error");
+        let info = error
+            .and_then(|error| error.get("codex_error_info"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        if !codex_error_info_is_auth(info) {
+            // Any terminal turn that did not fail on the account closes the
+            // episode, including one that failed for an unrelated reason: the
+            // harness reached the model, so the credential worked.
+            latest = Some(AuthFailureEvidence::Healthy);
+            continue;
+        }
+        let message = error
+            .and_then(|error| error.get("message"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("Codex refused the turn as unauthorized")
+            .to_string();
+        let occurrence = record
+            .get("timestamp")
+            .and_then(serde_json::Value::as_str)
+            .map_or_else(|| format!("line-{index}"), str::to_owned);
+        latest = Some(AuthFailureEvidence::Failed {
+            message,
+            occurrence,
+        });
+    }
+    latest.unwrap_or(AuthFailureEvidence::Unavailable)
+}
+
+fn codex_error_info_is_auth(info: &str) -> bool {
+    matches!(
+        info.to_ascii_lowercase().as_str(),
+        "unauthorized" | "unauthenticated" | "auth_error" | "invalid_credentials"
+    )
+}
+
+/// Claude's JSONL transcript carries assistant/user records rather than a
+/// terminal turn marker, so the account signal is an error record whose text
+/// names an authentication failure, with any later assistant output closing
+/// the episode.
+pub fn claude_transcript_auth_failure(tail: &str) -> AuthFailureEvidence {
+    let mut latest: Option<AuthFailureEvidence> = None;
+    for (index, line) in tail.lines().enumerate() {
+        let Ok(record) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let kind = record
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        if kind == "assistant" {
+            // The model answered, so whatever the credential state was, it
+            // worked. This is the guard against killing a worker over a
+            // transient 401 the harness retried past.
+            latest = Some(AuthFailureEvidence::Healthy);
+            continue;
+        }
+        let text = claude_record_text(&record);
+        if text.is_empty() || !claude_text_is_auth_failure(&text) {
+            continue;
+        }
+        let occurrence = record
+            .get("timestamp")
+            .and_then(serde_json::Value::as_str)
+            .map_or_else(|| format!("line-{index}"), str::to_owned);
+        latest = Some(AuthFailureEvidence::Failed {
+            message: text,
+            occurrence,
+        });
+    }
+    latest.unwrap_or(AuthFailureEvidence::Unavailable)
+}
+
+fn claude_record_text(record: &serde_json::Value) -> String {
+    for key in ["error", "message", "result", "subtype"] {
+        match record.get(key) {
+            Some(serde_json::Value::String(text)) => return text.clone(),
+            Some(value @ serde_json::Value::Object(_)) => {
+                if let Some(text) = value.get("message").and_then(serde_json::Value::as_str) {
+                    return text.to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+    String::new()
+}
+
+fn claude_text_is_auth_failure(text: &str) -> bool {
+    let lowered = text.to_ascii_lowercase();
+    // Both halves must match: "401" alone appears in ordinary tool output, and
+    // an agent discussing authentication is not an authentication failure.
+    let names_auth = lowered.contains("oauth")
+        || lowered.contains("api key")
+        || lowered.contains("authentication")
+        || lowered.contains("credentials")
+        || lowered.contains("401");
+    let names_failure = lowered.contains("invalid")
+        || lowered.contains("expired")
+        || lowered.contains("revoked")
+        || lowered.contains("unauthorized")
+        || lowered.contains("please run /login")
+        || lowered.contains("please log in")
+        || lowered.contains("log out and sign in");
+    names_auth && names_failure
+}
+
+/// What the operator has to do, naming the account the worker actually used.
+/// A remedy that does not name the directory is unactionable on a host with
+/// several accounts, which is exactly the host this runs on.
+pub fn auth_failure_remedy(cli: cas_mux::SupervisorCli, account_dir: Option<&str>) -> String {
+    match cli {
+        cas_mux::SupervisorCli::Codex => match account_dir {
+            Some(dir) if !dir.trim().is_empty() => format!(
+                "Run `CODEX_HOME={} codex login` on this host, then re-issue the spawn.",
+                dir.trim()
+            ),
+            _ => "Run `codex login` on this host (default CODEX_HOME ~/.codex), then re-issue the spawn.".to_string(),
+        },
+        cas_mux::SupervisorCli::Claude => match account_dir {
+            Some(dir) if !dir.trim().is_empty() => format!(
+                "Run `CLAUDE_CONFIG_DIR={} claude login` on this host, then re-issue the spawn.",
+                dir.trim()
+            ),
+            _ => "Run `claude login` on this host, then re-issue the spawn.".to_string(),
+        },
+        other => format!(
+            "Re-authenticate the {} account on this host, then re-issue the spawn.",
+            harness_label(other)
+        ),
+    }
+}
+
+fn harness_label(cli: cas_mux::SupervisorCli) -> &'static str {
+    match cli {
+        cas_mux::SupervisorCli::Claude => "claude",
+        cas_mux::SupervisorCli::Codex => "codex",
+        cas_mux::SupervisorCli::Grok => "grok",
+        cas_mux::SupervisorCli::OpenCode => "opencode",
+    }
+}
+
+/// The supervisor-facing sentence for a worker killed by its account.
+pub fn auth_failure_detail(
+    worker: &str,
+    cli: cas_mux::SupervisorCli,
+    account_dir: Option<&str>,
+    message: &str,
+) -> String {
+    format!(
+        "Worker '{worker}' never started work: its {} harness ended the first turn with an account failure — {message} \
+         The worker process may still be heartbeating, so this is not visible as a dead worker. {}",
+        harness_label(cli),
+        auth_failure_remedy(cli, account_dir),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verbatim shape of the four rollouts from the 2026-09-03 incident.
+    const UNAUTHORIZED_FIRST_TURN: &str = r#"{"timestamp":"2026-09-03T14:12:58.000Z","type":"session_meta","payload":{"id":"01a06879"}}
+{"timestamp":"2026-09-03T14:12:59.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1","started_at":1788459179}}
+{"timestamp":"2026-09-03T14:13:01.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":null,"error":{"message":"Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.","codex_error_info":"unauthorized"},"duration_ms":2428}}"#;
+
+    const HEALTHY_FIRST_TURN: &str = r#"{"timestamp":"2026-09-03T14:12:58.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1"}}
+{"timestamp":"2026-09-03T14:13:30.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":"Started cas-1234."}}"#;
+
+    #[test]
+    fn codex_unauthorized_first_turn_is_an_account_failure_with_its_message() {
+        let evidence = codex_rollout_auth_failure(UNAUTHORIZED_FIRST_TURN);
+        let AuthFailureEvidence::Failed {
+            message,
+            occurrence,
+        } = evidence
+        else {
+            panic!("expected an account failure, got {evidence:?}");
+        };
+        assert!(message.contains("refresh token was revoked"), "{message}");
+        assert_eq!(occurrence, "2026-09-03T14:13:01.000Z");
+    }
+
+    #[test]
+    fn codex_healthy_turn_is_not_an_account_failure() {
+        assert_eq!(
+            codex_rollout_auth_failure(HEALTHY_FIRST_TURN),
+            AuthFailureEvidence::Healthy
+        );
+    }
+
+    #[test]
+    fn a_transient_unauthorized_turn_followed_by_a_completed_turn_does_not_kill_a_worker() {
+        // The whole reason evidence is "latest terminal turn wins": Codex
+        // retries past transient authorization failures, and a worker that is
+        // demonstrably working must not be killed by an old line.
+        let tail = format!("{UNAUTHORIZED_FIRST_TURN}\n{HEALTHY_FIRST_TURN}");
+        assert_eq!(
+            codex_rollout_auth_failure(&tail),
+            AuthFailureEvidence::Healthy
+        );
+    }
+
+    #[test]
+    fn a_turn_that_failed_for_an_unrelated_reason_is_not_an_account_failure() {
+        let tail = r#"{"timestamp":"2026-09-03T14:13:01.000Z","type":"event_msg","payload":{"type":"task_complete","error":{"message":"stream disconnected before completion","codex_error_info":"stream_error"}}}"#;
+        assert_eq!(codex_rollout_auth_failure(tail), AuthFailureEvidence::Healthy);
+    }
+
+    #[test]
+    fn an_empty_or_unreadable_rollout_is_unavailable_rather_than_healthy() {
+        assert_eq!(codex_rollout_auth_failure(""), AuthFailureEvidence::Unavailable);
+        assert_eq!(
+            codex_rollout_auth_failure("not json\nalso not json"),
+            AuthFailureEvidence::Unavailable
+        );
+    }
+
+    #[test]
+    fn claude_oauth_expiry_is_an_account_failure_and_an_answer_closes_it() {
+        let failure = r#"{"timestamp":"2026-09-03T14:13:01.000Z","type":"error","error":{"message":"OAuth token expired. Please run /login to authenticate."}}"#;
+        assert!(claude_transcript_auth_failure(failure).failed());
+
+        let recovered = format!(
+            "{failure}\n{}",
+            r#"{"timestamp":"2026-09-03T14:14:00.000Z","type":"assistant","message":{"content":"working on it"}}"#
+        );
+        assert_eq!(
+            claude_transcript_auth_failure(&recovered),
+            AuthFailureEvidence::Healthy
+        );
+    }
+
+    #[test]
+    fn claude_prose_about_authentication_is_not_an_account_failure() {
+        // An agent reading a 401 out of a curl it ran, or discussing an API
+        // key, must not be mistaken for a harness that cannot authenticate.
+        let tail = r#"{"timestamp":"2026-09-03T14:13:01.000Z","type":"user","message":{"content":"the docs mention an api key and authentication"}}
+{"timestamp":"2026-09-03T14:13:02.000Z","type":"error","error":{"message":"curl returned 401 from the vendor sandbox"}}"#;
+        assert_eq!(
+            claude_transcript_auth_failure(tail),
+            AuthFailureEvidence::Unavailable
+        );
+    }
+
+    #[test]
+    fn the_remedy_names_the_account_directory_the_worker_used() {
+        let remedy = auth_failure_remedy(cas_mux::SupervisorCli::Codex, Some("~/.codex-alt"));
+        assert!(remedy.contains("CODEX_HOME=~/.codex-alt"), "{remedy}");
+        assert!(remedy.contains("codex login"), "{remedy}");
+
+        let default = auth_failure_remedy(cas_mux::SupervisorCli::Codex, None);
+        assert!(default.contains("~/.codex"), "{default}");
+
+        let claude = auth_failure_remedy(cas_mux::SupervisorCli::Claude, Some("~/.claude-alt"));
+        assert!(claude.contains("CLAUDE_CONFIG_DIR=~/.claude-alt"), "{claude}");
+    }
+
+    #[test]
+    fn the_supervisor_detail_names_the_worker_the_cause_and_the_remedy() {
+        let detail = auth_failure_detail(
+            "zen-eagle-20",
+            cas_mux::SupervisorCli::Codex,
+            None,
+            "Your access token could not be refreshed because your refresh token was revoked.",
+        );
+        assert!(detail.contains("zen-eagle-20"), "{detail}");
+        assert!(detail.contains("refresh token was revoked"), "{detail}");
+        assert!(detail.contains("codex login"), "{detail}");
+        assert!(detail.contains("never started work"), "{detail}");
+    }
+}

--- a/cas-cli/src/lib.rs
+++ b/cas-cli/src/lib.rs
@@ -37,6 +37,7 @@ pub mod daemon;
 pub mod duplicate_check;
 pub mod error;
 pub mod extraction;
+pub mod factory_auth_health;
 pub mod factory_context_reset;
 pub mod factory_isolation;
 pub mod factory_preflight;

--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -172,6 +172,84 @@ fn preflight_codex_config_dir(raw: &str) -> Result<(), String> {
     }
 }
 
+/// Bound on the account probes run before a spawn cuts a worktree. Two
+/// harnesses at two seconds each is the worst case, and a spawn that waits
+/// that long still beats a worker that heartbeats for half an hour without
+/// ever taking a turn.
+const ACCOUNT_PREFLIGHT_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Refuse a spawn whose harness account is logged out, before any worktree is
+/// cut (cas-8a55).
+///
+/// `preflight_codex_config_dir` proves an `auth.json` exists; it cannot prove
+/// the credential inside it still works. In the incident this exists for the
+/// file was present and the refresh token behind it had been revoked, so four
+/// worktrees were cut, four workers registered, and every first turn died in
+/// about a second.
+///
+/// Only an affirmative `Unavailable` refuses. `Unknown` — no CLI on PATH, a
+/// probe that timed out, a harness with no account plumbing — must not block a
+/// spawn: a preflight that fails closed on its own unreliability would ground
+/// the factory over a slow binary.
+fn preflight_account_auth(specs: &[cas_mux::WorkerSpec]) -> Result<(), String> {
+    let deadline = crate::bounded_process::Deadline::after(ACCOUNT_PREFLIGHT_BUDGET);
+    preflight_account_auth_with(specs, |cli, account_dir| {
+        crate::capability::probe_account_auth(cli, account_dir, deadline)
+    })
+}
+
+/// Probe-injected core of [`preflight_account_auth`], so the refusal policy is
+/// testable without a CLI on PATH.
+fn preflight_account_auth_with(
+    specs: &[cas_mux::WorkerSpec],
+    probe: impl Fn(cas_mux::SupervisorCli, Option<&str>) -> cas_factory::CapabilityEvidence,
+) -> Result<(), String> {
+    let mut seen: std::collections::BTreeSet<(cas_mux::SupervisorCli, Option<String>)> =
+        std::collections::BTreeSet::new();
+    for spec in specs {
+        if !account_dir_supported(spec.cli) {
+            continue;
+        }
+        // The account a worker will actually use: its own override first, the
+        // requesting supervisor's captured account otherwise.
+        let account_dir = spec
+            .config_dir
+            .clone()
+            .or_else(|| spec.requester_config_dir.clone())
+            .map(|dir| dir.trim().to_string())
+            .filter(|dir| !dir.is_empty());
+        if !seen.insert((spec.cli, account_dir.clone())) {
+            continue;
+        }
+        let evidence = probe(spec.cli, account_dir.as_deref());
+        if evidence.availability != cas_factory::CapabilityAvailability::Unavailable {
+            continue;
+        }
+        let account = account_dir
+            .as_deref()
+            .map_or_else(|| default_account_label(spec.cli), str::to_string);
+        let reason = evidence
+            .reason
+            .unwrap_or_else(|| "the account probe reported it unavailable".to_string());
+        return Err(format!(
+            "spawn refused: the {} account at {account} is not usable — {reason}. {} \
+             No worktree was created and no task was assigned.",
+            spec.cli.backend().name(),
+            crate::factory_auth_health::auth_failure_remedy(spec.cli, account_dir.as_deref()),
+        ));
+    }
+    Ok(())
+}
+
+/// What to call the account when the caller named no directory.
+fn default_account_label(cli: cas_mux::SupervisorCli) -> String {
+    match cli {
+        cas_mux::SupervisorCli::Codex => "the default CODEX_HOME (~/.codex)".to_string(),
+        cas_mux::SupervisorCli::Claude => "the default Claude configuration directory".to_string(),
+        other => format!("the default {} account", other.backend().name()),
+    }
+}
+
 /// Heartbeat age at which a worker is considered **stale** and becomes
 /// eligible for the opportunistic prune in `factory_worker_status`.
 ///
@@ -1886,6 +1964,11 @@ impl CasService {
                 ));
             }
         }
+        // cas-8a55: the last gate before this request becomes worktrees. A
+        // logged-out account is refused here, by name, instead of producing
+        // workers that register, take their task and die on the first turn
+        // while still heartbeating.
+        preflight_account_auth(&specs).map_err(|e| Self::error(ErrorCode::INVALID_PARAMS, e))?;
         for notice in notices.iter().chain(config_dir_warnings.iter()) {
             tracing::warn!(target: "cas::factory", "{notice}");
         }
@@ -7719,6 +7802,61 @@ pub(crate) fn worker_usage_limit_evidence(
     codex_rollout_usage_limit_evidence(rollout.as_deref(), cli)
 }
 
+/// Account health read from the worker's own transcript.
+///
+/// The sibling of [`worker_usage_limit_evidence`] for the failure that hides
+/// even better than an exhausted account: a harness that cannot authenticate
+/// ends its first turn in about a second and then heartbeats forever, so the
+/// worker reads as live, assigned and merely slow (cas-8a55).
+pub(crate) fn worker_auth_failure_evidence(
+    cas_root: &std::path::Path,
+    agent: &cas_types::Agent,
+) -> crate::factory_auth_health::AuthFailureEvidence {
+    use crate::factory_auth_health::AuthFailureEvidence;
+    let cli = worker_cli_from_agent(agent);
+    let Some(transcript) = worker_transcript_path_for_agent(cas_root, agent) else {
+        return AuthFailureEvidence::Unavailable;
+    };
+    let Some(tail) = read_transcript_tail(&transcript) else {
+        return AuthFailureEvidence::Unavailable;
+    };
+    match cli {
+        cas_mux::SupervisorCli::Codex => {
+            crate::factory_auth_health::codex_rollout_auth_failure(&tail)
+        }
+        cas_mux::SupervisorCli::Claude => {
+            crate::factory_auth_health::claude_transcript_auth_failure(&tail)
+        }
+        // Harnesses without a transcript reader must not be reported as
+        // failing on evidence nobody collected.
+        _ => AuthFailureEvidence::Unavailable,
+    }
+}
+
+/// The account directory a worker was actually spawned against, which is what
+/// a remedy has to name on a host running several of them.
+pub(crate) fn worker_account_dir(agent: &cas_types::Agent) -> Option<String> {
+    agent
+        .metadata
+        .get("worker_account_dir")
+        .map(|dir| dir.trim().to_string())
+        .filter(|dir| !dir.is_empty())
+}
+
+/// Bounded tail read shared by the transcript scanners. A transcript can grow
+/// without limit; the terminal records that matter are always at its end.
+fn read_transcript_tail(path: &std::path::Path) -> Option<String> {
+    const TAIL_BYTES: u64 = 256 * 1024;
+    let metadata = std::fs::metadata(path).ok()?;
+    let start = metadata.len().saturating_sub(TAIL_BYTES);
+    let mut file = std::fs::File::open(path).ok()?;
+    use std::io::{Read, Seek, SeekFrom};
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut tail = String::new();
+    file.read_to_string(&mut tail).ok()?;
+    Some(tail)
+}
+
 fn codex_rollout_reports_usage_limit(
     rollout: Option<&std::path::Path>,
     cli: cas_mux::SupervisorCli,
@@ -8877,6 +9015,107 @@ mod spawn_lifecycle_tests {
 
     fn render(rows: &[SpawnLifecycle]) -> String {
         format_spawn_lifecycle_section(rows, chrono::Utc::now())
+    }
+
+    fn spec_for(cli: cas_mux::SupervisorCli, config_dir: Option<&str>) -> cas_mux::WorkerSpec {
+        cas_mux::WorkerSpec {
+            name: None,
+            cli,
+            model: None,
+            effort: None,
+            config_dir: config_dir.map(str::to_string),
+            requester_config_dir: None,
+            requester_secure_storage_dir: None,
+        }
+    }
+
+    fn evidence(availability: cas_factory::CapabilityAvailability, reason: &str) -> cas_factory::CapabilityEvidence {
+        let mut evidence = cas_factory::CapabilityEvidence::new(availability, 0);
+        evidence.reason = Some(reason.to_string());
+        evidence
+    }
+
+    #[test]
+    fn a_logged_out_account_refuses_the_spawn_by_name_before_any_worktree_exists() {
+        let specs = vec![spec_for(cas_mux::SupervisorCli::Codex, Some("~/.codex-alt"))];
+        let error = preflight_account_auth_with(&specs, |_, _| {
+            evidence(
+                cas_factory::CapabilityAvailability::Unavailable,
+                "Codex login status reports no authenticated account",
+            )
+        })
+        .expect_err("a logged-out account must refuse the spawn");
+        assert!(error.contains("~/.codex-alt"), "{error}");
+        assert!(error.contains("codex login"), "{error}");
+        assert!(error.contains("No worktree was created"), "{error}");
+        assert!(
+            error.contains("no authenticated account"),
+            "the probe's own reason must survive: {error}"
+        );
+    }
+
+    #[test]
+    fn a_refusal_names_the_default_account_when_the_caller_named_none() {
+        let specs = vec![spec_for(cas_mux::SupervisorCli::Codex, None)];
+        let error = preflight_account_auth_with(&specs, |_, _| {
+            evidence(
+                cas_factory::CapabilityAvailability::Unavailable,
+                "logged out",
+            )
+        })
+        .expect_err("refusal expected");
+        assert!(error.contains("~/.codex"), "{error}");
+    }
+
+    #[test]
+    fn an_unreadable_probe_never_blocks_a_spawn() {
+        // No CLI on PATH, a probe that timed out, or a harness with no account
+        // plumbing is absence of evidence. A preflight that failed closed on
+        // its own unreliability would ground the factory over a slow binary.
+        let specs = vec![spec_for(cas_mux::SupervisorCli::Codex, Some("~/.codex"))];
+        assert!(
+            preflight_account_auth_with(&specs, |_, _| {
+                evidence(
+                    cas_factory::CapabilityAvailability::Unknown,
+                    "Codex login status probe timed out",
+                )
+            })
+            .is_ok()
+        );
+        assert!(
+            preflight_account_auth_with(&specs, |_, _| {
+                evidence(cas_factory::CapabilityAvailability::Available, "logged in")
+            })
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn each_distinct_account_is_probed_once_and_harnesses_without_accounts_are_skipped() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = AtomicUsize::new(0);
+        let specs = vec![
+            spec_for(cas_mux::SupervisorCli::Codex, Some("~/.codex")),
+            spec_for(cas_mux::SupervisorCli::Codex, Some("~/.codex")),
+            spec_for(cas_mux::SupervisorCli::Codex, Some("~/.codex-alt")),
+            spec_for(cas_mux::SupervisorCli::Claude, Some("~/.claude")),
+            spec_for(cas_mux::SupervisorCli::Grok, None),
+        ];
+        preflight_account_auth_with(&specs, |cli, _| {
+            assert_ne!(
+                cli,
+                cas_mux::SupervisorCli::Grok,
+                "a harness with no account plumbing must not be probed"
+            );
+            calls.fetch_add(1, Ordering::SeqCst);
+            evidence(cas_factory::CapabilityAvailability::Available, "logged in")
+        })
+        .expect("healthy accounts pass");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            3,
+            "four Codex/Claude specs across three distinct accounts must cost three probes"
+        );
     }
 
     #[test]
@@ -12285,6 +12524,46 @@ effort = "high"
             }
         }
         assert_eq!(got, Some(sessions.join(rel)));
+    }
+
+    /// cas-8a55: the seam between the pure scanner and a registered worker.
+    #[test]
+    fn a_registered_codex_worker_whose_first_turn_was_unauthorized_reads_as_an_account_failure() {
+        // The seam between the pure scanner and a real registered worker: the
+        // agent's spawn-time CODEX_HOME has to reach the rollout, and the
+        // rollout's terminal turn has to reach the supervisor as evidence.
+        let clone = "/tmp/cas-8a55-unauthorized-worker";
+        let rel = "2026/09/03/rollout-2026-09-03T14-12-58-unauthorized.jsonl";
+        let (account_home, sessions) = fake_codex_sessions_dir(&[(rel, clone)]);
+        let account_dir = account_home.path().to_str().expect("utf-8 account home");
+        let rollout = sessions.join(rel);
+        let mut contents = std::fs::read_to_string(&rollout).expect("fixture rollout");
+        contents.push_str(
+            "\n{\"timestamp\":\"2026-09-03T14:13:01.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"task_complete\",\"last_agent_message\":null,\"error\":{\"message\":\"Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.\",\"codex_error_info\":\"unauthorized\"}}}\n",
+        );
+        std::fs::write(&rollout, contents).expect("write rollout");
+
+        let mut agent = cas_types::Agent::new(
+            "codex-zen-eagle-20-session".to_string(),
+            "zen-eagle-20".to_string(),
+        );
+        agent
+            .metadata
+            .insert("worker_cli".to_string(), "codex".to_string());
+        agent
+            .metadata
+            .insert("clone_path".to_string(), clone.to_string());
+        agent
+            .metadata
+            .insert("worker_account_dir".to_string(), account_dir.to_string());
+
+        let evidence = worker_auth_failure_evidence(account_home.path(), &agent);
+        let crate::factory_auth_health::AuthFailureEvidence::Failed { message, .. } = evidence
+        else {
+            panic!("a revoked-token first turn must read as an account failure: {evidence:?}");
+        };
+        assert!(message.contains("refresh token was revoked"), "{message}");
+        assert_eq!(worker_account_dir(&agent).as_deref(), Some(account_dir));
     }
 
     /// cas-66fd: the supervisor normally runs under its own (often default)

--- a/cas-cli/src/ui/factory/daemon/fork_first.rs
+++ b/cas-cli/src/ui/factory/daemon/fork_first.rs
@@ -568,6 +568,8 @@ impl DaemonInitPhase {
             dead_workers: std::collections::HashSet::new(),
             reported_unavailable_workers: std::collections::HashMap::new(),
             last_usage_limit_scan: None,
+        reported_auth_failed_workers: std::collections::HashMap::new(),
+        last_auth_failure_scan: None,
             cancelled_spawns: std::collections::HashSet::new(),
             last_idle_message_times: HashMap::new(),
             lifecycle_redelivery_attempts: HashMap::new(),

--- a/cas-cli/src/ui/factory/daemon/mod.rs
+++ b/cas-cli/src/ui/factory/daemon/mod.rs
@@ -248,6 +248,13 @@ pub struct FactoryDaemon {
     reported_unavailable_workers: std::collections::HashMap<String, String>,
     /// Last bounded rollout scan for terminal harness availability evidence.
     last_usage_limit_scan: Option<Instant>,
+    /// cas-8a55: workers whose harness refused a turn for an account reason
+    /// (revoked Codex token, expired Claude session). Agent id -> evidence
+    /// occurrence, so the supervisor is told once per failure rather than once
+    /// per scan, and a re-authenticated worker can be reported again later.
+    reported_auth_failed_workers: std::collections::HashMap<String, String>,
+    /// Last bounded transcript scan for harness account failures.
+    last_auth_failure_scan: Option<Instant>,
     /// In-flight spawns cancelled by a shutdown that targeted that specific
     /// generation. Entries are consumed when the matching spawn task finishes.
     cancelled_spawns: std::collections::HashSet<String>,

--- a/cas-cli/src/ui/factory/daemon/process.rs
+++ b/cas-cli/src/ui/factory/daemon/process.rs
@@ -337,6 +337,8 @@ pub async fn run_daemon_after_fork(
         dead_workers: std::collections::HashSet::new(),
         reported_unavailable_workers: std::collections::HashMap::new(),
         last_usage_limit_scan: None,
+        reported_auth_failed_workers: std::collections::HashMap::new(),
+        last_auth_failure_scan: None,
         cancelled_spawns: std::collections::HashSet::new(),
         last_idle_message_times: HashMap::new(),
         lifecycle_redelivery_attempts: HashMap::new(),

--- a/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
@@ -775,6 +775,8 @@ impl FactoryDaemon {
             dead_workers: std::collections::HashSet::new(),
             reported_unavailable_workers: std::collections::HashMap::new(),
             last_usage_limit_scan: None,
+        reported_auth_failed_workers: std::collections::HashMap::new(),
+        last_auth_failure_scan: None,
             cancelled_spawns: std::collections::HashSet::new(),
             last_idle_message_times: HashMap::new(),
             lifecycle_redelivery_attempts: HashMap::new(),
@@ -1223,6 +1225,11 @@ impl FactoryDaemon {
                     // Send notifications for detected events
                     self.app.notify_events(&delivery_events);
                     self.relay_usage_limited_workers();
+                    // cas-8a55: an account failure kills the worker's first
+                    // turn while its process keeps heartbeating, so it has to
+                    // be read from the transcript on the same tick that reads
+                    // availability rather than waiting for a stall threshold.
+                    self.relay_auth_failed_workers();
 
                     // cas-d4ae: the detector has already emitted exactly one
                     // event for this idle/stall episode and the app just

--- a/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/queue_and_events.rs
@@ -1421,6 +1421,141 @@ impl FactoryDaemon {
         }
     }
 
+    /// Report a worker whose harness refused a turn because of its account,
+    /// and give its task back (cas-8a55).
+    ///
+    /// This failure is worse than a crash because it looks like health: the
+    /// harness process stays up and keeps heartbeating, the MCP child stays
+    /// registered, and the only evidence is one line in a transcript. In the
+    /// incident this exists for, four Codex workers each died on their first
+    /// turn with a revoked refresh token and were still listed as live and
+    /// "assigned but unstarted" 34 minutes later, with their tasks held.
+    ///
+    /// One relay per episode, the spawn recorded as failed rather than
+    /// registered, and the pre-assigned task released so another worker — or
+    /// the same one after `codex login` — can pick it up.
+    pub(super) fn relay_auth_failed_workers(&mut self) {
+        const AUTH_FAILURE_SCAN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
+        let now = std::time::Instant::now();
+        if self
+            .last_auth_failure_scan
+            .is_some_and(|last| now.saturating_duration_since(last) < AUTH_FAILURE_SCAN_INTERVAL)
+        {
+            return;
+        }
+        self.last_auth_failure_scan = Some(now);
+
+        let Ok(agents) = crate::store::open_agent_store(self.app.cas_dir()) else {
+            return;
+        };
+        let Ok(active) = agents.list(Some(cas_types::AgentStatus::Active)) else {
+            return;
+        };
+        let workers: std::collections::HashSet<String> =
+            self.app.worker_names().iter().cloned().collect();
+        let candidates: Vec<cas_types::Agent> = active
+            .into_iter()
+            .filter(|agent| {
+                agent.role == cas_types::AgentRole::Worker
+                    && agent.factory_session.as_deref() == Some(self.session_name.as_str())
+                    && workers.contains(&agent.name)
+            })
+            .collect();
+
+        for agent in candidates {
+            use crate::factory_auth_health::AuthFailureEvidence;
+            let evidence = crate::mcp::tools::service::factory_ops::worker_auth_failure_evidence(
+                self.app.cas_dir(),
+                &agent,
+            );
+            let (message, occurrence) = match evidence {
+                // Only affirmative later evidence closes an episode; an
+                // unreadable transcript must never reset the dedupe key.
+                AuthFailureEvidence::Healthy => {
+                    self.reported_auth_failed_workers.remove(&agent.id);
+                    continue;
+                }
+                AuthFailureEvidence::Unavailable => continue,
+                AuthFailureEvidence::Failed {
+                    message,
+                    occurrence,
+                } => (message, occurrence),
+            };
+            let occurrence = format!("{}:{occurrence}", agent.id);
+            if self.reported_auth_failed_workers.get(&agent.id) == Some(&occurrence) {
+                continue;
+            }
+
+            let cli = crate::mcp::tools::service::factory_ops::worker_cli_from_agent(&agent);
+            let account_dir =
+                crate::mcp::tools::service::factory_ops::worker_account_dir(&agent);
+            let detail = crate::factory_auth_health::auth_failure_detail(
+                &agent.name,
+                cli,
+                account_dir.as_deref(),
+                &message,
+            );
+
+            // The task comes back first: a held task is the part of this
+            // failure that blocks the epic, and it must not depend on a
+            // relay write succeeding.
+            let released = crate::ui::factory::app::render_and_ops::epic_workers::release_worker_task_bindings(
+                self.app.cas_dir(),
+                &agent.name,
+            );
+            let detail = match released {
+                0 => detail,
+                1 => format!("{detail} Its assigned task was released back to open."),
+                count => format!("{detail} Its {count} assigned tasks were released back to open."),
+            };
+
+            crate::telemetry::track(
+                "factory_worker_spawn_result",
+                vec![("success", "false"), ("reason", "harness_unauthorized")],
+            );
+            append_spawn_audit(
+                self.app.cas_dir(),
+                &self.session_name,
+                None,
+                Some(&agent.name),
+                "harness_auth",
+                "failed",
+                &detail,
+            );
+            match enqueue_spawn_outcome_notice(
+                self.app.cas_dir(),
+                self.app.supervisor_name(),
+                &self.session_name,
+                None,
+                &agent.name,
+                "harness_auth",
+                false,
+                &detail,
+            ) {
+                Ok(_) => {
+                    self.reported_auth_failed_workers
+                        .insert(agent.id.clone(), occurrence);
+                    tracing::error!(
+                        target: "cas::coordination",
+                        stage = "worker_auth_failed",
+                        worker = %agent.name,
+                        harness = ?cli,
+                        "harness refused the worker's turn on its account — spawn reported failed and task released"
+                    );
+                }
+                Err(error) => {
+                    // Leaving the dedupe key unset retries the relay on the
+                    // next scan rather than losing the report entirely.
+                    tracing::warn!(
+                        worker = %agent.name,
+                        %error,
+                        "cas-8a55: failed to relay a harness account failure to the supervisor"
+                    );
+                }
+            }
+        }
+    }
+
     /// Bounce aged direct messages to their original sender. The prompt store
     /// owns the read/ack race and one-shot marker; this daemon layer adds the
     /// live recipient harness and the authoritative delivery-state context.


### PR DESCRIPTION
Factory: a Codex worker whose first turn dies with codex_error_info=unauthorized (revoked refresh token) was left "assigned, not started" for 34 minutes with a "registered" spawn receipt.

- preflight_account_auth: bounded `codex login status` / `claude auth status` probe per distinct resolved account before any worktree is cut; only an affirmative Unavailable refuses, naming the account directory and the exact re-login command.
- relay_auth_failed_workers: on the lifecycle tick, detect a terminal auth failure in the harness transcript (latest terminal turn wins), release the task back to open, record the spawn as failed, relay one message per episode with the remedy.
- 14 new tests; factory scoped suites 978 passed.

Task: cas-8a55. Worker: mighty-raven-39.