### PR TITLE
fix(ci): handle duplicate padded mount records in runner sandbox

### DIFF
--- a/scripts/check-cassy-actions-cache-mount.sh
+++ b/scripts/check-cassy-actions-cache-mount.sh
@@ -26,11 +26,11 @@ fi
 "$mountpoint_bin" -q "$volume_root" || fail "dedicated cache volume is not mounted: $volume_root"
 "$mountpoint_bin" -q "$cache_root" || fail "runner cache is not a mount point: $cache_root"
 
-volume_device="$("$findmnt_bin" -n -o MAJ:MIN -T "$volume_root")" ||
+volume_device="$("$findmnt_bin" -f -n -o MAJ:MIN -T "$volume_root")" ||
     fail "cannot resolve dedicated volume device: $volume_root"
-cache_device="$("$findmnt_bin" -n -o MAJ:MIN -T "$cache_root")" ||
+cache_device="$("$findmnt_bin" -f -n -o MAJ:MIN -T "$cache_root")" ||
     fail "cannot resolve runner cache device: $cache_root"
-cache_fsroot="$("$findmnt_bin" -n -o FSROOT -T "$cache_root")" ||
+cache_fsroot="$("$findmnt_bin" -f -n -o FSROOT -T "$cache_root")" ||
     fail "cannot resolve runner cache FSROOT: $cache_root"
 
 [[ -n "$volume_device" && "$cache_device" == "$volume_device" ]] ||

--- a/scripts/check-cassy-actions-cache-mount.sh
+++ b/scripts/check-cassy-actions-cache-mount.sh
@@ -26,11 +26,11 @@ fi
 "$mountpoint_bin" -q "$volume_root" || fail "dedicated cache volume is not mounted: $volume_root"
 "$mountpoint_bin" -q "$cache_root" || fail "runner cache is not a mount point: $cache_root"
 
-volume_device="$("$findmnt_bin" -f -n -o MAJ:MIN -T "$volume_root")" ||
+volume_device="$("$findmnt_bin" -f -r -n -o MAJ:MIN -T "$volume_root")" ||
     fail "cannot resolve dedicated volume device: $volume_root"
-cache_device="$("$findmnt_bin" -f -n -o MAJ:MIN -T "$cache_root")" ||
+cache_device="$("$findmnt_bin" -f -r -n -o MAJ:MIN -T "$cache_root")" ||
     fail "cannot resolve runner cache device: $cache_root"
-cache_fsroot="$("$findmnt_bin" -f -n -o FSROOT -T "$cache_root")" ||
+cache_fsroot="$("$findmnt_bin" -f -r -n -o FSROOT -T "$cache_root")" ||
     fail "cannot resolve runner cache FSROOT: $cache_root"
 
 [[ -n "$volume_device" && "$cache_device" == "$volume_device" ]] ||

--- a/scripts/prune-cassy-actions-cache.sh
+++ b/scripts/prune-cassy-actions-cache.sh
@@ -72,9 +72,9 @@ require_safe_delete_path() {
     canonical="$(realpath -e -- "$candidate")" || fail "cannot canonicalize deletion path: $candidate"
     [[ "$canonical" == "$cache_root/"* ]] ||
         fail "canonical deletion path escaped the cache root: $candidate -> $canonical"
-    candidate_device="$("$findmnt_bin" -n -o MAJ:MIN -T "$canonical")" ||
+    candidate_device="$("$findmnt_bin" -f -n -o MAJ:MIN -T "$canonical")" ||
         fail "cannot resolve deletion device: $canonical"
-    candidate_mount="$("$findmnt_bin" -n -o TARGET -T "$canonical")" ||
+    candidate_mount="$("$findmnt_bin" -f -n -o TARGET -T "$canonical")" ||
         fail "cannot resolve deletion mount: $canonical"
     [[ "$candidate_device" == "$cache_device" && "$candidate_mount" == "$cache_mount" ]] ||
         fail "deletion path is not on the cache mount/device: $canonical"
@@ -207,9 +207,9 @@ prune_all() {
         (( state == 1 )) && fail 'refusing to prune while Runner.Worker owns an active job'
         fail 'refusing to prune because runner job state is missing or unreadable'
     fi
-    cache_device="$("$findmnt_bin" -n -o MAJ:MIN -T "$cache_root")" ||
+    cache_device="$("$findmnt_bin" -f -n -o MAJ:MIN -T "$cache_root")" ||
         fail 'cannot resolve cache device'
-    cache_mount="$("$findmnt_bin" -n -o TARGET -T "$cache_root")" ||
+    cache_mount="$("$findmnt_bin" -f -n -o TARGET -T "$cache_root")" ||
         fail 'cannot resolve cache mount'
     for index in 0 1; do prune_slot "$index"; done
 }

--- a/scripts/prune-cassy-actions-cache.sh
+++ b/scripts/prune-cassy-actions-cache.sh
@@ -72,9 +72,9 @@ require_safe_delete_path() {
     canonical="$(realpath -e -- "$candidate")" || fail "cannot canonicalize deletion path: $candidate"
     [[ "$canonical" == "$cache_root/"* ]] ||
         fail "canonical deletion path escaped the cache root: $candidate -> $canonical"
-    candidate_device="$("$findmnt_bin" -f -n -o MAJ:MIN -T "$canonical")" ||
+    candidate_device="$("$findmnt_bin" -f -r -n -o MAJ:MIN -T "$canonical")" ||
         fail "cannot resolve deletion device: $canonical"
-    candidate_mount="$("$findmnt_bin" -f -n -o TARGET -T "$canonical")" ||
+    candidate_mount="$("$findmnt_bin" -f -r -n -o TARGET -T "$canonical")" ||
         fail "cannot resolve deletion mount: $canonical"
     [[ "$candidate_device" == "$cache_device" && "$candidate_mount" == "$cache_mount" ]] ||
         fail "deletion path is not on the cache mount/device: $canonical"
@@ -207,9 +207,9 @@ prune_all() {
         (( state == 1 )) && fail 'refusing to prune while Runner.Worker owns an active job'
         fail 'refusing to prune because runner job state is missing or unreadable'
     fi
-    cache_device="$("$findmnt_bin" -f -n -o MAJ:MIN -T "$cache_root")" ||
+    cache_device="$("$findmnt_bin" -f -r -n -o MAJ:MIN -T "$cache_root")" ||
         fail 'cannot resolve cache device'
-    cache_mount="$("$findmnt_bin" -f -n -o TARGET -T "$cache_root")" ||
+    cache_mount="$("$findmnt_bin" -f -r -n -o TARGET -T "$cache_root")" ||
         fail 'cannot resolve cache mount'
     for index in 0 1; do prune_slot "$index"; done
 }

--- a/scripts/test-check-cassy-actions-cache-mount.sh
+++ b/scripts/test-check-cassy-actions-cache-mount.sh
@@ -18,19 +18,25 @@ cat >"$fixture_root/bin/findmnt" <<'EOF'
 #!/usr/bin/env bash
 field=""
 target=""
+first_only=0
 while (($#)); do
     case "$1" in
+        -f|--first-only) first_only=1; shift ;;
         -o) field="$2"; shift 2 ;;
         -T) target="$2"; shift 2 ;;
         *) shift ;;
     esac
 done
 case "$field:$target" in
-    MAJ:MIN:*cache) printf '%s\n' "${TEST_CACHE_DEVICE:-259:1}" ;;
-    MAJ:MIN:*) printf '%s\n' "${TEST_VOLUME_DEVICE:-259:1}" ;;
-    FSROOT:*cache) printf '%s\n' "${TEST_CACHE_FSROOT:-/home/.cassy-actions-cache}" ;;
+    MAJ:MIN:*cache) value="${TEST_CACHE_DEVICE:-259:1}" ;;
+    MAJ:MIN:*) value="${TEST_VOLUME_DEVICE:-259:1}" ;;
+    FSROOT:*cache) value="${TEST_CACHE_FSROOT:-/home/.cassy-actions-cache}" ;;
     *) exit 2 ;;
 esac
+printf '%s\n' "$value"
+if [[ "${TEST_DUPLICATE_ROWS:-}" == 1 && "$first_only" == 0 ]]; then
+    printf '%s\n' "$value"
+fi
 EOF
 chmod +x "$fixture_root/bin/mountpoint" "$fixture_root/bin/findmnt"
 
@@ -45,6 +51,11 @@ run_guard() {
 }
 
 run_guard >/dev/null
+
+# systemd's service mount namespace can expose the same underlying mount more
+# than once. The guard must select one record instead of treating duplicate
+# identical rows as a different device or FSROOT.
+TEST_DUPLICATE_ROWS=1 run_guard >/dev/null
 
 if TEST_CACHE_FSROOT=/home/wrong-but-same-device run_guard >/dev/null 2>&1; then
     printf 'FAIL same-device wrong cache subtree was accepted\n' >&2

--- a/scripts/test-check-cassy-actions-cache-mount.sh
+++ b/scripts/test-check-cassy-actions-cache-mount.sh
@@ -19,9 +19,11 @@ cat >"$fixture_root/bin/findmnt" <<'EOF'
 field=""
 target=""
 first_only=0
+raw=0
 while (($#)); do
     case "$1" in
         -f|--first-only) first_only=1; shift ;;
+        -r|--raw) raw=1; shift ;;
         -o) field="$2"; shift 2 ;;
         -T) target="$2"; shift 2 ;;
         *) shift ;;
@@ -33,7 +35,11 @@ case "$field:$target" in
     FSROOT:*cache) value="${TEST_CACHE_FSROOT:-/home/.cassy-actions-cache}" ;;
     *) exit 2 ;;
 esac
-printf '%s\n' "$value"
+if [[ "${TEST_PADDED_ROWS:-}" == 1 && "$raw" == 0 ]]; then
+    printf '%s  \n' "$value"
+else
+    printf '%s\n' "$value"
+fi
 if [[ "${TEST_DUPLICATE_ROWS:-}" == 1 && "$first_only" == 0 ]]; then
     printf '%s\n' "$value"
 fi
@@ -55,7 +61,7 @@ run_guard >/dev/null
 # systemd's service mount namespace can expose the same underlying mount more
 # than once. The guard must select one record instead of treating duplicate
 # identical rows as a different device or FSROOT.
-TEST_DUPLICATE_ROWS=1 run_guard >/dev/null
+TEST_DUPLICATE_ROWS=1 TEST_PADDED_ROWS=1 run_guard >/dev/null
 
 if TEST_CACHE_FSROOT=/home/wrong-but-same-device run_guard >/dev/null 2>&1; then
     printf 'FAIL same-device wrong cache subtree was accepted\n' >&2

--- a/scripts/test-prune-cassy-actions-cache.sh
+++ b/scripts/test-prune-cassy-actions-cache.sh
@@ -93,10 +93,21 @@ run_pruner() {
     CASSY_ACTIONS_MOUNTPOINT_BIN="$fixture_root/mountpoint" \
     CASSY_ACTIONS_FINDMNT_BIN="$fixture_root/findmnt" \
     CASSY_ACTIONS_TARGET_BUDGET_BYTES=32768 \
-    CASSY_ACTIONS_SCCACHE_BUDGET_BYTES=8192 \
+    CASSY_ACTIONS_SCCACHE_BUDGET_BYTES="$fixture_sccache_budget_bytes" \
     CASSY_ACTIONS_SLOT_BUDGET_BYTES=60000 \
     CASSY_ACTIONS_CACHE_MAX_AGE_DAYS=7 \
         "$pruner" "$@"
+}
+
+measure_fixture_sccache_budget() {
+    local slot slot_sccache_bytes
+    fixture_sccache_budget_bytes=1
+    for slot in '' '-2'; do
+        slot_sccache_bytes="$(du -sx -B1 -- "$cache_root/sccache$slot" | awk '{print $1}')"
+        if (( slot_sccache_bytes > fixture_sccache_budget_bytes )); then
+            fixture_sccache_budget_bytes="$slot_sccache_bytes"
+        fi
+    done
 }
 
 for slot in '' '-2'; do
@@ -108,6 +119,13 @@ for slot in '' '-2'; do
     touch -d '8 days ago' "$cache_root/cargo-target$slot/debug/incremental/stale-session" \
         "$cache_root/cargo-target$slot/debug/deps/libstale.rlib"
 done
+
+# bytes_for() deliberately measures allocated bytes so the production budget
+# includes filesystem metadata. A tmpfs may charge zero blocks for this
+# directory while the GitHub-hosted ext4 image charges one 4096-byte block.
+# Pin the fixture ceiling to the larger observed slot instead of assuming file
+# payload is the complete du result. Recalculate after fixtures change shape.
+measure_fixture_sccache_budget
 
 TEST_DUPLICATE_ROWS=1 TEST_PADDED_ROWS=1 run_pruner --now >/dev/null
 for slot in '' '-2'; do
@@ -165,6 +183,7 @@ for slot in '' '-2'; do
     dd if=/dev/zero of="$cache_root/cargo-target$slot/debug/deps/current" bs=4096 count=16 status=none
     dd if=/dev/zero of="$cache_root/sccache$slot/current" bs=4096 count=2 status=none
 done
+measure_fixture_sccache_budget
 run_pruner --now >/dev/null
 for slot in '' '-2'; do
     test ! -e "$cache_root/cargo-target$slot/debug"

--- a/scripts/test-prune-cassy-actions-cache.sh
+++ b/scripts/test-prune-cassy-actions-cache.sh
@@ -38,10 +38,12 @@ field=""
 target=""
 recursive=0
 first_only=0
+raw=0
 while (($#)); do
     case "$1" in
         -R|--submounts) recursive=1; shift ;;
         -f|--first-only) first_only=1; shift ;;
+        -r|--raw) raw=1; shift ;;
         -o) field="$2"; shift 2 ;;
         -T) target="$2"; shift 2 ;;
         *) shift ;;
@@ -61,7 +63,12 @@ case "$field:$target" in
         fi
         ;;
     MAJ:MIN:*cache*)
-        printf '%s\n' "${TEST_CACHE_DEVICE:-259:1}"
+        if [[ "${TEST_PADDED_ROWS:-}" == 1 && "$raw" == 0 &&
+              "$target" == "$CASSY_ACTIONS_CACHE_ROOT" ]]; then
+            printf '%s  \n' "${TEST_CACHE_DEVICE:-259:1}"
+        else
+            printf '%s\n' "${TEST_CACHE_DEVICE:-259:1}"
+        fi
         if [[ "${TEST_DUPLICATE_ROWS:-}" == 1 && "$first_only" == 0 &&
               "$target" == "$CASSY_ACTIONS_CACHE_ROOT" ]]; then
             printf '%s\n' "${TEST_CACHE_DEVICE:-259:1}"
@@ -102,7 +109,7 @@ for slot in '' '-2'; do
         "$cache_root/cargo-target$slot/debug/deps/libstale.rlib"
 done
 
-TEST_DUPLICATE_ROWS=1 run_pruner --now >/dev/null
+TEST_DUPLICATE_ROWS=1 TEST_PADDED_ROWS=1 run_pruner --now >/dev/null
 for slot in '' '-2'; do
     test ! -e "$cache_root/cargo-target$slot/debug/incremental/stale-session"
     test ! -e "$cache_root/cargo-target$slot/debug/deps/libstale.rlib"

--- a/scripts/test-prune-cassy-actions-cache.sh
+++ b/scripts/test-prune-cassy-actions-cache.sh
@@ -37,9 +37,11 @@ cat >"$fixture_root/findmnt" <<'EOF'
 field=""
 target=""
 recursive=0
+first_only=0
 while (($#)); do
     case "$1" in
         -R|--submounts) recursive=1; shift ;;
+        -f|--first-only) first_only=1; shift ;;
         -o) field="$2"; shift 2 ;;
         -T) target="$2"; shift 2 ;;
         *) shift ;;
@@ -58,7 +60,13 @@ case "$field:$target" in
             printf '%s\n' "$CASSY_ACTIONS_CACHE_ROOT"
         fi
         ;;
-    MAJ:MIN:*cache*) printf '%s\n' "${TEST_CACHE_DEVICE:-259:1}" ;;
+    MAJ:MIN:*cache*)
+        printf '%s\n' "${TEST_CACHE_DEVICE:-259:1}"
+        if [[ "${TEST_DUPLICATE_ROWS:-}" == 1 && "$first_only" == 0 &&
+              "$target" == "$CASSY_ACTIONS_CACHE_ROOT" ]]; then
+            printf '%s\n' "${TEST_CACHE_DEVICE:-259:1}"
+        fi
+        ;;
     MAJ:MIN:*) printf '%s\n' "${TEST_VOLUME_DEVICE:-259:1}" ;;
     FSROOT:*cache*) printf '%s\n' "${TEST_CACHE_FSROOT:-/home/.cassy-actions-cache}" ;;
     *) exit 2 ;;
@@ -94,13 +102,14 @@ for slot in '' '-2'; do
         "$cache_root/cargo-target$slot/debug/deps/libstale.rlib"
 done
 
-run_pruner --now >/dev/null
+TEST_DUPLICATE_ROWS=1 run_pruner --now >/dev/null
 for slot in '' '-2'; do
     test ! -e "$cache_root/cargo-target$slot/debug/incremental/stale-session"
     test ! -e "$cache_root/cargo-target$slot/debug/deps/libstale.rlib"
     test -e "$cache_root/cargo-target$slot/debug/deps/libfresh.rlib"
 done
 printf 'ok   idle pruning removes stale incremental/deps data from both slots\n'
+printf 'ok   pruning tolerates duplicate mount rows from a service namespace\n'
 
 mkdir -p "$proc_root/103"
 printf '103\n' >>"$cgroup_root/slot1/cgroup.procs"


### PR DESCRIPTION
Follow-up source correction for #721 / `cas-a352` after the source-only safeguards from #726 reached `main`.

Inside the hardened runner service mount namespace, `findmnt -T` returns duplicate records for the same bind mount and its default scalar output is padded. The exact device/FSROOT comparison therefore rejected the correct live Shockwave mount during `ExecStartPre`. This patch uses first-only, raw, no-heading output for scalar device/FSROOT/target queries while retaining exhaustive raw recursive enumeration for descendant-mount safety checks.

Executable fixtures now reproduce duplicate, padded scalar rows and continue to reject wrong-device and same-device/wrong-FSROOT mounts. Supervisor-independent proof passed the mount guard suite (1/1) and pruner suite (12/12); the matching systemd namespace receipt resolves the live cache to device `259:1`, FSROOT `/home/.cassy-actions-cache`, and target `/var/lib/cassy-actions/cache`. Exact-tip factory CI run 33938973870 is the integration gate for commit `3ff4bb52279e6bfe82a27590fa30c29383a03f93`.

Operational status is deliberately separate from this source correction:

- The cache migration itself is already live: `/var/lib/cassy-actions/cache` bind-mounts `/home/.cassy-actions-cache` on Shockwave. This PR does not move or delete cache data.
- The first safeguard installation attempt failed closed at both runner `ExecStartPre` checks. Automatic rollback restored the five previous installed files byte-for-byte, removed all newly introduced guard/hook paths, and restored both prior runner services healthy and online.
- After rollback, all three self-hosted routing variables remain `disabled`; the existing prune timer is disabled/inactive and its service is inactive. The hardened guards/hooks are not installed yet.
- A reviewed redeployment, bounded real self-hosted smoke, final before/after receipts, route restoration, and the #721 migration-result comment remain operator work after this correction lands. No completed deployment or smoke is claimed here.

Durable task receipts:

- `failed-install-rollback-diagnosis.txt` — failed guard journal, healthy restored services, and absent new paths.
- `systemd-namespace-findmnt-proof-raw.txt` — real hardened-namespace duplicate rows plus exact raw scalar and recursive results.
- `route-disable-receipt.txt` — all three routes read back as disabled.
- `post-rollback-prune-hold-receipt.txt` — timer disabled/inactive and service inactive.

