### PR TITLE
fix(factory): audit the actual worker CLI and account (cas-7eed)

### DIFF
--- a/cas-cli/src/mcp/tools/service/factory_ops.rs
+++ b/cas-cli/src/mcp/tools/service/factory_ops.rs
@@ -10711,6 +10711,111 @@ mod tests {
         assert_eq!(spec.effort, Some(cas_mux::Effort::High));
     }
 
+    /// cas-7eed: connect request resolution, queue serialization, receipt,
+    /// launcher construction and registration metadata under a Claude default.
+    #[test]
+    fn codex_spawn_routes_match_launcher_receipt_and_registration() {
+        let mut env = TestEnvGuard::temp_home();
+        let project = tempfile::tempdir().unwrap();
+        let config = project.path().join("config.toml");
+        let mut cases = Vec::new();
+        for configured in ["claude", "codex"] {
+            std::fs::write(
+                &config,
+                format!("[llm.worker]\nharness = \"{configured}\"\n"),
+            )
+            .unwrap();
+            for (label, cli, workers) in [
+                ("explicit", Some("codex"), None),
+                (
+                    "per-worker",
+                    Some("claude"),
+                    Some(r#"[{"cli":"codex","model":"gpt-5.6-luna","effort":"xhigh"}]"#),
+                ),
+            ] {
+                let specs = build_spawn_specs_with_project_config(
+                    1,
+                    cli,
+                    None,
+                    None,
+                    None,
+                    workers,
+                    Some(config.clone()),
+                )
+                .unwrap();
+                cases.push((format!("{label}/configured-{configured}"), specs));
+            }
+            if configured == "codex" {
+                cases.push((
+                    "config-default".into(),
+                    build_spawn_specs_with_project_config(
+                        1,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        Some(config.clone()),
+                    )
+                    .unwrap(),
+                ));
+            }
+        }
+        for lane in ["standard", "heavy"] {
+            let (specs, _, _) = build_lane_spawn_specs(
+                1,
+                lane,
+                None,
+                None,
+                &cas_factory::CapabilitySnapshot::default(),
+            )
+            .unwrap();
+            cases.push((lane.into(), specs));
+        }
+        let mut mux = cas_mux::Mux::new(24, 80);
+        mux.set_default_worker_spec(cas_mux::WorkerSpec::builtin_default());
+        mux.set_worker_spec("probe", cas_mux::WorkerSpec::builtin_default());
+        for (label, specs) in cases {
+            let receipt = spawn_specs_summary(&specs, &[]);
+            assert!(receipt.contains(": codex model="), "{label}: {receipt}");
+            // Queue producers serialize the fully resolved spec. The daemon
+            // must hand that same spec to the dynamic launcher.
+            let queued = serde_json::to_string(&specs[0]).unwrap();
+            let spec: cas_mux::WorkerSpec = serde_json::from_str(&queued).unwrap();
+            let launch = mux.build_add_worker_config(
+                "probe",
+                project.path().into(),
+                None,
+                "supervisor",
+                None,
+                Some(spec),
+            );
+            let launched_cli = if launch.command == "nice" {
+                launch.args[2].as_str()
+            } else {
+                launch.command.as_str()
+            };
+            assert_eq!(launched_cli, "codex", "{label}");
+            let registered_cli = launch
+                .args
+                .iter()
+                .find_map(|arg| arg.strip_prefix("mcp_servers.cs.env.CAS_FACTORY_WORKER_CLI="))
+                .expect("Codex MCP registration must receive the launched CLI");
+            let registered_cli: String = serde_json::from_str(registered_cli).unwrap();
+            assert_eq!(registered_cli, launched_cli, "{label}");
+            env.set("CAS_FACTORY_WORKER_CLI", &registered_cli);
+            env.set("CAS_AGENT_ROLE", "worker");
+            let mut agent = cas_types::Agent::new("codex-probe".into(), "probe".into());
+            crate::mcp::daemon::apply_factory_worker_metadata(&mut agent, None);
+            assert_eq!(
+                worker_cli_from_agent(&agent),
+                cas_mux::SupervisorCli::Codex,
+                "{label}"
+            );
+            assert_eq!(agent.metadata["worker_cli"], launched_cli, "{label}");
+        }
+    }
+
     #[test]
     fn spawn_specs_keep_per_worker_harness_and_account_overrides() {
         let specs = build_spawn_specs_with_project_config(

--- a/crates/cas-pty/src/pty.rs
+++ b/crates/cas-pty/src/pty.rs
@@ -1952,6 +1952,78 @@ fn command_launches_codex(command: &str, args: &[String]) -> bool {
     command == "codex" || (command == "nice" && args.iter().any(|arg| arg == "codex"))
 }
 
+/// Audit the actual executable and its provider's account environment. Do not
+/// infer the worker CLI from the supervisor's inherited metadata.
+#[derive(Debug)]
+struct WorkerSpawnAudit<'a> {
+    worker: &'a str,
+    cli: &'a str,
+    model: &'a str,
+    effort: &'a str,
+    account_env: &'static str,
+    account: String,
+    source: &'static str,
+}
+
+fn worker_spawn_audit(
+    config: &PtyConfig,
+    inherited: impl Fn(&str) -> Option<String>,
+) -> Option<WorkerSpawnAudit<'_>> {
+    let env = |name: &str| {
+        config
+            .env
+            .iter()
+            .rev()
+            .find_map(|(key, value)| (key == name).then_some(value.as_str()))
+    };
+    if env("CAS_AGENT_ROLE") != Some("worker") {
+        return None;
+    }
+    // This is the exact wrapper emitted by maybe_wrap_with_nice.
+    let cli = if config.command == "nice" && config.args.first().map(String::as_str) == Some("-n") {
+        config.args.get(2).map(String::as_str).unwrap_or("nice")
+    } else {
+        &config.command
+    };
+    let (account_env, source_env, default) = match cli {
+        "claude" => (
+            "CLAUDE_CONFIG_DIR",
+            "CAS_FACTORY_CLAUDE_CONFIG_DIR_SOURCE",
+            "default (~/.claude)",
+        ),
+        "codex" => (
+            "CODEX_HOME",
+            "CAS_FACTORY_CODEX_HOME_SOURCE",
+            "default (~/.codex)",
+        ),
+        _ => ("none", "", "no account directory"),
+    };
+    let (account, source) = if account_env == "none" {
+        (default.to_string(), "none")
+    } else if let Some(dir) = env(account_env) {
+        let source = match env(source_env) {
+            Some("supervisor") => "supervisor session",
+            _ => "explicit param",
+        };
+        (dir.to_string(), source)
+    } else if !config.env_remove.iter().any(|key| key == account_env)
+        && let Some(dir) = inherited(account_env)
+    {
+        (dir, "host env")
+    } else {
+        (default.to_string(), "default")
+    };
+    Some(WorkerSpawnAudit {
+        worker: env("CAS_AGENT_NAME").unwrap_or("unknown"),
+        cli,
+        model: env("CAS_FACTORY_WORKER_MODEL").unwrap_or("(backend default)"),
+        effort: env("CAS_FACTORY_WORKER_EFFORT").unwrap_or("(backend default)"),
+        account_env,
+        account,
+        source,
+    })
+}
+
 impl Pty {
     /// Spawn a new PTY with the given configuration
     pub fn spawn(id: impl Into<String>, config: PtyConfig) -> Result<Self> {
@@ -2042,44 +2114,24 @@ impl Pty {
             cmd.env_remove("CODEX_ACCESS_TOKEN");
         }
 
-        if config
-            .env
-            .iter()
-            .any(|(key, value)| key == "CAS_AGENT_ROLE" && value == "worker")
-        {
-            let explicit =
-                config.env.iter().rev().find_map(|(key, value)| {
-                    (key == "CLAUDE_CONFIG_DIR").then_some(value.as_str())
-                });
-            let inherited = std::env::var("CLAUDE_CONFIG_DIR").ok();
-            let pushed_source = config.env.iter().rev().find_map(|(key, value)| {
-                (key == "CAS_FACTORY_CLAUDE_CONFIG_DIR_SOURCE").then_some(value.as_str())
-            });
-            let (config_dir, source) = match (explicit, pushed_source, inherited.as_deref()) {
-                (Some(dir), Some("explicit"), _) => (dir, "explicit param"),
-                (Some(dir), Some("supervisor"), _) => (dir, "supervisor session"),
-                (Some(dir), _, _) => (dir, "explicit param"),
-                (None, _, Some(dir)) => (dir, "host env"),
-                (None, _, None) => ("default (~/.claude)", "default"),
-            };
-            let worker = config
-                .env
-                .iter()
-                .find_map(|(key, value)| (key == "CAS_AGENT_NAME").then_some(value.as_str()))
-                .unwrap_or("unknown");
-            tracing::info!(
-                worker,
-                claude_config_dir = config_dir,
-                source,
-                "factory worker spawn: effective Claude account directory"
-            );
-        }
-
         // Spawn the child process
         let child = pair
             .slave
             .spawn_command(cmd)
             .map_err(|e| Error::pty(format!("Failed to spawn command: {e}")))?;
+
+        if let Some(audit) = worker_spawn_audit(&config, |key| std::env::var(key).ok()) {
+            tracing::info!(
+                worker = audit.worker,
+                cli = audit.cli,
+                model = audit.model,
+                effort = audit.effort,
+                account_env = audit.account_env,
+                account = audit.account,
+                source = audit.source,
+                "factory worker spawn"
+            );
+        }
 
         // Drop slave - the child process owns it now
         drop(pair.slave);
@@ -2410,6 +2462,89 @@ fn filter_cursor_position_requests(carry: &[u8], chunk: &[u8]) -> (Vec<u8>, Vec<
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn worker_spawn_audit_tracks_launched_cli_and_provider_account() {
+        for cli in ["codex", "claude", "grok", "opencode"] {
+            for wrapped in [false, true] {
+                for source in ["explicit", "supervisor", "inherited", "default", "removed"] {
+                    let mut config = PtyConfig {
+                        command: if wrapped { "nice" } else { cli }.to_string(),
+                        args: if wrapped {
+                            vec!["-n".into(), "10".into(), cli.into()]
+                        } else {
+                            vec![]
+                        },
+                        env: vec![
+                            ("CAS_AGENT_ROLE".into(), "worker".into()),
+                            ("CAS_AGENT_NAME".into(), "probe".into()),
+                            ("CAS_FACTORY_WORKER_MODEL".into(), "requested-model".into()),
+                            ("CAS_FACTORY_WORKER_EFFORT".into(), "high".into()),
+                            // A stale supervisor hint must not change the audit.
+                            ("CAS_FACTORY_WORKER_CLI".into(), "claude".into()),
+                        ],
+                        ..PtyConfig::default()
+                    };
+                    let (account_env, source_env) = if cli == "codex" {
+                        ("CODEX_HOME", "CAS_FACTORY_CODEX_HOME_SOURCE")
+                    } else {
+                        ("CLAUDE_CONFIG_DIR", "CAS_FACTORY_CLAUDE_CONFIG_DIR_SOURCE")
+                    };
+                    if matches!(source, "explicit" | "supervisor") {
+                        config.env.push((account_env.into(), "/selected".into()));
+                        config.env.push((source_env.into(), source.into()));
+                    }
+                    if source == "removed" {
+                        config.env_remove.push(account_env.into());
+                    }
+                    let audit = worker_spawn_audit(&config, |key| {
+                        if source == "default" {
+                            None
+                        } else {
+                            Some(
+                                if key == account_env {
+                                    "/inherited"
+                                } else {
+                                    "/wrong-provider"
+                                }
+                                .into(),
+                            )
+                        }
+                    })
+                    .unwrap();
+                    assert_eq!(audit.cli, cli);
+                    assert_eq!(audit.worker, "probe");
+                    assert_eq!(audit.model, "requested-model");
+                    assert_eq!(audit.effort, "high");
+                    if matches!(cli, "grok" | "opencode") {
+                        assert_eq!(audit.account, "no account directory");
+                        assert_eq!(audit.account_env, "none");
+                        assert_eq!(audit.source, "none");
+                    } else {
+                        assert_eq!(audit.account_env, account_env);
+                        let expected = match source {
+                            "explicit" | "supervisor" => "/selected",
+                            "inherited" => "/inherited",
+                            _ if cli == "codex" => "default (~/.codex)",
+                            _ => "default (~/.claude)",
+                        };
+                        assert_eq!(audit.account, expected, "{cli}/{wrapped}/{source}");
+                        assert_eq!(
+                            audit.source,
+                            match source {
+                                "explicit" => "explicit param",
+                                "supervisor" => "supervisor session",
+                                "inherited" => "host env",
+                                _ => "default",
+                            }
+                        );
+                    }
+                }
+            }
+        }
+        assert!(worker_spawn_audit(&PtyConfig::default(), |_| None).is_none());
+    }
+
+
     use crate::pty::*;
     use std::sync::{Mutex, MutexGuard};
 


### PR DESCRIPTION
The PTY spawn audit line previously read "effective Claude account directory" for every worker, including real Codex workers, and inferred the CLI from the supervisor's inherited metadata. It now names the launched CLI, model, effort, and the provider's account environment (CLAUDE_CONFIG_DIR or CODEX_HOME) with its source. Adds a regression test pinning cli=codex to the Codex launcher, receipt, and registration across explicit, per-worker, config-default, standard-lane, and heavy-lane resolution. Operator-reported Claude-for-Codex swap did not reproduce on the installed 3.21.0 or a dev build (receipts under the cas-7eed artifacts directory).

Proof: clean-env scoped nextest 17/17; cargo check exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)