### PR TITLE
Release 3.15.2 — migration ledger reconciliation, project discovery and user-level refresh, BOM-decoded docs, release-gate scratch base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,31 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.15.2] - 2026-09-04
+
 ### Fixed
+- `cas update` no longer reports a project as refreshed while its schema stays
+  behind. A migration whose name had already been recorded under another id
+  (a store migrated by a pre-release build that numbered it differently) made
+  the ledger write fail with "schema was detected but its ledger row could not
+  be recorded" on every run, leaving the project pinned two migrations short.
+  The runner now reconciles such rows — the stale entry is logged to the
+  reconciliation ledger with both ids and removed, the migration is recorded
+  under its current id, and whatever migration now owns the vacated id is
+  re-evaluated honestly (detected or applied). Every pending migration gets
+  its turn before the first failure is reported, and the ledger-write error
+  names both ids involved. Read-only checks still report the wedge; only
+  `cas update` repairs it.
+- `cas update` finds every local project, not just the ones already in its
+  registry. The filesystem scan stopped at the first `.cas` it met — on any
+  machine with a user-level store that was `$HOME` itself — so discovery had
+  silently collapsed to the registry and dozens of projects never received
+  migrations while the summary said "N projects refreshed". The scan now
+  descends (skipping `.cas/`, hidden and vendored directories), refreshed
+  projects are registered so discovery converges, a `.cas` without a database
+  is listed as "not refreshed (unregistered)", the user-level `~/.cas` store
+  gets its own refresh phase, every schema line names the store it migrated,
+  and `cas update --register <path>` adds a project by hand.
 - A `CHANGELOG.md` or project doc saved as UTF-16, or with a UTF-8 byte-order
   mark, is now read instead of skipped. The changelog index no longer fails the
   whole pass on an encoding it can decode, a leading byte-order mark no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- A `CHANGELOG.md` or project doc saved as UTF-16, or with a UTF-8 byte-order
+  mark, is now read instead of skipped. The changelog index no longer fails the
+  whole pass on an encoding it can decode, a leading byte-order mark no longer
+  swallows the file's first release heading, and a doc that genuinely cannot be
+  decoded is reported by name and reason in the pass report rather than
+  disappearing from the knowledge wiki with no explanation.
+- `scripts/release-gate.sh` picks its own scratch base (`/var/tmp/cas-release-gate`)
+  instead of one under `$HOME`. On a machine with a user-level `~/.cas` store the
+  old default sat beneath it, so the gate refused its own archive-mode and
+  snapshot-portability rows until an environment variable was exported by hand.
+  Setting `CAS_RELEASE_GATE_HOME_DIR` still overrides the base, and the receipt
+  now names the base it used and where that value came from.
+
 ## [3.15.1] - 2026-09-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.15.1"
+version = "3.15.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.15.1"
+version = "3.15.2"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.15.1"
+version = "3.15.2"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.15.1"
+version = "3.15.2"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.15.1"
+version = "3.15.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.15.1"
+version = "3.15.2"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.15.1"
+version = "3.15.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/cas-cli/src/builtins/codex/skills/cas-cut-release/SKILL.md
+++ b/cas-cli/src/builtins/codex/skills/cas-cut-release/SKILL.md
@@ -29,8 +29,11 @@ and do not claim success without its receipt.
    `cargo update --workspace --offline`, update CHANGELOG, the runtime-release
    draft, and the previous POSTED receipt; then run
    `scripts/release-gate.sh <version>` and require every row PASS.
-5. For archive mode, put the archive and TMPDIR under a large real-disk
-   scratch base with no `.cas` ancestor, never `/tmp` tmpfs. Build a remap
+5. For archive mode, the gate already puts the archive and TMPDIR under
+   `/var/tmp/cas-release-gate` — a large real-disk scratch base with no `.cas`
+   ancestor, never `/tmp` tmpfs. Set `CAS_RELEASE_GATE_HOME_DIR` only to move
+   that base; the receipt names the base and where it came from, and the gate
+   still refuses any base with a `.cas` ancestor. Build a remap
    with root `Cargo.toml` and every package path from `git ls-files
    '*/Cargo.toml'`; run outside the checkout with symlinks for
    cargo/rustc/git/sh/bash/jq/python3, no `rg`, and `--workspace-remap`.

--- a/cas-cli/src/builtins/grok/skills/cas-cut-release/SKILL.md
+++ b/cas-cli/src/builtins/grok/skills/cas-cut-release/SKILL.md
@@ -29,8 +29,11 @@ and do not claim success without its receipt.
    `cargo update --workspace --offline`, update CHANGELOG, the runtime-release
    draft, and the previous POSTED receipt; then run
    `scripts/release-gate.sh <version>` and require every row PASS.
-5. For archive mode, put the archive and TMPDIR under a large real-disk
-   scratch base with no `.cas` ancestor, never `/tmp` tmpfs. Build a remap
+5. For archive mode, the gate already puts the archive and TMPDIR under
+   `/var/tmp/cas-release-gate` — a large real-disk scratch base with no `.cas`
+   ancestor, never `/tmp` tmpfs. Set `CAS_RELEASE_GATE_HOME_DIR` only to move
+   that base; the receipt names the base and where it came from, and the gate
+   still refuses any base with a `.cas` ancestor. Build a remap
    with root `Cargo.toml` and every package path from `git ls-files
    '*/Cargo.toml'`; run outside the checkout with symlinks for
    cargo/rustc/git/sh/bash/jq/python3, no `rg`, and `--workspace-remap`.

--- a/cas-cli/src/builtins/skills/cas-cut-release/SKILL.md
+++ b/cas-cli/src/builtins/skills/cas-cut-release/SKILL.md
@@ -29,8 +29,11 @@ and do not claim success without its receipt.
    `cargo update --workspace --offline`, update CHANGELOG, the runtime-release
    draft, and the previous POSTED receipt; then run
    `scripts/release-gate.sh <version>` and require every row PASS.
-5. For archive mode, put the archive and TMPDIR under a large real-disk
-   scratch base with no `.cas` ancestor, never `/tmp` tmpfs. Build a remap
+5. For archive mode, the gate already puts the archive and TMPDIR under
+   `/var/tmp/cas-release-gate` — a large real-disk scratch base with no `.cas`
+   ancestor, never `/tmp` tmpfs. Set `CAS_RELEASE_GATE_HOME_DIR` only to move
+   that base; the receipt names the base and where it came from, and the gate
+   still refuses any base with a `.cas` ancestor. Build a remap
    with root `Cargo.toml` and every package path from `git ls-files
    '*/Cargo.toml'`; run outside the checkout with symlinks for
    cargo/rustc/git/sh/bash/jq/python3, no `rg`, and `--workspace-remap`.

--- a/cas-cli/src/cli/knowledge_cmd.rs
+++ b/cas-cli/src/cli/knowledge_cmd.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use clap::{Args, Subcommand};
 
 use crate::knowledge::{
-    ClaudeCliRunner, DistillConfig, LlmRunner, ScriptedLlm, SymbolLite, collect_sources,
+    ClaudeCliRunner, DistillConfig, LlmRunner, ScriptedLlm, SymbolLite, scan_sources,
     run_distillation_until,
 };
 use cas_store::{KnowledgeStore, SqliteKnowledgeStore};
@@ -183,7 +183,11 @@ fn execute_build(args: &BuildArgs, cas_root: &Path) -> anyhow::Result<()> {
     let project_root = project_root_of(cas_root)?;
     let store = SqliteKnowledgeStore::open(cas_root)?;
     let load = load_symbols(cas_root, args.max_symbols);
-    let sources = collect_sources(&project_root, &load.symbols);
+    let scan = scan_sources(&project_root, &load.symbols);
+    // Taken before the sources are moved out: a file that could not be decoded
+    // is reported with the pass, not dropped on the floor (cas-c736).
+    let skip_notes = scan.skip_notes();
+    let sources = scan.sources;
 
     let config = DistillConfig {
         max_sources_per_pass: args.max_sources,
@@ -217,8 +221,9 @@ fn execute_build(args: &BuildArgs, cas_root: &Path) -> anyhow::Result<()> {
         )
     };
 
-    let report =
+    let mut report =
         run_distillation_until(&store, runner.as_ref(), &sources, &config, build_deadline)?;
+    report.notes.extend(skip_notes);
 
     if args.dry_run {
         println!("Knowledge distillation (dry run — nothing was written)");

--- a/cas-cli/src/cli/update.rs
+++ b/cas-cli/src/cli/update.rs
@@ -192,6 +192,11 @@ pub struct UpdateArgs {
     #[arg(long)]
     pub all_projects: bool,
 
+    /// Register an existing project in the host registry so every later
+    /// `cas update` refreshes it without relying on the filesystem scan.
+    #[arg(long, value_name = "PATH")]
+    pub register: Option<PathBuf>,
+
     /// Run the post-swap hook from a freshly installed binary.
     #[arg(long = "post-swap", hide = true)]
     pub post_swap: bool,
@@ -211,6 +216,10 @@ pub fn execute(args: &UpdateArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
     // binary, otherwise every update would recursively launch updates.
     if args.post_swap {
         return execute_post_swap(args, cli, current_version);
+    }
+
+    if let Some(path) = &args.register {
+        return register_project(path, cli);
     }
 
     // This is also the no-download entry point for a host which already has
@@ -287,6 +296,40 @@ pub fn execute(args: &UpdateArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
     Ok(())
 }
 
+/// Add an existing project to the host registry.
+///
+/// The escape hatch for a project the scan cannot reach — one outside `$HOME`
+/// and outside `CAS_PROJECT_ROOTS`, or nested deeper than [`MAX_SCAN_DEPTH`].
+/// Registration is what stops the project from depending on the scan at all.
+fn register_project(path: &Path, cli: &Cli) -> anyhow::Result<()> {
+    let project = canonical_path(path);
+    if !project.join(".cas").is_dir() {
+        anyhow::bail!(
+            "{} is not a Cassy project (no .cas directory) — run `cas init` there first",
+            project.display()
+        );
+    }
+    crate::store::known_repos::ensure_host_schema()
+        .context("could not open the host known-repo registry")?;
+    crate::store::known_repos::register_repo_strict(&project)
+        .with_context(|| format!("could not register {}", project.display()))?;
+
+    if cli.json {
+        println!(
+            "{}",
+            serde_json::json!({ "registered": project, "store": project.join(".cas") })
+        );
+    } else {
+        let mut out = io::stdout();
+        let mut fmt = Formatter::stdout(&mut out, ActiveTheme::default());
+        fmt.success(&format!(
+            "Registered {} — future `cas update` runs refresh it",
+            project.display()
+        ))?;
+    }
+    Ok(())
+}
+
 /// Outcome printed in the final all-projects receipt. Phase failures are kept
 /// as data so one bad checkout never prevents the remaining projects from
 /// becoming current.
@@ -359,6 +402,10 @@ impl ProjectPhase {
 
 struct ProjectRefreshReceipt {
     project: PathBuf,
+    /// Found by the filesystem scan rather than the host registry. Refreshed
+    /// exactly like any other project, then registered so the next run finds
+    /// it without scanning.
+    unregistered: bool,
     migration: ProjectPhase,
     search_index: ProjectPhase,
     skills: ProjectPhase,
@@ -379,6 +426,9 @@ impl ProjectRefreshReceipt {
 struct RefreshReport {
     project_count: usize,
     failed_count: usize,
+    /// Directories carrying a `.cas/` but no store. Counted in the banner so a
+    /// refresh can never claim a clean sweep while leaving stores untouched.
+    skipped_unregistered: usize,
     elapsed: Duration,
 }
 
@@ -684,17 +734,29 @@ fn render_project_phase_details(
     strip_repeated_warning_lines(&selected, warnings, project, verbose, true)
 }
 
-fn print_update_banner_with_formatter(
-    fmt: &mut Formatter<'_>,
-    report: &RefreshReport,
-) -> io::Result<()> {
-    fmt.success(&format!(
-        "Cassy {} · {} projects refreshed · {} failed · {}",
+fn update_banner_text(report: &RefreshReport) -> String {
+    let skipped = if report.skipped_unregistered > 0 {
+        format!(
+            " · {} unregistered store(s) not refreshed",
+            report.skipped_unregistered
+        )
+    } else {
+        String::new()
+    };
+    format!(
+        "Cassy {} · {} projects refreshed · {} failed{skipped} · {}",
         env!("CARGO_PKG_VERSION"),
         report.project_count,
         report.failed_count,
         format_elapsed(report.elapsed)
-    ))
+    )
+}
+
+fn print_update_banner_with_formatter(
+    fmt: &mut Formatter<'_>,
+    report: &RefreshReport,
+) -> io::Result<()> {
+    fmt.success(&update_banner_text(report))
 }
 
 fn capture_phase<T>(enabled: bool, operation: impl FnOnce() -> T) -> (T, String) {
@@ -785,10 +847,11 @@ fn refresh_all_projects(
     current_cas_root: Option<&Path>,
 ) -> anyhow::Result<RefreshReport> {
     let started_at = Instant::now();
-    let projects = discover_local_projects(current_cas_root);
-    let mut receipts = Vec::with_capacity(projects.len());
+    let discovery = discover_local_projects(current_cas_root);
+    let mut receipts = Vec::with_capacity(discovery.projects.len());
 
-    for project in projects {
+    for project in &discovery.projects {
+        let project = project.clone();
         let cas_root = project.join(".cas");
         let mut details = String::new();
 
@@ -824,8 +887,17 @@ fn refresh_all_projects(
         details.push_str(&output);
         phase_details.push((cloud.is_ok(), output));
 
+        // Registration is what makes discovery converge: a project the scan had
+        // to find this time is in the registry for every later run, and for
+        // every other Cassy entry point that reads it.
+        let unregistered = discovery.unregistered.contains(&project);
+        if unregistered && !args.dry_run && !migration.failed() {
+            crate::store::known_repos::register_repo(&project);
+        }
+
         receipts.push(ProjectRefreshReceipt {
             project,
+            unregistered,
             migration,
             search_index,
             skills,
@@ -836,20 +908,18 @@ fn refresh_all_projects(
         });
     }
 
-    let (user_builtins, user_details) = capture_phase(!cli.json, || {
-        if args.dry_run {
-            ProjectPhase::Planned("user-level builtins".to_string())
-        } else {
-            match sync_user_builtins(cli) {
-                Ok(()) => ProjectPhase::Ok("user-level builtins".to_string()),
-                Err(error) => ProjectPhase::Failed(error.to_string()),
-            }
-        }
-    });
-    print_project_refresh_summary(&receipts, &user_builtins, &user_details, cli);
+    let (user_level, user_details) =
+        capture_phase(!cli.json, || refresh_user_level_store(args, cli));
+    print_project_refresh_summary(
+        &receipts,
+        &user_level,
+        &user_details,
+        &discovery.skipped_unregistered,
+        cli,
+    );
 
-    let failed_count = receipts.iter().filter(|receipt| receipt.failed()).count()
-        + usize::from(user_builtins.failed());
+    let failed_count =
+        receipts.iter().filter(|receipt| receipt.failed()).count() + usize::from(user_level.failed());
     if failed_count > 0 {
         anyhow::bail!(
             "one or more projects were not fully refreshed; see the per-project phase summary above"
@@ -858,8 +928,43 @@ fn refresh_all_projects(
     Ok(RefreshReport {
         project_count: receipts.len(),
         failed_count,
+        skipped_unregistered: discovery.skipped_unregistered.len(),
         elapsed: started_at.elapsed(),
     })
+}
+
+/// Refresh the user-level store (`~/.cas`) as its own phase.
+///
+/// Before cas-9d5c the all-projects sweep distributed user-level builtins but
+/// never ran migrations on `~/.cas`, so the host store drifted behind every
+/// project on the machine while the receipt reported a clean run. It is
+/// deliberately not a project: it is never counted in the project totals and
+/// never appears in the project table.
+fn refresh_user_level_store(args: &UpdateArgs, cli: &Cli) -> ProjectPhase {
+    let Some(cas_root) = user_level_store_root() else {
+        return ProjectPhase::Skipped("no home directory".to_string());
+    };
+    if !cas_root.join("cas.db").is_file() {
+        return match sync_user_builtins(cli) {
+            Ok(()) => ProjectPhase::Ok(format!("builtins only — no store at {}", cas_root.display())),
+            Err(error) => ProjectPhase::Failed(error.to_string()),
+        };
+    }
+
+    if args.dry_run {
+        return ProjectPhase::Planned(format!("migrate {} and sync builtins", cas_root.display()));
+    }
+
+    let migration = run_project_phase("user-level migration", false, || {
+        run_schema_migrations(args, cli, Some(&cas_root))
+    });
+    if migration.failed() {
+        return migration;
+    }
+    match sync_user_builtins(cli) {
+        Ok(()) => ProjectPhase::Ok(format!("migrated {} and synced builtins", cas_root.display())),
+        Err(error) => ProjectPhase::Failed(error.to_string()),
+    }
 }
 
 /// Repair the pre-cas-bc42 Tantivy root as part of the native update walk.
@@ -1136,8 +1241,9 @@ fn cloud_phase_from_summaries(summaries: &[SyncSummary]) -> ProjectPhase {
 
 fn print_project_refresh_summary(
     receipts: &[ProjectRefreshReceipt],
-    user_builtins: &ProjectPhase,
+    user_level: &ProjectPhase,
     user_details: &str,
+    skipped_unregistered: &[PathBuf],
     cli: &Cli,
 ) {
     if cli.json {
@@ -1146,6 +1252,8 @@ fn print_project_refresh_summary(
             .map(|receipt| {
                 serde_json::json!({
                     "project": receipt.project,
+                    "store": receipt.project.join(".cas"),
+                    "registered": !receipt.unregistered,
                     "migration": receipt.migration.summary(),
                     "search_index": receipt.search_index.summary(),
                     "skills": receipt.skills.summary(),
@@ -1156,7 +1264,17 @@ fn print_project_refresh_summary(
             .collect::<Vec<_>>();
         println!(
             "{}",
-            serde_json::json!({ "projects": projects, "user_builtins": user_builtins.summary() })
+            serde_json::json!({
+                "projects": projects,
+                "user_level_store": {
+                    "store": user_level_store_root(),
+                    "status": user_level.summary(),
+                },
+                // Retained for compatibility with readers of the pre-cas-9d5c
+                // receipt, which only ever reported the builtin distribution.
+                "user_builtins": user_level.summary(),
+                "skipped_unregistered": skipped_unregistered,
+            })
         );
         return;
     }
@@ -1206,17 +1324,75 @@ fn print_project_refresh_summary(
             }
         }
     }
+
+    // The user-level store is host state, so it gets a named line of its own
+    // rather than a project row it would otherwise be miscounted in.
+    println!(
+        "  [{}] user-level store: {}",
+        user_level.status_label().trim_matches(['[', ']']),
+        user_level.detail()
+    );
+
+    if !skipped_unregistered.is_empty() {
+        println!(
+            "  not refreshed (unregistered): {} — run `cas update` inside them or `cas update --register <path>`",
+            skipped_unregistered.len()
+        );
+        for path in skipped_unregistered.iter().take(5) {
+            println!("    ! {}", path.display());
+        }
+        if skipped_unregistered.len() > 5 {
+            println!("    … and {} more", skipped_unregistered.len() - 5);
+        }
+    }
     print!("{}", warnings.render(cli.verbose));
 }
 
-/// Discovery is the union of the host's known-repo registry and the legacy
-/// helper's scan roots. The latter is deliberately retained for binary-only
-/// machines that have never seeded `known_repos`.
-fn discover_local_projects(current_cas_root: Option<&Path>) -> Vec<PathBuf> {
-    let mut projects = BTreeSet::new();
+/// How far below each scan root discovery will walk. Deep enough for the
+/// `~/Workspace/group/project` shapes real hosts use, shallow enough that a
+/// whole-home walk stays bounded on a machine with a large source tree.
+const MAX_SCAN_DEPTH: usize = 8;
+
+/// What one discovery pass found, split by what the refresh can actually do
+/// with each entry.
+#[derive(Debug, Default)]
+struct ProjectDiscovery {
+    /// Every project the refresh will process: the host registry plus every
+    /// scan-discovered directory that actually holds a store.
+    projects: Vec<PathBuf>,
+    /// The subset of `projects` that the filesystem scan found but the host
+    /// registry does not know about. These are refreshed and then registered,
+    /// so discovery converges without the operator doing anything.
+    unregistered: BTreeSet<PathBuf>,
+    /// Scan-discovered directories carrying a `.cas/` but no `cas.db`. There
+    /// is nothing to migrate, so they are reported rather than refreshed —
+    /// previously they were silently absent from the receipt entirely.
+    skipped_unregistered: Vec<PathBuf>,
+}
+
+/// The host's user-level store (`~/.cas`). It is never a project — it gets its
+/// own refresh phase — but it must be named, because before cas-9d5c it was
+/// neither refreshed nor mentioned.
+fn user_level_store_root() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| canonical_path(&home.join(".cas")))
+}
+
+/// Discovery is the union of the host's known-repo registry and a bounded
+/// filesystem scan. The scan is not a fallback for binary-only machines: the
+/// registry only holds repos some Cassy entry point happened to touch, so a
+/// project cloned and initialized by hand is invisible to it forever.
+///
+/// The scan must keep descending after it records a project. `~/.cas` exists on
+/// every host that has ever run Cassy, and the previous early return meant the
+/// walk recorded `$HOME`, stopped, and then dropped `$HOME` as host state — a
+/// scan that structurally could not discover anything (cas-9d5c). The same
+/// early return also hid every project nested under a parent that is itself a
+/// project, which is the normal monorepo-of-repos layout.
+fn discover_local_projects(current_cas_root: Option<&Path>) -> ProjectDiscovery {
+    let mut registered = BTreeSet::new();
     if let Ok(known) = crate::worktree::discovery::list_tracked_repos() {
         for repo in known.into_iter().filter(|repo| repo.healthy) {
-            projects.insert(canonical_path(&repo.path));
+            registered.insert(canonical_path(&repo.path));
         }
     }
 
@@ -1229,13 +1405,34 @@ fn discover_local_projects(current_cas_root: Option<&Path>) -> Vec<PathBuf> {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_else(|| dirs::home_dir().into_iter().collect());
+    let mut scanned = BTreeSet::new();
     for root in roots {
-        scan_for_projects(&root, &mut projects);
+        scan_for_projects(&root, MAX_SCAN_DEPTH, &mut scanned);
     }
-    // The user-level store (~/.cas) is never a project: a cwd under the home
-    // directory but outside any project walks up to it, and without this
-    // guard `cas update --all-projects` lists the home directory itself.
-    let user_level_root = dirs::home_dir().map(|home| canonical_path(&home.join(".cas")));
+
+    let user_level_root = user_level_store_root();
+    let home = dirs::home_dir().map(|home| canonical_path(&home));
+
+    let mut projects = registered.clone();
+    let mut unregistered = BTreeSet::new();
+    let mut skipped_unregistered = Vec::new();
+    for candidate in scanned {
+        if Some(&candidate) == home.as_ref() {
+            continue;
+        }
+        if registered.contains(&candidate) {
+            continue;
+        }
+        if candidate.join(".cas").join("cas.db").is_file() {
+            projects.insert(candidate.clone());
+            unregistered.insert(candidate);
+        } else {
+            skipped_unregistered.push(candidate);
+        }
+    }
+
+    // The store the operator is standing in always counts, even if neither the
+    // registry nor the scan roots cover it.
     if let Some(cas_root) = current_cas_root
         && let Some(project) = cas_root.parent()
         && user_level_root.as_deref() != Some(canonical_path(cas_root).as_path())
@@ -1243,21 +1440,37 @@ fn discover_local_projects(current_cas_root: Option<&Path>) -> Vec<PathBuf> {
         projects.insert(canonical_path(project));
     }
 
-    // `~/.cas` is host state, not a project. The legacy helper made the same
-    // distinction and migrated it separately.
-    if let Some(home) = dirs::home_dir() {
-        projects.remove(&canonical_path(&home));
+    // `~/.cas` is host state, not a project: it is migrated by its own
+    // user-level phase so it can never be counted in the project totals.
+    if let Some(home) = home {
+        projects.remove(&home);
+        unregistered.remove(&home);
     }
-    projects.into_iter().collect()
+
+    ProjectDiscovery {
+        projects: projects.into_iter().collect(),
+        unregistered,
+        skipped_unregistered,
+    }
 }
 
 fn canonical_path(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
-fn scan_for_projects(root: &Path, projects: &mut BTreeSet<PathBuf>) {
+/// Record `root` when it carries a `.cas/`, then keep walking its children.
+///
+/// Never descends into a `.cas/` directory itself: factory worktrees
+/// (`.cas/worktrees/<lane>`) and migration backups (`.cas/backup/<stamp>`) both
+/// contain a `cas.db` and are emphatically not separate projects. Hidden
+/// directories are skipped for the same reason plus cost — `~/.cargo`,
+/// `~/.rustup`, and `~/.claude` are large and hold no projects, and anything
+/// genuinely living under one is reachable through the host registry.
+fn scan_for_projects(root: &Path, depth: usize, projects: &mut BTreeSet<PathBuf>) {
     if root.join(".cas").is_dir() {
         projects.insert(canonical_path(root));
+    }
+    if depth == 0 {
         return;
     }
     let Ok(entries) = std::fs::read_dir(root) else {
@@ -1271,28 +1484,26 @@ fn scan_for_projects(root: &Path, projects: &mut BTreeSet<PathBuf>) {
         if !metadata.is_dir() || metadata.is_symlink() {
             continue;
         }
+        let name = path.file_name().and_then(|name| name.to_str());
+        if name.is_none_or(|name| name.starts_with('.')) {
+            continue;
+        }
         if matches!(
-            path.file_name().and_then(|name| name.to_str()),
+            name,
             Some(
                 "node_modules"
                     | "target"
-                    | ".git"
-                    | ".cargo"
-                    | ".cache"
-                    | ".npm"
-                    | ".rustup"
-                    | ".pnpm-store"
-                    | ".venv"
                     | "venv"
                     | "dist"
                     | "build"
-                    | ".next"
-                    | ".turbo"
+                    | "vendor"
+                    | "Library"
+                    | "snap"
             )
         ) {
             continue;
         }
-        scan_for_projects(&path, projects);
+        scan_for_projects(&path, depth - 1, projects);
     }
 }
 
@@ -1809,6 +2020,20 @@ fn sync_user_builtins(cli: &Cli) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Prefix every `schema_status` receipt with the store it actually migrated.
+///
+/// Without this a `CAS_ROOT` override, a user-level phase, and a project phase
+/// all emit byte-identical lines, so an operator reading the receipt cannot
+/// tell which store moved — the exact ambiguity behind the "says applied but
+/// didn't" report in cas-9d5c.
+fn schema_status_json(store: Option<&Path>, body: &str) -> String {
+    let store = match store {
+        Some(path) => serde_json::Value::String(path.display().to_string()),
+        None => serde_json::Value::Null,
+    };
+    format!(r#"{{"store":{store},{body}}}"#)
+}
+
 /// Run schema migrations only
 fn run_schema_migrations(
     args: &UpdateArgs,
@@ -1820,7 +2045,13 @@ fn run_schema_migrations(
         Some(path) => path.to_path_buf(),
         None => {
             if cli.json {
-                println!(r#"{{"schema_status":"not_initialized","migrations_applied":0}}"#);
+                println!(
+                    "{}",
+                    schema_status_json(
+                        None,
+                        r#""schema_status":"not_initialized","migrations_applied":0"#
+                    )
+                );
             } else {
                 let mut out = io::stdout();
                 let theme = ActiveTheme::default();
@@ -1850,7 +2081,13 @@ fn run_schema_migrations(
             .unwrap_or(0);
         if table_count < 3 {
             if cli.json {
-                println!(r#"{{"schema_status":"not_initialized","migrations_applied":0}}"#);
+                println!(
+                    "{}",
+                    schema_status_json(
+                        Some(&cas_root),
+                        r#""schema_status":"not_initialized","migrations_applied":0"#
+                    )
+                );
             } else {
                 let mut out = io::stdout();
                 let theme = ActiveTheme::default();
@@ -1879,14 +2116,24 @@ fn run_schema_migrations(
     if !tx.has_changes() {
         if cli.json {
             println!(
-                r#"{{"schema_status":"up_to_date","current_version":{},"migrations_applied":0}}"#,
-                status.current_version
+                "{}",
+                schema_status_json(
+                    Some(&cas_root),
+                    &format!(
+                        r#""schema_status":"up_to_date","current_version":{},"migrations_applied":0"#,
+                        status.current_version
+                    )
+                )
             );
         } else {
             let mut out = io::stdout();
             let theme = ActiveTheme::default();
             let mut fmt = Formatter::stdout(&mut out, theme);
-            fmt.success(&format!("Schema up to date (v{})", status.current_version))?;
+            fmt.success(&format!(
+                "Schema up to date (v{}) — {}",
+                status.current_version,
+                cas_root.display()
+            ))?;
         }
         return Ok(());
     }
@@ -1997,11 +2244,17 @@ fn run_schema_migrations(
             .collect();
 
         println!(
-            r#"{{"schema_status":"updated","current_version":{},"migrations_applied":{},"applied":[{}],"files_updated":{}}}"#,
-            final_status.current_version,
-            result.applied_count,
-            applied_json.join(","),
-            tx.file_change_count()
+            "{}",
+            schema_status_json(
+                Some(&cas_root),
+                &format!(
+                    r#""schema_status":"updated","current_version":{},"migrations_applied":{},"applied":[{}],"files_updated":{}"#,
+                    final_status.current_version,
+                    result.applied_count,
+                    applied_json.join(","),
+                    tx.file_change_count()
+                )
+            )
         );
     } else {
         let mut out = io::stdout();
@@ -2015,8 +2268,9 @@ fn run_schema_migrations(
 
         fmt.newline()?;
         fmt.success(&format!(
-            "Schema updated to v{}",
-            final_status.current_version
+            "Schema updated to v{} — {}",
+            final_status.current_version,
+            cas_root.display()
         ))?;
 
         if args.keep_backup {

--- a/cas-cli/src/cli/update.rs
+++ b/cas-cli/src/cli/update.rs
@@ -918,8 +918,8 @@ fn refresh_all_projects(
         cli,
     );
 
-    let failed_count =
-        receipts.iter().filter(|receipt| receipt.failed()).count() + usize::from(user_level.failed());
+    let failed_count = receipts.iter().filter(|receipt| receipt.failed()).count()
+        + usize::from(user_level.failed());
     if failed_count > 0 {
         anyhow::bail!(
             "one or more projects were not fully refreshed; see the per-project phase summary above"
@@ -946,7 +946,10 @@ fn refresh_user_level_store(args: &UpdateArgs, cli: &Cli) -> ProjectPhase {
     };
     if !cas_root.join("cas.db").is_file() {
         return match sync_user_builtins(cli) {
-            Ok(()) => ProjectPhase::Ok(format!("builtins only — no store at {}", cas_root.display())),
+            Ok(()) => ProjectPhase::Ok(format!(
+                "builtins only — no store at {}",
+                cas_root.display()
+            )),
             Err(error) => ProjectPhase::Failed(error.to_string()),
         };
     }
@@ -962,7 +965,10 @@ fn refresh_user_level_store(args: &UpdateArgs, cli: &Cli) -> ProjectPhase {
         return migration;
     }
     match sync_user_builtins(cli) {
-        Ok(()) => ProjectPhase::Ok(format!("migrated {} and synced builtins", cas_root.display())),
+        Ok(()) => ProjectPhase::Ok(format!(
+            "migrated {} and synced builtins",
+            cas_root.display()
+        )),
         Err(error) => ProjectPhase::Failed(error.to_string()),
     }
 }

--- a/cas-cli/src/cli/update_tests/tests.rs
+++ b/cas-cli/src/cli/update_tests/tests.rs
@@ -279,7 +279,10 @@ fn discovery_does_not_descend_into_cas_internal_directories() {
         discovery.projects
     );
     assert!(
-        !discovery.projects.iter().any(|path| path.starts_with(&backup)),
+        !discovery
+            .projects
+            .iter()
+            .any(|path| path.starts_with(&backup)),
         "migration backups under .cas/ are not projects: {:?}",
         discovery.projects
     );

--- a/cas-cli/src/cli/update_tests/tests.rs
+++ b/cas-cli/src/cli/update_tests/tests.rs
@@ -22,6 +22,7 @@ fn test_is_newer() {
 fn project_table_plain_uses_phase_glyphs_and_compact_project_names() {
     let receipts = vec![ProjectRefreshReceipt {
         project: PathBuf::from("/home/alice/projects/demo"),
+        unregistered: false,
         migration: ProjectPhase::Ok("v248".to_owned()),
         search_index: ProjectPhase::Warning("busy".to_owned()),
         skills: ProjectPhase::Skipped("not installed".to_owned()),
@@ -52,6 +53,7 @@ fn project_table_phase_headers_are_not_truncated_at_supported_widths() {
         project: PathBuf::from(
             "/home/alice/projects/a-project-with-a-deliberately-long-name/another-project",
         ),
+        unregistered: false,
         migration: ProjectPhase::Ok("v248".to_owned()),
         search_index: ProjectPhase::Ok("up to date".to_owned()),
         skills: ProjectPhase::Ok("up to date".to_owned()),
@@ -85,6 +87,7 @@ fn project_table_phase_headers_are_not_truncated_at_supported_widths() {
 fn non_ok_phase_details_include_phase_summary_when_capture_is_empty() {
     let receipt = ProjectRefreshReceipt {
         project: PathBuf::from("/home/alice/projects/demo"),
+        unregistered: false,
         migration: ProjectPhase::Ok("v248".to_owned()),
         search_index: ProjectPhase::Ok("up to date".to_owned()),
         skills: ProjectPhase::Ok("up to date".to_owned()),
@@ -113,6 +116,7 @@ fn non_ok_phase_details_include_phase_summary_when_capture_is_empty() {
 fn cloud_warning_summary_stays_under_the_non_ok_project_row() {
     let receipt = ProjectRefreshReceipt {
         project: PathBuf::from("/home/alice/projects/demo"),
+        unregistered: false,
         migration: ProjectPhase::Ok("v248".to_owned()),
         search_index: ProjectPhase::Ok("up to date".to_owned()),
         skills: ProjectPhase::Ok("up to date".to_owned()),

--- a/cas-cli/src/cli/update_tests/tests.rs
+++ b/cas-cli/src/cli/update_tests/tests.rs
@@ -194,6 +194,186 @@ fn capture_phase_collects_both_stdout_and_stderr() {
     assert!(output.contains("captured stderr"), "output was: {output:?}");
 }
 
+/// Create a directory that looks exactly like an initialized Cassy project:
+/// a `.cas/` directory holding a `cas.db` file.
+fn make_project(root: &Path) {
+    let cas_root = root.join(".cas");
+    std::fs::create_dir_all(&cas_root).expect("create fixture .cas directory");
+    std::fs::write(cas_root.join("cas.db"), b"").expect("create fixture store");
+}
+
+#[test]
+fn discovery_finds_sibling_projects_below_a_parent_that_is_itself_a_project() {
+    // The regression: `~/.cas` exists on every real host, and the scan used to
+    // stop at the first ancestor carrying a `.cas` directory. That made the
+    // filesystem walk a no-op — home was recorded, the walk returned, and home
+    // was then dropped as "not a project", so nothing was ever discovered.
+    let guard = crate::test_env_guard::TestEnvGuard::temp_home();
+    let home = guard.home().to_path_buf();
+    let workspace = home.join("Workspace");
+    make_project(&workspace);
+    make_project(&workspace.join("alpha"));
+    make_project(&workspace.join("beta"));
+    make_project(&workspace.join("nested").join("deep"));
+
+    let discovery = discover_local_projects(None);
+
+    for expected in [
+        workspace.clone(),
+        workspace.join("alpha"),
+        workspace.join("beta"),
+        workspace.join("nested").join("deep"),
+    ] {
+        assert!(
+            discovery.projects.contains(&expected),
+            "{} missing from discovery: {:?}",
+            expected.display(),
+            discovery.projects
+        );
+    }
+    assert!(
+        !discovery.projects.contains(&home),
+        "the home directory is host state, not a project: {:?}",
+        discovery.projects
+    );
+}
+
+#[test]
+fn discovery_never_returns_the_user_level_store_as_a_project() {
+    let guard = crate::test_env_guard::TestEnvGuard::temp_home();
+    let home = guard.home().to_path_buf();
+    make_project(&home.join("Workspace"));
+
+    let discovery = discover_local_projects(Some(&home.join(".cas")));
+
+    assert_eq!(user_level_store_root(), Some(home.join(".cas")));
+    assert!(
+        !discovery.projects.contains(&home),
+        "the user-level store must never be counted as a project: {:?}",
+        discovery.projects
+    );
+}
+
+#[test]
+fn discovery_does_not_descend_into_cas_internal_directories() {
+    let guard = crate::test_env_guard::TestEnvGuard::temp_home();
+    let home = guard.home().to_path_buf();
+    let project = home.join("Workspace").join("demo");
+    make_project(&project);
+    let worktree = project.join(".cas").join("worktrees").join("lane-1");
+    make_project(&worktree);
+    let backup = project.join(".cas").join("backup").join("20260904_000000");
+    std::fs::create_dir_all(&backup).expect("create fixture backup");
+    std::fs::write(backup.join("cas.db"), b"").expect("create fixture backup store");
+
+    let discovery = discover_local_projects(None);
+
+    assert!(discovery.projects.contains(&project));
+    assert!(
+        !discovery.projects.contains(&worktree),
+        "factory worktrees under .cas/ are not separate projects: {:?}",
+        discovery.projects
+    );
+    assert!(
+        !discovery.projects.iter().any(|path| path.starts_with(&backup)),
+        "migration backups under .cas/ are not projects: {:?}",
+        discovery.projects
+    );
+}
+
+#[test]
+fn discovery_separates_registered_projects_from_scan_only_and_storeless_ones() {
+    let guard = crate::test_env_guard::TestEnvGuard::temp_home();
+    let home = guard.home().to_path_buf();
+    let workspace = home.join("Workspace");
+    let with_store = workspace.join("with-store");
+    make_project(&with_store);
+    let storeless = workspace.join("storeless");
+    std::fs::create_dir_all(storeless.join(".cas")).expect("create storeless fixture");
+
+    let discovery = discover_local_projects(None);
+
+    assert!(
+        discovery.unregistered.contains(&with_store),
+        "a project found only by the filesystem scan is unregistered: {:?}",
+        discovery.unregistered
+    );
+    assert!(
+        discovery.skipped_unregistered.contains(&storeless),
+        "a scan-only directory with no cas.db must be listed, not silently dropped: {:?}",
+        discovery.skipped_unregistered
+    );
+    assert!(
+        !discovery.projects.contains(&storeless),
+        "a directory with no store has nothing to migrate: {:?}",
+        discovery.projects
+    );
+}
+
+#[test]
+fn schema_status_json_names_the_store_it_migrated() {
+    let line = schema_status_json(
+        Some(Path::new("/home/alice/projects/demo/.cas")),
+        r#""schema_status":"updated","current_version":248"#,
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(&line).expect("schema status is JSON");
+    assert_eq!(parsed["store"], "/home/alice/projects/demo/.cas");
+    assert_eq!(parsed["schema_status"], "updated");
+    assert_eq!(parsed["current_version"], 248);
+
+    let unset = schema_status_json(None, r#""schema_status":"not_initialized""#);
+    let parsed: serde_json::Value = serde_json::from_str(&unset).expect("schema status is JSON");
+    assert!(parsed["store"].is_null(), "line was: {unset}");
+}
+
+#[test]
+fn update_banner_reports_projects_failures_and_skipped_unregistered_stores() {
+    let banner = update_banner_text(&RefreshReport {
+        project_count: 29,
+        failed_count: 1,
+        skipped_unregistered: 2,
+        elapsed: std::time::Duration::from_secs(3),
+    });
+
+    assert!(banner.contains("29 projects refreshed"), "banner: {banner}");
+    assert!(banner.contains("1 failed"), "banner: {banner}");
+    assert!(
+        banner.contains("2 unregistered store(s) not refreshed"),
+        "banner: {banner}"
+    );
+
+    let clean = update_banner_text(&RefreshReport {
+        project_count: 29,
+        failed_count: 0,
+        skipped_unregistered: 0,
+        elapsed: std::time::Duration::from_secs(3),
+    });
+    assert!(
+        !clean.contains("unregistered"),
+        "a clean run stays quiet: {clean}"
+    );
+}
+
+#[test]
+fn register_flag_parses_and_targets_a_project_path() {
+    let parsed = crate::cli::try_parse_from_with_wordmark([
+        "cas",
+        "update",
+        "--register",
+        "/home/alice/projects/demo",
+    ])
+    .expect("--register must parse");
+
+    let Some(crate::cli::Commands::Update(args)) = parsed.command else {
+        panic!("expected update command");
+    };
+    assert_eq!(
+        args.register.as_deref(),
+        Some(Path::new("/home/alice/projects/demo"))
+    );
+}
+
 #[test]
 fn post_swap_command_targets_install_destination_path() {
     let install_destination = Path::new("/usr/local/bin/cas");
@@ -274,6 +454,7 @@ fn post_swap_mode_is_a_terminal_update_path() {
         dry_run: false,
         keep_backup: false,
         all_projects: false,
+        register: None,
         post_swap: true,
         from: Some("3.7.7".to_owned()),
     };

--- a/cas-cli/src/history/changelog.rs
+++ b/cas-cli/src/history/changelog.rs
@@ -279,7 +279,7 @@ pub fn changelog_path(repo_root: &Path) -> Option<std::path::PathBuf> {
 /// boundary, not swallowed and not raised as a failure.
 ///
 /// The file is read as bytes and decoded through
-/// [`crate::daemon::source_text::decode_source`] rather than demanding UTF-8
+/// `crate::daemon::source_text::decode_source` rather than demanding UTF-8
 /// up front (GH #698, extended by cas-c736). A CHANGELOG that has been through
 /// a Windows editor is commonly UTF-16 or UTF-8-with-BOM; `read_to_string`
 /// failed the whole changelog pass on the first with an encoding message that

--- a/cas-cli/src/history/changelog.rs
+++ b/cas-cli/src/history/changelog.rs
@@ -277,12 +277,28 @@ pub fn changelog_path(repo_root: &Path) -> Option<std::path::PathBuf> {
 ///
 /// `Ok(None)` means there is no CHANGELOG — reported by the caller as a
 /// boundary, not swallowed and not raised as a failure.
+///
+/// The file is read as bytes and decoded through
+/// [`crate::daemon::source_text::decode_source`] rather than demanding UTF-8
+/// up front (GH #698, extended by cas-c736). A CHANGELOG that has been through
+/// a Windows editor is commonly UTF-16 or UTF-8-with-BOM; `read_to_string`
+/// failed the whole changelog pass on the first with an encoding message that
+/// named no remedy, and silently glued the BOM onto the second's first heading
+/// so its opening release parsed as prose. A file we genuinely cannot decode is
+/// reported by name and reason, which the caller records as the pass's
+/// `changelog_error`.
 pub fn collect(repo_root: &Path, repository: &str) -> Result<Option<Vec<HistoryDoc>>> {
     let Some(path) = changelog_path(repo_root) else {
         return Ok(None);
     };
-    let text = std::fs::read_to_string(&path)
-        .with_context(|| format!("reading {}", path.display()))?;
+    let bytes = std::fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+    let text = crate::daemon::source_text::decode_source(&bytes).map_err(|reason| {
+        anyhow::anyhow!(
+            "skipped {}: {}",
+            path.display(),
+            reason.as_str()
+        )
+    })?;
     let tags = repo_tags(repo_root);
     let resolved = resolve_ranges(parse_sections(&text), &tags);
     Ok(Some(
@@ -427,13 +443,104 @@ Oldest section.
         assert!(collect(dir.path(), "/repo").unwrap().is_none());
     }
 
+    /// cas-c736: encoding fixtures for the read site itself.
+    ///
+    /// `SAMPLE` is re-encoded rather than hand-written per case so the assertion
+    /// is about the decode, not about a second copy of the changelog grammar.
+    fn write_changelog(dir: &Path, bytes: &[u8]) {
+        std::fs::write(dir.join("CHANGELOG.md"), bytes).unwrap();
+    }
+
+    fn utf16_bytes(text: &str, little_endian: bool) -> Vec<u8> {
+        let mut bytes = if little_endian {
+            vec![0xFF, 0xFE]
+        } else {
+            vec![0xFE, 0xFF]
+        };
+        for unit in text.encode_utf16() {
+            bytes.extend_from_slice(&if little_endian {
+                unit.to_le_bytes()
+            } else {
+                unit.to_be_bytes()
+            });
+        }
+        bytes
+    }
+
+    fn collected_versions(dir: &Path) -> Vec<String> {
+        collect(dir, "/repo")
+            .expect("a decodable changelog must not fail the pass")
+            .expect("CHANGELOG.md is present")
+            .iter()
+            .map(|doc| doc.id.clone())
+            .collect()
+    }
+
+    #[test]
+    fn a_utf16_le_changelog_is_decoded_rather_than_failing_the_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        write_changelog(dir.path(), &utf16_bytes(SAMPLE, true));
+        let ids = collected_versions(dir.path());
+        assert!(
+            ids.contains(&"changelog:v2.51.0".to_string()),
+            "UTF-16 LE changelog did not parse: {ids:?}"
+        );
+        assert_eq!(ids.len(), 4, "every release section must survive the decode");
+    }
+
+    #[test]
+    fn a_utf16_be_changelog_is_decoded_rather_than_failing_the_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        write_changelog(dir.path(), &utf16_bytes(SAMPLE, false));
+        let ids = collected_versions(dir.path());
+        assert!(
+            ids.contains(&"changelog:v2.49.0".to_string()),
+            "UTF-16 BE changelog did not parse: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn a_utf8_bom_does_not_swallow_the_changelogs_first_heading() {
+        // The quiet half: with the BOM left on, a file whose FIRST line is a
+        // release heading has that heading read as "\u{feff}## [1.0.0] ..." and
+        // the whole release is lost. Start the fixture at the heading so the
+        // difference is visible rather than hidden behind a preamble.
+        let dir = tempfile::tempdir().unwrap();
+        let mut bytes = vec![0xEF, 0xBB, 0xBF];
+        bytes.extend_from_slice(b"## [1.0.0] - 2026-01-01\n\n### Added\n- first release\n");
+        write_changelog(dir.path(), &bytes);
+        let ids = collected_versions(dir.path());
+        assert_eq!(ids, vec!["changelog:v1.0.0".to_string()]);
+    }
+
+    #[test]
+    fn an_undecodable_changelog_is_named_with_its_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        // A UTF-16 BOM followed by an odd byte count: decodable by no rule we
+        // are willing to guess at.
+        let mut bytes = utf16_bytes("## [1.0.0] - 2026-01-01\n", true);
+        bytes.push(0x41);
+        write_changelog(dir.path(), &bytes);
+        let error = collect(dir.path(), "/repo")
+            .expect_err("an undecodable changelog must be reported, not silently empty")
+            .to_string();
+        assert!(
+            error.contains("CHANGELOG.md") && error.contains("odd byte count"),
+            "the failure must name the file and the reason, got: {error}"
+        );
+    }
+
     /// The real file on this repository, parsed end to end.
     #[test]
     fn parses_this_repositorys_own_changelog() {
         let root = crate::test_paths::workspace_root();
-        let Ok(text) = std::fs::read_to_string(root.join("CHANGELOG.md")) else {
+        let Ok(bytes) = std::fs::read(root.join("CHANGELOG.md")) else {
             return; // not a source checkout; nothing to assert against
         };
+        // Decoded the same way `collect` does, so this test cannot pass on a
+        // path the production reader would refuse.
+        let text = crate::daemon::source_text::decode_source(&bytes)
+            .expect("this repository's own CHANGELOG must decode");
         let sections = parse_sections(&text);
         assert!(
             sections.len() > 20,

--- a/cas-cli/src/knowledge/mod.rs
+++ b/cas-cli/src/knowledge/mod.rs
@@ -24,7 +24,10 @@ pub use llm::{ClaudeCliRunner, LlmError, LlmRunner, ScriptedLlm};
 pub use merge::{MergeTier, StripOutcome};
 pub use pipeline::{DistillConfig, DistillReport, run_distillation, run_distillation_with_timeout};
 pub(crate) use pipeline::run_distillation_until;
-pub use sources::{LoadedSource, SourceKind, SymbolLite, collect_file_sources};
+pub use sources::{
+    LoadedSource, SkippedSource, SourceKind, SourceScan, SymbolLite, collect_file_sources,
+    scan_file_sources,
+};
 
 /// Environment gate for automatic distillation inside the daemon.
 ///
@@ -53,9 +56,21 @@ pub fn parse_auto_distill(value: &str) -> bool {
 /// `symbols` is passed in rather than fetched so the collector stays pure and
 /// the caller decides how many symbols it is willing to load.
 pub fn collect_sources(project_root: &Path, symbols: &[SymbolLite]) -> Vec<LoadedSource> {
-    let mut all = collect_file_sources(project_root);
-    all.extend(sources::build_module_sources(symbols, project_root));
-    all
+    scan_sources(project_root, symbols).sources
+}
+
+/// [`collect_sources`] plus the files it could not decode, named.
+///
+/// Callers that print or log a pass report should use this one: a source that
+/// silently drops out produces a wiki with a hole in it and no explanation
+/// (cas-c736). Synthesized `code://` module sources can never be skipped —
+/// they are built from already-indexed symbols, not re-read from disk — so the
+/// skip list is exactly the file walk's.
+pub fn scan_sources(project_root: &Path, symbols: &[SymbolLite]) -> SourceScan {
+    let mut scan = scan_file_sources(project_root);
+    scan.sources
+        .extend(sources::build_module_sources(symbols, project_root));
+    scan
 }
 
 #[cfg(test)]

--- a/cas-cli/src/knowledge/sources.rs
+++ b/cas-cli/src/knowledge/sources.rs
@@ -156,11 +156,48 @@ pub fn classify_path(rel_path: &str) -> Option<SourceKind> {
     }
 }
 
+/// A distillable file the collector could not turn into text, with the reason.
+///
+/// cas-c736: these used to vanish. A UTF-16 `README.md` was dropped by a bare
+/// `let Ok(...) else { continue }`, so the wiki simply had no page for it and
+/// no line anywhere said why — the failure mode that is hardest to notice,
+/// because the output looks complete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkippedSource {
+    /// Project-relative path, the same identity a [`LoadedSource`] carries.
+    pub path: String,
+    /// Operator-facing reason, already phrased to stand alone in a report line.
+    pub reason: String,
+}
+
+/// The result of a source walk: what loaded, and what was passed over by name.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SourceScan {
+    pub sources: Vec<LoadedSource>,
+    pub skipped: Vec<SkippedSource>,
+}
+
+impl SourceScan {
+    /// Report lines for the skipped files, ready to append to a pass's notes.
+    pub fn skip_notes(&self) -> Vec<String> {
+        self.skipped
+            .iter()
+            .map(|skip| format!("source skipped: {} ({})", skip.path, skip.reason))
+            .collect()
+    }
+}
+
 /// Walk `project_root` and load every distillable file, sorted by path so a
-/// pass is deterministic. Unreadable, oversized and non-UTF-8 files are skipped
-/// silently — they are inputs, not errors.
-pub fn collect_file_sources(project_root: &Path) -> Vec<LoadedSource> {
+/// pass is deterministic.
+///
+/// Oversized files are skipped by design (a vendored blob is cost without
+/// signal) and stay unreported. Files that cannot be read or decoded are
+/// reported by name in [`SourceScan::skipped`]: they were *meant* to be
+/// distilled, so their absence from the wiki is a fact the pass owes its
+/// operator.
+pub fn scan_file_sources(project_root: &Path) -> SourceScan {
     let mut found: BTreeMap<String, LoadedSource> = BTreeMap::new();
+    let mut skipped: BTreeMap<String, SkippedSource> = BTreeMap::new();
 
     let walker = ignore::WalkBuilder::new(project_root)
         .hidden(false)
@@ -187,8 +224,33 @@ pub fn collect_file_sources(project_root: &Path) -> Vec<LoadedSource> {
         if too_big {
             continue;
         }
-        let Ok(content) = std::fs::read_to_string(entry.path()) else {
-            continue;
+        // Bytes then decode, not `read_to_string`: a BOM-marked UTF-16 doc is
+        // ordinary prose, and a UTF-8 BOM left on the front glues itself to the
+        // first markdown heading the distiller reads (GH #698, cas-c736).
+        let content = match std::fs::read(entry.path()) {
+            Ok(bytes) => match crate::daemon::source_text::decode_source(&bytes) {
+                Ok(content) => content,
+                Err(reason) => {
+                    skipped.insert(
+                        rel_path.clone(),
+                        SkippedSource {
+                            path: rel_path,
+                            reason: reason.as_str().to_string(),
+                        },
+                    );
+                    continue;
+                }
+            },
+            Err(error) => {
+                skipped.insert(
+                    rel_path.clone(),
+                    SkippedSource {
+                        path: rel_path,
+                        reason: error.to_string(),
+                    },
+                );
+                continue;
+            }
         };
         found.insert(
             rel_path.clone(),
@@ -196,7 +258,15 @@ pub fn collect_file_sources(project_root: &Path) -> Vec<LoadedSource> {
         );
     }
 
-    found.into_values().collect()
+    SourceScan {
+        sources: found.into_values().collect(),
+        skipped: skipped.into_values().collect(),
+    }
+}
+
+/// [`scan_file_sources`] for callers that only need the loaded set.
+pub fn collect_file_sources(project_root: &Path) -> Vec<LoadedSource> {
+    scan_file_sources(project_root).sources
 }
 
 /// The slice of an indexed symbol that a module summary needs.
@@ -393,5 +463,79 @@ mod tests {
         let sources = collect_file_sources(root);
         let paths: Vec<&str> = sources.iter().map(|s| s.path.as_str()).collect();
         assert_eq!(paths, vec!["small.md"]);
+    }
+
+    /// cas-c736 encoding fixtures.
+    fn utf16(text: &str, little_endian: bool) -> Vec<u8> {
+        let mut bytes = if little_endian {
+            vec![0xFF, 0xFE]
+        } else {
+            vec![0xFE, 0xFF]
+        };
+        for unit in text.encode_utf16() {
+            bytes.extend_from_slice(&if little_endian {
+                unit.to_le_bytes()
+            } else {
+                unit.to_be_bytes()
+            });
+        }
+        bytes
+    }
+
+    #[test]
+    fn utf16_and_bom_marked_docs_are_loaded_rather_than_dropped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("le.md"), utf16("# Little endian\n", true)).unwrap();
+        std::fs::write(root.join("be.md"), utf16("# Big endian\n", false)).unwrap();
+        let mut bom = vec![0xEF, 0xBB, 0xBF];
+        bom.extend_from_slice(b"# Bom stripped\n");
+        std::fs::write(root.join("bom.md"), bom).unwrap();
+
+        let scan = scan_file_sources(root);
+        let paths: Vec<&str> = scan.sources.iter().map(|s| s.path.as_str()).collect();
+        assert_eq!(paths, vec!["be.md", "bom.md", "le.md"]);
+        assert!(scan.skipped.is_empty(), "{:?}", scan.skipped);
+
+        let by_path = |name: &str| -> String {
+            scan.sources
+                .iter()
+                .find(|s| s.path == name)
+                .expect("source present")
+                .content
+                .clone()
+        };
+        assert_eq!(by_path("le.md"), "# Little endian\n");
+        assert_eq!(by_path("be.md"), "# Big endian\n");
+        // The BOM must be gone, not merely tolerated: left on, the distiller
+        // reads the first heading as "\u{feff}# Bom stripped".
+        assert_eq!(by_path("bom.md"), "# Bom stripped\n");
+    }
+
+    #[test]
+    fn an_undecodable_doc_is_reported_by_name_instead_of_vanishing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("ok.md"), "# Fine").unwrap();
+        // Not UTF-8, no BOM to name another encoding: a latin-1 byte.
+        std::fs::write(root.join("broken.md"), [b'#', b' ', 0xFF, b'\n']).unwrap();
+
+        let scan = scan_file_sources(root);
+        let paths: Vec<&str> = scan.sources.iter().map(|s| s.path.as_str()).collect();
+        assert_eq!(paths, vec!["ok.md"]);
+        assert_eq!(scan.skipped.len(), 1);
+        assert_eq!(scan.skipped[0].path, "broken.md");
+        assert!(
+            scan.skipped[0].reason.contains("not valid UTF-8"),
+            "the skip must carry a reason, got {:?}",
+            scan.skipped[0].reason
+        );
+        assert_eq!(
+            scan.skip_notes(),
+            vec![
+                "source skipped: broken.md (not valid UTF-8 and no BOM identifies its encoding)"
+                    .to_string()
+            ]
+        );
     }
 }

--- a/cas-cli/src/mcp/daemon.rs
+++ b/cas-cli/src/mcp/daemon.rs
@@ -1221,7 +1221,14 @@ impl EmbeddedDaemon {
             // set with no `code://` module sources would cascade-delete every
             // module page the CLI had built (and re-bill them next pass).
             let symbols = crate::cli::knowledge_symbols_with_limit(&cas_root, crate::cli::KNOWLEDGE_MAX_SYMBOLS);
-            let sources = crate::knowledge::collect_sources(&project_root, &symbols.symbols);
+            let scan = crate::knowledge::scan_sources(&project_root, &symbols.symbols);
+            // A source that could not be decoded is named here rather than
+            // dropped: its page will be missing from the wiki either way, and a
+            // silent hole is the one an operator never chases (cas-c736).
+            for note in scan.skip_notes() {
+                tracing::warn!(%note, "Knowledge distillation skipped a source");
+            }
+            let sources = scan.sources;
             let runner = crate::knowledge::ClaudeCliRunner::new(Some(model));
             let config = crate::knowledge::DistillConfig {
                 protected_prefixes: if symbols.truncated {

--- a/cas-cli/src/migration/mod.rs
+++ b/cas-cli/src/migration/mod.rs
@@ -23,7 +23,7 @@ pub use detector::detect_applied_migrations;
 pub use migrations::MIGRATIONS;
 
 use chrono::{DateTime, Utc};
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 use std::path::Path;
 
 use crate::error::CasError;
@@ -318,6 +318,87 @@ fn migration_is_detected(conn: &Connection, migration: &Migration) -> bool {
         .is_some_and(|detected| detected > 0)
 }
 
+/// Repair ledger rows whose name belongs to a different id in the current
+/// registry (cas-d9c7).
+///
+/// A migration renamed or renumbered between builds leaves its old name in the
+/// ledger under the old id. `cas_migrations.name` is UNIQUE, so the new id can
+/// never be recorded: `INSERT OR IGNORE` swallows the conflict, the row count
+/// for the new id stays 0, and the phase dies with "schema was detected but its
+/// ledger row could not be recorded" on every run — gabber-studio sat at 252
+/// with 2 pending indefinitely. The same stale row also fails
+/// `reconcile_recorded_migration`'s identity check once the *old* id belongs to
+/// a different registry migration.
+///
+/// The stale row is logged into `cas_migration_reconciliations` (naming both
+/// ids and preserving its original `applied_at`) and then deleted, which frees
+/// both the name and the id. Everything after that is ordinary machinery: the
+/// renamed migration is recorded when its predicate holds, and whichever
+/// registry migration now owns the vacated id is re-evaluated honestly —
+/// detected means recorded, undetected means applied. Nothing is skipped
+/// because its id happened to be occupied.
+///
+/// Deleting rather than renaming the row to `<name>@legacy-<id>` is deliberate:
+/// `id` is the PRIMARY KEY, so a legacy-named row would keep the old id
+/// occupied under a name no registry migration claims — exactly the state that
+/// trips the identity-mismatch check later. The audit lives in the
+/// reconciliations table, which already records the previous `applied_at`.
+fn reconcile_renamed_ledger_rows(conn: &Connection) -> Result<Vec<String>> {
+    let mut repaired = Vec::new();
+    for migration in MIGRATIONS {
+        let stale: Option<(u32, String)> = conn
+            .query_row(
+                "SELECT id, applied_at FROM cas_migrations WHERE name = ?1 AND id != ?2",
+                params![migration.name, migration.id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        let Some((stale_id, previous_applied_at)) = stale else {
+            continue;
+        };
+
+        let reason = format!(
+            "migration '{name}' moved from ledger id {stale_id} to registry id {current_id}; \
+             stale row retired so both ids can be re-evaluated against the schema",
+            name = migration.name,
+            current_id = migration.id,
+        );
+        conn.execute(
+            "INSERT INTO cas_migration_reconciliations
+                 (migration_id, migration_name, previous_applied_at, reconciled_at, reason)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                migration.id,
+                migration.name,
+                previous_applied_at,
+                Utc::now().to_rfc3339(),
+                reason,
+            ],
+        )?;
+        conn.execute("DELETE FROM cas_migrations WHERE id = ?1", [stale_id])?;
+        repaired.push(reason);
+    }
+    Ok(repaired)
+}
+
+/// Which ledger id currently owns `name`, if any. Used to say *why* a row
+/// could not be recorded instead of reporting a bare failure.
+fn ledger_id_holding_name(conn: &Connection, name: &str) -> Option<u32> {
+    conn.query_row(
+        "SELECT id FROM cas_migrations WHERE name = ?1",
+        [name],
+        |row| row.get::<_, u32>(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+}
+
+/// Records a detected migration. A name held by another ledger id makes this
+/// return `false` rather than repairing: the read paths (`check_migrations`,
+/// `cas update --check`) must report the wedged ledger honestly, and repair
+/// belongs to the write path in `run_migrations`, inside its serialized
+/// transaction (cas-d9c7).
 fn record_detected_migration(conn: &Connection, migration: &Migration) -> Result<bool> {
     conn.execute(
         "INSERT OR IGNORE INTO cas_migrations (id, name, subsystem, applied_at)
@@ -644,7 +725,7 @@ fn apply_migration(conn: &Connection, migration: &Migration) -> Result<()> {
 }
 
 /// Result of running migrations
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct MigrationResult {
     /// Number of migrations applied
     pub applied_count: usize,
@@ -652,6 +733,8 @@ pub struct MigrationResult {
     pub applied_names: Vec<String>,
     /// Any errors encountered (migration name -> error message)
     pub errors: Vec<(String, String)>,
+    /// Ledger rows repaired before the run (human-readable, one per repair).
+    pub reconciliations: Vec<String>,
 }
 
 /// Check if the database has been initialized with base schemas.
@@ -709,8 +792,15 @@ pub fn run_migrations(cas_dir: &Path, dry_run: bool) -> Result<MigrationResult> 
     // ledger and retain stale pending lists before either reaches its first
     // per-migration BEGIN IMMEDIATE.
     conn.execute("BEGIN IMMEDIATE", [])?;
+    let mut reconciliations = Vec::new();
     let status = (|| {
         ensure_migrations_table(&conn)?;
+
+        // cas-d9c7: retire ledger rows whose name now belongs to a different
+        // registry id BEFORE anything reads the ledger, so detection and the
+        // pending list are computed against a ledger that can actually be
+        // written to.
+        reconciliations = reconcile_renamed_ledger_rows(&conn)?;
 
         // Ensure every subsystem's base schema exists before any ALTER
         // migration runs. Fix for cas-bdb9: `cas doctor --fix` previously
@@ -736,13 +826,13 @@ pub fn run_migrations(cas_dir: &Path, dry_run: bool) -> Result<MigrationResult> 
             applied_count: status.pending.len(),
             applied_names: status.pending.iter().map(|m| m.name.to_string()).collect(),
             errors: vec![],
+            reconciliations,
         });
     }
 
     let mut result = MigrationResult {
-        applied_count: 0,
-        applied_names: vec![],
-        errors: vec![],
+        reconciliations,
+        ..Default::default()
     };
 
     for migration in status.pending {
@@ -774,14 +864,13 @@ pub fn run_migrations(cas_dir: &Path, dry_run: bool) -> Result<MigrationResult> 
                 }
                 Err(error) => {
                     conn.execute("ROLLBACK", [])?;
-                    let reason = error.to_string();
+                    // cas-d9c7: one migration's failure must not strand every
+                    // later pending migration. Record it and keep going; the
+                    // collected errors still fail the phase below.
                     result
                         .errors
-                        .push((migration.name.to_string(), reason.clone()));
-                    return Err(CasError::MigrationFailed {
-                        name: migration.name.to_string(),
-                        reason,
-                    });
+                        .push((migration.name.to_string(), error.to_string()));
+                    continue;
                 }
             }
         }
@@ -797,27 +886,33 @@ pub fn run_migrations(cas_dir: &Path, dry_run: bool) -> Result<MigrationResult> 
                     continue;
                 }
                 Ok(false) => {
+                    let holder = ledger_id_holding_name(&conn, migration.name);
                     conn.execute("ROLLBACK", [])?;
-                    let reason =
-                        "schema was detected but its ledger row could not be recorded".to_string();
+                    let reason = match holder {
+                        Some(other_id) => format!(
+                            "schema was detected but its ledger row could not be recorded: \
+                             id {id} is unwritable because ledger id {other_id} still holds the \
+                             name '{name}'",
+                            id = migration.id,
+                            name = migration.name,
+                        ),
+                        None => format!(
+                            "schema was detected but its ledger row for id {id} could not be \
+                             recorded",
+                            id = migration.id,
+                        ),
+                    };
                     result
                         .errors
-                        .push((migration.name.to_string(), reason.clone()));
-                    return Err(CasError::MigrationFailed {
-                        name: migration.name.to_string(),
-                        reason,
-                    });
+                        .push((migration.name.to_string(), reason));
+                    continue;
                 }
                 Err(error) => {
                     conn.execute("ROLLBACK", [])?;
-                    let reason = error.to_string();
                     result
                         .errors
-                        .push((migration.name.to_string(), reason.clone()));
-                    return Err(CasError::MigrationFailed {
-                        name: migration.name.to_string(),
-                        reason,
-                    });
+                        .push((migration.name.to_string(), error.to_string()));
+                    continue;
                 }
             }
         }
@@ -830,19 +925,24 @@ pub fn run_migrations(cas_dir: &Path, dry_run: bool) -> Result<MigrationResult> 
             }
             Err(e) => {
                 conn.execute("ROLLBACK", [])?;
-                let reason = e.to_string();
                 result
                     .errors
-                    .push((migration.name.to_string(), reason.clone()));
-                return Err(CasError::MigrationFailed {
-                    name: migration.name.to_string(),
-                    reason,
-                });
+                    .push((migration.name.to_string(), e.to_string()));
             }
         }
     }
 
     backfill_task_origin_project(&conn, cas_dir)?;
+
+    // Every pending migration got its turn. A failure is still loud — callers
+    // (cas update, doctor --fix, MCP startup, init) treat Err as failure — but
+    // the store keeps whatever progress the other migrations made.
+    if let Some((name, reason)) = result.errors.first() {
+        return Err(CasError::MigrationFailed {
+            name: name.clone(),
+            reason: reason.clone(),
+        });
+    }
 
     Ok(result)
 }
@@ -2321,10 +2421,13 @@ mod tests {
         let cas_dir = project.join(".cas");
         let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
 
-        // m254's table must be absent so the run has real work to apply after
+        // m254's columns must be absent so the run has real work to APPLY after
         // the reconciliation, not just rows to record.
-        conn.execute_batch("DROP TABLE IF EXISTS code_index_skipped_files;")
-            .unwrap();
+        conn.execute_batch(
+            "ALTER TABLE code_index_state DROP COLUMN skipped_files;
+             ALTER TABLE code_index_state DROP COLUMN skipped_detail;",
+        )
+        .unwrap();
         if drop_embedding_error_column {
             // The name matches but the schema is NOT there: the migration must
             // be applied, never assumed from the ledger row.
@@ -2393,6 +2496,10 @@ mod tests {
             Some("code_index_skipped_files"),
             "later pending migrations must still be applied"
         );
+        assert!(
+            cas_store::shared_db::column_exists(&conn, "code_index_state", "skipped_files"),
+            "m254 must have really applied, not just been recorded"
+        );
         assert_eq!(
             conn.query_row(
                 "SELECT COUNT(*) FROM cas_migrations WHERE name = 'history_embedding_error'",
@@ -2448,6 +2555,98 @@ mod tests {
             Some("history_embedding_error")
         );
         assert_eq!(check_migrations(&cas_dir).unwrap().pending_count(), 0);
+    }
+
+    /// cas-d9c7 (2): one migration's failure must not strand the later pending
+    /// ones. m248's `up` is a bare UPDATE, so a store whose predicate is false
+    /// again (a legacy status row reappears) cannot be safely replayed and its
+    /// reconciliation fails by design — while m254 is independent and must
+    /// still land. Before this change the phase returned at the first failure
+    /// and m254 never ran.
+    #[test]
+    fn a_failing_migration_does_not_strand_later_pending_migrations() {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("partial-failure");
+        std::fs::create_dir_all(&project).unwrap();
+        crate::store::init_cas_dir(&project).unwrap();
+        let cas_dir = project.join(".cas");
+
+        {
+            let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
+            // Falsify m248's predicate while its ledger row stays recorded.
+            conn.execute(
+                "INSERT INTO tasks (id, title, status, created_at, updated_at)
+                 VALUES ('cas-legacy', 'legacy row', 'pending_supervisor_review', ?1, ?1)",
+                [Utc::now().to_rfc3339()],
+            )
+            .unwrap();
+            // Make the later, independent migration genuinely pending.
+            conn.execute_batch(
+                "ALTER TABLE code_index_state DROP COLUMN skipped_files;
+                 ALTER TABLE code_index_state DROP COLUMN skipped_detail;",
+            )
+            .unwrap();
+            conn.execute("DELETE FROM cas_migrations WHERE id >= 254", [])
+                .unwrap();
+        }
+
+        let error = run_migrations(&cas_dir, false)
+            .expect_err("an unreplayable migration must still fail the phase");
+        let CasError::MigrationFailed { name, .. } = &error else {
+            panic!("expected MigrationFailed, got {error:?}");
+        };
+        assert_eq!(name, "tasks_retire_pending_supervisor_review", "{error:?}");
+
+        let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
+        assert!(
+            cas_store::shared_db::column_exists(&conn, "code_index_state", "skipped_files"),
+            "the later independent migration must still have been applied"
+        );
+        assert_eq!(
+            ledger_name(&conn, 254).as_deref(),
+            Some("code_index_skipped_files"),
+            "and it must be recorded in the ledger"
+        );
+    }
+
+    /// Opt-in repair harness for a real store (cas-d9c7 verification).
+    ///
+    /// Point `CAS_MIGRATION_REPAIR_STORE` at a directory holding a **copy** of
+    /// a `cas.db` (take it with `sqlite3 <live> ".backup <copy>"`), then run
+    /// `cargo test -p cas --lib migration::tests::repair_store_from_env -- --ignored --nocapture`.
+    /// Never point this at a live store.
+    #[test]
+    #[ignore = "opt-in: requires CAS_MIGRATION_REPAIR_STORE pointing at a store copy"]
+    fn repair_store_from_env() {
+        let Some(dir) = std::env::var_os("CAS_MIGRATION_REPAIR_STORE") else {
+            panic!("set CAS_MIGRATION_REPAIR_STORE to a directory holding a cas.db copy");
+        };
+        let cas_dir = PathBuf::from(dir);
+
+        let before = check_migrations(&cas_dir).expect("read status before");
+        eprintln!(
+            "before: version {} pending {}",
+            before.current_version,
+            before.pending_count()
+        );
+
+        let result = run_migrations(&cas_dir, false).expect("migration phase must complete");
+        for line in &result.reconciliations {
+            eprintln!("reconciled: {line}");
+        }
+        eprintln!(
+            "applied {}: {:?}; errors {:?}",
+            result.applied_count, result.applied_names, result.errors
+        );
+
+        let after = check_migrations(&cas_dir).expect("read status after");
+        eprintln!(
+            "after: version {} pending {}",
+            after.current_version,
+            after.pending_count()
+        );
+        assert_eq!(after.pending_count(), 0, "pending: {:?}", after.pending);
+        assert_eq!(after.current_version, MIGRATIONS.last().unwrap().id);
     }
 
     #[test]

--- a/cas-cli/src/migration/mod.rs
+++ b/cas-cli/src/migration/mod.rs
@@ -2304,6 +2304,152 @@ mod tests {
         });
     }
 
+    // =========================================================================
+    // cas-d9c7: a migration renamed/renumbered in flight leaves its old name in
+    // the ledger under a different id. `cas_migrations.name` is UNIQUE, so the
+    // new id can never be recorded and the phase dies on every run — observed
+    // on gabber-studio, stuck at 252 with 2 pending forever.
+    // =========================================================================
+
+    /// A fully migrated store rewound to the exact gabber-studio ledger shape:
+    /// row 250 carries `history_embedding_error` (the pre-renumber name) while
+    /// the registry has m250=quarantined_rows and m253=history_embedding_error.
+    fn renamed_ledger_fixture(temp: &TempDir, drop_embedding_error_column: bool) -> PathBuf {
+        let project = temp.path().join("renamed-ledger");
+        std::fs::create_dir_all(&project).unwrap();
+        crate::store::init_cas_dir(&project).unwrap();
+        let cas_dir = project.join(".cas");
+        let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
+
+        // m254's table must be absent so the run has real work to apply after
+        // the reconciliation, not just rows to record.
+        conn.execute_batch("DROP TABLE IF EXISTS code_index_skipped_files;")
+            .unwrap();
+        if drop_embedding_error_column {
+            // The name matches but the schema is NOT there: the migration must
+            // be applied, never assumed from the ledger row.
+            conn.execute_batch("ALTER TABLE history_docs DROP COLUMN embedding_error;")
+                .unwrap();
+        }
+
+        conn.execute("DELETE FROM cas_migrations WHERE id >= 250", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO cas_migrations (id, name, subsystem, applied_at)
+             VALUES (250, 'history_embedding_error', 'code', 'DETECTED')",
+            [],
+        )
+        .unwrap();
+        for (id, name, subsystem) in [
+            (251u32, "sync_revisions", "tasks"),
+            (252, "sync_conflicts_add_revisions", "tasks"),
+        ] {
+            conn.execute(
+                "INSERT INTO cas_migrations (id, name, subsystem, applied_at)
+                 VALUES (?1, ?2, ?3, 'DETECTED')",
+                params![id, name, subsystem],
+            )
+            .unwrap();
+        }
+        cas_dir
+    }
+
+    fn ledger_name(conn: &Connection, id: u32) -> Option<String> {
+        conn.query_row(
+            "SELECT name FROM cas_migrations WHERE id = ?1",
+            [id],
+            |row| row.get::<_, String>(0),
+        )
+        .ok()
+    }
+
+    #[test]
+    fn renamed_ledger_row_is_reconciled_and_the_phase_completes() {
+        let temp = TempDir::new().unwrap();
+        let cas_dir = renamed_ledger_fixture(&temp, false);
+
+        // The wedge, before the fix: the phase fails and nothing advances.
+        let result = run_migrations(&cas_dir, false)
+            .expect("a renamed ledger row must not fail the migration phase");
+        assert!(
+            result.errors.is_empty(),
+            "no migration should error: {:?}",
+            result.errors
+        );
+
+        let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
+        assert_eq!(
+            ledger_name(&conn, 250).as_deref(),
+            Some("quarantined_rows"),
+            "id 250 must end up owned by the registry migration that holds it"
+        );
+        assert_eq!(
+            ledger_name(&conn, 253).as_deref(),
+            Some("history_embedding_error"),
+            "the renamed migration must be recorded under its current id"
+        );
+        assert_eq!(
+            ledger_name(&conn, 254).as_deref(),
+            Some("code_index_skipped_files"),
+            "later pending migrations must still be applied"
+        );
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM cas_migrations WHERE name = 'history_embedding_error'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+            1,
+            "the stale row must be gone, not duplicated"
+        );
+
+        let status = check_migrations(&cas_dir).unwrap();
+        assert_eq!(status.pending_count(), 0, "pending: {:?}", status.pending);
+        assert_eq!(
+            status.current_version,
+            MIGRATIONS.last().unwrap().id,
+            "the store must reach the latest schema version"
+        );
+
+        let reconciliation: (i64, String, String) = conn
+            .query_row(
+                "SELECT migration_id, migration_name, reason FROM cas_migration_reconciliations
+                 WHERE migration_name = 'history_embedding_error' ORDER BY id DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("the rename must be recorded as a reconciliation");
+        assert_eq!(reconciliation.0, 253);
+        assert!(
+            reconciliation.2.contains("250") && reconciliation.2.contains("253"),
+            "the reconciliation must name both ids: {}",
+            reconciliation.2
+        );
+
+        let second = run_migrations(&cas_dir, false).expect("repair must be idempotent");
+        assert_eq!(second.applied_count, 0, "second run must be a no-op");
+    }
+
+    #[test]
+    fn ledger_name_match_without_schema_applies_the_migration() {
+        let temp = TempDir::new().unwrap();
+        let cas_dir = renamed_ledger_fixture(&temp, true);
+
+        run_migrations(&cas_dir, false).expect("the phase must complete");
+
+        let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
+        assert!(
+            cas_store::shared_db::column_exists(&conn, "history_docs", "embedding_error"),
+            "a name match with the schema absent must APPLY the migration, not assume it"
+        );
+        assert_eq!(
+            ledger_name(&conn, 253).as_deref(),
+            Some("history_embedding_error")
+        );
+        assert_eq!(check_migrations(&cas_dir).unwrap().pending_count(), 0);
+    }
+
     #[test]
     fn test_failing_migration_rolls_back_cleanly() {
         let temp = TempDir::new().unwrap();

--- a/cas-cli/src/migration/mod.rs
+++ b/cas-cli/src/migration/mod.rs
@@ -938,9 +938,14 @@ pub fn run_migrations(cas_dir: &Path, dry_run: bool) -> Result<MigrationResult> 
     // (cas update, doctor --fix, MCP startup, init) treat Err as failure — but
     // the store keeps whatever progress the other migrations made.
     if let Some((name, reason)) = result.errors.first() {
+        let others = result.errors.len() - 1;
         return Err(CasError::MigrationFailed {
             name: name.clone(),
-            reason: reason.clone(),
+            reason: if others > 0 {
+                format!("{reason} ({others} further migration(s) also failed this run)")
+            } else {
+                reason.clone()
+            },
         });
     }
 
@@ -2550,6 +2555,49 @@ mod tests {
             cas_store::shared_db::column_exists(&conn, "history_docs", "embedding_error"),
             "a name match with the schema absent must APPLY the migration, not assume it"
         );
+        assert_eq!(
+            ledger_name(&conn, 253).as_deref(),
+            Some("history_embedding_error")
+        );
+        assert_eq!(check_migrations(&cas_dir).unwrap().pending_count(), 0);
+    }
+
+    /// Supervisor ruling (4): two registry migrations whose names are swapped
+    /// in the ledger must both resolve in a SINGLE run — neither id can be
+    /// written while the other holds its name.
+    #[test]
+    fn swapped_ledger_names_resolve_in_one_run() {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("swapped-ledger");
+        std::fs::create_dir_all(&project).unwrap();
+        crate::store::init_cas_dir(&project).unwrap();
+        let cas_dir = project.join(".cas");
+
+        {
+            let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
+            conn.execute("DELETE FROM cas_migrations WHERE id IN (250, 253)", [])
+                .unwrap();
+            // 250 holds 253's name and 253 holds 250's.
+            conn.execute(
+                "INSERT INTO cas_migrations (id, name, subsystem, applied_at)
+                 VALUES (250, 'history_embedding_error', 'code', 'DETECTED'),
+                        (253, 'quarantined_rows', 'tasks', 'DETECTED')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let result = run_migrations(&cas_dir, false).expect("one run must untangle both rows");
+        assert!(result.errors.is_empty(), "{:?}", result.errors);
+        assert_eq!(
+            result.reconciliations.len(),
+            2,
+            "both rows must be reported: {:?}",
+            result.reconciliations
+        );
+
+        let conn = Connection::open(cas_dir.join("cas.db")).unwrap();
+        assert_eq!(ledger_name(&conn, 250).as_deref(), Some("quarantined_rows"));
         assert_eq!(
             ledger_name(&conn, 253).as_deref(),
             Some("history_embedding_error")

--- a/cas-cli/tests/update_all_projects_test.rs
+++ b/cas-cli/tests/update_all_projects_test.rs
@@ -199,6 +199,54 @@ fn all_projects_refreshes_nested_projects_and_the_user_level_store() {
     );
 }
 
+/// cas-9d5c: the user-level store must be migrated by the sweep, not merely
+/// mentioned. Before this fix `~/.cas` only received the builtin distribution,
+/// so on the reporting host it sat at schema 248 with 6 pending migrations
+/// while the banner claimed every project was refreshed.
+#[test]
+fn all_projects_runs_migrations_against_the_user_level_store() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    let home = root.join(".test-home");
+    let projects = root.join("projects");
+    let project = projects.join("demo");
+    init_project(root, &project);
+    // Make `$HOME/.cas` a real store rather than the bare known-repo registry.
+    // `cas init` guards the home directory, which is exactly the distinction
+    // this phase exists to honour: the user-level store is host state.
+    std::fs::create_dir_all(&home).unwrap();
+    cas_cmd(root)
+        .current_dir(&home)
+        .args(["init", "--yes", "--allow-non-project"])
+        .assert()
+        .success();
+
+    let update = cas_cmd(root)
+        .current_dir(root)
+        .env("CAS_ROOT", project.join(".cas"))
+        .env("CAS_PROJECT_ROOTS", &projects)
+        .args(["--json", "update", "--all-projects"])
+        .assert()
+        .success();
+    let output = String::from_utf8_lossy(&update.get_output().stdout);
+
+    let user_store = home.join(".cas").to_string_lossy().into_owned();
+    let migrated_user_store = output
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .any(|value| {
+            value.get("schema_status").is_some() && value["store"].as_str() == Some(&user_store)
+        });
+    assert!(
+        migrated_user_store,
+        "no schema_status receipt names the user-level store {user_store}:\n{output}"
+    );
+    assert!(
+        !output.contains(&format!("\"project\":\"{}\"", home.to_string_lossy())),
+        "the home directory must never appear as a project:\n{output}"
+    );
+}
+
 #[test]
 fn all_projects_repairs_stray_search_roots_and_reports_clean_projects() {
     let temp = TempDir::new().unwrap();

--- a/cas-cli/tests/update_all_projects_test.rs
+++ b/cas-cli/tests/update_all_projects_test.rs
@@ -110,6 +110,95 @@ fn all_projects_dry_run_is_non_mutating_then_syncs_every_discovered_project() {
     );
 }
 
+/// cas-9d5c: the sweep used to stop descending at the first directory carrying
+/// a `.cas/`, so a project nested inside another project was invisible, and the
+/// user-level store was never migrated at all — while the banner still reported
+/// a clean run.
+#[test]
+fn all_projects_refreshes_nested_projects_and_the_user_level_store() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+    let projects = root.join("projects");
+    let parent = projects.join("workspace");
+    let nested = parent.join("inner");
+    init_project(root, &parent);
+    init_project(root, &nested);
+    // A `.cas/` with no store: nothing to migrate, so it must be listed rather
+    // than silently dropped from the receipt.
+    std::fs::create_dir_all(projects.join("storeless/.cas")).unwrap();
+
+    let update = cas_cmd(root)
+        .current_dir(root)
+        .env("CAS_ROOT", parent.join(".cas"))
+        .env("CAS_PROJECT_ROOTS", &projects)
+        .args(["update", "--all-projects"])
+        .assert()
+        .success();
+    let output = String::from_utf8_lossy(&update.get_output().stdout);
+
+    assert!(
+        output.contains("workspace/inner"),
+        "a project nested under another project must be refreshed:\n{output}"
+    );
+    assert!(
+        output.contains(&format!(
+            "Cassy {} · 2 projects refreshed · 0 failed · 1 unregistered store(s) not refreshed",
+            env!("CARGO_PKG_VERSION")
+        )),
+        "banner must count the skipped store:\n{output}"
+    );
+    assert!(
+        output.contains("not refreshed (unregistered): 1"),
+        "the storeless directory must be named:\n{output}"
+    );
+    assert!(
+        output.contains("user-level store:"),
+        "the user-level store needs its own reported phase:\n{output}"
+    );
+
+    let json = cas_cmd(root)
+        .current_dir(root)
+        .env("CAS_ROOT", parent.join(".cas"))
+        .env("CAS_PROJECT_ROOTS", &projects)
+        .args(["--json", "update", "--all-projects"])
+        .assert()
+        .success();
+    let json_out = String::from_utf8_lossy(&json.get_output().stdout);
+    let receipt: serde_json::Value = json_out
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find(|value| value.get("projects").is_some())
+        .expect("all-projects JSON receipt");
+
+    let stores = receipt["projects"]
+        .as_array()
+        .expect("projects array")
+        .iter()
+        .map(|project| project["store"].as_str().unwrap_or_default().to_owned())
+        .collect::<Vec<_>>();
+    assert!(
+        stores
+            .iter()
+            .any(|store| store.ends_with("workspace/inner/.cas")),
+        "every project receipt names the store it migrated: {stores:?}"
+    );
+    assert_eq!(
+        receipt["skipped_unregistered"]
+            .as_array()
+            .expect("skipped_unregistered array")
+            .len(),
+        1,
+        "receipt was: {receipt}"
+    );
+    assert_eq!(
+        receipt["user_level_store"]["store"]
+            .as_str()
+            .expect("user-level store path"),
+        root.join(".test-home/.cas").to_string_lossy(),
+        "receipt was: {receipt}"
+    );
+}
+
 #[test]
 fn all_projects_repairs_stray_search_roots_and_reports_clean_projects() {
     let temp = TempDir::new().unwrap();

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.15.1"
+version = "3.15.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.15.1"
+version = "3.15.2"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.15.1"
+version = "3.15.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.15.1"
+version = "3.15.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.15.1"
+version = "3.15.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-09-04-v3.15.2-slack.md
+++ b/docs/release-notes/2026-09-04-v3.15.2-slack.md
@@ -1,0 +1,53 @@
+# Slack draft — Cassy v3.15.2 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Cassy v3.15.2: `cas update` now actually brings every local project up to date — the "migration applied" message no longer lies, and projects the updater never knew about are found and migrated.
+
+**Reply (Was → Now):**
+- Was: a project could stay two migrations behind forever while every update reported it refreshed (the ledger refused to record a migration whose name had moved to a new number); projects not already in the updater's registry were silently skipped, so dozens sat at an old schema while the summary said "N projects refreshed"; the user-level store was never migrated; a UTF-16 CHANGELOG was dropped from the knowledge wiki without a word; the release gate refused to run on a machine with a user-level store unless you exported a variable by hand. Now: the updater repairs the mis-numbered ledger row, records the migration correctly and moves on, reporting exactly which store each line refers to; every directory with a Cassy store is discovered, refreshed and registered, and anything it cannot refresh is named with the command to fix it; the user-level store gets its own refresh line; UTF-16 and BOM-marked docs are read and anything undecodable is named; the release gate picks a safe scratch location on its own.
+- Install: use `cas update` for an existing installation, or download the
+  v3.15.2 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v3.15.2: run_migrations reconciles renamed ledger rows inside the serialized transaction (audit row, delete, re-evaluate) and attempts every pending migration before erroring; discover_local_projects descends past $HOME/.cas and registers what it refreshes, with a user-level store phase, store paths in schema_status and `cas update --register`; source_text BOM decoding at the changelog/knowledge readers; release-gate.sh scratch base defaults to /var/tmp with leak cleanup.
+
+**Reply (Was → Now):**
+- Was: record_detected_migration hit UNIQUE(name) on a row recorded under another id, INSERT OR IGNORE swallowed it, the phase failed and later migrations never ran; scan_for_projects returned at the first `.cas` (i.e. $HOME) so discovery collapsed to known_repos and the summary counted only what it iterated; ~/.cas was excluded from refresh; changelog/knowledge readers used read_to_string; release-gate.sh defaulted its scratch base to $HOME/.cache and leaked a snapshot-portability scratch dir per run. Now: reconcile_renamed_ledger_rows writes cas_migration_reconciliations (both ids, original applied_at) and deletes the stale row; swapped names resolve in one run; failures accumulate and the Err names the first plus a count; read paths (`--check`) stay honest; MigrationResult.reconciliations; scan descends to depth 8 skipping .cas/ and hidden dirs, ProjectDiscovery{projects, unregistered, skipped_unregistered}, register_repo on refresh, refresh_user_level_store phase, JSON receipt gains store/registered/user_level_store/skipped_unregistered; decode_source at history/changelog.rs and knowledge/sources.rs with named skips; scratch_base_default=/var/tmp/cas-release-gate with .cas-ancestor refusal, explicit CAS_RELEASE_GATE_HOME_DIR wins, scratch dirs removed after the run (self-test 19/19).
+- Validation and artifact: {{VALIDATION_SUMMARY}} The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |

--- a/scripts/release-gate.sh
+++ b/scripts/release-gate.sh
@@ -81,6 +81,27 @@ cd "$repo_root"
 
 cargo_bin="${CARGO:-cargo}"
 reference_history_script="${RELEASE_GATE_GEN_REFERENCE_HISTORY:-$repo_root/scripts/gen-builtin-reference-history.sh}"
+
+# Scratch base for the two checks that must build OUTSIDE every checkout
+# (archive-mode, snapshot-portability).
+#
+# The old default was $HOME/.cache/cas-release-gate. On any machine where the
+# operator has a user-level ~/.cas store — which is every machine Cassy is
+# actually installed on — that base has a .cas ancestor, so the gate's own
+# assert_no_cas_ancestor refused those two rows and the release could not be
+# cut until the operator exported CAS_RELEASE_GATE_HOME_DIR by hand. cas-4ccc
+# fixed that for the self-test only; cas-c736 fixes the gate itself, so the
+# variable becomes an override rather than a prerequisite. /var/tmp mirrors the
+# merge-queue runner: outside every checkout and outside $HOME.
+readonly scratch_base_default='/var/tmp/cas-release-gate'
+if [[ -n "${CAS_RELEASE_GATE_HOME_DIR:-}" ]]; then
+    scratch_base="$CAS_RELEASE_GATE_HOME_DIR"
+    scratch_base_origin='CAS_RELEASE_GATE_HOME_DIR'
+else
+    scratch_base="$scratch_base_default"
+    scratch_base_origin='default'
+fi
+readonly scratch_base scratch_base_origin
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/cas-release-gate.XXXXXX")"
 trap 'rm -rf "$tmp_dir"' EXIT
 
@@ -260,12 +281,16 @@ assert_no_cas_ancestor() {
     probe="$(cd "$(dirname "$base")" 2>/dev/null && pwd -P || printf '%s' "$(dirname "$base")")"
     while [[ "$probe" != "/" && -n "$probe" ]]; do
         if [[ -d "$probe/.cas" ]]; then
-            printf 'scratch base %s has a .cas ancestor at %s; set CAS_RELEASE_GATE_HOME_DIR to a path with no .cas ancestor (the queue runner has none)\n' "$base" "$probe/.cas"
+            printf 'scratch base %s (from %s) has a .cas ancestor at %s; set CAS_RELEASE_GATE_HOME_DIR to a path with no .cas ancestor (the queue runner has none)\n' \
+                "$base" "$scratch_base_origin" "$probe/.cas"
             return 1
         fi
         probe="$(dirname "$probe")"
     done
-    [[ -d "/.cas" ]] && { printf 'scratch base %s has a .cas ancestor at /.cas\n' "$base"; return 1; }
+    [[ -d "/.cas" ]] && {
+        printf 'scratch base %s (from %s) has a .cas ancestor at /.cas\n' "$base" "$scratch_base_origin"
+        return 1
+    }
     return 0
 }
 
@@ -284,7 +309,7 @@ make_archive_path() {
 
 check_archive_mode() {
     local archive_base archive_dir archive remap archive_tmp archive_path manifest package_dir status
-    archive_base="${CAS_RELEASE_GATE_HOME_DIR:-${HOME:?}/.cache/cas-release-gate}"
+    archive_base="$scratch_base"
     mkdir -p "$(dirname "$archive_base")"
     assert_no_cas_ancestor "$archive_base" || return 1
     archive_dir="$(mktemp -d "${archive_base}.XXXXXX")"
@@ -346,7 +371,7 @@ check_snapshot_portability() {
     # The deep TMPDIR must live OUTSIDE every checkout: worktrees sit under the
     # main repo's .cas/, so a temp dir inside the tree lets find_cas_root walk
     # up into the real project store and the snapshot captures live data.
-    local deep_base="${CAS_RELEASE_GATE_HOME_DIR:-${HOME:?}/.cache/cas-release-gate}"
+    local deep_base="$scratch_base"
     mkdir -p "$(dirname "$deep_base")"
     assert_no_cas_ancestor "$deep_base" || return 1
     local deep_tmp
@@ -468,6 +493,7 @@ check_working_tree() {
 printf '=== CAS RELEASE GATE RECEIPT ===\n'
 printf 'version: %s\n' "$version"
 printf 'repository: %s\n' "$repo_root"
+printf 'scratch base: %s (from %s)\n' "$scratch_base" "$scratch_base_origin"
 neutralize_ancestor_proxy_config
 
 run_check failure-log \

--- a/scripts/release-gate.sh
+++ b/scripts/release-gate.sh
@@ -374,8 +374,15 @@ check_snapshot_portability() {
     local deep_base="$scratch_base"
     mkdir -p "$(dirname "$deep_base")"
     assert_no_cas_ancestor "$deep_base" || return 1
-    local deep_tmp
-    deep_tmp="$(mktemp -d "${deep_base}.snap.XXXXXX")/$(printf 'deep-temp-path-%.0s' {1..12})"
+    # The scratch root is kept in its own variable so it can be removed: this
+    # row used to leak one <base>.snap.XXXXXX directory per invocation, where
+    # check_archive_mode has always cleaned up after itself. That was survivable
+    # while the base was an opt-in path; now that /var/tmp/cas-release-gate is
+    # the default on every host, an uncleaned run would accumulate there for
+    # everyone, including once per self-test fixture.
+    local deep_root deep_tmp
+    deep_root="$(mktemp -d "${deep_base}.snap.XXXXXX")"
+    deep_tmp="$deep_root/$(printf 'deep-temp-path-%.0s' {1..12})"
     mkdir -p "$deep_tmp"
     # COLUMNS must be absent, rather than merely empty: terminal-width probes
     # commonly distinguish the two states.
@@ -383,6 +390,7 @@ check_snapshot_portability() {
     env -u COLUMNS INSTA_UPDATE=no TMPDIR="$deep_tmp" \
         "$cargo_bin" nextest run -p cas --test component_output_test
     status=$?
+    rm -rf "$deep_root"
     # Never leave insta's pending-snapshot artifacts behind: they would fail
     # the working-tree row of this same gate.
     find . -path ./target -prune -o -name '*.snap.new' -print0 2>/dev/null | xargs -0 rm -f --

--- a/scripts/test-release-gate.sh
+++ b/scripts/test-release-gate.sh
@@ -11,13 +11,15 @@ gate="$script_dir/release-gate.sh"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-# The gate refuses any scratch base with a .cas ancestor, and its own default is
+# The gate refuses any scratch base with a .cas ancestor. Its default used to be
 # $HOME/.cache/cas-release-gate — which on a developer machine sits under the
-# user-level ~/.cas. Unset, this self-test therefore died mid-run on the two
-# rows that build a scratch base, printing no summary and reading as a broken
-# script rather than the host condition it is (cas-4ccc). Default to a base
-# with no .cas above it, matching the queue runner, and let an explicit value
-# win so the variable stays overridable.
+# user-level ~/.cas — so unset, this self-test died mid-run on the two rows that
+# build a scratch base, printing no summary and reading as a broken script
+# rather than the host condition it is (cas-4ccc). cas-c736 moved the same
+# default into release-gate.sh itself, so this line is now belt-and-braces
+# rather than a prerequisite; it is kept so the harness is deterministic even
+# when an operator has the variable exported to somewhere else. The
+# default-scratch-base fixture below deliberately runs with it UNSET.
 : "${CAS_RELEASE_GATE_HOME_DIR:=/var/tmp/cas-release-gate}"
 export CAS_RELEASE_GATE_HOME_DIR
 mkdir -p "$CAS_RELEASE_GATE_HOME_DIR"
@@ -265,6 +267,48 @@ if grep -qF 'FAIL ancestor-proxy-config' <<<"$output"; then
     bad "the repository's own .cas/proxy.toml must not trip the ancestor check"
 else
     ok "the repository's own .cas/proxy.toml is not treated as an ancestor leak"
+fi
+
+# cas-c736. With CAS_RELEASE_GATE_HOME_DIR UNSET the gate must pick its own
+# scratch base rather than $HOME/.cache/cas-release-gate, which has a .cas
+# ancestor on every machine with a user-level store and made archive-mode and
+# snapshot-portability refuse before they ran. This is the fixture that proves
+# the default path is the one taken, so the variable is an override and not a
+# prerequisite for cutting a release.
+run_gate_unset_home() {
+    local repo="$1"
+    (cd "$repo" && \
+      env -u CAS_RELEASE_GATE_HOME_DIR \
+      GATE_FIXTURE_CARGO_LOG="$tmp/cargo.log" \
+      CARGO="$repo/scripts/cargo-stub" \
+      RELEASE_GATE_GEN_REFERENCE_HISTORY="$repo/scripts/gen-builtin-reference-history.sh" \
+      "$repo/scripts/release-gate.sh" 9.8.7)
+}
+
+repo="$(new_fixture default-scratch-base)"
+output="$(run_gate_unset_home "$repo" 2>&1 || true)"
+if grep -qF 'scratch base: /var/tmp/cas-release-gate (from default)' <<<"$output" \
+    && grep -qF 'PASS archive-mode' <<<"$output" \
+    && grep -qF 'PASS snapshot-portability' <<<"$output"; then
+    ok 'an unset CAS_RELEASE_GATE_HOME_DIR takes the gate default, and the scratch rows run'
+else
+    bad "unset CAS_RELEASE_GATE_HOME_DIR did not take the gate default (output: $output)"
+fi
+
+# ...and an explicit value still wins, named in the receipt so a reader can see
+# which base a release was actually gated against.
+override="$tmp/scratch-override"
+mkdir -p "$override"
+repo="$(new_fixture explicit-scratch-base)"
+output="$(cd "$repo" && env CAS_RELEASE_GATE_HOME_DIR="$override/base" \
+    GATE_FIXTURE_CARGO_LOG="$tmp/cargo.log" \
+    CARGO="$repo/scripts/cargo-stub" \
+    RELEASE_GATE_GEN_REFERENCE_HISTORY="$repo/scripts/gen-builtin-reference-history.sh" \
+    "$repo/scripts/release-gate.sh" 9.8.7 2>&1 || true)"
+if grep -qF "scratch base: $override/base (from CAS_RELEASE_GATE_HOME_DIR)" <<<"$output"; then
+    ok 'an explicit CAS_RELEASE_GATE_HOME_DIR still wins over the default'
+else
+    bad "explicit CAS_RELEASE_GATE_HOME_DIR was not honoured (output: $output)"
 fi
 
 repo="$(new_fixture passing)"

--- a/scripts/test-release-gate.sh
+++ b/scripts/test-release-gate.sh
@@ -311,6 +311,25 @@ else
     bad "explicit CAS_RELEASE_GATE_HOME_DIR was not honoured (output: $output)"
 fi
 
+# cas-c736. The gate must not accumulate scratch directories under its base.
+# snapshot-portability leaked one <base>.snap.XXXXXX per invocation where
+# archive-mode has always cleaned up after itself; harmless while the base was
+# opt-in, but the default base is now /var/tmp/cas-release-gate on every host,
+# so every run and every fixture below would pile up there forever.
+scratch_leftovers() {
+    find "$(dirname "$CAS_RELEASE_GATE_HOME_DIR")" -maxdepth 1 \
+        -name "$(basename "$CAS_RELEASE_GATE_HOME_DIR").*" 2>/dev/null | wc -l
+}
+repo="$(new_fixture scratch-cleanup)"
+leftovers_before="$(scratch_leftovers)"
+run_gate "$repo" '' "$repo/scripts/release-gate.sh" 9.8.7 >/dev/null 2>&1 || true
+leftovers_after="$(scratch_leftovers)"
+if [[ "$leftovers_after" -eq "$leftovers_before" ]]; then
+    ok 'a gate run leaves no scratch directory behind under its base'
+else
+    bad "gate run leaked $((leftovers_after - leftovers_before)) scratch dir(s) under $CAS_RELEASE_GATE_HOME_DIR"
+fi
+
 repo="$(new_fixture passing)"
 output="$(run_gate "$repo" '' "$repo/scripts/release-gate.sh" 9.8.7 2>&1)"
 assert_all_pass "$output"


### PR DESCRIPTION
## Release 3.15.2 — migration ledger reconciliation, project discovery, encoding, release gate

Epic cas-4f6f (three children verified and merged). Version 3.15.2; CHANGELOG `## [3.15.2]`.

### Fixed
- **Migration ledger wedge (operator-reported "says applied but doesn't").** A migration recorded under another id by a pre-release build made `record_detected_migration` fail on `UNIQUE(name)` (swallowed by `INSERT OR IGNORE`), the phase failed and later migrations never ran (gabber-studio pinned at 252/254). `run_migrations` now reconciles renamed rows inside its serialized transaction (audit row in `cas_migration_reconciliations`, stale row deleted, migration recorded under its current id, vacated id re-evaluated), attempts every pending migration before reporting the first failure, and names both ids in the error. Read paths stay honest; only `cas update` repairs.
- **Discovery collapse.** `scan_for_projects` returned at the first `.cas` (i.e. `$HOME/.cas`), so filesystem discovery was dead and only `known_repos` were refreshed (dozens of projects left at schema 236 while the summary said "N projects refreshed"). The scan now descends (skipping `.cas/`, hidden and vendored dirs), refreshed projects are registered, unregistered stores are listed, the user-level `~/.cas` store gets its own refresh phase, every schema_status line names its store, and `cas update --register <path>` exists.
- BOM/UTF-16 decoding at the changelog and knowledge readers with named skips.
- `release-gate.sh` scratch base defaults to `/var/tmp/cas-release-gate` (refuses a base with a `.cas` ancestor by name; explicit `CAS_RELEASE_GATE_HOME_DIR` wins) and no longer leaks a scratch dir per snapshot-portability run.

### Validation
- `scripts/release-gate.sh 3.15.2` on the epic tip (receipt in the PR thread). hub-web unchanged; no Commander promotion.
- Live evidence: gabber-studio store copy 252/2 pending → 254/0 with the fix; pixel-hive 236 → 254 via the new discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
