### PR TITLE
docs(release-notes): v3.20.0 announcement receipts and PR #771 receipt

### DIFF
--- a/docs/release-notes/2026-09-08-release-gate-timing-slack.md
+++ b/docs/release-notes/2026-09-08-release-gate-timing-slack.md
@@ -1,0 +1,24 @@
+# Slack draft — release gate timing and reuse (main merge, PR #771)
+
+Channel: #cas-internal. Deploy target: Live on production (main).
+
+## User thread
+
+Top-level:
+Live on production · User · Cassy's release checks now run the test suite once instead of twice and can re-check an unchanged release in under a minute.
+
+Reply:
+Was → every release check compiled and ran the whole test suite twice and started from scratch after any one-line fix, so a release spent most of an hour re-checking work it had already verified. Now → the suite runs once, every check records how long it took, and an unchanged release can be re-checked in about forty seconds while the safety rules that decide what may ship stay exactly as strict.
+
+## Dev thread
+
+Top-level:
+Live on production · Dev · The release gate records per-row timings, runs the workspace suite once across the nextest and archive rows, and offers an opt-in content-keyed `--reuse` re-gate that never authorizes the pipeline.
+
+Reply:
+Was → `scripts/release-gate.sh` ran the in-tree nextest workspace and the archive run as two full suite executions, kept no per-row timings, and the doctest row bypassed the CI verified-test wrapper; a fix forced a full ~20-minute re-gate. Now → rows log UTC/wall/user/system timings, the nextest row covers only the snapshot complement while the archive run executes the workspace once, `--reuse` re-gates an unchanged tree from content-keyed PASS receipts and can never authorize `--pipeline`, and doctests use the same wrapper and identity scrub as ci.yml. Measured: baseline 1207 s, optimized 1170 s, unchanged reuse 37.5 s. PR #771.
+
+## POSTED
+Posted 2026-09-08 23:34Z via the claude.ai Slack MCP to #cas-internal (C0B44GUKDK2):
+- User top-level ts 1788910476.381799 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788910476381799 (reply in thread)
+- Dev top-level ts 1788910477.288529 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788910477288529 (reply in thread)

--- a/docs/release-notes/2026-09-08-v3.20.0-slack.md
+++ b/docs/release-notes/2026-09-08-v3.20.0-slack.md
@@ -2,7 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-Status: DRAFT.
+Status: POSTED (see the POSTED block at the end).
 
 User top-level
 
@@ -32,7 +32,7 @@ User reply
 
 • *Quiet waiting* — Was: an idle code watcher could keep a CPU core busy. Now: `cas serve` waits for file changes without spinning.
 
-Report: [docs/release-reports/v3.20.0.html](../release-reports/v3.20.0.html) · [docs/release-reports/v3.20.0.pdf](../release-reports/v3.20.0.pdf) (forthcoming).
+Report: docs/release-reports/v3.20.0.html and docs/release-reports/v3.20.0.pdf (release-report epic branch cas-b36e at 5e54b807; lands on main with the next release).
 
 Install: update with `cas update`, or download the Linux x86_64 archive (`927ce9b5a594bb7d6d14858c043415587e61c30f3a377ab4e432b22242425b35`) or macOS ARM64 archive (`a39b21961c94d1f77174e257b27503c76b04b1db6a816704e47aa05ef2ef49c5`) from the Cassy v3.20.0 release.
 ```
@@ -84,3 +84,12 @@ Posting sequence
    order, spacing writes at least one second apart.
 6. Append the `## POSTED` receipt with UTC timestamps, channel id, and every
    returned message id and permalink, then carry it into the next preparation.
+
+## POSTED
+
+Posted 2026-09-08 23:41Z via the claude.ai Slack MCP to #cas-internal (C0B44GUKDK2), after `release-published-receipt.sh v3.20.0 --write-draft` replaced both digests (PUBLISHED_AT=2026-09-08T23:17:25Z) and the v3.20.0 report (cas-16a3) was merged:
+
+- User top-level ts 1788910859.837649 — https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788910859837649
+- User reply ts 1788910889.196679 (thread of the user top-level; the ambient recall bullet was reworded at post time to state the live 3.20.0 result honestly)
+- Dev top-level ts 1788910860.795289 — https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788910860795289
+- Dev reply ts 1788910898.204009 (thread of the dev top-level; adds the PR #773 follow-up note)

--- a/docs/release-notes/2026-09-08-v3.20.0-slack.md
+++ b/docs/release-notes/2026-09-08-v3.20.0-slack.md
@@ -34,7 +34,7 @@ User reply
 
 Report: [docs/release-reports/v3.20.0.html](../release-reports/v3.20.0.html) · [docs/release-reports/v3.20.0.pdf](../release-reports/v3.20.0.pdf) (forthcoming).
 
-Install: update with `cas update`, or download the Linux x86_64 archive (`{{LINUX_SHA256}}`) or macOS ARM64 archive (`{{MACOS_SHA256}}`) from the Cassy v3.20.0 release.
+Install: update with `cas update`, or download the Linux x86_64 archive (`927ce9b5a594bb7d6d14858c043415587e61c30f3a377ab4e432b22242425b35`) or macOS ARM64 archive (`a39b21961c94d1f77174e257b27503c76b04b1db6a816704e47aa05ef2ef49c5`) from the Cassy v3.20.0 release.
 ```
 
 Dev top-level
@@ -67,7 +67,7 @@ Dev reply
 
 Validation: `scripts/release-gate.sh 3.20.0 --only changelog-and-versions,version-literals`; `cargo check -p cas --lib --tests`.
 
-Install: `cas-x86_64-unknown-linux-gnu.tar.gz` (`{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (`{{MACOS_SHA256}}`) will be published by CI for Linux and macOS.
+Install: `cas-x86_64-unknown-linux-gnu.tar.gz` (`927ce9b5a594bb7d6d14858c043415587e61c30f3a377ab4e432b22242425b35`) and `cas-aarch64-apple-darwin.tar.gz` (`a39b21961c94d1f77174e257b27503c76b04b1db6a816704e47aa05ef2ef49c5`) will be published by CI for Linux and macOS.
 ```
 
 Posting sequence


### PR DESCRIPTION
Was: the v3.20.0 announcement draft carried digest placeholders and no posting receipts, and the release-gate timing merge had no saved receipt. Now: the draft has both asset digests, the report location, and four Slack POSTED receipts; the PR #771 receipt is recorded.