### PR TITLE
fix(ci): repair published install proof and record v3.16.0 release receipts

### DIFF
--- a/.github/workflows/install-path-proof.yml
+++ b/.github/workflows/install-path-proof.yml
@@ -108,7 +108,7 @@ jobs:
               /bin/zsh -lc 'set -e; cas; cas doctor'
           )"
           printf '%s\n' "$fresh_commands_output"
-          grep -qF 'Welcome to Cassy. Run `cas init` in a project directory to get started.' \
+          grep -qF 'Welcome to Cassy. Run `cas setup` in a project directory to get started.' \
             <<<"$fresh_commands_output"
           grep -qF "Not found. Run 'cas init'" <<<"$fresh_commands_output"
 
@@ -215,7 +215,7 @@ jobs:
               /bin/bash -lc 'set -e; cas; cas doctor'
           )"
           printf '%s\n' "$fresh_commands_output"
-          grep -qF 'Welcome to Cassy. Run `cas init` in a project directory to get started.' \
+          grep -qF 'Welcome to Cassy. Run `cas setup` in a project directory to get started.' \
             <<<"$fresh_commands_output"
           grep -qF "Not found. Run 'cas init'" <<<"$fresh_commands_output"
 

--- a/cas-cli/src/cli/first_run.rs
+++ b/cas-cli/src/cli/first_run.rs
@@ -63,6 +63,58 @@ mod tests {
         assert!(!hint.contains('\n'), "first-run hint must be one line: {hint}");
     }
 
+    /// The published install proof runs the released binary on a clean machine
+    /// and greps for this exact greeting. It cannot read `FRONT_DOOR_COMMAND`
+    /// at run time — it curls an installer onto a runner with no checkout — so
+    /// the sentence is duplicated in the workflow and drifts the moment the
+    /// front door is renamed. The v3.16.0 proof failed on both macOS and Linux
+    /// for exactly that reason: the workflow still asserted `cas init` while
+    /// the shipped binary printed `cas setup`. This test is the coupling that
+    /// was missing.
+    #[test]
+    fn install_path_proof_asserts_the_greeting_the_binary_prints() {
+        let root = crate::test_paths::workspace_root();
+        let Ok(workflow) =
+            std::fs::read_to_string(root.join(".github/workflows/install-path-proof.yml"))
+        else {
+            return; // not a source checkout; nothing to assert against
+        };
+
+        let hint = front_door_hint();
+        let greetings: Vec<_> = workflow
+            .lines()
+            .filter(|line| line.contains("Welcome to Cassy."))
+            .collect();
+
+        assert!(
+            !greetings.is_empty(),
+            "install-path-proof.yml no longer proves the first-run greeting; \
+             a renamed front door would reach users unchecked"
+        );
+        for line in &greetings {
+            assert!(
+                line.contains(&hint),
+                "install-path-proof.yml asserts a greeting this binary never prints.\n  \
+                 workflow: {}\n  binary:   {hint}",
+                line.trim()
+            );
+        }
+
+        // Every platform that runs the onboarding block must assert the
+        // greeting, so a failing platform cannot be "fixed" by deleting its
+        // check.
+        let onboarding_blocks = workflow
+            .matches("Checking bare cas and cas doctor in a fresh login shell.")
+            .count();
+        assert_eq!(
+            greetings.len(),
+            onboarding_blocks,
+            "{onboarding_blocks} platform(s) run the onboarding block but only \
+             {} assert the greeting",
+            greetings.len()
+        );
+    }
+
     #[test]
     fn a_host_cas_dir_means_the_machine_is_configured() {
         let temp = tempfile::tempdir().unwrap();

--- a/docs/release-notes/2026-09-04-v3.16.0-slack.md
+++ b/docs/release-notes/2026-09-04-v3.16.0-slack.md
@@ -2,70 +2,86 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-Status: DRAFT — do not post until v3.16.0 is published and both release archives have fresh published checksums.
+Status: DRAFT, bodies final. The four fenced bodies below are postable verbatim
+once two conditions hold: the v3.16.0 tag workflow has published both required
+assets, and `./scripts/release-published-receipt.sh v3.16.0 --write-draft
+docs/release-notes/2026-09-04-v3.16.0-slack.md` has replaced both digest
+placeholders from fresh published downloads. Do not transcribe a digest by hand
+and do not post before that command succeeds.
 
 User top-level
 
 ```text
 *Live on production — User — Cassy v3.16.0*
-Was: a project refresh could pull other projects' work into yours, new-machine setup took several manual steps, and hosted pairing failed. Now: projects stay separate, cleanup can finish, setup is one command, and pairing works.
+Was: refreshing one project could pull other projects' work into yours. Now: each project keeps to itself, and new-computer setup is one command.
 ```
 
 User reply
 
 ```text
-• *Project refresh* — Was: refreshing Cassy could scan temporary copies and container folders as if they were real projects. Now: Cassy skips them, explains why, lets you forget stale entries, and warns when a saved location should not sync.
+• *Project separation* — Was: a refresh could treat temporary copies and plain folders as real projects and mix their work together. Now: Cassy skips them, says why, and lets you drop stale entries.
 
-• *Safer setup* — Was: a folder-only project could create a separate cloud home. Now: Cassy refuses that setup before it can create unwanted data.
+• *Safer setup* — Was: a plain folder could quietly create its own cloud home. Now: Cassy refuses that before any unwanted data is created.
 
-• *Cleanup* — Was: cleanup could leave behind links to another project's updates and suggest a repair that did not help. Now: cleanup removes those leftovers and shows the right next step.
+• *Cleanup* — Was: cleanup could leave links to another project's updates behind and suggest a repair that did not help. Now: cleanup removes the leftovers and points at the step that works.
 
-• *Reliable refresh* — Was: a refresh could bring another project's tasks back or stop on one malformed record. Now: other-project work stays out, bad records wait safely with an explanation, and connection failures include useful details.
+• *Reliable refresh* — Was: a refresh could bring another project's tasks back, or stop dead on one bad record. Now: other projects' work stays out, bad records wait aside with an explanation, and failures explain themselves.
 
-• *Reviewed cleanup* — Was: heavily mixed project histories could not be cleaned even after review. Now: an explicit confirmation can allow that cleanup after Cassy rechecks the preview, while its other safety checks stay on.
+• *Reviewed cleanup* — Was: badly mixed project histories could not be cleaned even after you reviewed them. Now: an explicit confirmation allows it, after Cassy rechecks the preview and with its other safety checks still on.
 
-• *Computer setup* — Was: setting up a new computer required several separate steps and could expose credentials too broadly. Now: `cas integrate mecha-cassy` guides one secure setup using your Cassy login, the computer name, protected credentials, and a final check, and stops safely until the service endpoint is available.
+• *New computer setup* — Was: setting up a new computer took several manual steps. Now: `cas integrate mecha-cassy` does it in one guided pass, keeps your sign-in details private, and stops safely if the service is not ready.
 
-<!-- pending: cas-d2bb -->
-• *Service health* — Was: a missing connection setting could look like a generic service outage. Now: Cassy names the missing setting so it can be fixed directly.
+• *Clearer warnings* — Was: a missing connection setting looked like a general service outage. Now: Cassy names the setting that is missing so it can be fixed directly.
 
-<!-- pending: cas-38a1 -->
-• *Hosted pairing* — Was: pairing hosted Commander could fail even with a valid invitation. Now: the invitation format matches what the service expects and errors identify the actual problem.
+• *Hosted pairing* — Was: pairing with hosted Commander failed even with a valid invitation. Now: pairing works again, and a rejected invitation says what actually went wrong.
 
 Install
-Download the Linux x86_64 or macOS ARM64 archive from the Cassy v3.16.0 release. SHA-256: Linux `{{LINUX_SHA256}}` · macOS `{{MACOS_SHA256}}`.
+Update with `cas update`, or download the Linux x86_64 or macOS ARM64 archive from the Cassy v3.16.0 release. SHA-256: Linux `{{LINUX_SHA256}}` · macOS `{{MACOS_SHA256}}`.
 ```
 
 Dev top-level
 
 ```text
 *Live on production — Dev — Cassy v3.16.0*
-Was: project refresh, cloud intake, and release checks trusted shared state. Now: each root is scoped, malformed rows are parked, and gates verify the delivery inputs.
+Was: refresh and cloud pull trusted shared state, letting foreign rows cross projects. Now: every root is scoped, foreign rows refused, malformed rows parked.
 ```
 
 Dev reply
 
 ```text
-• *Discovery guards* — Was: update discovery treated artifact copies, probes, temporary roots, and bare container folders as syncable projects. Now: each is skipped with a reason, `cas known-repos forget <path>` removes stale entries, and doctor reports registered roots that should not sync.
+• *Discovery guards* — Was: update discovery treated artifact copies, probes, temporary roots, and bare container folders as syncable projects. Now: each is skipped with a stated reason, `cas known-repos forget <path>` clears stale entries, and doctor flags roots that must not sync.
 
-• *Push identity* — Was: an unpinned store could mint a cloud identity from its folder name. Now: root-bound personal, team, and knowledge pushes refuse bare-folder identities before a junk cloud scope is created.
+• *Push identity* — Was: an unpinned store could mint a cloud identity from its folder name. Now: root-bound personal, team, and knowledge pushes refuse bare-folder identities before a junk cloud scope exists.
 
-• *Purge metadata* — Was: foreign `team_project_registered_*`, `last_team_pull_at_*`, and `last_knowledge_push_project_id` values survived cleanup, while doctor suggested a command that did not clear them. Now: purge removes foreign identity metadata and doctor points to the purge-and-sync remediation.
+• *Purge metadata* — Was: foreign team-registration and knowledge-push identity values survived cleanup, and doctor suggested a command that cleared nothing. Now: purge removes that foreign identity metadata and doctor points at the purge-and-sync remediation.
 
-• *Pull ownership* — Was: personal pulls could upsert explicit foreign-origin rows or stamp null origins from the requested scope, and one malformed team row could abort the response. Now: ownership is checked before upsert, identity-free rows are parked, malformed rows are parked with a reason, and push failures retain status, body, and request identifiers.
+• *Pull ownership* — Was: personal pulls re-admitted foreign-origin rows or stamped null origins from the requested scope, and one malformed row aborted the response. Now: ownership is checked before upsert, identity-free and malformed rows park with a reason, and push failures keep status, body, and request ids.
 
-• *Majority override* — Was: the 50% foreign-row guard had no explicit operator path. Now: `cas cloud purge-foreign --allow-majority-foreign --yes` re-runs a same-store dry-run, verifies its delete-set hash, records the ratio and backup, and leaves collision, stale-state, and unpushed-work guards active.
+• *Majority override* — Was: the 50% foreign-row guard had no explicit operator path. Now: `cas cloud purge-foreign --allow-majority-foreign --yes` re-runs a same-store dry run, verifies its delete-set hash, records ratio and backup, and keeps every other guard active.
 
-• *MechaCassy onboarding* — Was: machine onboarding required separate credential, profile, registration, and verification steps. Now: `cas integrate mecha-cassy` derives the hostname label, uses the Cassy Cloud bearer through the hub, writes 0600 credentials plus the login-shell source line, registers, verifies, and fails closed when the hub route is unavailable.
+• *MechaCassy onboarding* — Was: machine onboarding needed separate credential, profile, and verification steps. Now: `cas integrate mecha-cassy` derives the hostname label, mints the bearer through the hub, writes 0600 credentials plus the login-shell source line, verifies, and fails closed without the hub route.
 
-<!-- pending: cas-d2bb -->
-• *Worker proxy* — Was: worker processes inherited an unavailable MechaCassy upstream and health collapsed missing credentials to `connection_failed`. Now: worker launch carries configured credential names, while proxy health and doctor name an unset variable.
+• *Proxy credentials* — Was: spawned processes inherited an unavailable MechaCassy upstream, and health collapsed a missing credential to `connection_failed`. Now: launches carry the configured credential names, and proxy health and doctor name the unset variable.
 
-<!-- pending: cas-38a1 -->
-• *Hosted pairing* — Was: relay completion received a three-key invitation while its parser accepted only `pair` and `hub`, producing a misleading invalid-expiry error. Now: relay completion sends the two-key form, local Commander retains declared scopes, and invalid invitations report the offending field and sent shape.
+• *Hosted pairing* — Was: relay completion received a three-key invitation while its parser accepted only `pair` and `hub`, producing a misleading invalid-expiry error. Now: relay completion sends the two-key form, local Commander keeps declared scopes, and invalid invitations name the offending field.
 
-• *Release gates* — Was: stale epic worktrees, missing Zig, and an undocumented `pr-body.md` input could fail late in the train. Now: freshness and Zig checks fail early with actionable guidance, and the release skill documents the run-directory body required before pipeline execution.
+• *Release gates* — Was: a stale release worktree, a missing Zig toolchain, and an undocumented `pr-body.md` input failed late in the release train. Now: freshness and Zig checks fail early with actionable guidance, and the release skill documents the required run-directory body.
 
 Validation
-Release gate, scoped tests, and the full library proof: record fresh results from the merged v3.16.0 tree before publication. Published archives: `cas-x86_64-unknown-linux-gnu.tar.gz` (`{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (`{{MACOS_SHA256}}`).
+The 3.16.0 tree passed merge-queue validation and the post-landing checks for PR #720 before the tag workflow published both archives: `cas-x86_64-unknown-linux-gnu.tar.gz` (`{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (`{{MACOS_SHA256}}`).
 ```
+
+## Posting sequence
+
+1. Confirm the tag workflow published v3.16.0 with both required assets.
+2. Run `./scripts/release-published-receipt.sh v3.16.0 --write-draft
+   docs/release-notes/2026-09-04-v3.16.0-slack.md`; it downloads and hashes both
+   published assets before replacing every digest placeholder.
+3. Authenticated preflight: `tools/list` must show exactly `mecha_read` and
+   `mecha_post`, then a bounded `mecha_read` on `cas-internal` with `since` to
+   prove membership and dedupe.
+4. Post user top-level, user reply (`reply_to` = user top-level `message_id`),
+   dev top-level, dev reply (`reply_to` = dev top-level `message_id`), spacing
+   the writes at least one second apart.
+5. Append the `## POSTED` receipt below with the UTC timestamp, channel id, and
+   every `message_id` and returned permalink, then commit and push.

--- a/docs/release-notes/2026-09-04-v3.16.0-slack.md
+++ b/docs/release-notes/2026-09-04-v3.16.0-slack.md
@@ -2,12 +2,14 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-Status: DRAFT, bodies final. The four fenced bodies below are postable verbatim
-once two conditions hold: the v3.16.0 tag workflow has published both required
-assets, and `./scripts/release-published-receipt.sh v3.16.0 --write-draft
-docs/release-notes/2026-09-04-v3.16.0-slack.md` has replaced both digest
-placeholders from fresh published downloads. Do not transcribe a digest by hand
-and do not post before that command succeeds.
+Status: POSTED 2026-09-04T22:47Z. v3.16.0 published 2026-09-04T22:43:42Z by
+release workflow run 33926335907 (success) from annotated tag
+25134098ce464bfe28c3d77ce9e8b0516782346a, peeling to the PR #720 landing at
+main bbc1629b. Digests below were written by
+`./scripts/release-published-receipt.sh v3.16.0 --write-draft
+docs/release-notes/2026-09-04-v3.16.0-slack.md` from fresh downloads of the
+published assets; none was transcribed by hand. The four fenced bodies are the
+text that was posted.
 
 User top-level
 
@@ -36,7 +38,7 @@ User reply
 • *Hosted pairing* — Was: pairing with hosted Commander failed even with a valid invitation. Now: pairing works again, and a rejected invitation says what actually went wrong.
 
 Install
-Update with `cas update`, or download the Linux x86_64 or macOS ARM64 archive from the Cassy v3.16.0 release. SHA-256: Linux `{{LINUX_SHA256}}` · macOS `{{MACOS_SHA256}}`.
+Update with `cas update`, or download the Linux x86_64 or macOS ARM64 archive from the Cassy v3.16.0 release. SHA-256: Linux `058a03d79d1b216a311893d9af5288272962ad8ee26c23025b2d25d23f58011c` · macOS `ce28b3f7c07490f69b6fd5e44305026df52c253195a123c808af88a2b003d489`.
 ```
 
 Dev top-level
@@ -68,7 +70,7 @@ Dev reply
 • *Release gates* — Was: a stale release worktree, a missing Zig toolchain, and an undocumented `pr-body.md` input failed late in the release train. Now: freshness and Zig checks fail early with actionable guidance, and the release skill documents the required run-directory body.
 
 Validation
-The 3.16.0 tree passed merge-queue validation and the post-landing checks for PR #720 before the tag workflow published both archives: `cas-x86_64-unknown-linux-gnu.tar.gz` (`{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (`{{MACOS_SHA256}}`).
+The 3.16.0 tree passed merge-queue validation and the post-landing checks for PR #720 before the tag workflow published both archives: `cas-x86_64-unknown-linux-gnu.tar.gz` (`058a03d79d1b216a311893d9af5288272962ad8ee26c23025b2d25d23f58011c`) and `cas-aarch64-apple-darwin.tar.gz` (`ce28b3f7c07490f69b6fd5e44305026df52c253195a123c808af88a2b003d489`).
 ```
 
 ## Posting sequence
@@ -85,3 +87,16 @@ The 3.16.0 tree passed merge-queue validation and the post-landing checks for PR
    the writes at least one second apart.
 5. Append the `## POSTED` receipt below with the UTC timestamp, channel id, and
    every `message_id` and returned permalink, then commit and push.
+
+## POSTED
+
+- **Posted at (UTC):** `2026-09-04T22:46:57Z` – `2026-09-04T22:47:34Z`
+- **Channel:** `#cas-internal` (`C0B44GUKDK2`)
+- **User top-level:** `message_id=1788562017.602519` · https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788562017602519
+- **User reply:** `message_id=1788562031.789729` (`thread_id=1788562017.602519`) · https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788562031789729?thread_ts=1788562017.602519&cid=C0B44GUKDK2
+- **Dev top-level:** `message_id=1788562038.257939` · https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788562038257939
+- **Dev reply:** `message_id=1788562054.283769` (`thread_id=1788562038.257939`) · https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788562054283769?thread_ts=1788562038.257939&cid=C0B44GUKDK2
+
+Published assets (SHA-256 from `release-published-receipt.sh v3.16.0`):
+`cas-x86_64-unknown-linux-gnu.tar.gz` `058a03d79d1b216a311893d9af5288272962ad8ee26c23025b2d25d23f58011c`,
+`cas-aarch64-apple-darwin.tar.gz` `ce28b3f7c07490f69b6fd5e44305026df52c253195a123c808af88a2b003d489`.


### PR DESCRIPTION
Repairs the stale onboarding greeting assertion on Linux and macOS, adds a source/workflow drift regression, and records the completed v3.16.0 Slack publication receipts. No runtime behavior changes. Six scoped first-run tests pass; reverting the expected greeting makes the regression fail. Published-asset installation proof is dispatched from this feature ref in run33927932557. Merge only after required CI and both-platform proof succeed.