### PR TITLE
fix(task): bind close gates to task delivery history (cas-863a, GH #767)

### DIFF
--- a/cas-cli/docs/CONTRIBUTING.md
+++ b/cas-cli/docs/CONTRIBUTING.md
@@ -242,3 +242,24 @@ These require a major version bump:
    asset is still uploading, or a downloaded byte hash disagrees with GitHub.
    Copy its emitted fields into the release-note draft; never transcribe a
    digest from `dist/local-audit/`.
+
+### Task close delivery attribution
+
+Close posture checks (`additive-only`, `value-only`), no-code intent, and the
+receipt diff stat share task delivery attribution in
+`mcp/tools/core/task/lifecycle/close_ops/task_attribution.rs`. The remote-tracking
+integration target is preferred when present. Unmerged commits are bounded by
+the task work window; already integrated commits need task identity. An explicit
+commit receipt caps the displayed history and includes unnamed predecessor
+commits within the work window, stopping at another task's commit. Receipt
+inputs remain hexadecimal commit IDs, including unambiguous abbreviations.
+
+A live registered supervisor may use `supervisor_override=true` with a non-empty
+reason to waive additive-only/value-only posture checks and the receipt epoch
+check for a retroactive record task. Close records the decision. Repository
+binding, ancestry, non-empty delivery, and target-content checks still apply.
+
+An empty `execution_note` update may clear a constraint after approval when its
+exact repository proof is unchanged. Pending, skipped, unbound, and changed
+proofs remain locked; changing other scope fields or replacing the constraint
+still requires a fresh proof cycle.

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -1,3 +1,5 @@
+mod task_attribution;
+
 use super::TaskLifecycleGateError;
 use crate::harness_policy::{
     is_supervisor_from_env, is_worker_without_subagents_from_env, supervisor_harness_from_env,
@@ -2020,11 +2022,9 @@ impl CasCore {
         };
         let mut advanced = task.clone();
         let now = chrono::Utc::now();
-        let Some(audit) = Self::apply_awaiting_merge_anchor_advance(
-            &mut advanced,
-            factory_branch_anchor,
-            now,
-        ) else {
+        let Some(audit) =
+            Self::apply_awaiting_merge_anchor_advance(&mut advanced, factory_branch_anchor, now)
+        else {
             return;
         };
 
@@ -2350,7 +2350,7 @@ impl CasCore {
         if let Err(message) = validate_supervisor_override(
             supervisor_override,
             req.reason.as_deref(),
-            is_supervisor_from_env(),
+            !supervisor_override || self.resolve_live_supervisor_authority().is_ok(),
         ) {
             return Ok(Self::tool_error(message));
         }
@@ -2821,11 +2821,15 @@ impl CasCore {
                 .ok()
                 .and_then(|store| store.get_lease_history(&req.id, None).ok())
                 .unwrap_or_default();
-            Some(resolve_task_commit_receipt_window(
+            let mut window = resolve_task_commit_receipt_window(
                 task.created_at,
                 &lease_history,
                 task_commit_identity.clone(),
-            ))
+            );
+            if supervisor_override {
+                window.supervisor_override_reason = req.reason.clone();
+            }
+            Some(window)
         };
 
         // For Epics: Check that all worker branches are merged before verification
@@ -3181,10 +3185,7 @@ impl CasCore {
                             // shows a genuine conflict or cannot be evaluated.
                             // Refresh the flag so the worker exit remains open
                             // without duplicating the park audit note.
-                            self.mark_awaiting_merge_conflicted(
-                                task_store.as_ref(),
-                                &task.id,
-                            );
+                            self.mark_awaiting_merge_conflicted(task_store.as_ref(), &task.id);
                         }
                     }
 
@@ -4195,18 +4196,31 @@ impl CasCore {
         // path has been deleted in this commit because it reintroduced
         // the exact wrong-worktree-scope bug cas-bc1b was filed to fix.
         if close_disposition.requires_delivery_gates()
+            && !supervisor_override
             && task.execution_note.as_deref() == Some("additive-only")
         {
             if let Some(worker_wt) = worker_worktree_path.as_ref() {
                 // cas-7efe: use the single close-time resolver instead of
                 // an independent worktree-only lookup that fell back to a
                 // bare "main".
-                let violations = check_additive_only_branch_violations(
-                    worker_wt,
-                    &resolved_parent_branch,
-                    task.deliverables.factory_branch_anchor.as_deref(),
-                    &task_commit_identity,
-                );
+                let violations = commit_receipt_window
+                    .as_ref()
+                    .and_then(|window| {
+                        task_attribution::violations(
+                            worker_wt,
+                            &resolved_parent_branch,
+                            window,
+                            &|status| matches!(status, 'M' | 'D' | 'R'),
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        check_additive_only_branch_violations(
+                            worker_wt,
+                            &resolved_parent_branch,
+                            task.deliverables.factory_branch_anchor.as_deref(),
+                            &task_commit_identity,
+                        )
+                    });
                 if !violations.is_empty() {
                     let file_list = violations
                         .iter()
@@ -4232,15 +4246,28 @@ impl CasCore {
         // gates below; unlike an additive-only task, it has a real modified
         // diff for those gates to inspect.
         if close_disposition.requires_delivery_gates()
+            && !supervisor_override
             && task.execution_note.as_deref() == Some("value-only")
         {
             if let Some(worker_wt) = worker_worktree_path.as_ref() {
-                let violations = check_value_only_branch_violations(
-                    worker_wt,
-                    &resolved_parent_branch,
-                    task.deliverables.factory_branch_anchor.as_deref(),
-                    &task_commit_identity,
-                );
+                let violations = commit_receipt_window
+                    .as_ref()
+                    .and_then(|window| {
+                        task_attribution::violations(
+                            worker_wt,
+                            &resolved_parent_branch,
+                            window,
+                            &|status| status != 'M',
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        check_value_only_branch_violations(
+                            worker_wt,
+                            &resolved_parent_branch,
+                            task.deliverables.factory_branch_anchor.as_deref(),
+                            &task_commit_identity,
+                        )
+                    });
                 if !violations.is_empty() {
                     let file_list = violations
                         .iter()
@@ -6501,6 +6528,25 @@ fn check_branch_violations(
 ) -> Vec<AdditiveOnlyViolation> {
     use std::process::Command;
 
+    if !identity.is_empty() && factory_branch_anchor.is_none() {
+        let floor = chrono::DateTime::from_timestamp(0, 0).expect("Unix epoch");
+        let window = TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
+            not_before: floor,
+            task_floor: floor,
+            basis: "legacy task identity",
+            identity: identity.clone(),
+        };
+        if let Some(violations) = task_attribution::violations(
+            worker_worktree_path,
+            parent_branch,
+            &window,
+            &is_violation,
+        ) {
+            return violations;
+        }
+    }
+
     // cas-3f7f: once the parked worker tip is integrated, HEAD and the
     // parent branch may both point at (or beyond) an epic merge. Re-scanning
     // merge-base..HEAD then includes unrelated epic history. Find the
@@ -8620,13 +8666,9 @@ mod parent_branch_resolver_tests {
     fn epic_work_target_wins_over_project_trunk_when_legacy_branch_is_missing() {
         let dir = init_committed_repo("main");
         git(dir.path(), &["checkout", "-q", "-b", "staging"]);
-        let resolved = resolve_close_parent_branch(
-            None,
-            None,
-            Some("staging".to_string()),
-            dir.path(),
-        )
-        .expect("parent epic WorkTarget must resolve before project trunk");
+        let resolved =
+            resolve_close_parent_branch(None, None, Some("staging".to_string()), dir.path())
+                .expect("parent epic WorkTarget must resolve before project trunk");
         assert_eq!(resolved, "staging");
         assert_ne!(resolved, "main");
     }
@@ -9140,6 +9182,7 @@ fn render_close_diff_stat(
                 filtered_commits.push(full_sha);
             }
             augmented_window = Some(TaskCommitReceiptWindow {
+                supervisor_override_reason: window.supervisor_override_reason.clone(),
                 not_before: window.not_before,
                 basis: "durable task commit identity across task lifetime",
                 task_floor: window.task_floor,
@@ -9157,9 +9200,9 @@ fn render_close_diff_stat(
         window
     };
 
-    match effective_window
-        .and_then(|window| get_task_attributable_diff_stat(repo_path, parent_branch, window))
-    {
+    match effective_window.and_then(|window| {
+        task_attribution::diff_stat(repo_path, parent_branch, window, explicit_receipt)
+    }) {
         Some(measurement) if !measurement.stat.is_empty() => format!(
             "\n\n📊 Task-attributed committed diff stat (target {}; basis: {}):\n{}",
             measurement.target_ref, measurement.basis, measurement.stat
@@ -9180,111 +9223,6 @@ fn render_close_diff_stat(
             }
         }
     }
-}
-
-/// Return the net stat for the contiguous commits durably attributable to this
-/// task. Commit-message identity (or a recorded anchor/receipt SHA) prevents a
-/// recent inherited target commit from entering the display merely because it
-/// falls inside the task's clock window.
-///
-/// `None` means Git cannot prove a task-only contiguous range. The caller may
-/// show branch-wide context only when it labels that weaker scope explicitly.
-fn get_task_attributable_diff_stat(
-    repo_path: &std::path::Path,
-    parent_branch: &str,
-    window: &TaskCommitReceiptWindow,
-) -> Option<TaskAttributedDiffStat> {
-    use std::process::Command;
-
-    if !is_safe_git_refname(parent_branch) || window.identity.is_empty() {
-        return None;
-    }
-    let mut history_command = Command::new("git");
-    history_command.args(["log", "--reverse", "--first-parent"]);
-    if let Some(since) = task_commit_receipt_since(window.task_floor) {
-        history_command.arg(format!("--since={since}"));
-    }
-    let history = history_command
-        .args(["--format=%H%x1f%B%x1e", "HEAD"])
-        .current_dir(repo_path)
-        .output()
-        .ok()?;
-    if !history.status.success() {
-        return None;
-    }
-    let records = String::from_utf8_lossy(&history.stdout);
-    let commits: Vec<String> = records
-        .split('\u{1e}')
-        .filter_map(|record| {
-            let record = record.trim();
-            if record.is_empty() {
-                return None;
-            }
-            let (commit, message) = record.split_once('\u{1f}').unwrap_or((record, ""));
-            let commit = commit.trim();
-            let attributable = window.identity.matches_known_commit(commit)
-                || window
-                    .identity
-                    .task_id
-                    .as_deref()
-                    .is_some_and(|task_id| message_references_task(message, task_id));
-            attributable.then(|| commit.to_string())
-        })
-        .collect();
-
-    let target_ref = preferred_diff_target_ref(repo_path, parent_branch);
-    let Some((first, last)) = commits.first().zip(commits.last()) else {
-        return Some(TaskAttributedDiffStat {
-            stat: String::new(),
-            target_ref,
-            basis: "durable task commit identity across task lifetime",
-        });
-    };
-    let base_out = Command::new("git")
-        .args(["rev-parse", &format!("{first}^")])
-        .current_dir(repo_path)
-        .output()
-        .ok()?;
-    if !base_out.status.success() {
-        return None;
-    }
-    let base = String::from_utf8_lossy(&base_out.stdout).trim().to_string();
-    if base.is_empty() {
-        return None;
-    }
-
-    // A net diff is task-only only when every first-parent commit between the
-    // selected endpoints is attributable. Otherwise refuse to relabel a
-    // mixed history as the task's work and let the caller show honest context.
-    let range = format!("{base}..{last}");
-    let contiguous_out = Command::new("git")
-        .args(["rev-list", "--first-parent", "--reverse", &range])
-        .current_dir(repo_path)
-        .output()
-        .ok()?;
-    if !contiguous_out.status.success() {
-        return None;
-    }
-    let contiguous_stdout = String::from_utf8_lossy(&contiguous_out.stdout);
-    let contiguous: Vec<&str> = contiguous_stdout
-        .lines()
-        .map(str::trim)
-        .filter(|commit| !commit.is_empty())
-        .collect();
-    if contiguous.len() != commits.len()
-        || !contiguous
-            .iter()
-            .zip(&commits)
-            .all(|(actual, expected)| *actual == expected)
-    {
-        return None;
-    }
-
-    Some(TaskAttributedDiffStat {
-        stat: get_diff_stat_for_range(repo_path, &base, last),
-        target_ref,
-        basis: "durable task commit identity across task lifetime",
-    })
 }
 
 /// Return a `git diff --stat` summary for commits on `HEAD` beyond
@@ -9423,6 +9361,7 @@ fn task_commit_receipt_since(task_floor: chrono::DateTime<chrono::Utc>) -> Optio
 /// Durable lower bound used to attribute a receipt to one task work cycle.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TaskCommitReceiptWindow {
+    pub supervisor_override_reason: Option<String>,
     pub not_before: chrono::DateTime<chrono::Utc>,
     pub basis: &'static str,
     /// cas-9596 (GH #82): lower bound of the task's ENTIRE life, not just the
@@ -9448,12 +9387,14 @@ pub(crate) fn resolve_task_commit_receipt_window(
         .max();
     match cycle_start {
         Some(timestamp) if timestamp > task_created_at => TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
             not_before: timestamp,
             basis: "latest task lease claim/transfer",
             task_floor: task_created_at,
             identity,
         },
         _ => TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
             not_before: task_created_at,
             basis: "task creation time (lease-history fallback)",
             task_floor: task_created_at,
@@ -9646,10 +9587,19 @@ pub(crate) fn validate_task_commit_receipt(
     let earliest_allowed = window.not_before.timestamp() - COMMIT_RECEIPT_CLOCK_SKEW_SECS;
     let mut prior_cycle_basis = None;
     if commit_epoch < earliest_allowed {
-        let task_floor = window.task_floor.timestamp() - COMMIT_RECEIPT_CLOCK_SKEW_SECS;
-        if commit_epoch >= task_floor
-            && commit_is_task_attributable(repo_path, &full_receipt, &window.identity)
+        if let Some(reason) = window
+            .supervisor_override_reason
+            .as_deref()
+            .filter(|reason| !reason.trim().is_empty())
         {
+            prior_cycle_basis = Some(format!(
+                " Registered supervisor override accepted historical receipt despite task epoch boundary. Reason: {reason}"
+            ));
+        } else if task_attribution::in_work_window(
+            window,
+            commit_epoch,
+            commit_is_task_attributable(repo_path, &full_receipt, &window.identity),
+        ) {
             prior_cycle_basis = Some(format!(
                 " The commit predates the current work cycle beginning {} ({}), but it is \
                  attributable to an earlier work cycle of this task, postdates the task itself \
@@ -9711,7 +9661,7 @@ pub(crate) fn validate_task_commit_receipt(
     Ok(format!(
         "decision: accepted commit_receipt `{receipt}` resolved to full commit `{full_receipt}` \
          as task-attributed merge evidence; \
-         commit epoch {commit_epoch} is within the current task work cycle beginning {} \
+         commit epoch {commit_epoch} accepted against the task work cycle beginning {} \
          (basis: {}; {}s clock-skew allowance), the commit is merged into \
          {parent_branch}/origin/{parent_branch}, and its merge-aware file diff is non-empty.{}",
         window.not_before.to_rfc3339(),
@@ -10966,9 +10916,7 @@ pub(crate) fn collect_epic_branch_statuses_with_options(
                 .filter(|candidate| git_ref_exists(repo_path, candidate))
                 .find(|candidate| {
                     commit_tip_tree_reachable_from(repo_path, anchor, candidate)
-                            || anchor_work_patches_equivalent_on_parent(
-                                repo_path, anchor, candidate,
-                            )
+                        || anchor_work_patches_equivalent_on_parent(repo_path, anchor, candidate)
                 });
             if let Some(content_parent) = content_parent {
                 unmerged_count = 0;
@@ -12224,45 +12172,7 @@ pub(crate) fn has_task_attributable_reviewable_changes(
     parent_branch: &str,
     window: &TaskCommitReceiptWindow,
 ) -> Option<bool> {
-    use std::process::Command;
-
-    if !is_safe_git_refname(parent_branch) {
-        return None;
-    }
-
-    let merge_base_out = Command::new("git")
-        .args(["merge-base", "HEAD", parent_branch])
-        .current_dir(repo_path)
-        .output()
-        .ok()?;
-    if !merge_base_out.status.success() {
-        return None;
-    }
-    let merge_base = String::from_utf8_lossy(&merge_base_out.stdout)
-        .trim()
-        .to_string();
-    if merge_base.is_empty() {
-        return None;
-    }
-
-    let mut log_command = Command::new("git");
-    log_command.args(["log", "--name-only", "--pretty=format:"]);
-    if let Some(since) = task_commit_receipt_since(window.not_before) {
-        log_command.arg(format!("--since={since}"));
-    }
-    let log_out = log_command
-        .arg(format!("{merge_base}..HEAD"))
-        .current_dir(repo_path)
-        .output()
-        .ok()?;
-    if !log_out.status.success() {
-        return None;
-    }
-    let output = String::from_utf8_lossy(&log_out.stdout);
-    Some(output.lines().any(|line| {
-        let trimmed = line.trim();
-        !trimmed.is_empty() && is_reviewable_path(trimmed)
-    }))
+    task_attribution::reviewable(repo_path, parent_branch, window)
 }
 
 /// Parse name-status rows and retain exactly the statuses a constrained
@@ -16767,6 +16677,7 @@ mod merge_state_gate_tests {
 
     fn window_at(epoch: i64, basis: &'static str) -> TaskCommitReceiptWindow {
         TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
             not_before: chrono::DateTime::from_timestamp(epoch, 0).unwrap(),
             basis,
             task_floor: chrono::DateTime::from_timestamp(epoch, 0).unwrap(),
@@ -17830,6 +17741,7 @@ mod merge_state_gate_tests {
         // is task-attributable, so the administrative reset must not disown
         // the real merged receipt.
         let window = TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
             not_before: chrono::Utc::now() + chrono::Duration::hours(1),
             basis: "latest task lease claim/transfer after administrative request_changes",
             task_floor: chrono::Utc::now() - chrono::Duration::hours(1),
@@ -20268,7 +20180,12 @@ mod epic_status_gate_tests {
     #[test]
     fn epic_status_full_view_budget_stays_bounded_for_60_children() {
         let workers: Vec<(&str, usize)> = (0..60)
-            .map(|index| (Box::leak(format!("anchored-worker-{index}").into_boxed_str()) as &str, 1))
+            .map(|index| {
+                (
+                    Box::leak(format!("anchored-worker-{index}").into_boxed_str()) as &str,
+                    1,
+                )
+            })
             .collect();
         let dir = init_epic_repo(&workers);
         let subtasks: Vec<Task> = workers
@@ -20280,8 +20197,10 @@ mod epic_status_gate_tests {
                     TaskStatus::Closed,
                     Some(worker),
                 );
-                task.deliverables.factory_branch_anchor =
-                    Some(epic_git_stdout(dir.path(), &["rev-parse", &format!("factory/{worker}")]));
+                task.deliverables.factory_branch_anchor = Some(epic_git_stdout(
+                    dir.path(),
+                    &["rev-parse", &format!("factory/{worker}")],
+                ));
                 task
             })
             .collect();
@@ -22489,6 +22408,7 @@ mod zero_change_close_tests {
 
     fn test_receipt_window() -> TaskCommitReceiptWindow {
         TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
             not_before: chrono::Utc::now() - chrono::Duration::hours(1),
             basis: "test fixture",
             task_floor: chrono::Utc::now() - chrono::Duration::hours(2),
@@ -23976,6 +23896,7 @@ mod zero_change_close_tests {
         let window = TaskCommitReceiptWindow {
             // Put the task cycle definitively after the fixture commit. This
             // reproduces copying an arbitrary old merged SHA from git log.
+            supervisor_override_reason: None,
             not_before: chrono::Utc::now() + chrono::Duration::hours(1),
             basis: "latest task lease claim/transfer",
             // cas-9596: the task itself is younger than the borrowed commit, so
@@ -24036,6 +23957,7 @@ mod zero_change_close_tests {
         // The restart put the current cycle after the commit; the task itself
         // is older than it.
         let window = TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
             not_before: chrono::Utc::now() + chrono::Duration::hours(1),
             basis: "latest task lease claim/transfer",
             task_floor: chrono::Utc::now() - chrono::Duration::hours(2),
@@ -24076,6 +23998,7 @@ mod zero_change_close_tests {
         );
 
         let window = TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
             not_before: chrono::Utc::now() + chrono::Duration::hours(1),
             basis: "latest task lease claim/transfer",
             task_floor: chrono::Utc::now() - chrono::Duration::hours(2),
@@ -24108,6 +24031,7 @@ mod zero_change_close_tests {
         );
 
         let window = TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
             not_before: chrono::Utc::now() + chrono::Duration::hours(2),
             basis: "latest task lease claim/transfer",
             task_floor: chrono::Utc::now() + chrono::Duration::hours(1),
@@ -24147,6 +24071,7 @@ mod zero_change_close_tests {
         git(dir.path(), &["reset", "--hard", "main"]);
 
         let window = TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
             not_before: chrono::Utc::now() - chrono::Duration::hours(1),
             basis: "latest task lease claim/transfer",
             task_floor: chrono::Utc::now() - chrono::Duration::hours(2),
@@ -24288,13 +24213,8 @@ mod zero_change_close_tests {
         // The fix: resolve_close_parent_branch must select the epic
         // branch, never guess "main", when the worktree store has
         // nothing recorded (the common System-B factory-isolation shape).
-        let resolved = resolve_close_parent_branch(
-            None,
-            Some("epic/foo".to_string()),
-            None,
-            p,
-        )
-        .expect("explicit epic branch resolves");
+        let resolved = resolve_close_parent_branch(None, Some("epic/foo".to_string()), None, p)
+            .expect("explicit epic branch resolves");
         assert_eq!(
             resolved, "epic/foo",
             "must resolve the real epic branch, never a bare 'main'"
@@ -24672,6 +24592,7 @@ mod zero_diff_spike_close_tests {
     fn window() -> TaskCommitReceiptWindow {
         let cycle_start = chrono::DateTime::from_timestamp(CYCLE_START_EPOCH, 0).unwrap();
         TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
             not_before: cycle_start,
             basis: "latest task lease claim/transfer",
             // cas-9596: these tests exercise cycle-scoped attribution only —

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops/task_attribution.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops/task_attribution.rs
@@ -100,7 +100,16 @@ fn task_delivery_ranges(
             let foreign = !owned
                 && message
                     .split(|c: char| !c.is_ascii_alphanumeric() && c != '-')
-                    .any(|word| word.starts_with("cas-") && word.len() > 4);
+                    .any(|word| {
+                        // TaskStore::generate_hash_id emits hexadecimal IDs.
+                        // Crate/path words such as cas-cli are not task claims.
+                        word.get(..4)
+                            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("cas-"))
+                            && word.get(4..).is_some_and(|id| {
+                                (4..=8).contains(&id.len())
+                                    && id.bytes().all(|byte| byte.is_ascii_hexdigit())
+                            })
+                    });
             Some(Commit {
                 sha,
                 parent: fields[1].split_whitespace().next().unwrap_or("").into(),
@@ -281,6 +290,41 @@ mod tests {
             },
         }
     }
+    #[test]
+    fn crate_names_are_not_foreign_task_ids() {
+        let dir = fixture();
+        let p = dir.path();
+        commit(
+            p,
+            "crate_change.rs",
+            "own\n",
+            "fix cas-cli build and cas-core integration",
+        );
+        commit(p, "foreign.rs", "foreign\n", "cas-a1b2: unrelated task");
+        commit(
+            p,
+            "explicit.rs",
+            "explicit\n",
+            "cas-taskb: follow up on cas-a1b2",
+        );
+        let known = commit(p, "recorded.rs", "known\n", "cas-cafe: recorded delivery");
+        let mut scope = window();
+        scope.identity.known_commits.push(known);
+        let stat = diff_stat(p, "main", &scope, None).unwrap().stat;
+        assert!(
+            stat.contains("crate_change.rs"),
+            "crate wording must remain attributed: {stat}"
+        );
+        assert!(
+            !stat.contains("foreign.rs"),
+            "other task IDs must remain excluded: {stat}"
+        );
+        assert!(
+            stat.contains("explicit.rs") && stat.contains("recorded.rs"),
+            "own task ID and known commit must take precedence: {stat}"
+        );
+    }
+
     #[test]
     fn historical_record_receipt_requires_audited_supervisor_exception() {
         let dir = fixture();

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops/task_attribution.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops/task_attribution.rs
@@ -1,0 +1,411 @@
+//! Shared task delivery attribution for close gates and their receipt display.
+use super::*;
+
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug)]
+struct DeliveryRange {
+    base: String,
+    tip: String,
+}
+
+fn git_text(repo: &Path, args: &[&str]) -> Option<String> {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Current-cycle commits and durably identified earlier-cycle commits share
+/// the same epoch contract in selection and receipt validation.
+pub(super) fn in_work_window(window: &TaskCommitReceiptWindow, epoch: i64, owned: bool) -> bool {
+    epoch
+        >= window
+            .not_before
+            .timestamp()
+            .saturating_sub(COMMIT_RECEIPT_CLOCK_SKEW_SECS)
+        || (owned
+            && epoch
+                >= window
+                    .task_floor
+                    .timestamp()
+                    .saturating_sub(COMMIT_RECEIPT_CLOCK_SKEW_SECS))
+}
+
+/// Select first-parent delivery segments once for every close consumer.
+/// Target-reachable history needs durable task identity. Unmerged history may
+/// also use the lease window. A receipt expands through unnamed predecessors
+/// in that window, stopping at another task or the task's time boundary.
+fn task_delivery_ranges(
+    repo: &Path,
+    parent: &str,
+    window: &TaskCommitReceiptWindow,
+    tip: Option<&str>,
+) -> Option<Vec<DeliveryRange>> {
+    if !is_safe_git_refname(parent) {
+        return None;
+    }
+    let target = preferred_diff_target_ref(repo, parent);
+    let tip = tip.unwrap_or("HEAD");
+    let base = git_text(repo, &["merge-base", tip, &target])?;
+    let unmerged: std::collections::HashSet<String> = git_text(
+        repo,
+        &["rev-list", "--first-parent", &format!("{base}..{tip}")],
+    )?
+    .lines()
+    .map(str::to_owned)
+    .collect();
+    let mut history_args = vec![
+        "log".to_string(),
+        "--first-parent".into(),
+        "--reverse".into(),
+        "--format=%H%x1f%P%x1f%ct%x1f%B%x1e".into(),
+    ];
+    if let Some(since) = task_commit_receipt_since(window.task_floor) {
+        history_args.push(format!("--since-as-filter={since}"));
+    }
+    history_args.push(tip.into());
+    let history = git_text(
+        repo,
+        &history_args.iter().map(String::as_str).collect::<Vec<_>>(),
+    )?;
+    struct Commit {
+        sha: String,
+        parent: String,
+        epoch: i64,
+        owned: bool,
+        foreign: bool,
+        merge: bool,
+    }
+    let commits: Vec<Commit> = history
+        .split('\u{1e}')
+        .filter_map(|record| {
+            let fields: Vec<_> = record.trim().splitn(4, '\u{1f}').collect();
+            if fields.len() != 4 {
+                return None;
+            }
+            let sha = fields[0].to_string();
+            let message = fields[3];
+            let owned = window.identity.matches_known_commit(&sha)
+                || window
+                    .identity
+                    .task_id
+                    .as_deref()
+                    .is_some_and(|id| message_references_task(message, id));
+            let foreign = !owned
+                && message
+                    .split(|c: char| !c.is_ascii_alphanumeric() && c != '-')
+                    .any(|word| word.starts_with("cas-") && word.len() > 4);
+            Some(Commit {
+                sha,
+                parent: fields[1].split_whitespace().next().unwrap_or("").into(),
+                epoch: fields[2].parse().ok()?,
+                owned,
+                foreign,
+                merge: fields[1].split_whitespace().count() > 1,
+            })
+        })
+        .collect();
+    let floor = window
+        .task_floor
+        .timestamp()
+        .saturating_sub(COMMIT_RECEIPT_CLOCK_SKEW_SECS);
+    let mut selected: Vec<bool> = commits
+        .iter()
+        .map(|c| {
+            !c.parent.is_empty()
+                && !c.foreign
+                && (c.owned || unmerged.contains(&c.sha))
+                && in_work_window(window, c.epoch, c.owned)
+        })
+        .collect();
+    // The end of a delivery is an upper boundary, not its only commit.
+    for i in (0..commits.len()).rev() {
+        if !selected[i]
+            || commits[i].merge
+            || !window.identity.matches_known_commit(&commits[i].sha)
+        {
+            continue;
+        }
+        let mut j = i;
+        while j > 0 {
+            let previous = &commits[j - 1];
+            if previous.parent.is_empty()
+                || previous.foreign
+                || previous.merge
+                || previous.epoch < floor
+            {
+                break;
+            }
+            selected[j - 1] = true;
+            j -= 1;
+        }
+    }
+    let mut ranges: Vec<DeliveryRange> = vec![];
+    let mut contiguous = false;
+    for (commit, selected) in commits.into_iter().zip(selected) {
+        if selected {
+            if contiguous {
+                ranges.last_mut()?.tip = commit.sha;
+            } else {
+                ranges.push(DeliveryRange {
+                    base: commit.parent,
+                    tip: commit.sha,
+                });
+            }
+        }
+        contiguous = selected;
+    }
+    Some(ranges)
+}
+
+pub(super) fn reviewable(
+    repo: &Path,
+    target: &str,
+    window: &TaskCommitReceiptWindow,
+) -> Option<bool> {
+    let ranges = task_delivery_ranges(repo, target, window, None)?;
+    for range in ranges {
+        let paths = git_text(
+            repo,
+            &["diff", "--name-only", &range.base, &range.tip, "--"],
+        )?;
+        if paths.lines().any(is_reviewable_path) {
+            return Some(true);
+        }
+    }
+    Some(false)
+}
+
+pub(super) fn violations(
+    repo: &Path,
+    target: &str,
+    window: &TaskCommitReceiptWindow,
+    is_violation: &impl Fn(char) -> bool,
+) -> Option<Vec<AdditiveOnlyViolation>> {
+    let ranges = task_delivery_ranges(repo, target, window, None)?;
+    let mut violations = vec![];
+    for range in ranges {
+        let statuses = git_text(
+            repo,
+            &["diff", "--name-status", &range.base, &range.tip, "--"],
+        )?;
+        violations.extend(retain_foreign_violations(
+            repo,
+            &range.base,
+            &window.identity,
+            parse_name_status_filtered(&statuses, is_violation),
+        ));
+    }
+    Some(violations)
+}
+
+pub(super) fn diff_stat(
+    repo: &Path,
+    target: &str,
+    window: &TaskCommitReceiptWindow,
+    receipt: Option<&str>,
+) -> Option<TaskAttributedDiffStat> {
+    let receipt = receipt
+        .map(|receipt| resolve_task_commit_receipt_sha(repo, receipt))
+        .transpose()
+        .ok()?;
+    let ranges = task_delivery_ranges(repo, target, window, receipt.as_deref())?;
+    Some(TaskAttributedDiffStat {
+        stat: ranges
+            .iter()
+            .map(|r| get_diff_stat_for_range(repo, &r.base, &r.tip))
+            .filter(|stat| !stat.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        target_ref: preferred_diff_target_ref(repo, target),
+        basis: "task delivery commits bounded by target and work window",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::process::Command;
+
+    fn git(repo: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .env("GIT_AUTHOR_NAME", "fixture")
+            .env("GIT_AUTHOR_EMAIL", "fixture@example.test")
+            .env("GIT_COMMITTER_NAME", "fixture")
+            .env("GIT_COMMITTER_EMAIL", "fixture@example.test")
+            .env("GIT_AUTHOR_DATE", "2026-09-01T12:00:00Z")
+            .env("GIT_COMMITTER_DATE", "2026-09-01T12:00:00Z")
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+    fn commit(repo: &Path, file: &str, contents: &str, message: &str) -> String {
+        std::fs::write(repo.join(file), contents).unwrap();
+        git(repo, &["add", file]);
+        git(repo, &["commit", "-qm", message]);
+        git(repo, &["rev-parse", "HEAD"])
+    }
+    fn fixture() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        git(dir.path(), &["init", "-q", "-b", "main"]);
+        commit(dir.path(), "copy.txt", "old\n", "baseline");
+        git(dir.path(), &["checkout", "-qb", "factory/worker"]);
+        dir
+    }
+    fn window() -> TaskCommitReceiptWindow {
+        let floor = chrono::DateTime::parse_from_rfc3339("2026-09-01T11:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        TaskCommitReceiptWindow {
+            supervisor_override_reason: None,
+            not_before: floor,
+            task_floor: floor,
+            basis: "fixture",
+            identity: TaskCommitIdentity {
+                task_id: Some("cas-taskb".into()),
+                known_commits: vec![],
+            },
+        }
+    }
+    #[test]
+    fn historical_record_receipt_requires_audited_supervisor_exception() {
+        let dir = fixture();
+        let p = dir.path();
+        commit(
+            p,
+            "hotfix.rs",
+            "pub fn fixed() {}\n",
+            "hotfix delivered before record task",
+        );
+        git(p, &["checkout", "main"]);
+        git(
+            p,
+            &["merge", "--no-ff", "factory/worker", "-m", "hotfix merge"],
+        );
+        let receipt = git(p, &["rev-parse", "HEAD"]);
+        let mut scope = window();
+        scope.not_before += chrono::Duration::days(2);
+        scope.task_floor = scope.not_before;
+        assert!(
+            validate_task_commit_receipt(p, &receipt, "main", &scope)
+                .unwrap_err()
+                .contains("predates")
+        );
+        scope.supervisor_override_reason = Some("record previously delivered hotfix".into());
+        let note = validate_task_commit_receipt(p, &receipt, "main", &scope).unwrap();
+        assert!(
+            note.contains("Registered supervisor override")
+                && note.contains("record previously delivered hotfix")
+        );
+        let outcome = check_zero_commit_close(
+            p,
+            "main",
+            "cas-taskb",
+            &TaskType::Bug,
+            None,
+            false,
+            None,
+            Some(&receipt),
+            Some(&scope),
+        );
+        assert!(
+            matches!(outcome, ZeroCommitCloseOutcome::ProceedWithReceipt(ref decision)
+            if decision.contains("Registered supervisor override")),
+            "{outcome:?}"
+        );
+        // An epoch exception does not authorize an unmerged receipt.
+        git(p, &["checkout", "factory/worker"]);
+        let unmerged = commit(p, "other.rs", "unmerged\n", "another change");
+        assert!(
+            validate_task_commit_receipt(p, &unmerged, "main", &scope)
+                .unwrap_err()
+                .contains("not an ancestor")
+        );
+    }
+
+    #[test]
+    fn receipt_upper_boundary_excludes_later_sibling_commit() {
+        let dir = fixture();
+        let p = dir.path();
+        commit(p, "first.md", "first\n", "first part");
+        let receipt = commit(p, "second.md", "second\n", "second part");
+        commit(p, "sibling.rs", "foreign\n", "cas-sibling: other task");
+        let stat = render_close_diff_stat(p, "main", Some(&window()), Some(&receipt));
+        assert!(
+            stat.contains("first.md") && stat.contains("second.md") && !stat.contains("sibling.rs"),
+            "{stat}"
+        );
+    }
+
+    #[test]
+    fn value_only_ignores_earlier_task_merged_on_remote_target() {
+        let dir = fixture();
+        let p = dir.path();
+        let prior = commit(
+            p,
+            "prior.rs",
+            "pub fn prior() {}\n",
+            "cas-taska: prior delivery",
+        );
+        git(p, &["update-ref", "refs/remotes/origin/main", &prior]);
+        commit(p, "copy.txt", "new\n", "cas-taskb: edit value");
+        assert!(check_value_only_branch_violations(p, "main", None, &window().identity).is_empty());
+        assert!(
+            violations(p, "main", &window(), &|status| status != 'M')
+                .unwrap()
+                .is_empty()
+        );
+    }
+    #[test]
+    fn receipt_diff_includes_unnamed_predecessor_of_two_commit_delivery() {
+        let dir = fixture();
+        let p = dir.path();
+        commit(p, "first.md", "first\n", "first part");
+        let receipt = commit(p, "second.md", "second\n", "second part");
+        git(p, &["update-ref", "refs/remotes/origin/main", &receipt]);
+        let stat = render_close_diff_stat(p, "main", Some(&window()), Some(&receipt));
+        assert!(
+            stat.contains("first.md") && stat.contains("second.md"),
+            "{stat}"
+        );
+        let mut restarted = window();
+        restarted.not_before += chrono::Duration::days(1);
+        let stat = render_close_diff_stat(p, "main", Some(&restarted), Some(&receipt));
+        assert!(
+            stat.contains("first.md") && stat.contains("second.md"),
+            "{stat}"
+        );
+    }
+    #[test]
+    fn no_code_after_reset_to_remote_trunk_ignores_inherited_code() {
+        let dir = fixture();
+        let p = dir.path();
+        let release = commit(
+            p,
+            "release.rs",
+            "pub fn released() {}\n",
+            "merged epic release",
+        );
+        git(p, &["update-ref", "refs/remotes/origin/main", &release]);
+        git(p, &["reset", "--hard", "origin/main"]);
+        commit(p, "NOTES.md", "release notes\n", "cas-taskb: documentation");
+        assert_eq!(
+            has_task_attributable_reviewable_changes(p, "main", &window()),
+            Some(false)
+        );
+    }
+}

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/proof_scope.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/proof_scope.rs
@@ -214,6 +214,30 @@ fn exact_proof_locks_scope(cas_root: &Path, task: &Task) -> Result<bool, String>
     }
 }
 
+fn approved_repository_is_unchanged(cas_root: &Path, task: &Task) -> bool {
+    let Ok(Some(dispatch)) = cas_store::get_latest_verification_dispatch(cas_root, &task.id) else {
+        return false;
+    };
+    if dispatch.task_id != task.id || dispatch.state != VerificationDispatchState::Resolved {
+        return false;
+    }
+    let Ok(Some(verdict)) = cas_store::get_verification_for_dispatch(cas_root, &dispatch.id) else {
+        return false;
+    };
+    if verdict.status != VerificationStatus::Approved
+        || verdict.provenance == VerificationProvenance::Legacy
+        || verdict.dispatch_id.as_deref() != Some(dispatch.id.as_str())
+    {
+        return false;
+    }
+    dispatch.repository.as_ref().is_some_and(|proof| {
+        matches!(
+            super::repository_proof::evaluate_repository_proof(proof),
+            Ok(super::repository_proof::RepositoryProofStatus::Unchanged)
+        )
+    })
+}
+
 /// Reject mutations that could change a terminal task or an active exact proof.
 ///
 /// This guard must run immediately after loading the task, before receipt
@@ -252,6 +276,18 @@ pub(crate) fn guard_task_proof_scope(
             .is_some_and(|reference| !reference.trim().is_empty())
     {
         locked_fields.retain(|field| *field != "external_ref");
+    }
+    // Clearing a constraint does not change the reviewed delivery. Require
+    // an approved exact repository snapshot and an unchanged checkout; pending,
+    // skipped, stale, and unbound proofs keep the ordinary scope lock.
+    if let ProofScopeOperation::TaskUpdate { request, .. } = operation
+        && request
+            .execution_note
+            .as_deref()
+            .is_some_and(|note| note.trim().is_empty())
+        && approved_repository_is_unchanged(cas_root, task)
+    {
+        locked_fields.retain(|field| *field != "execution_note");
     }
     if locked_fields.is_empty() {
         return Ok(());
@@ -605,6 +641,96 @@ mod tests {
             assert_eq!(reopened.status, TaskStatus::Open);
             assert_eq!(reopened.assignee.as_deref(), Some("worker"));
         }
+    }
+
+    #[test]
+    fn approved_unchanged_delivery_allows_only_posture_clear() {
+        let root = TempDir::new().unwrap();
+        let repo = TempDir::new().unwrap();
+        for args in [
+            vec!["init", "-q"],
+            vec![
+                "-c",
+                "user.name=fixture",
+                "-c",
+                "user.email=fixture@example.test",
+                "commit",
+                "--allow-empty",
+                "-qm",
+                "seed",
+            ],
+        ] {
+            assert!(
+                std::process::Command::new("git")
+                    .args(args)
+                    .current_dir(repo.path())
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+        }
+        let proof = super::super::repository_proof::capture_repository_proof_with_anchors(
+            repo.path(),
+            repo.path(),
+            vec![],
+        )
+        .unwrap();
+        let mut task = Task::new("cas-clear-posture".into(), "reviewed delivery".into());
+        task.execution_note = Some("value-only".into());
+        cas_store::create_verification_dispatch_bound(
+            root.path(),
+            &task.id,
+            "requester",
+            FIXTURE_SUPERVISOR_ID,
+            &VerificationProofBoundary::task_at(proof),
+            chrono::Utc::now() + chrono::Duration::minutes(10),
+            false,
+        )
+        .unwrap();
+        let mut update = empty_update();
+        update.execution_note = Some(String::new());
+        let check = |update: &TaskUpdateRequest| {
+            guard_task_proof_scope(
+                root.path(),
+                &task,
+                ProofScopeOperation::TaskUpdate {
+                    request: update,
+                    target_repo_supplied: false,
+                    target_branch_supplied: false,
+                },
+            )
+        };
+        assert!(check(&update).is_err(), "pending proof cannot be changed");
+        let dispatch = cas_store::get_latest_verification_dispatch(root.path(), &task.id)
+            .unwrap()
+            .unwrap();
+        add_exact_supervisor_fixture_verdict(
+            root.path(),
+            cas_types::Verification::approved(
+                "ver-clear".into(),
+                task.id.clone(),
+                "approved exact repository".into(),
+            ),
+            &dispatch,
+        );
+        assert!(
+            check(&update).is_ok(),
+            "clearing posture preserves unchanged approved delivery"
+        );
+        update.title = Some("different scope".into());
+        assert!(check(&update).is_err());
+        update.title = None;
+        update.execution_note = Some("no-code".into());
+        assert!(
+            check(&update).is_err(),
+            "replacing a methodology remains locked"
+        );
+        update.execution_note = Some(String::new());
+        std::fs::write(repo.path().join("changed.rs"), "changed scope").unwrap();
+        assert!(
+            check(&update).is_err(),
+            "changed repository needs fresh verification"
+        );
     }
 
     #[test]

--- a/cas-cli/src/mcp/tools/core/task/repo_context.rs
+++ b/cas-cli/src/mcp/tools/core/task/repo_context.rs
@@ -1961,6 +1961,7 @@ mod tests {
             ));
 
             let window = TaskCommitReceiptWindow {
+                supervisor_override_reason: None,
                 not_before: chrono::DateTime::from_timestamp(0, 0).unwrap(),
                 basis: "test task creation",
                 task_floor: chrono::DateTime::from_timestamp(0, 0).unwrap(),

--- a/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
+++ b/cas-cli/tests/mcp_tools_test/task_tools/verification_flow.rs
@@ -5947,6 +5947,31 @@ impl ScopedSupervisorEnv {
     }
 }
 
+#[tokio::test]
+async fn test_supervisor_override_rejects_worker_with_supervisor_env_only() {
+    let (_temp, service) = setup_cas();
+    let _env_lock = env_test_lock();
+    let created = service
+        .cas_task_create(Parameters(simple_task_req("override authority")))
+        .await
+        .unwrap();
+    let id = extract_task_id(&extract_text(created)).unwrap().to_string();
+    let _guard = ScopedSupervisorEnv::new();
+    let result = service
+        .cas_task_close(Parameters(TaskCloseRequest {
+            stranded_branch_override: None,
+            id,
+            reason: Some("historical record".into()),
+            supervisor_override: Some(true),
+            legacy_bypass_code_review: None,
+            search_manifest: None,
+            commit_receipt: None,
+        }))
+        .await
+        .unwrap();
+    assert!(extract_text(result).contains("SUPERVISOR OVERRIDE REJECTED"));
+}
+
 /// A supervisor-owned epic has no ordinary task assignee by design. Once the
 /// configured verification owner passes the close gate, the response and
 /// audit row must describe the epic verification semantics rather than the
@@ -6265,7 +6290,7 @@ async fn test_close_supervisor_bypass_ghost_assignee() {
 /// "assignee inactive".
 #[tokio::test]
 async fn test_close_supervisor_active_worker_assignee_by_name() {
-    let (temp, service) = setup_cas();
+    let (temp, service) = setup_cas_as(AgentRole::Supervisor);
     let _env_lock = env_test_lock();
     let cas_dir = temp.path().join(".cas");
     let task_store = open_task_store(&cas_dir).unwrap();
@@ -9244,7 +9269,7 @@ async fn test_timeout_escalation_uses_codex_supervisor_verification_alias_cas_79
 /// verification_flow's domain (supervisor orphan bypass → Closed).
 #[tokio::test]
 async fn test_062d_close_lifecycle_push_to_owning_supervisor() {
-    let (temp, service) = setup_cas();
+    let (temp, service) = setup_cas_as(AgentRole::Supervisor);
     let _env_lock = env_test_lock();
     let cas_dir = temp.path().join(".cas");
 


### PR DESCRIPTION
Close gates attributed the whole factory branch history to a task. This binds posture gates (additive-only, value-only), the no-code intent gate, the receipt diff stat, and the receipt epoch check to one shared first-parent delivery range: commits owned by the task (message id or known SHA) or unmerged commits inside its work window, bounded by the merge-base with the target, excluding commits that name another task id, and expanding a receipt through its unnamed predecessors. A registered supervisor override with a reason passes posture and epoch gates with a logged decision; clearing execution_note no longer invalidates an approved verification when the exact repository proof is unchanged. Legacy merged-anchor fallback retained.

Fixes the four cases in #767: sibling file charged to a value-only close, receipt diff stat missing the first of two commits, retroactive record task unclosable under override, no-code docs task rejected after a reset onto trunk. A follow-up correction restricts the foreign-task heuristic to hex task ids so crate names like cas-cli stay attributed.

Proof: lib task lifecycle + mcp_tools_test 830/830; fixture tests for all four cases plus authority and reverse-state coverage.

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)