### PR TITLE
docs(release-notes): v3.20.0 report file receipts

### DIFF
--- a/docs/release-notes/2026-09-08-v3.20.0-slack.md
+++ b/docs/release-notes/2026-09-08-v3.20.0-slack.md
@@ -93,3 +93,4 @@ Posted 2026-09-08 23:41Z via the claude.ai Slack MCP to #cas-internal (C0B44GUKD
 - User reply ts 1788910889.196679 (thread of the user top-level; the ambient recall bullet was reworded at post time to state the live 3.20.0 result honestly)
 - Dev top-level ts 1788910860.795289 — https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788910860795289
 - Dev reply ts 1788910898.204009 (thread of the dev top-level; adds the PR #773 follow-up note)
+- Report files posted 2026-09-09 00:1xZ in the user thread: PDF F0C0J4Z8HHU https://petra-stella.slack.com/files/U076KKG4DGU/F0C0J4Z8HHU/cassy-v3.20.0-release-report.pdf ; HTML F0C04MSK0MV https://petra-stella.slack.com/files/U076KKG4DGU/F0C04MSK0MV/cassy-v3.20.0-release-report.html


### PR DESCRIPTION
Was: the v3.20.0 announcement receipt did not record the report files. Now: the PDF and HTML Slack file ids and links are recorded in the user-thread receipt.