### PR TITLE
docs(release-notes): POSTED receipts for v3.19.0 and PR #760

### DIFF
--- a/docs/release-notes/2026-09-08-factory-status-live-workers-slack.md
+++ b/docs/release-notes/2026-09-08-factory-status-live-workers-slack.md
@@ -1,0 +1,27 @@
+# Slack draft — factory status shows live workers (main merge, PR #760)
+
+Channel: #cas-internal. Deploy target: Live on production (main).
+
+## User thread
+
+Top-level:
+Live on production · User · The factory status view now shows every worker that is actually running, not just the ones the daemon happened to record.
+
+Reply:
+Was → the status and agents views hid workers started through the coordination tools, so an operator could see one agent while three were working. Now → both views read the live worker registry, and a worker shows up the moment it registers.
+
+## Dev thread
+
+Top-level:
+Live on production · Dev · `cas factory status` and `cas factory agents` filter agents through the registry-backed session roster instead of the daemon metadata roster.
+
+Reply:
+Was → `session_agent_name_set` in `cli/factory/queries.rs` read `metadata.workers`, which MCP `spawn_workers` never appends to, so live registry workers were dropped from status, agents, and activity filtering. Now → it extends with `SessionInfo::worker_names()` (registry with metadata fallback); regression test covers an empty roster with an active registry worker. PR #760.
+
+## POSTED
+Posted 2026-09-08 via claude.ai Slack MCP to #cas-internal (C0B44GUKDK2):
+- User top-level ts 1788895911.486499 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788895911486499
+- User reply ts 1788895922.451619
+- Dev top-level ts 1788895923.462889 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788895923462889
+- Dev reply: see thread of 1788895923.462889
+Note: mecha-cassy MCP was unusable (malformed resultType), filed Richards-LLC/mecha-cassy#8.

--- a/docs/release-notes/2026-09-08-v3.19.0-slack.md
+++ b/docs/release-notes/2026-09-08-v3.19.0-slack.md
@@ -2,9 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-Status: DRAFT — source preparation only. Do not post until v3.19.0 is
-published and `release-published-receipt.sh --write-draft` has replaced both
-digest placeholders from fresh downloads of the published assets.
+Status: POSTED (see the POSTED block at the end).
 
 User top-level
 
@@ -50,7 +48,7 @@ User reply
 
 • *Safer installs* — Was: a temporary GitHub hiccup could make the installer give up with no explanation. Now: it retries with credentials and tells you exactly what the release service returned.
 
-Install: update with `cas update`, or download the Linux x86_64 archive (`{{LINUX_SHA256}}`) or macOS ARM64 archive (`{{MACOS_SHA256}}`) from the Cassy v3.19.0 release.
+Install: update with `cas update`, or download the Linux x86_64 archive (`4bb221b30252ffbf45cb164fbe9ac4c64b8e9f0709b53ce617c68072274c05d5`) or macOS ARM64 archive (`0980b70998be147a7f8a7e109b94eba120e72f36ecc2506ff08ae62cc846c4eb`) from the Cassy v3.19.0 release.
 ```
 
 Dev top-level
@@ -121,7 +119,7 @@ Dev reply
 
 Validation: `scripts/release-gate.sh 3.19.0 --only changelog-and-versions,version-literals`; `cargo check -p cas --lib --tests`.
 
-Install: `cas-x86_64-unknown-linux-gnu.tar.gz` (`{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (`{{MACOS_SHA256}}`) are published by CI for Linux and macOS.
+Install: `cas-x86_64-unknown-linux-gnu.tar.gz` (`4bb221b30252ffbf45cb164fbe9ac4c64b8e9f0709b53ce617c68072274c05d5`) and `cas-aarch64-apple-darwin.tar.gz` (`0980b70998be147a7f8a7e109b94eba120e72f36ecc2506ff08ae62cc846c4eb`) are published by CI for Linux and macOS.
 ```
 
 Posting sequence
@@ -138,3 +136,14 @@ Posting sequence
    order, spacing writes at least one second apart.
 6. Append the `## POSTED` receipt with UTC timestamps, channel id, and every
    returned message id and permalink, then commit it in the next preparation.
+
+## POSTED
+
+Posted 2026-09-08 via the claude.ai Slack MCP to #cas-internal (C0B44GUKDK2), after `release-published-receipt.sh v3.19.0 --write-draft` replaced both digests (PUBLISHED_AT=2026-09-08T20:46:23Z):
+
+- User top-level ts 1788900879.977669 — https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788900879977669
+- User reply ts 1788900949.845359 (thread of the user top-level)
+- Dev top-level ts 1788900939.054789 — https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788900939054789
+- Dev reply (thread of the dev top-level; posted 20:56Z)
+
+MechaCassy direct MCP was unusable at post time (malformed result, Richards-LLC/mecha-cassy#8); the canonical claude.ai route was used.


### PR DESCRIPTION
Was: the v3.19.0 Slack draft and the factory-status announcement draft lived only on the release host with their POSTED receipts uncommitted. Now: both are committed with timestamps and permalinks so the next release prep carries the prior receipt.