### PR TITLE
docs(release-notes): v3.21.0 POSTED receipts and report links

### DIFF
--- a/docs/release-notes/2026-09-09-v3.21.0-slack.md
+++ b/docs/release-notes/2026-09-09-v3.21.0-slack.md
@@ -2,7 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-Status: Draft. Do not post until the tagged GitHub workflow publishes both assets and `release-published-receipt.sh --write-draft` has replaced both checksum placeholders below.
+Status: POSTED (see the POSTED block at the end).
 
 User top-level
 
@@ -30,7 +30,9 @@ User reply
 
 • *Faster release checks* — Was: every release check ran the test suite twice. Now: once, with an unchanged release re-checked in under a minute.
 
-Install: update with `cas update`, or download the Linux x86_64 archive (`{{LINUX_SHA256}}`) or macOS ARM64 archive (`{{MACOS_SHA256}}`) from the Cassy v3.21.0 release.
+Report: the v3.21.0 release report (PDF and HTML) is attached below in this thread.
+
+Install: update with `cas update`, or download the Linux x86_64 archive (`dfcbdf1936dc1c8a8643153ed1cfd53e6ac621fde6f00847d4cbf7de806deed2`) or macOS ARM64 archive (`ebbd648122c72533feb8dd2b65329c4280a5ea0f1fe64e75922413e3925cfb6b`) from the Cassy v3.21.0 release.
 ```
 
 Dev top-level
@@ -57,15 +59,24 @@ Dev reply
 
 *Carried from main since 3.20.0*
 
-• *Turn context delivery* — PostToolUse and the MCP response wrapper deliver recall and inbox once per prompt when UserPromptSubmit is silent; doctor row counts misses (PR #772, #763).
-• *Ambient ranking* — overlap before recency, 16-term cap, 1500 ms semantic deadline, commits behind guidance (PR #773, #764).
-• *Release gate* — single workspace suite execution, per-row timings, `--reuse` for unchanged trees (PR #771).
+• *Turn context delivery* — Was: recall and factory inbox reached a session only through the UserPromptSubmit hook, which Claude Code 2.1.263+ omits in long-lived team sessions. Now: PostToolUse and the MCP response wrapper deliver them once per prompt when that hook is silent, and a doctor row counts misses (PR #772, #763).
 
-Validation: full release gate on the exact candidate tip; merge queue validates the synthetic tree.
+• *Ambient ranking* — Was: discovery read the eight most recently updated rows, so same-day exact matches were missed and the semantic step timed out at 400 ms. Now: overlap ranks before recency, prompt terms cap at 16, the semantic deadline is 1500 ms, and commits sort behind guidance (PR #773, #764).
 
-Install: `cas-x86_64-unknown-linux-gnu.tar.gz` (`{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (`{{MACOS_SHA256}}`) will be published by CI for Linux and macOS.
+• *Release gate* — Was: the gate ran the workspace suite twice and kept no per-row timings. Now: a single suite execution across the nextest and archive rows, per-row timings, and `--reuse` for unchanged trees (PR #771).
+
+Validation: full release gate green on the exact candidate tip 4d93394e (second run; the first failed one skill-size guardrail test that was fixed on the assembled tree); merge queue validated the synthetic tree (PR #777, run 34356617509). Tag-to-published 163 s; green-to-published 2,402 s.
+
+Install: `cas-x86_64-unknown-linux-gnu.tar.gz` (`dfcbdf1936dc1c8a8643153ed1cfd53e6ac621fde6f00847d4cbf7de806deed2`) and `cas-aarch64-apple-darwin.tar.gz` (`ebbd648122c72533feb8dd2b65329c4280a5ea0f1fe64e75922413e3925cfb6b`) published by CI for Linux and macOS.
 ```
 
 ## POSTED
 
-(pending)
+Posted 2026-09-09 14:23Z via the MechaCassy hub (mecha_post) to #cas-internal (C0B44GUKDK2), after `release-published-receipt.sh v3.21.0 --write-draft` replaced both digests (PUBLISHED_AT=2026-09-09T13:54:22Z) and the v3.21.0 report (cas-a3cf) was merged to the release-report epic branch at 8a4333c8:
+
+- User top-level ts 1788963809.375939 — https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788963809375939
+- User reply ts 1788963820.389439 (thread of the user top-level)
+- Dev top-level ts 1788963821.644219 — https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788963821644219
+- Dev reply ts 1788963843.922819 (thread of the dev top-level; the three carried-from-main bullets were reworded to Was → Now at post time, and the validation line names the gate runs and latencies)
+- Report files posted 14:25Z in the user thread via the claude.ai Slack MCP: PDF F0C0R6VPLSG https://petra-stella.slack.com/files/U076KKG4DGU/F0C0R6VPLSG/cassy-v3.21.0-release-report.pdf ; HTML F0C1FTM3JU8 https://petra-stella.slack.com/files/U076KKG4DGU/F0C1FTM3JU8/cassy-v3.21.0-release-report.html
+- Host verification: `cas update --yes` refresh_binary_version=3.21.0; `cas --version` = 3.21.0 (7bf6d2c); hub 3.21.0. Receipts: ~/.cas/artifacts/release/v3.21.0-epic-2229-merge/ (release-workflow.json run 34359808234; install-path-proof.json run 34360105639, Linux + macOS success; release-published.receipt; release-latency.receipt; host-update.json).


### PR DESCRIPTION
Records the Slack POSTED receipts for the Cassy v3.21.0 announcement (user and dev threads, report PDF/HTML file links), the published asset digests, and host verification receipts. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)