### PR TITLE
Release 3.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.15.6] - 2026-09-04
+
 ### Fixed
 - Updating no longer ends with a false alarm. After the new version installed
   and its post-install work ran correctly, the update still failed with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- Updating no longer ends with a false alarm. After the new version installed
+  and its post-install work ran correctly, the update still failed with a
+  message saying the wrong version had done the work and telling you to run it
+  again. It was reading the build date out of the version line and comparing
+  that to the version number. It now reads the version number itself, and still
+  stops the moment the work really was done by a different version.
+
 ## [3.15.5] - 2026-09-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.15.5"
+version = "3.15.6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.15.5"
+version = "3.15.6"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.15.5"
+version = "3.15.6"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.15.5"
+version = "3.15.6"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.15.5"
+version = "3.15.6"
 dependencies = [
  "anyhow",
  "blake3",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.15.5"
+version = "3.15.6"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.15.5"
+version = "3.15.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/cas-cli/src/cli/update.rs
+++ b/cas-cli/src/cli/update.rs
@@ -2728,10 +2728,44 @@ fn reported_binary_version(binary: &Path) -> Option<String> {
     if !output.status.success() {
         return None;
     }
-    String::from_utf8_lossy(&output.stdout)
-        .split_whitespace()
-        .last()
-        .map(|version| version.trim_start_matches('v').to_string())
+    parse_reported_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// The semver inside a `--version` line, or None when there is none.
+///
+/// Clap prints `cas <semver> (<hash>[-dirty] <date>)`, so the last whitespace
+/// token is the build date (`2026-09-04)`), not a version. Take the first token
+/// that is actually a semver instead, with the optional `v` prefix stripped.
+fn parse_reported_version(output: &str) -> Option<String> {
+    output.split_whitespace().find_map(|token| {
+        let candidate = token.strip_prefix('v').unwrap_or(token);
+        is_semver_token(candidate).then(|| candidate.to_string())
+    })
+}
+
+/// `major.minor.patch` in digits, plus an optional `-pre`/`+build` suffix.
+fn is_semver_token(token: &str) -> bool {
+    let core_end = token.find(['-', '+']).unwrap_or(token.len());
+    let (core, suffix) = token.split_at(core_end);
+
+    let mut parts = core.split('.');
+    let core_is_semver = match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some(major), Some(minor), Some(patch), None) => [major, minor, patch]
+            .iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|b| b.is_ascii_digit())),
+        _ => false,
+    };
+    if !core_is_semver {
+        return false;
+    }
+
+    // A suffix must carry something after its `-`/`+` and stay inside the
+    // characters semver allows, so `3.15.5-` or `3.15.5-(x)` do not pass.
+    suffix.is_empty()
+        || (suffix.len() > 1
+            && suffix[1..]
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-' || b == b'+'))
 }
 
 /// The operator-facing line for a swap whose post-install phases did not run.

--- a/cas-cli/src/cli/update_tests/tests.rs
+++ b/cas-cli/src/cli/update_tests/tests.rs
@@ -600,6 +600,57 @@ fn version_verification_accepts_only_the_installed_version() {
 }
 
 #[test]
+fn reported_version_is_the_semver_not_the_build_date() {
+    // The real shapes `cas --version` prints.
+    assert_eq!(
+        parse_reported_version("cas 3.15.5 (a94b6ac 2026-09-04)\n").as_deref(),
+        Some("3.15.5")
+    );
+    assert_eq!(
+        parse_reported_version("cas 2.27.0 (9b52e17-dirty 2026-07-16)\n").as_deref(),
+        Some("2.27.0")
+    );
+    assert_eq!(parse_reported_version("cas 3.15.5\n").as_deref(), Some("3.15.5"));
+    assert_eq!(parse_reported_version("v3.15.5").as_deref(), Some("3.15.5"));
+    assert_eq!(
+        parse_reported_version("cas 3.16.0-rc.1 (a94b6ac 2026-09-04)").as_deref(),
+        Some("3.16.0-rc.1")
+    );
+
+    // Nothing that is a version means we cannot vouch for the child.
+    assert_eq!(parse_reported_version("cas (a94b6ac 2026-09-04)"), None);
+    assert_eq!(parse_reported_version(""), None);
+    assert_eq!(parse_reported_version("2026-09-04"), None);
+}
+
+#[cfg(unix)]
+#[test]
+fn post_swap_refresh_accepts_the_real_version_line_and_still_rejects_a_stale_binary() {
+    let temp_dir = tempfile::tempdir().expect("create post-swap version test directory");
+
+    // The interactive path asks the installed binary for its version.
+    let installed_binary = temp_dir.path().join("cas-current");
+    write_stub_binary(
+        &installed_binary,
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then \
+         printf 'cas 3.15.5 (a94b6ac 2026-09-04)\\n'; fi\nexit 0\n",
+    );
+    run_post_swap_refresh(&installed_binary, "3.15.4", "3.15.5", false)
+        .expect("a correct refresh under the installed binary must read as converged");
+
+    let stale_binary = temp_dir.path().join("cas-stale");
+    write_stub_binary(
+        &stale_binary,
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then \
+         printf 'cas 3.15.4 (0000000 2026-09-03)\\n'; fi\nexit 0\n",
+    );
+    let error = run_post_swap_refresh(&stale_binary, "3.15.4", "3.15.5", false)
+        .expect_err("a refresh performed by the wrong version must not read as converged");
+    let message = format!("{error:#}");
+    assert!(message.contains("3.15.4") && message.contains("3.15.5"), "{message}");
+}
+
+#[test]
 fn skipped_refresh_receipt_says_the_update_did_not_converge() {
     let receipt = skipped_refresh_receipt(
         "3.15.2",

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.15.5"
+version = "3.15.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.15.5"
+version = "3.15.6"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.15.5"
+version = "3.15.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.15.5"
+version = "3.15.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.15.5"
+version = "3.15.6"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-09-04-v3.15.5-slack.md
+++ b/docs/release-notes/2026-09-04-v3.15.5-slack.md
@@ -2,9 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
-assets and `release-published-receipt.sh --write-draft` has replaced both
-checksum placeholders below.
+**Status:** POSTED 2026-09-04T07:39Z via MechaCassy `mecha_post` (channel `cas-internal`). Published 2026-09-04T07:38:16Z, tag run 33849435019, publish latency 164 s (budget 600). Merge-queue run 33847797659 for PR #712, landed main a94b6ac6. Host updated 3.15.4 → 3.15.5 at 07:42Z: the post-swap refresh ran once, under 3.15.5 (43 projects, 0 failed), but `cas update` exited 1 because its version guard misparsed `cas --version` output (reported "2026-09-04)" instead of 3.15.5) — the install and refresh are correct; the guard is the bug.
 
 ## User thread
 
@@ -14,8 +12,8 @@ Live on production — **User** — Cassy v3.15.5: a worker's merge request now 
 **Reply (Was → Now):**
 - Was: a finished task parked pending a merge could sit unseen for hours because the message saying so was delivered silently; every message to an idle worker arrived twice, once wrapped and once as a bare prompt with nothing marking the repeat, so a worker could act on it twice; a message could interrupt a supervisor's screen just by carrying another supervisor's name, since the name was checked against the roster but anyone sending a message chooses the name it carries; a message that could not interrupt read the same whether it was routine chatter or a stalled request; a supervisor with unread messages found out only by checking. Now: whether a message may interrupt a supervisor depends on who actually sent it, as recorded when the message was written, and a registered worker's merge request interrupts an idle supervisor while ordinary chatter still waits for the next turn; the second copy to a worker is a single line saying a message is waiting and naming it, and the message itself is delivered once; a supervisor whose messages have gone unread past their window is told how many are waiting and who sent the oldest, once, and again only when a different message becomes the oldest; a message that could not interrupt says which of the two reasons applied; and the release train can now tag and publish the landed commit from its own script with the same receipts as the gate and pipeline.
 - Install: use `cas update` for an existing installation, or download the
-  v3.15.5 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
-  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+  v3.15.5 archive for Linux x86_64 (SHA-256 `63891325a046fc03882d0f07737cf249db6635b4867ff3aff747586870b27a82`) or macOS ARM64
+  (SHA-256 `75e6f13e45d4664b33d930fff99f80f691ed3ca8ad3320488f178b58e569d1a9`) from the GitHub release.
 
 ## Dev thread
 
@@ -24,9 +22,9 @@ Live on production — **Dev** — v3.15.5: prompt_queue gains server-stamped or
 
 **Reply (Was → Now):**
 - Was: the wake gate read the caller-settable `prompt_queue.source`, and the peer-supervisor allowance sat in front of the envelope check with `names_a_registered_supervisor(agents, source)` as its only authority, so `--from "<a real supervisor's name>"` obtained a PTY write of arbitrary text; deliver_to_worker_with_idle_nudge wrote the inbox copy and then handed the same text to pty_nudge, which typed it into the pane (one header composed once at queue_and_events.rs:3541, two writes); delivery_stalled_candidates bounced unread messages to their SENDER only; the wake_attempt_detail prefix covered both an ineligible row and an eligible row the pane refused; the publish step was a hand-written wrapper per release. Now: QueueOrigin { RegisteredAgent{agent_id}, Daemon, Unattributed } populated through an explicit Option<&QueueOrigin> on the three inserting enqueue methods (MCP message/interrupt/clear_context stamp the resolved registry row id; lifecycle push, worker-died/orphan recovery, CI-red, worker-attention, spawn and Viktor relays stamp Daemon; `cas factory message` and bridge POST /message reach enqueue/enqueue_with_session which take no origin parameter at all); supervisor_wake_decision requires Daemon + lifecycle/worker-died/spawn/CI/attention envelope (the `lifecycle-wake:` marker is read only on Daemon rows), or a registered Supervisor that is not this pane's echo, or a registered Worker with a CAS-attached <cas-merge-request>; WakeOutcome persisted via WakeDecision::status_detail; one Daemon-stamped supervisor_unread relay per distinct backlog head with wake-eligible rows excluded from the count; pty_nudge(target, source, notification_id) types pointer_wake_payload and registers provenance with the real id; `release-train.sh <version> <worktree> --publish [sha]` tags from a detached worktree at the landed sha with refusals before side effects and release.log/pid/done in the run dir. Local write access to .cas/cas.db remains the trust boundary; no stronger claim is made.
-- Validation and artifact: {{VALIDATION_SUMMARY}} The published archives are
-  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
-  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+- Validation and artifact: The release tree passed the thirteen-row local release gate through the repository's release-train script, the merge-queue validation run for PR #712, and the tag workflow; hub-web is unchanged so no Commander promotion was needed. The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `63891325a046fc03882d0f07737cf249db6635b4867ff3aff747586870b27a82`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `75e6f13e45d4664b33d930fff99f80f691ed3ca8ad3320488f178b58e569d1a9`). Linux and
   macOS are both available from CI, regardless of the tagger's host.
 
 ## Posting sequence
@@ -47,7 +45,7 @@ Channel: `#cas-internal` (`C0B44GUKDK2`).
 
 | Message | UTC timestamp | Permalink |
 | --- | --- | --- |
-| User top-level |  |  |
-| User reply (Was → Now) |  |  |
-| Dev top-level |  |  |
-| Dev reply (Was → Now) |  |  |
+| User top-level | 1788507530.009729 (2026-09-04T07:39Z) | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788507530009729 |
+| User reply (Was → Now) | 1788507544.607549 (2026-09-04T07:39Z) | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788507544607549?thread_ts=1788507530.009729&cid=C0B44GUKDK2 |
+| Dev top-level | 1788507552.326549 (2026-09-04T07:39Z) | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788507552326549 |
+| Dev reply (Was → Now) | 1788507570.940499 (2026-09-04T07:39Z) | https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788507570940499?thread_ts=1788507552.326549&cid=C0B44GUKDK2 |

--- a/docs/release-notes/2026-09-04-v3.15.6-slack.md
+++ b/docs/release-notes/2026-09-04-v3.15.6-slack.md
@@ -1,0 +1,53 @@
+# Slack draft — Cassy v3.15.6 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+Live on production — **User** — Cassy v3.15.6: `cas update` no longer ends with a false alarm telling you to run it again after it already finished the job.
+
+**Reply (Was → Now):**
+- Was: since v3.15.4, an interactive `cas update` installed the new version and ran its post-install refresh correctly, then still exited with an error saying the refresh had been done by the wrong version and that you should run the update again. It was reading the build date out of the version line and comparing that to the version number. Now: it reads the version number itself, reports a converged update with exit code 0 after one refresh pass, and still stops the moment the refresh really was done by a different binary.
+- Install: use `cas update` for an existing installation, or download the
+  v3.15.6 archive for Linux x86_64 (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64
+  (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+
+## Dev thread
+
+**Top-level:**
+Live on production — **Dev** — v3.15.6: reported_binary_version() parses the first semver token of the `cas --version` line instead of `split_whitespace().last()`, which returned the build date and made verify_refresh_binary_version() reject a correct post-swap refresh in the interactive path.
+
+**Reply (Was → Now):**
+- Was: `cas 3.15.5 (a94b6ac 2026-09-04)` reduced to `2026-09-04)`, so the non-JSON branch of run_post_swap_refresh() bailed with "the refresh ran as version … refusing to report a converged update — run `cas update` again" and exit 1 after the child had refreshed every project under the new binary; the JSON path (receipt.refresh_binary_version from CARGO_PKG_VERSION) was unaffected. Now: parse_reported_version() takes the first whitespace token that is a semver after stripping an optional leading `v`; is_semver_token() requires digits-only major.minor.patch and a semver-legal `-pre`/`+build` suffix when one is present; tests cover the release, -dirty, bare, v-prefixed, pre-release, hash-only, empty and bare-date shapes, and the fail-closed case where the reporting binary is a genuinely different version still bails naming both versions.
+- Validation and artifact: {{VALIDATION_SUMMARY}} The published archives are
+  `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and
+  `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`). Linux and
+  macOS are both available from CI, regardless of the tagger's host.
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing with
+   `scripts/release-train.sh 3.15.6 <epic-worktree> --publish`. A bare
+   `release.sh` is a local audit and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |


### PR DESCRIPTION
Release v3.15.6 — hotfix epic cas-2296.

## [3.15.6] - 2026-09-04

### Fixed
- Updating no longer ends with a false alarm. After the new version installed
  and its post-install work ran correctly, the update still failed with a
  message saying the wrong version had done the work and telling you to run it
  again. It was reading the build date out of the version line and comparing
  that to the version number. It now reads the version number itself, and still
  stops the moment the work really was done by a different version.


Gate receipt: release-train.sh 3.15.6 (gate.log in the run directory), all rows PASS on the source tip.
