### PR TITLE
fix(hooks): recover factory context when the prompt hook is silent

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,13 +53,12 @@
       {
         "hooks": [
           {
-            "async": true,
             "command": "cas hook PostToolUse",
             "timeout": 3000,
             "type": "command"
           }
         ],
-        "matcher": "Write|Edit|Bash"
+        "matcher": "*"
       }
     ],
     "PostToolUseFailure": [

--- a/cas-cli/docs/ARCHITECTURE.md
+++ b/cas-cli/docs/ARCHITECTURE.md
@@ -125,3 +125,20 @@ Rules that keep that boundary honest:
 **Factory worker commit guard** (`cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs`, `check_worker_git_commit_scope`): Fires for ALL factory workers (`CAS_AGENT_ROLE=worker` + `CAS_FACTORY_MODE`) on every `git commit` / `git merge` Bash command. Denies commits to protected branches (`main`, `master`, `staging`, detached HEAD) regardless of whether the worker has an isolated worktree (`CAS_CLONE_PATH`). Isolated workers also get a cwd-outside-worktree guard. Non-isolated (standalone-task) workers that run in the shared primary checkout are therefore prevented from committing to `main` (cas-ba04 fix). The only bypass is switching to a non-protected branch — `--no-verify` does NOT bypass this guard (it only skips git hooks, not the Claude Code PreToolUse harness).
 
 **Team scope resolution chain** (`cas-cli/src/cloud/config.rs::active_team_id`, cas-ea2f5): When a write is dual-enqueued to the team push queue, the team UUID is resolved at `open_store` time via a four-step chain. (0) Kill-switch: if `team_auto_promote = Some(false)` in the project `.cas/cloud.json`, the result is always `None` — no team dual-enqueue regardless of other config. (1) Project-level explicit override: `team_id` in the project `.cas/cloud.json` wins unconditionally; set via `cas cloud team set <uuid>`. (2) User default: `default_team_id` in `~/.cas/cloud.json`, populated by `cas cloud team default <slug>` or automatically by `fetch_and_cache_teams` (`cloud/me.rs`) on `cas login`. (3) Implicit single-team auto-pick: if `teams[]` has exactly one entry and no `default_team_id` is set, that team is used automatically — no configuration needed. (4) `None` — ambiguous (0 or ≥2 teams without a nominated default) or not logged in. The testable inner `active_team_id_with_user_config(user_cfg: Option<&CloudConfig>)` accepts an injected user config for unit tests without disk I/O; the production `active_team_id()` reads from `user_level_cloud_json_path()` (honours the `CAS_USER_CLOUD_JSON` test-seam env var).
+
+### Factory context when a prompt hook is silent
+
+Claude's `UserPromptSubmit` remains the primary context channel. If it does
+not run, the first synchronous `PostToolUse` hook or successful CAS MCP tool
+response recovers inbox messages and local ambient recall. Both channels use
+`hooks/turn_context.rs`: the latest external prompt in a bounded Claude
+transcript tail supplies `promptId`, and a locked per-session receipt prevents
+repeated tools from reopening the inbox or retrievers. Normal prompt hooks
+record the same identifier. Recovery performs no embedding-provider requests
+and never captures transcript text into attribution or memory stores.
+
+`cas doctor` reports recent observed prompt-hook misses from these receipts;
+missing attribution rows alone are not evidence because supervisors omit them
+intentionally. Recovery needs a readable Claude transcript; missing or foreign
+transcripts do not authorize context delivery. Explicit PostToolUse matcher
+filters still apply, while the generated default covers all tools.

--- a/cas-cli/src/ambient_recall.rs
+++ b/cas-cli/src/ambient_recall.rs
@@ -1749,7 +1749,17 @@ pub(crate) fn build_ambient_recall_context(
         session_start,
         None,
         None,
+        true,
     )
+}
+
+/// Local-only recovery on the synchronous tool-result path. Never waits for cloud.
+pub(crate) fn build_local_ambient_recall_context(
+    input: &cas_core::hooks::types::HookInput,
+    cas_root: &Path,
+    prompt: &str,
+) -> Option<RecallPacket> {
+    build_ambient_recall_context_with_factory_identity(input, cas_root, Some(prompt), false, None, None, false)
 }
 
 /// Build an ambient packet for a factory launch before the harness has made
@@ -1770,6 +1780,7 @@ pub(crate) fn build_ambient_recall_context_for_factory_launch(
         true,
         Some(agent_name),
         Some(factory_session),
+        true,
     )
 }
 
@@ -1815,6 +1826,7 @@ fn build_ambient_recall_context_with_factory_identity(
     session_start: bool,
     factory_agent_name: Option<&str>,
     factory_session: Option<&str>,
+    allow_semantic: bool,
 ) -> Option<RecallPacket> {
     if crate::internal_llm::is_internal_invocation() {
         record_recall_decision(
@@ -1919,7 +1931,7 @@ fn build_ambient_recall_context_with_factory_identity(
         return None;
     };
     let config = crate::cloud::CloudConfig::load_from_cas_dir(cas_root).unwrap_or_default();
-    let semantic = SemanticRecallRetriever::existing(cas_root, &config);
+    let semantic = allow_semantic.then(|| SemanticRecallRetriever::existing(cas_root, &config)).flatten();
     let mut retrievers: Vec<&dyn RecallRetriever> = vec![&retriever];
     if let Some(semantic) = semantic.as_ref() {
         retrievers.push(semantic);

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -1129,6 +1129,19 @@ fn factory_supervisor_checks(agents: &[crate::types::Agent]) -> Vec<Check> {
         .collect()
 }
 
+fn prompt_hook_check(cas_root: &Path) -> Check {
+    let count = crate::hooks::turn_context::silent_prompt_count(cas_root);
+    Check {
+        name: "prompt hook".into(),
+        status: if count == 0 { CheckStatus::Ok } else { CheckStatus::Warning },
+        message: if count == 0 {
+            "No recent observed UserPromptSubmit misses".into()
+        } else {
+            format!("UserPromptSubmit hook silent for {count} prompts; restart Claude")
+        },
+    }
+}
+
 pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow::Result<()> {
     let started = Instant::now();
     let mut checks = Vec::new();
@@ -1268,6 +1281,8 @@ pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
     let host = host_checks(Some(project_root));
     if cli.full { checks.extend(host); } else { checks.push(host_summary(&host)); }
     recorder.mark("host checks", &checks);
+    checks.push(prompt_hook_check(&cas_root));
+    recorder.mark("prompt hook", &checks);
     // Check 2: Store type and database
     let store_type = detect_store_type(&cas_root);
     match store_type {
@@ -8974,4 +8989,24 @@ fn output_checks_timed(
     )?;
     fmt.flush()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod prompt_hook_tests {
+    use super::*;
+
+    #[test]
+    fn prompt_hook_row_reports_observed_silence_and_ignores_old_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(matches!(prompt_hook_check(temp.path()).status, CheckStatus::Ok));
+        let directory = temp.path().join("turn-context");
+        fs::create_dir(&directory).unwrap();
+        let now = chrono::Utc::now().timestamp();
+        for (name, count, timestamp) in [("recent", 3, now), ("expired", 9, now - 90_000)] {
+            fs::write(directory.join(format!("{name}.json")), serde_json::json!({"delivered": [], "silent_prompts": count, "updated_at": timestamp}).to_string()).unwrap();
+        }
+        let check = prompt_hook_check(temp.path());
+        assert!(matches!(check.status, CheckStatus::Warning));
+        assert_eq!(check.message, "UserPromptSubmit hook silent for 3 prompts; restart Claude");
+    }
 }

--- a/cas-cli/src/cli/hook/config_gen.rs
+++ b/cas-cli/src/cli/hook/config_gen.rs
@@ -377,7 +377,8 @@ pub(crate) fn get_cas_hooks_config(config: &crate::config::HookConfig) -> serde_
         );
     }
 
-    // async: true - observation recording, doesn't affect execution
+    // Context recovery must reach the first tool result of a turn. Async
+    // hooks defer additionalContext and can lose the only working channel.
     if config.post_tool_use.enabled {
         let matcher = config.post_tool_use.matcher.join("|");
         hooks.insert(
@@ -389,8 +390,7 @@ pub(crate) fn get_cas_hooks_config(config: &crate::config::HookConfig) -> serde_
                         {
                             "type": "command",
                             "command": "cas hook PostToolUse",
-                            "timeout": config.post_tool_use.timeout,
-                            "async": true
+                            "timeout": config.post_tool_use.timeout
                         }
                     ]
                 }
@@ -990,5 +990,16 @@ mod codex_provision_tests {
         let post_key = format!("{}:post_tool_use:0:0", hooks_path.display());
         assert!(state.get(&pre_key).is_some());
         assert!(state.get(&post_key).is_some());
+    }
+}
+
+#[cfg(test)]
+mod turn_context_tests {
+    #[test]
+    fn post_tool_context_runs_synchronously_for_read_and_mcp_tools() {
+        let hooks = super::get_cas_hooks_config(&crate::config::HookConfig::default());
+        let hook = &hooks["hooks"]["PostToolUse"][0];
+        assert_eq!(hook["matcher"], "*");
+        assert!(hook["hooks"][0].get("async").is_none());
     }
 }

--- a/cas-cli/src/config/hooks.rs
+++ b/cas-cli/src/config/hooks.rs
@@ -143,7 +143,7 @@ fn default_post_tool_use_timeout() -> u32 {
 }
 
 fn default_post_tool_use_matcher() -> Vec<String> {
-    vec!["Write".into(), "Edit".into(), "Bash".into()]
+    vec!["*".into()]
 }
 
 fn default_max_observations() -> usize {

--- a/cas-cli/src/hooks/handlers.rs
+++ b/cas-cli/src/hooks/handlers.rs
@@ -283,7 +283,7 @@ pub use handlers_state::{
     get_session_files, handle_subagent_start, handle_subagent_stop, handle_verifier_spawn_cleanup,
 };
 
-mod handlers_middle;
+pub(crate) mod handlers_middle;
 #[cfg(test)]
 pub(crate) use handlers_middle::is_file_within_project;
 pub use handlers_middle::{handle_post_tool_use, handle_stop, handle_user_prompt_submit};

--- a/cas-cli/src/hooks/handlers/handlers_middle/mod.rs
+++ b/cas-cli/src/hooks/handlers/handlers_middle/mod.rs
@@ -1,4 +1,4 @@
-mod factory_inbox;
+pub(crate) mod factory_inbox;
 mod post_tool;
 mod prompt_capture;
 mod session_stop;

--- a/cas-cli/src/hooks/handlers/handlers_middle/post_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_middle/post_tool.rs
@@ -7,9 +7,18 @@ pub fn handle_post_tool_use(
     input: &HookInput,
     cas_root: Option<&Path>,
 ) -> Result<HookOutput, MemError> {
-    handle_post_tool_use_with_guardrail(input, cas_root, |cas_root, input, stores| {
-        maybe_tmpfs_guardrail_warning(cas_root, input, stores.config())
-    })
+    let output =
+        handle_post_tool_use_with_guardrail(input, cas_root, |cas_root, input, stores| {
+            maybe_tmpfs_guardrail_warning(cas_root, input, stores.config())
+        })?;
+    let Some(context) =
+        cas_root.and_then(|root| crate::hooks::turn_context::fallback_context(root, input))
+    else {
+        return Ok(output);
+    };
+    Ok(HookOutput::with_post_tool_context(
+        merge_post_tool_contexts(Some(&output), context),
+    ))
 }
 
 fn handle_post_tool_use_with_guardrail(

--- a/cas-cli/src/hooks/handlers/handlers_tests/basic.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/basic.rs
@@ -3,6 +3,7 @@ use crate::hooks::handlers::*;
 #[test]
 fn test_format_file_change() {
     let input = HookInput {
+        prompt_id: None,
         session_id: "test".to_string(),
         agent_id: None,
         agent_type: None,
@@ -36,6 +37,7 @@ fn test_format_file_change() {
 #[test]
 fn test_format_bash_skips_simple() {
     let input = HookInput {
+        prompt_id: None,
         session_id: "test".to_string(),
         agent_id: None,
         agent_type: None,
@@ -69,6 +71,7 @@ fn test_format_bash_skips_simple() {
 #[test]
 fn test_format_bash_captures_cargo() {
     let input = HookInput {
+        prompt_id: None,
         session_id: "test".to_string(),
         agent_id: None,
         agent_type: None,
@@ -178,6 +181,7 @@ fn make_hook_input(
     tool_response: Option<serde_json::Value>,
 ) -> HookInput {
     HookInput {
+        prompt_id: None,
         session_id: "test-session".to_string(),
         agent_id: None,
         agent_type: None,
@@ -633,6 +637,7 @@ fn test_format_observation_unknown_tool() {
 #[test]
 fn test_format_observation_no_tool_input() {
     let input = HookInput {
+        prompt_id: None,
         session_id: "test".to_string(),
         agent_id: None,
         agent_type: None,

--- a/cas-cli/src/hooks/handlers/handlers_tests/factory_inbox_surfacing.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/factory_inbox_surfacing.rs
@@ -385,14 +385,15 @@ fn factory_worker_captures_operator_context_but_not_typed_machine_relays() {
                     MachinePromptOrigin::DirectorGenerated => "director-generated",
                 }
             );
-            let payload = crate::ui::factory::daemon::runtime::delivery::prepare_pty_machine_delivery(
-                &cas_root,
-                WORKER,
-                SupervisorCli::Codex,
-                source,
-                &rendered,
-                Some(123),
-            );
+            let payload =
+                crate::ui::factory::daemon::runtime::delivery::prepare_pty_machine_delivery(
+                    &cas_root,
+                    WORKER,
+                    SupervisorCli::Codex,
+                    source,
+                    &rendered,
+                    Some(123),
+                );
             let input: HookInput = serde_json::from_value(serde_json::json!({
                 "session_id": "hook-test-session",
                 "cwd": project.path(),
@@ -495,4 +496,117 @@ fn a_non_factory_session_surfaces_nothing() {
         .user_prompt_context()
         .is_some_and(|c| c.contains("factory-only traffic"));
     assert!(!surfaced, "a solo session must not drain factory queues");
+}
+
+/// cas-b8f6: read-first turns recover mail even when UserPromptSubmit is absent.
+#[test]
+fn post_tool_read_recovers_mail_once_without_prompt_hook() {
+    let _lock = super::env_lock();
+    let _env = worker_env();
+    let temp = TempDir::new().unwrap();
+    let store = store_at(&temp);
+    store
+        .enqueue_with_session("supervisor", WORKER, "recover missing hook mail", SESSION)
+        .unwrap();
+    let mut hook = input("worker");
+    hook.hook_event_name = "PostToolUse".into();
+    hook.tool_name = Some("Read".into());
+    let transcript = temp.path().join("session.jsonl");
+    std::fs::write(
+        &transcript,
+        r#"{"type":"user","promptId":"p","message":{"content":"continue"}}"#,
+    )
+    .unwrap();
+    hook.transcript_path = Some(transcript.to_string_lossy().into_owned());
+    let output = crate::hooks::handle_post_tool_use(&hook, Some(temp.path())).unwrap();
+    let Some(HookSpecificOutput::PostToolUse {
+        additional_context: Some(additional_context),
+    }) = output.hook_specific_output
+    else {
+        panic!("read-first PostToolUse must surface queued mail");
+    };
+    assert!(additional_context.contains("recover missing hook mail"));
+    let second = crate::hooks::handle_post_tool_use(&hook, Some(temp.path())).unwrap();
+    assert!(second.hook_specific_output.is_none());
+    assert_receipted_for_every_alias(&store, &[WORKER.into()]);
+}
+
+/// Exact 2.1.265 headless payload shape captured during the live investigation.
+#[test]
+fn captured_265_prompt_payload_reaches_handler_and_records_turn() {
+    let _lock = super::env_lock();
+    let _env = worker_env();
+    let temp = TempDir::new().unwrap();
+    let _root = EnvGuard::set(&[("CAS_ROOT", Some(temp.path().to_str().unwrap()))]);
+    let store = store_at(&temp);
+    store
+        .enqueue_with_session("supervisor", WORKER, "captured payload mail", SESSION)
+        .unwrap();
+    let payload = r#"{"session_id":"cbd23493-0cf2-404e-95a3-ad60bf9d1505","transcript_path":"/fixture/session.jsonl","cwd":"/fixture/project","prompt_id":"695ddcaa-d5b2-4d95-9bdd-4f20a4ed0923","permission_mode":"default","hook_event_name":"UserPromptSubmit","prompt":"reply with the single word ok","session_title":"[supervisor] factory"}"#;
+    let input: HookInput = serde_json::from_str(payload).unwrap();
+    assert_eq!(
+        input.prompt_id.as_deref(),
+        Some("695ddcaa-d5b2-4d95-9bdd-4f20a4ed0923")
+    );
+    let output = crate::hooks::handle_hook("UserPromptSubmit", input).unwrap();
+    assert!(context_of(&output).contains("captured payload mail"));
+    assert_eq!(
+        crate::hooks::turn_context::silent_prompt_count(temp.path()),
+        0
+    );
+    assert_eq!(
+        std::fs::read_dir(temp.path().join("turn-context"))
+            .unwrap()
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn post_tool_second_prompt_recovers_recall_and_skips_repeated_tools() {
+    let _lock = super::env_lock();
+    let _env = supervisor_env();
+    let project = TempDir::new().unwrap();
+    let cas_root = crate::store::init_cas_dir(project.path()).unwrap();
+    let entries = crate::store::open_store_local(&cas_root).unwrap();
+    let mut memory = Entry::new("recall-hook-recovery".into(), "epic_status compares child branches against stale local main; fast-forward origin/main before trusting its unmerged report".into());
+    memory.entry_type = EntryType::Learning;
+    memory.importance = 0.95;
+    entries.add(&memory).unwrap();
+    let transcript = project.path().join("session.jsonl");
+    let mut hook = input("supervisor");
+    hook.cwd = project.path().to_string_lossy().into_owned();
+    hook.transcript_path = Some(transcript.to_string_lossy().into_owned());
+    hook.prompt_id = Some("first".into());
+    crate::hooks::turn_context::record_prompt_hook(&cas_root, &hook);
+    std::fs::write(&transcript, format!("{{\"type\":\"user\",\"sessionId\":\"{}\",\"promptId\":\"second\",\"message\":{{\"content\":\"Investigate epic_status before trusting stale refs on main\"}}}}\n", hook.session_id)).unwrap();
+    hook.hook_event_name = "PostToolUse".into();
+    hook.tool_name = Some("Read".into());
+    let output = crate::hooks::handle_post_tool_use(&hook, Some(&cas_root)).unwrap();
+    let Some(HookSpecificOutput::PostToolUse {
+        additional_context: Some(additional_context),
+    }) = output.hook_specific_output
+    else {
+        panic!("missing recovered recall");
+    };
+    assert!(
+        additional_context.contains("recall-hook-recovery"),
+        "{additional_context}"
+    );
+    assert_eq!(
+        crate::hooks::turn_context::silent_prompt_count(&cas_root),
+        1
+    );
+    let repeated = crate::hooks::handle_post_tool_use(&hook, Some(&cas_root)).unwrap();
+    assert!(repeated.hook_specific_output.is_none());
+    assert_eq!(
+        crate::hooks::turn_context::silent_prompt_count(&cas_root),
+        1
+    );
+    hook.prompt_id = Some("second".into());
+    crate::hooks::turn_context::record_prompt_hook(&cas_root, &hook);
+    assert_eq!(
+        crate::hooks::turn_context::silent_prompt_count(&cas_root),
+        0
+    );
 }

--- a/cas-cli/src/hooks/mod.rs
+++ b/cas-cli/src/hooks/mod.rs
@@ -14,7 +14,7 @@
 //! - **Stop**: Generates session summary when agent finishes
 //! - **SubagentStop**: Cleans up subagent leases when subagent finishes
 //! - **PostToolUse**: Captures interesting tool interactions as observations
-//! - **UserPromptSubmit**: Optional prompt capture (currently passthrough)
+//! - **UserPromptSubmit**: Factory context delivery and prompt capture
 //!
 //! # Usage
 //!
@@ -28,6 +28,7 @@ pub(crate) mod delivery_provenance;
 pub(crate) mod handlers;
 pub mod scorer;
 pub mod transcript;
+pub(crate) mod turn_context;
 mod types;
 
 // Re-export types from cas-core
@@ -147,7 +148,7 @@ pub fn handle_hook(event_name: &str, mut input: HookInput) -> Result<HookOutput,
             });
     }
 
-    match event_name {
+    let result = match event_name {
         "SessionStart" => handle_session_start(&input, cas_root.as_deref()),
         "SessionEnd" => handle_session_end(&input, cas_root.as_deref()),
         "Stop" => handle_stop(&input, cas_root.as_deref()),
@@ -167,7 +168,13 @@ pub fn handle_hook(event_name: &str, mut input: HookInput) -> Result<HookOutput,
             // Unknown hook, just pass through
             Ok(HookOutput::empty())
         }
+    };
+    if event_name == "UserPromptSubmit" && result.is_ok() {
+        if let Some(root) = cas_root.as_deref() {
+            turn_context::record_prompt_hook(root, &input);
+        }
     }
+    result
 }
 
 #[cfg(test)]

--- a/cas-cli/src/hooks/turn_context.rs
+++ b/cas-cli/src/hooks/turn_context.rs
@@ -1,0 +1,272 @@
+//! Redundant factory context delivery when Claude skips UserPromptSubmit.
+//!
+//! A bounded transcript tail identifies turns; a per-session file lock shares
+//! receipts between hook processes and the MCP server. Prompt bodies are never
+//! persisted here or sent to attribution/memory ingestion.
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::HookInput;
+
+const TAIL_BYTES: u64 = 256 * 1024;
+const RECENT_TURNS: usize = 32;
+
+#[derive(Default, Serialize, Deserialize)]
+struct TurnState {
+    delivered: Vec<String>,
+    silent_prompts: u64,
+    updated_at: i64,
+}
+
+struct Receipt {
+    file: File,
+    state: TurnState,
+}
+
+impl Receipt {
+    fn open(root: &Path, session: &str) -> Option<Self> {
+        if session.trim().is_empty() {
+            return None;
+        }
+        let directory = root.join("turn-context");
+        fs::create_dir_all(&directory).ok()?;
+        let key = format!("{:x}", Sha256::digest(session.as_bytes()));
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(directory.join(format!("{key}.json")))
+            .ok()?;
+        file.try_lock_exclusive().ok()?;
+        let mut data = String::new();
+        (&mut file).take(16 * 1024).read_to_string(&mut data).ok()?;
+        let state = if data.is_empty() {
+            TurnState::default()
+        } else {
+            serde_json::from_str(&data).ok()?
+        };
+        Some(Self { file, state })
+    }
+
+    fn save(&mut self) -> Option<()> {
+        self.state.updated_at = chrono::Utc::now().timestamp();
+        let data = serde_json::to_vec(&self.state).ok()?;
+        self.file.seek(SeekFrom::Start(0)).ok()?;
+        self.file.write_all(&data).ok()?;
+        self.file.set_len(data.len() as u64).ok()?;
+        Some(())
+    }
+
+    fn remember(&mut self, key: &str) {
+        if !self.state.delivered.iter().any(|seen| seen == key) {
+            self.state.delivered.push(key.to_string());
+            if self.state.delivered.len() > RECENT_TURNS {
+                self.state.delivered.remove(0);
+            }
+        }
+    }
+}
+
+/// Successful normal hooks suppress fallback recall for that same prompt.
+pub(crate) fn record_prompt_hook(root: &Path, input: &HookInput) {
+    if crate::internal_llm::is_internal_invocation() {
+        return;
+    }
+    let Some(key) = input.prompt_id.as_deref() else {
+        return;
+    };
+    let Some(mut receipt) = Receipt::open(root, &input.session_id) else {
+        return;
+    };
+    receipt.remember(key);
+    receipt.state.silent_prompts = 0;
+    let _ = receipt.save();
+}
+
+/// Read only real external user messages, never tool results, sidechains or
+/// meta reminders. `promptId` aligns with the normal hook's `prompt_id`.
+fn latest_turn(path: &Path, session: &str) -> Option<(String, String)> {
+    let mut file = File::open(path).ok()?;
+    let size = file.metadata().ok()?.len();
+    let start = size.saturating_sub(TAIL_BYTES);
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut bytes = Vec::new();
+    file.take(TAIL_BYTES).read_to_end(&mut bytes).ok()?;
+    let text = String::from_utf8_lossy(&bytes);
+    for line in text.lines().rev() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if value["type"] != "user" || value["isMeta"] == true || value["isSidechain"] == true {
+            continue;
+        }
+        if value
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .is_some_and(|id| id != session)
+        {
+            continue;
+        }
+        // Claude emits operator prompts as strings. Arrays include tool_result
+        // and synthetic user messages; do not guess their provenance.
+        let Some(prompt) = value["message"]["content"].as_str() else {
+            continue;
+        };
+        let Some(key) = value["promptId"]
+            .as_str()
+            .or_else(|| value["uuid"].as_str())
+        else {
+            continue;
+        };
+        return Some((key.to_string(), prompt.to_string()));
+    }
+    None
+}
+
+/// Called by PostToolUse and by successful MCP responses. Inbox receipts are
+/// already atomic and shared with UserPromptSubmit. Recall runs once per turn,
+/// including read tools, independent of observation capture filters.
+pub(crate) fn fallback_context(root: &Path, input: &HookInput) -> Option<String> {
+    if crate::internal_llm::is_internal_invocation()
+        || !crate::harness_policy::is_factory_agent(input)
+    {
+        return None;
+    }
+    let (key, prompt) = latest_turn(
+        Path::new(input.transcript_path.as_deref()?),
+        &input.session_id,
+    )?;
+    let mut receipt = Receipt::open(root, &input.session_id)?;
+    if receipt.state.delivered.contains(&key) {
+        return None;
+    }
+    // Both recovery channels share this claim before any inbox/store work.
+    receipt.remember(&key);
+    receipt.state.silent_prompts = receipt.state.silent_prompts.saturating_add(1);
+    receipt.save()?;
+    let mut parts = Vec::new();
+    if let Some(mail) =
+        super::handlers::handlers_middle::factory_inbox::surface_factory_inbox(Some(root), input)
+    {
+        parts.push(mail);
+    }
+    if let Some(packet) =
+        crate::ambient_recall::build_local_ambient_recall_context(input, root, &prompt)
+    {
+        parts.push(packet.full);
+    }
+    (!parts.is_empty()).then(|| parts.join("\n\n"))
+}
+
+/// Recent observed misses only: never infer silence from absent attribution
+/// rows (supervisors intentionally omit them). Expire stopped sessions after a day.
+pub(crate) fn silent_prompt_count(root: &Path) -> u64 {
+    let Ok(entries) = fs::read_dir(root.join("turn-context")) else {
+        return 0;
+    };
+    let cutoff = chrono::Utc::now().timestamp() - 24 * 60 * 60;
+    entries
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|e| e == "json"))
+        .filter_map(|entry| fs::read(entry.path()).ok())
+        .filter_map(|data| serde_json::from_slice::<TurnState>(&data).ok())
+        .filter(|state| state.updated_at >= cutoff)
+        .map(|state| state.silent_prompts)
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcript_turn_excludes_tool_results_and_other_sessions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("transcript.jsonl");
+        fs::write(&path, concat!(
+            "{\"type\":\"user\",\"sessionId\":\"s\",\"promptId\":\"p\",\"message\":{\"content\":\"question\"}}\n",
+            "{\"type\":\"user\",\"uuid\":\"tool\",\"message\":{\"content\":[{\"type\":\"tool_result\"}]}}\n",
+            "{\"type\":\"user\",\"isMeta\":true,\"uuid\":\"meta\",\"message\":{\"content\":\"ignore\"}}\n",
+            "{\"type\":\"user\",\"sessionId\":\"other\",\"uuid\":\"other\",\"message\":{\"content\":\"foreign\"}}\n",
+        )).unwrap();
+        assert_eq!(
+            latest_turn(&path, "s"),
+            Some(("p".into(), "question".into()))
+        );
+    }
+
+    #[test]
+    fn prompt_hook_receipt_recovers_silence_and_deduplicates() {
+        let _guard = crate::hooks::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let mut receipt = Receipt::open(dir.path(), "s").unwrap();
+        receipt.state.silent_prompts = 2;
+        receipt.save().unwrap();
+        drop(receipt);
+        assert_eq!(silent_prompt_count(dir.path()), 2);
+        record_prompt_hook(
+            dir.path(),
+            &HookInput {
+                session_id: "s".into(),
+                prompt_id: Some("p".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(silent_prompt_count(dir.path()), 0);
+        let receipt = Receipt::open(dir.path(), "s").unwrap();
+        assert_eq!(receipt.state.delivered, ["p"]);
+        assert!(
+            Receipt::open(dir.path(), "s").is_none(),
+            "concurrent readers must not duplicate a turn"
+        );
+    }
+    #[test]
+    fn served_turn_noop_is_under_50ms_and_does_not_open_stores() {
+        let _env = crate::test_support::TestEnvGuard::with_optional_vars(&[
+            ("CAS_AGENT_ROLE", Some("worker")),
+            (crate::internal_llm::INTERNAL_LLM_ENV, None),
+        ]);
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir.path().join("session.jsonl");
+        fs::write(
+            &transcript,
+            r#"{"type":"user","promptId":"p","message":{"content":"continue"}}"#,
+        )
+        .unwrap();
+        let input = HookInput {
+            session_id: "s".into(),
+            prompt_id: Some("p".into()),
+            transcript_path: Some(transcript.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        record_prompt_hook(dir.path(), &input);
+        let state_file = fs::read_dir(dir.path().join("turn-context"))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        let modified = fs::metadata(&state_file).unwrap().modified().unwrap();
+        let started = std::time::Instant::now();
+        for _ in 0..100 {
+            assert!(fallback_context(dir.path(), &input).is_none());
+        }
+        let average = started.elapsed() / 100;
+        eprintln!("served-turn recovery average: {average:?} (100 calls)");
+        assert!(average < std::time::Duration::from_millis(50));
+        assert_eq!(
+            fs::metadata(state_file).unwrap().modified().unwrap(),
+            modified
+        );
+        assert!(
+            !dir.path().join("cas.db").exists(),
+            "no-op must never open a store"
+        );
+    }
+}

--- a/cas-cli/src/mcp/server/prompts.rs
+++ b/cas-cli/src/mcp/server/prompts.rs
@@ -115,6 +115,7 @@ impl CasCore {
                     });
                 let context = crate::hooks::build_context(
                     &crate::hooks::HookInput {
+                        prompt_id: None,
                         session_id: "mcp".to_string(),
                         transcript_path: None,
                         cwd: self

--- a/cas-cli/src/mcp/tools/core/agent_coordination/agent_session.rs
+++ b/cas-cli/src/mcp/tools/core/agent_coordination/agent_session.rs
@@ -164,6 +164,7 @@ impl CasCore {
         });
 
         let input = HookInput {
+            prompt_id: None,
             session_id: session_id.clone(),
             cwd,
             workspace_root: None,
@@ -349,6 +350,7 @@ impl CasCore {
             .to_string();
 
         let input = HookInput {
+            prompt_id: None,
             session_id: session_id.clone(),
             cwd,
             workspace_root: None,

--- a/cas-cli/src/mcp/tools/core/system.rs
+++ b/cas-cli/src/mcp/tools/core/system.rs
@@ -118,6 +118,7 @@ impl CasCore {
 
         // Create a minimal HookInput for context building
         let hook_input = HookInput {
+            prompt_id: None,
             session_id: "mcp".to_string(),
             transcript_path: None,
             cwd: self
@@ -181,6 +182,7 @@ impl CasCore {
         let task_content = format!("{} {}", task.title, task.description);
 
         let hook_input = HookInput {
+            prompt_id: None,
             session_id: "mcp".to_string(),
             transcript_path: None,
             cwd: self

--- a/cas-cli/src/mcp/tools/service/server_handler.rs
+++ b/cas-cli/src/mcp/tools/service/server_handler.rs
@@ -55,7 +55,12 @@ impl ServerHandler for CasService {
             }
 
             let resources = self.inner.build_resources();
-            info!(method = "resources/list", count = resources.len(), elapsed_ms = start.elapsed().as_millis() as u64, "MCP resources/list DONE");
+            info!(
+                method = "resources/list",
+                count = resources.len(),
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                "MCP resources/list DONE"
+            );
             Ok(ListResourcesResult {
                 resources,
                 next_cursor: None,
@@ -120,7 +125,12 @@ impl ServerHandler for CasService {
             let start = std::time::Instant::now();
             info!(method = "tools/list", "MCP tools/list START");
             let tools = self.tool_router.list_all();
-            info!(method = "tools/list", count = tools.len(), elapsed_ms = start.elapsed().as_millis() as u64, "MCP tools/list DONE");
+            info!(
+                method = "tools/list",
+                count = tools.len(),
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                "MCP tools/list DONE"
+            );
 
             Ok(ListToolsResult {
                 tools,
@@ -177,12 +187,81 @@ impl ServerHandler for CasService {
                 }
             };
 
-            result
+            self.append_factory_context(result).await
         }
     }
 }
 
+/// This MCP process belongs to the caller's cwd/account. A supervisor has no
+/// worker clone, so worker-status's conventional worktree path is unsuitable.
+fn caller_transcript_path(agent: &crate::types::Agent) -> Option<std::path::PathBuf> {
+    if super::factory_ops::worker_cli_from_agent(agent) != cas_mux::SupervisorCli::Claude {
+        return None;
+    }
+    let cwd = std::env::current_dir().ok()?;
+    let slug: String = cwd
+        .to_string_lossy()
+        .chars()
+        .map(|c| if matches!(c, '/' | '.') { '-' } else { c })
+        .collect();
+    let account = agent
+        .metadata
+        .get("worker_account_dir")
+        .map(std::path::PathBuf::from)
+        .or_else(|| std::env::var_os("CLAUDE_CONFIG_DIR").map(std::path::PathBuf::from))
+        .or_else(|| dirs::home_dir().map(|home| home.join(".claude")))?;
+    let session = agent.cc_session_id.as_deref().unwrap_or(&agent.id);
+    let path = account
+        .join("projects")
+        .join(slug)
+        .join(format!("{session}.jsonl"));
+    path.is_file().then_some(path)
+}
+
 impl CasService {
+    /// Preserve the tool's result and attach recoverable factory mail/recall.
+    /// Only the registered process identity may read its inbox or transcript.
+    async fn append_factory_context(
+        &self,
+        result: Result<rmcp::model::CallToolResult, rmcp::ErrorData>,
+    ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+        let Ok(mut output) = result else {
+            return result;
+        };
+        let this = self.clone();
+        let context = tokio::task::spawn_blocking(move || {
+            if crate::internal_llm::is_internal_invocation() {
+                return None;
+            }
+            let id = this.inner.get_registered_agent_id_read_only().ok()?;
+            let agent = this.inner.open_agent_store().ok()?.get(&id).ok()?;
+            let name = std::env::var("CAS_AGENT_NAME").ok()?;
+            if agent.name != name {
+                return None;
+            }
+            let role = match agent.role {
+                crate::types::AgentRole::Supervisor => "supervisor",
+                crate::types::AgentRole::Worker => "worker",
+                _ => return None,
+            };
+            let input = crate::hooks::HookInput {
+                session_id: agent.cc_session_id.clone().unwrap_or(agent.id.clone()),
+                agent_role: Some(role.into()),
+                transcript_path: caller_transcript_path(&agent)
+                    .map(|path| path.to_string_lossy().into_owned()),
+                ..Default::default()
+            };
+            crate::hooks::turn_context::fallback_context(&this.inner.cas_root, &input)
+        })
+        .await
+        .ok()
+        .flatten();
+        if let Some(context) = context {
+            output.content.push(rmcp::model::Content::text(context));
+        }
+        Ok(output)
+    }
+
     /// A response-layer timeout cancels the handler, but a synchronous store
     /// write may have committed just before that cancellation. Never leave a
     /// caller guessing whether retrying a mutating request would duplicate it.
@@ -240,6 +319,84 @@ fn potentially_mutating_call(tool_name: &str, action: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::potentially_mutating_call;
+
+    #[tokio::test]
+    async fn response_fallback_preserves_result_and_surfaces_mail_once() {
+        use crate::mcp::server::CasCore;
+        use crate::mcp::tools::service::CasService;
+        use crate::test_support::TestEnvGuard;
+        use cas_store::{PromptQueueStore, SqlitePromptQueueStore};
+        let temp = tempfile::tempdir().unwrap();
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_AGENT_NAME", Some("response-worker")),
+            ("CAS_AGENT_ROLE", Some("worker")),
+            ("CAS_FACTORY_SESSION", Some("response-factory")),
+            (crate::internal_llm::INTERNAL_LLM_ENV, None),
+        ]);
+        let core = CasCore::with_daemon(temp.path().to_path_buf(), None, None);
+        core.register_agent("response-session".into(), "response-worker".into(), None)
+            .unwrap();
+        let service = CasService::new(
+            core,
+            #[cfg(feature = "mcp-proxy")]
+            None,
+        );
+        let account = temp.path().join("account");
+        let slug: String = std::env::current_dir()
+            .unwrap()
+            .to_string_lossy()
+            .chars()
+            .map(|c| if matches!(c, '/' | '.') { '-' } else { c })
+            .collect();
+        let transcripts = account.join("projects").join(slug);
+        std::fs::create_dir_all(&transcripts).unwrap();
+        std::fs::write(
+            transcripts.join("response-session.jsonl"),
+            r#"{"type":"user","promptId":"response-turn","message":{"content":"continue"}}"#,
+        )
+        .unwrap();
+        let store = service.inner.open_agent_store().unwrap();
+        let mut agent = store.get("response-session").unwrap();
+        agent.metadata.insert(
+            "worker_account_dir".into(),
+            account.to_string_lossy().into_owned(),
+        );
+        agent.metadata.insert("worker_cli".into(), "claude".into());
+        store.update(&agent).unwrap();
+        assert_eq!(agent.role, crate::types::AgentRole::Worker);
+        assert_eq!(agent.name, "response-worker");
+        assert_eq!(
+            service.inner.get_registered_agent_id_read_only().unwrap(),
+            agent.id
+        );
+        assert_eq!(
+            super::caller_transcript_path(&agent),
+            Some(transcripts.join("response-session.jsonl"))
+        );
+        let queue = SqlitePromptQueueStore::open(temp.path()).unwrap();
+        queue.init().unwrap();
+        queue
+            .enqueue_with_session(
+                "supervisor",
+                "response-worker",
+                "mail via MCP fallback",
+                "response-factory",
+            )
+            .unwrap();
+        let output = service
+            .append_factory_context(Ok(CasCore::success("original result")))
+            .await
+            .unwrap();
+        assert_eq!(output.content.len(), 2);
+        let text = serde_json::to_string(&output).unwrap();
+        assert!(text.contains("original result"));
+        assert!(text.contains("mail via MCP fallback"));
+        let repeated = service
+            .append_factory_context(Ok(CasCore::success("next result")))
+            .await
+            .unwrap();
+        assert_eq!(repeated.content.len(), 1);
+    }
 
     #[test]
     fn timeout_backstop_never_treats_task_close_as_read_only() {

--- a/crates/cas-core/src/hooks/types.rs
+++ b/crates/cas-core/src/hooks/types.rs
@@ -71,6 +71,10 @@ pub struct HookInput {
     #[serde(default, alias = "sessionId")]
     pub session_id: String,
 
+    /// Claude's stable turn identifier, also stored as `promptId` in its transcript.
+    #[serde(default)]
+    pub prompt_id: Option<String>,
+
     /// Path to the transcript file
     #[serde(default, alias = "transcriptPath")]
     pub transcript_path: Option<String>,

--- a/docs/design/cli/doctor-hook-silence.brief.md
+++ b/docs/design/cli/doctor-hook-silence.brief.md
@@ -1,0 +1,9 @@
+# Doctor hook silence diagnostic
+
+| Field | Contract |
+| --- | --- |
+| First two lines | The existing doctor verdict includes a warning when recent factory turns were observed without UserPromptSubmit. |
+| Scannable | One `prompt hook` row shows the number of missed prompts across recently active sessions. |
+| Readable | The finding identifies UserPromptSubmit and directs the operator to restart Claude; fallback delivery continues in the current session. |
+| Machine output | The existing doctor JSON check carries `name`, `status`, and `message`; no new output envelope or ANSI is introduced. |
+| Omitted | Raw prompts, session identifiers, and transcript bodies stay out of the diagnostic; only bounded delivery receipts are counted. |

--- a/docs/design/cli/doctor-hook-silence.brief.md
+++ b/docs/design/cli/doctor-hook-silence.brief.md
@@ -7,3 +7,28 @@
 | Readable | The finding identifies UserPromptSubmit and directs the operator to restart Claude; fallback delivery continues in the current session. |
 | Machine output | The existing doctor JSON check carries `name`, `status`, and `message`; no new output envelope or ANSI is introduced. |
 | Omitted | Raw prompts, session identifiers, and transcript bodies stay out of the diagnostic; only bounded delivery receipts are counted. |
+
+
+## Critique
+
+terminal-qa: PASS cas-doctor-hook-silence · 12 runs · 0 fail · 0 warn · 0 allowed
+
+The gate used `--escape-flag --verbose`, matching doctor's existing footer,
+and `--json-flag --json`. Full receipts and captures are in the task's durable
+`terminal-qa-final/` artifact directory. The warning-row capture at 80 columns:
+
+```text
+  ⚠ prompt hook  UserPromptSubmit hook silent for 1 prompts; restart Claude
+```
+
+| Dimension | Score | Evidence |
+| --- | --- | --- |
+| Hierarchy | 4 | The warning participates in the first-line count and names the failed channel. |
+| Fit | 5 | All 80-column captures fit; the complete new finding occupies one line. |
+| Craft | 4 | One count and one remedy use the existing doctor row vocabulary. |
+| Theme safety | 5 | Four palettes, NO_COLOR, and C locale pass without exceptions. |
+| Machine contract | 5 | One valid JSON document carries the same check and finding. |
+
+Scored by clever-jay-9 on 2026-09-08. The initial gate used its default
+`--full` escape flag and rejected unrelated truncations; using doctor's actual
+`--verbose` escape resolved all 12 findings without renderer changes.


### PR DESCRIPTION
Was: ambient recall, the supervisor reminder, and factory inbox surfacing were delivered only by the UserPromptSubmit hook; since Claude Code 2.1.263 long-lived team sessions never invoke it, so mid-session recall and mail were dead for two days without any signal.
Now: a shared per-prompt turn-context receipt lets the PostToolUse hook (now synchronous, all tools) or any MCP tool response deliver the same context exactly once per turn when the prompt hook did not; `cas doctor` reports observed prompt-hook silence. Live two-prompt team-session proof with the prompt hook omitted; no-op cost 10.6 ms mean.

Closes #763.