### PR TITLE
fix(hooks): SessionStart compaction keeps ambient recall; budget doctor row (cas-6a20)

### DIFF
--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -3708,6 +3708,7 @@ This is the body content."#;
     #[test]
     fn test_supervisor_guidance_under_8kb() {
         let guide = supervisor_guidance();
+        let headroom = SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES.saturating_sub(guide.len());
         assert!(
             guide.len() < SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES,
             "supervisor_guidance is {} bytes — over the {SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES}B SessionStart ceiling. \
@@ -3722,6 +3723,14 @@ This is the body content."#;
              into cas-supervisor/references/ to keep CI headroom.",
             guide.len(),
             SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES - guide.len()
+        );
+        assert!(
+            headroom >= crate::hooks::handlers::session_budget::SESSION_START_MIN_HEADROOM_BYTES,
+            "supervisor_guidance is {} bytes — only {headroom}B remains below the \
+             {SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES}B hard ceiling; keep at least {}B of \
+             SessionStart headroom by moving detail into cas-supervisor/references/",
+            guide.len(),
+            crate::hooks::handlers::session_budget::SESSION_START_MIN_HEADROOM_BYTES
         );
     }
 

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor.md
@@ -52,23 +52,9 @@ mcp__cs__coordination action=spawn_workers count=1 cli=codex model=gpt-5.6-luna 
 
 Match controls via model-selection.md; see [reference.md](cas-supervisor/references/reference.md) for Claude account parameters.
 
-## Reporting style
+## On-demand references
 
-- **Facts, not narration.** Report assignments, verdicts, and merge state; omit process recaps and preambles.
-- **Brevity never trims evidence.** Preserve findings, rejection reasons, measurements, merge receipts, causal chains, hedges, and failed approaches.
-- **In the pane, shape beats compression.** Answer first; use bullets or a small table. Don't recap the message, restate the board, or close with a summary.
-
-## Release train
-
-Runtime releases use only skills/cas-cut-release/SKILL.md; it owns the mechanical gate, merge queue, publish receipt, Slack POSTED block, and host verification. The Slack transport is skills/mecha-cassy/SKILL.md — the default for every harness, so route a worker to it rather than taking its draft back by hand. Until worker proxy credentials are repaired, the `cas-cut-release` fallback lets the supervisor post through the direct configured MechaCassy MCP.
-
-## References
-
-Open the focused file in `cas-supervisor/references/`: preflight, intake, planning, workflow, model-selection, [reminders.md](cas-supervisor/references/reminders.md), [epic-driving.md](cas-supervisor/references/epic-driving.md), worker-recovery, reference, or filing-cas-bugs.
-
-## Cross-team routing
-
-Route every bug through the issue-repository registry: `issues.repo` for the current project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, and `issues.components.cloud` for Cloud sync/relay/pairing; inspect with `cas config get issues.repo` and the three `issues.components.*` keys. If you hit a bug during operation, file a ticket in the matching repo before moving on; `filing-cas-bugs` has the filing and receipt policy.
+Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured `issues.repo` / `issues.components.*` registry.
 
 ## Context budgeting
 

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor.md
@@ -54,7 +54,7 @@ Match controls via model-selection.md; see [reference.md](cas-supervisor/referen
 
 ## On-demand references
 
-Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured `issues.repo` / `issues.components.*` registry.
+Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured registry: `issues.repo` for this project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, `issues.components.cloud` for Cloud sync; if you hit a bug during operation, file a ticket in the matching repo before moving on.
 For reminder discipline, read `cas-supervisor/references/reminders.md`; for epic driving, read `cas-supervisor/references/epic-driving.md`.
 
 ## Context budgeting

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor.md
@@ -55,6 +55,7 @@ Match controls via model-selection.md; see [reference.md](cas-supervisor/referen
 ## On-demand references
 
 Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured `issues.repo` / `issues.components.*` registry.
+For reminder discipline, read `cas-supervisor/references/reminders.md`; for epic driving, read `cas-supervisor/references/epic-driving.md`.
 
 ## Context budgeting
 

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor.md
@@ -54,7 +54,7 @@ Match controls via model-selection.md; see [reference.md](cas-supervisor/referen
 
 ## On-demand references
 
-Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured `issues.repo` / `issues.components.*` registry.
+Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured registry: `issues.repo` for this project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, `issues.components.cloud` for Cloud sync; if you hit a bug during operation, file a ticket in the matching repo before moving on.
 For reminder discipline, read `cas-supervisor/references/reminders.md`; for epic driving, read `cas-supervisor/references/epic-driving.md`.
 
 ## Context budgeting

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor.md
@@ -55,6 +55,7 @@ Match controls via model-selection.md; see [reference.md](cas-supervisor/referen
 ## On-demand references
 
 Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured `issues.repo` / `issues.components.*` registry.
+For reminder discipline, read `cas-supervisor/references/reminders.md`; for epic driving, read `cas-supervisor/references/epic-driving.md`.
 
 ## Context budgeting
 

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor.md
@@ -52,23 +52,9 @@ cas__coordination action=spawn_workers count=1 cli=codex model=gpt-5.6-luna effo
 
 Match controls via model-selection.md; see [reference.md](cas-supervisor/references/reference.md) for Claude account parameters.
 
-## Reporting style
+## On-demand references
 
-- **Facts, not narration.** Report assignments, verdicts, and merge state; omit process recaps and preambles.
-- **Brevity never trims evidence.** Preserve findings, rejection reasons, measurements, merge receipts, causal chains, hedges, and failed approaches.
-- **In the pane, shape beats compression.** Answer first; use bullets or a small table. Don't recap the message, restate the board, or close with a summary.
-
-## Release train
-
-Runtime releases use only skills/cas-cut-release/SKILL.md; it owns the mechanical gate, merge queue, publish receipt, Slack POSTED block, and host verification. The Slack transport is skills/mecha-cassy/SKILL.md — the default for every harness, so route a worker to it rather than taking its draft back by hand. Until worker proxy credentials are repaired, the `cas-cut-release` fallback lets the supervisor post through the direct configured MechaCassy MCP.
-
-## References
-
-Open the focused file in `cas-supervisor/references/`: preflight, intake, planning, workflow, model-selection, [reminders.md](cas-supervisor/references/reminders.md), [epic-driving.md](cas-supervisor/references/epic-driving.md), worker-recovery, reference, or filing-cas-bugs.
-
-## Cross-team routing
-
-Route every bug through the issue-repository registry: `issues.repo` for the current project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, and `issues.components.cloud` for Cloud sync/relay/pairing; inspect with `cas config get issues.repo` and the three `issues.components.*` keys. If you hit a bug during operation, file a ticket in the matching repo before moving on; `filing-cas-bugs` has the filing and receipt policy.
+Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured `issues.repo` / `issues.components.*` registry.
 
 ## Context budgeting
 

--- a/cas-cli/src/builtins/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor.md
@@ -52,23 +52,9 @@ mcp__cas__coordination action=spawn_workers count=1 cli=codex model=gpt-5.6-luna
 
 Match controls via model-selection.md; see [reference.md](cas-supervisor/references/reference.md) for Claude account parameters.
 
-## Reporting style
+## On-demand references
 
-- **Facts, not narration.** Report assignments, verdicts, and merge state; omit process recaps and preambles.
-- **Brevity never trims evidence.** Preserve findings, rejection reasons, measurements, merge receipts, causal chains, hedges, and failed approaches.
-- **In the pane, shape beats compression.** Answer first; use bullets or a small table. Don't recap the message, restate the board, or close with a summary.
-
-## Release train
-
-Runtime releases use only skills/cas-cut-release/SKILL.md; it owns the mechanical gate, merge queue, publish receipt, Slack POSTED block, and host verification. The Slack transport is skills/mecha-cassy/SKILL.md — the default for every harness, so route a worker to it rather than taking its draft back by hand. Until worker proxy credentials are repaired, the `cas-cut-release` fallback lets the supervisor post through the direct configured MechaCassy MCP.
-
-## References
-
-Open the focused file in `cas-supervisor/references/`: preflight, intake, planning, workflow, model-selection, [reminders.md](cas-supervisor/references/reminders.md), [epic-driving.md](cas-supervisor/references/epic-driving.md), worker-recovery, reference, or filing-cas-bugs.
-
-## Cross-team routing
-
-Route every bug through the issue-repository registry: `issues.repo` for the current project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, and `issues.components.cloud` for Cloud sync/relay/pairing; inspect with `cas config get issues.repo` and the three `issues.components.*` keys. If you hit a bug during operation, file a ticket in the matching repo before moving on; `filing-cas-bugs` has the filing and receipt policy.
+Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured `issues.repo` / `issues.components.*` registry.
 
 ## Context budgeting
 

--- a/cas-cli/src/builtins/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor.md
@@ -54,7 +54,7 @@ Match controls via model-selection.md; see [reference.md](cas-supervisor/referen
 
 ## On-demand references
 
-Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured `issues.repo` / `issues.components.*` registry.
+Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured registry: `issues.repo` for this project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, `issues.components.cloud` for Cloud sync; if you hit a bug during operation, file a ticket in the matching repo before moving on.
 For reminder discipline, read `cas-supervisor/references/reminders.md`; for epic driving, read `cas-supervisor/references/epic-driving.md`.
 
 ## Context budgeting

--- a/cas-cli/src/builtins/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor.md
@@ -55,6 +55,7 @@ Match controls via model-selection.md; see [reference.md](cas-supervisor/referen
 ## On-demand references
 
 Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured `issues.repo` / `issues.components.*` registry.
+For reminder discipline, read `cas-supervisor/references/reminders.md`; for epic driving, read `cas-supervisor/references/epic-driving.md`.
 
 ## Context budgeting
 

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -253,7 +253,8 @@ impl CheckGroup {
             | "mcp stdio upstreams"
             | "mcp upstream reachability"
             | "sync target"
-            | "models" =>
+            | "models"
+            | "sessionstart budget" =>
             {
                 Self::Config
             }
@@ -1142,6 +1143,37 @@ fn prompt_hook_check(cas_root: &Path) -> Check {
     }
 }
 
+/// Keep the protected supervisor guidance comfortably below the SessionStart
+/// harness ceiling. Dynamic sections can compact, but guidance edits are
+/// protected and therefore consume the budget permanently.
+fn session_start_budget_check_for(guidance_bytes: usize) -> Check {
+    let hard_ceiling = crate::builtins::SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES;
+    let headroom = hard_ceiling.saturating_sub(guidance_bytes);
+    let minimum = crate::hooks::handlers::session_budget::SESSION_START_MIN_HEADROOM_BYTES;
+
+    if guidance_bytes < hard_ceiling && headroom >= minimum {
+        Check::new(
+            "SessionStart budget",
+            CheckStatus::Ok,
+            format!(
+                "supervisor guidance is {guidance_bytes}B; {headroom}B headroom below the {hard_ceiling}B protected ceiling"
+            ),
+        )
+    } else {
+        Check::new(
+            "SessionStart budget",
+            CheckStatus::Warning,
+            format!(
+                "supervisor guidance is {guidance_bytes}B; only {headroom}B headroom below the {hard_ceiling}B protected ceiling (need at least {minimum}B). Move detail into cas-supervisor/references/"
+            ),
+        )
+    }
+}
+
+fn session_start_budget_check() -> Check {
+    session_start_budget_check_for(crate::builtins::supervisor_guidance().len())
+}
+
 pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow::Result<()> {
     let started = Instant::now();
     let mut checks = Vec::new();
@@ -1283,6 +1315,8 @@ pub fn execute(args: &DoctorArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
     recorder.mark("host checks", &checks);
     checks.push(prompt_hook_check(&cas_root));
     recorder.mark("prompt hook", &checks);
+    checks.push(session_start_budget_check());
+    recorder.mark("SessionStart budget", &checks);
     // Check 2: Store type and database
     let store_type = detect_store_type(&cas_root);
     match store_type {
@@ -8994,6 +9028,20 @@ fn output_checks_timed(
 #[cfg(test)]
 mod prompt_hook_tests {
     use super::*;
+
+    #[test]
+    fn session_start_budget_row_requires_512_bytes_of_headroom() {
+        let hard_ceiling = crate::builtins::SUPERVISOR_GUIDANCE_HARD_CEILING_BYTES;
+        let minimum = crate::hooks::handlers::session_budget::SESSION_START_MIN_HEADROOM_BYTES;
+
+        let at_floor = session_start_budget_check_for(hard_ceiling - minimum);
+        assert!(matches!(at_floor.status, CheckStatus::Ok));
+        assert!(at_floor.message.contains("512B headroom"));
+
+        let below_floor = session_start_budget_check_for(hard_ceiling - minimum + 1);
+        assert!(matches!(below_floor.status, CheckStatus::Warning));
+        assert!(below_floor.message.contains("need at least 512B"));
+    }
 
     #[test]
     fn prompt_hook_row_reports_observed_silence_and_ignores_old_sessions() {

--- a/cas-cli/src/hooks/handlers/handlers_session.rs
+++ b/cas-cli/src/hooks/handlers/handlers_session.rs
@@ -1,4 +1,4 @@
-use crate::hooks::handlers::session_budget::SessionContextAssembler;
+use crate::hooks::handlers::session_budget::{DegradationPriority, SessionContextAssembler};
 use crate::hooks::handlers::*;
 
 fn registered_role_mismatch_banner(
@@ -217,7 +217,12 @@ pub fn handle_session_start(
 
     #[cfg(feature = "mcp-proxy")]
     if let Some(warning) = crate::mcp::viktor_watch::session_start_warning(cas_root) {
-        assembler.prepend_degradable(warning.clone(), warning);
+        assembler.prepend_degradable_with_priority(
+            "Viktor upstream warning",
+            warning.clone(),
+            warning,
+            DegradationPriority::Context,
+        );
     }
 
     // Planning is a shared write surface: two live supervisors can otherwise
@@ -228,7 +233,12 @@ pub fn handle_session_start(
         if let Some(banner) =
             active_peer_supervisor_banner(cas_root, std::env::var("CAS_AGENT_NAME").ok().as_deref())
         {
-            assembler.prepend_degradable(banner.clone(), banner);
+            assembler.prepend_degradable_with_priority(
+                "Concurrent supervisor warning",
+                banner.clone(),
+                banner,
+                DegradationPriority::Context,
+            );
         }
     }
 
@@ -238,7 +248,12 @@ pub fn handle_session_start(
     if let Some(packet) =
         crate::ambient_recall::build_ambient_recall_context(input, cas_root, None, true)
     {
-        assembler.append_degradable(packet.full, packet.compact);
+        assembler.append_degradable_with_priority(
+            "Ambient recall",
+            packet.full,
+            packet.compact,
+            DegradationPriority::AmbientRecall,
+        );
     }
 
     if let Some(staleness) =
@@ -247,9 +262,19 @@ pub fn handle_session_start(
         let full = staleness.format_injection(is_supervisor);
         let compact = staleness.format_injection_compact(is_supervisor);
         if staleness.is_high_severity(is_supervisor) {
-            assembler.prepend_degradable(full, compact);
+            assembler.prepend_degradable_with_priority(
+                "Codemap freshness",
+                full,
+                compact,
+                DegradationPriority::Context,
+            );
         } else {
-            assembler.append_degradable(full, compact);
+            assembler.append_degradable_with_priority(
+                "Codemap freshness",
+                full,
+                compact,
+                DegradationPriority::Context,
+            );
         }
     }
 
@@ -283,7 +308,12 @@ pub fn handle_session_start(
         if let Some(banner) =
             crate::hooks::handlers::session_hygiene::build_session_start_wip_banner_sized(cas_root)
         {
-            assembler.append_degradable(banner.full, banner.compact);
+            assembler.append_degradable_with_priority(
+                "Factory worktree changes",
+                banner.full,
+                banner.compact,
+                DegradationPriority::Context,
+            );
         }
     }
 
@@ -296,7 +326,12 @@ pub fn handle_session_start(
             cas_root,
         )
     {
-        assembler.append_degradable(banner.full, banner.compact);
+        assembler.append_degradable_with_priority(
+            "Stale builtin references",
+            banner.full,
+            banner.compact,
+            DegradationPriority::Context,
+        );
     }
 
     // cas-20f27: issue-filing detectors. Both are surfaced to every role — a
@@ -310,7 +345,12 @@ pub fn handle_session_start(
             cas_root,
         )
     {
-        assembler.append_degradable(banner.full, banner.compact);
+        assembler.append_degradable_with_priority(
+            "Unfiled reports",
+            banner.full,
+            banner.compact,
+            DegradationPriority::Context,
+        );
     }
 
     // (2) No issue target configured in a project that stages requests. Never
@@ -321,7 +361,12 @@ pub fn handle_session_start(
             cas_root, &config,
         )
     {
-        assembler.append_degradable(banner.full, banner.compact);
+        assembler.append_degradable_with_priority(
+            "Issue repository target",
+            banner.full,
+            banner.compact,
+            DegradationPriority::Context,
+        );
     }
 
     // cas-b7dd (GH #88): leftovers from dead sessions — orphan processes still
@@ -335,7 +380,12 @@ pub fn handle_session_start(
                 cas_root,
             )
         {
-            assembler.append_degradable(banner.full, banner.compact);
+            assembler.append_degradable_with_priority(
+                "Orphaned factory resources",
+                banner.full,
+                banner.compact,
+                DegradationPriority::Context,
+            );
         }
     }
 
@@ -348,7 +398,12 @@ pub fn handle_session_start(
         if let Some(banner) = crate::hooks::handlers::issue_triage::build_session_start_banner_sized(
             cas_root, &config,
         ) {
-            assembler.append_degradable(banner.full, banner.compact);
+            assembler.append_degradable_with_priority(
+                "GitHub issue triage",
+                banner.full,
+                banner.compact,
+                DegradationPriority::Context,
+            );
         }
     }
 

--- a/cas-cli/src/hooks/handlers/session_budget.rs
+++ b/cas-cli/src/hooks/handlers/session_budget.rs
@@ -27,8 +27,27 @@
 //!   are dropped entirely rather than cut mid-sentence. Their information is
 //!   always one named command away.
 //!
-//! Degradation order is deterministic: largest saving first, ties broken by
-//! assembly order. Same inputs always produce the same payload.
+//! Degradation order is deterministic: lower-value sections compact first,
+//! then the largest saving wins within one value tier, with assembly order as
+//! the final tie-breaker. Same inputs always produce the same payload.
+
+/// Value tier for a degradable SessionStart segment.
+///
+/// Lower values are compacted first. Ambient recall and factory inbox content
+/// are deliberately last: they are the session-specific evidence and
+/// coordination channels that static guidance and ordinary listings must make
+/// room for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum DegradationPriority {
+    /// Static indexes and boilerplate are cheap to retrieve again.
+    Static,
+    /// Ordinary context listings and runtime warnings.
+    Context,
+    /// Session-specific ambient evidence.
+    AmbientRecall,
+    /// Durable factory coordination messages.
+    FactoryInbox,
+}
 
 /// Aggregate byte budget for the assembled SessionStart `additionalContext`.
 ///
@@ -42,39 +61,41 @@ const SEP: &str = "\n";
 
 /// Base-context sections that may degrade to "heading + how to get it back".
 ///
-/// Each entry is `(heading prefix, remediation)`. These are progressive-
+/// Each entry is `(heading prefix, remediation, priority)`. These are progressive-
 /// disclosure *listings* — the heading itself already states the counts, and
 /// every item is retrievable on demand — so summarising them costs the session
 /// nothing, whereas losing role guidance to harness truncation costs it
 /// everything. Anything not listed here is protected.
-const DEGRADABLE_BASE_SECTIONS: &[(&str, &str)] = &[
-    ("## Ready Tasks", "task action=ready"),
-    ("## In Progress", "task action=mine"),
-    ("## Helpful Memories", "memory action=recent"),
-    ("## Related to Current Work", "search action=context"),
-    ("## Available Skills", "skill action=list"),
-    ("## Connected MCP Tools", "system action=status"),
+const DEGRADABLE_BASE_SECTIONS: &[(&str, &str, DegradationPriority)] = &[
+    ("## Ready Tasks", "task action=ready", DegradationPriority::Context),
+    ("## In Progress", "task action=mine", DegradationPriority::Context),
+    ("## Helpful Memories", "memory action=recent", DegradationPriority::Context),
+    ("## Related to Current Work", "search action=context", DegradationPriority::Context),
+    ("## Available Skills", "skill action=list", DegradationPriority::Static),
+    ("## Connected MCP Tools", "system action=status", DegradationPriority::Static),
 ];
 
 /// Split the base context into budget segments at its `## ` headings.
 ///
-/// Returns `(full, compact)` pairs in document order; `compact` is `None` for
-/// protected sections. Splitting is lossless: joining the full texts with
-/// [`SEP`] reproduces the input exactly.
-fn split_base_context(base: &str) -> Vec<(String, Option<String>)> {
+/// Returns `(full, compact, priority)` tuples in document order; `compact` is
+/// `None` for protected sections. Splitting is lossless: joining the full
+/// texts with [`SEP`] reproduces the input exactly.
+fn split_base_context(base: &str) -> Vec<(String, Option<String>, DegradationPriority)> {
     if base.is_empty() {
         return Vec::new();
     }
     let prefix = crate::harness_policy::own_tool_prefix();
-    let mut segments: Vec<(String, Option<String>)> = Vec::new();
+    let mut segments: Vec<(String, Option<String>, DegradationPriority)> = Vec::new();
     let mut current: Vec<&str> = Vec::new();
     let mut current_compact: Option<String> = None;
+    let mut current_priority = DegradationPriority::Context;
 
-    let flush = |segments: &mut Vec<(String, Option<String>)>,
+    let flush = |segments: &mut Vec<(String, Option<String>, DegradationPriority)>,
                  current: &mut Vec<&str>,
-                 compact: &mut Option<String>| {
+                 compact: &mut Option<String>,
+                 priority: &mut DegradationPriority| {
         if !current.is_empty() {
-            segments.push((current.join(SEP), compact.take()));
+            segments.push((current.join(SEP), compact.take(), *priority));
             current.clear();
         }
     };
@@ -82,17 +103,32 @@ fn split_base_context(base: &str) -> Vec<(String, Option<String>)> {
     for line in base.split(SEP) {
         let heading = line.starts_with("## ");
         if heading {
-            flush(&mut segments, &mut current, &mut current_compact);
+            flush(
+                &mut segments,
+                &mut current,
+                &mut current_compact,
+                &mut current_priority,
+            );
+            current_priority = DEGRADABLE_BASE_SECTIONS
+                .iter()
+                .find(|(name, _, _)| line.starts_with(name))
+                .map(|(_, _, priority)| *priority)
+                .unwrap_or(DegradationPriority::Context);
             current_compact = DEGRADABLE_BASE_SECTIONS
                 .iter()
-                .find(|(name, _)| line.starts_with(name))
-                .map(|(_, remediation)| {
+                .find(|(name, _, _)| line.starts_with(name))
+                .map(|(_, remediation, _)| {
                     format!("{line}\n(omitted to fit the session-start size budget — run `{prefix}{remediation}`)")
                 });
         }
         current.push(line);
     }
-    flush(&mut segments, &mut current, &mut current_compact);
+    flush(
+        &mut segments,
+        &mut current,
+        &mut current_compact,
+        &mut current_priority,
+    );
     segments
 }
 
@@ -108,6 +144,7 @@ struct Segment {
     full: String,
     /// `None` marks the segment protected — it is never compacted or dropped.
     compact: Option<String>,
+    priority: DegradationPriority,
     level: Level,
 }
 
@@ -150,8 +187,8 @@ impl SessionContextAssembler {
             segments: Vec::new(),
             budget: None,
         };
-        for (full, compact) in split_base_context(&base) {
-            assembler.push(false, full, compact);
+        for (full, compact, priority) in split_base_context(&base) {
+            assembler.push(false, full, compact, priority, None);
         }
         assembler
     }
@@ -163,13 +200,24 @@ impl SessionContextAssembler {
         self
     }
 
-    fn push(&mut self, front: bool, full: String, compact: Option<String>) {
+    fn push(
+        &mut self,
+        front: bool,
+        full: String,
+        compact: Option<String>,
+        priority: DegradationPriority,
+        label: Option<String>,
+    ) {
         if full.trim().is_empty() {
             return;
         }
+        let label = label.unwrap_or_else(|| section_label(&full));
         let segment = Segment {
             full,
-            compact: compact.filter(|c| !c.trim().is_empty()),
+            compact: compact
+                .filter(|c| !c.trim().is_empty())
+                .map(|compact| format!("[SessionStart compacted: {label}]\n{compact}")),
+            priority,
             level: Level::Full,
         };
         if front {
@@ -181,22 +229,68 @@ impl SessionContextAssembler {
 
     /// Append a segment that must survive verbatim.
     pub(crate) fn append_protected(&mut self, text: String) {
-        self.push(false, text, None);
+        self.push(
+            false,
+            text,
+            None,
+            DegradationPriority::FactoryInbox,
+            None,
+        );
     }
 
     /// Prepend a safety segment that must survive verbatim.
     pub(crate) fn prepend_protected(&mut self, text: String) {
-        self.push(true, text, None);
+        self.push(
+            true,
+            text,
+            None,
+            DegradationPriority::FactoryInbox,
+            None,
+        );
     }
 
     /// Append a segment that degrades to `compact` when over budget.
     pub(crate) fn append_degradable(&mut self, full: String, compact: String) {
-        self.push(false, full, Some(compact));
+        self.append_degradable_with_priority(
+            section_label(&full),
+            full,
+            compact,
+            DegradationPriority::Context,
+        );
     }
 
     /// Prepend a segment that degrades to `compact` when over budget.
     pub(crate) fn prepend_degradable(&mut self, full: String, compact: String) {
-        self.push(true, full, Some(compact));
+        self.prepend_degradable_with_priority(
+            section_label(&full),
+            full,
+            compact,
+            DegradationPriority::Context,
+        );
+    }
+
+    /// Append a degradable segment with an explicit value tier and output
+    /// label. The label appears in the payload whenever compaction occurs.
+    pub(crate) fn append_degradable_with_priority(
+        &mut self,
+        label: impl Into<String>,
+        full: String,
+        compact: String,
+        priority: DegradationPriority,
+    ) {
+        self.push(false, full, Some(compact), priority, Some(label.into()));
+    }
+
+    /// Prepend a degradable segment with an explicit value tier and output
+    /// label. The label appears in the payload whenever compaction occurs.
+    pub(crate) fn prepend_degradable_with_priority(
+        &mut self,
+        label: impl Into<String>,
+        full: String,
+        compact: String,
+        priority: DegradationPriority,
+    ) {
+        self.push(true, full, Some(compact), priority, Some(label.into()));
     }
 
     fn joined(&self) -> String {
@@ -208,7 +302,8 @@ impl SessionContextAssembler {
             .join(SEP)
     }
 
-    /// Degradation order: biggest saving first, ties broken by assembly order.
+    /// Degradation order: lower-value segments first, then biggest saving,
+    /// ties broken by assembly order.
     fn degradation_order(&self) -> Vec<usize> {
         let mut order: Vec<usize> = self
             .segments
@@ -224,7 +319,11 @@ impl SessionContextAssembler {
                     .len()
                     .saturating_sub(seg.compact.as_deref().map(str::len).unwrap_or(0))
             };
-            saving(*b).cmp(&saving(*a)).then(a.cmp(b))
+            self.segments[*a]
+                .priority
+                .cmp(&self.segments[*b].priority)
+                .then_with(|| saving(*b).cmp(&saving(*a)))
+                .then(a.cmp(b))
         });
         order
     }
@@ -283,6 +382,14 @@ impl SessionContextAssembler {
     }
 }
 
+fn section_label(full: &str) -> String {
+    full.lines()
+        .find(|line| line.starts_with("## "))
+        .map(|line| line.trim_start_matches("## ").trim().to_string())
+        .filter(|label| !label.is_empty())
+        .unwrap_or_else(|| "SessionStart context".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,11 +407,11 @@ mod tests {
 
     #[test]
     fn over_budget_degrades_largest_saver_first() {
-        let mut a = SessionContextAssembler::new(seg(100, 'b')).with_budget(200);
+        let mut a = SessionContextAssembler::new(seg(100, 'b')).with_budget(250);
         a.append_degradable(seg(50, 'x'), "x-compact".to_string());
         a.append_degradable(seg(200, 'y'), "y-compact".to_string());
         let out = a.render();
-        assert!(out.len() <= 200, "payload {} bytes", out.len());
+        assert!(out.len() <= 250, "payload {} bytes", out.len());
         // The bigger saver (y) compacts first; x keeps its full rendering.
         assert!(out.contains(&seg(50, 'x')), "small section kept full");
         assert!(out.contains("y-compact"), "large section compacted");
@@ -326,7 +433,7 @@ mod tests {
     #[test]
     fn degradation_is_deterministic() {
         let build = || {
-            let mut a = SessionContextAssembler::new(seg(100, 'b')).with_budget(220);
+            let mut a = SessionContextAssembler::new(seg(100, 'b')).with_budget(250);
             a.append_degradable(seg(80, 'x'), "x-compact".to_string());
             a.append_degradable(seg(80, 'y'), "y-compact".to_string());
             a.render()
@@ -336,6 +443,49 @@ mod tests {
         let out = build();
         assert!(out.contains("x-compact"));
         assert!(out.contains(&seg(80, 'y')));
+    }
+
+    #[test]
+    fn static_sections_compact_before_ambient_recall_and_factory_inbox() {
+        let mut a = SessionContextAssembler::new("protected".to_string()).with_budget(240);
+        a.append_degradable_with_priority(
+            "Static skills index",
+            seg(200, 's'),
+            "static summary".to_string(),
+            DegradationPriority::Static,
+        );
+        a.append_degradable_with_priority(
+            "Ambient recall",
+            seg(80, 'a'),
+            "ambient summary".to_string(),
+            DegradationPriority::AmbientRecall,
+        );
+        a.append_degradable_with_priority(
+            "Factory inbox",
+            seg(80, 'i'),
+            "inbox summary".to_string(),
+            DegradationPriority::FactoryInbox,
+        );
+
+        let out = a.render();
+        assert!(out.contains("[SessionStart compacted: Static skills index]"));
+        assert!(out.contains(&seg(80, 'a')), "ambient recall must survive");
+        assert!(out.contains(&seg(80, 'i')), "factory inbox must survive");
+    }
+
+    #[test]
+    fn every_compacted_segment_names_itself_in_payload() {
+        let mut a = SessionContextAssembler::new("protected".to_string()).with_budget(80);
+        a.append_degradable_with_priority(
+            "Codemap freshness",
+            seg(100, 'c'),
+            "codemap summary".to_string(),
+            DegradationPriority::Context,
+        );
+
+        let out = a.render();
+        assert!(out.contains("[SessionStart compacted: Codemap freshness]"));
+        assert!(out.contains("codemap summary"));
     }
 
     #[test]
@@ -502,7 +652,7 @@ mod tests {
         assert_eq!(
             segments
                 .iter()
-                .map(|(full, _)| full.clone())
+                .map(|(full, _, _)| full.clone())
                 .collect::<Vec<_>>()
                 .join(SEP),
             base,
@@ -510,8 +660,8 @@ mod tests {
         );
         let degradable: Vec<&str> = segments
             .iter()
-            .filter(|(_, compact)| compact.is_some())
-            .map(|(full, _)| full.as_str())
+            .filter(|(_, compact, _)| compact.is_some())
+            .map(|(full, _, _)| full.as_str())
             .collect();
         assert_eq!(degradable.len(), 1, "only the listing section degrades");
         assert!(degradable[0].starts_with("## Ready Tasks"));
@@ -519,7 +669,7 @@ mod tests {
         assert!(
             segments
                 .iter()
-                .any(|(full, compact)| full.starts_with("## Hard Rules") && compact.is_none())
+                .any(|(full, compact, _)| full.starts_with("## Hard Rules") && compact.is_none())
         );
     }
 
@@ -533,7 +683,7 @@ mod tests {
                 .map(|i| format!("- cas-{i:04} a ready task with a long-ish title\n"))
                 .collect::<String>();
         let payload = SessionContextAssembler::new(base)
-            .with_budget(200)
+            .with_budget(300)
             .render();
         assert!(payload.contains("## Ready Tasks (5/5 shown, ~100tk)"));
         assert!(payload.contains("action=ready"));

--- a/cas-cli/src/hooks/handlers/session_budget.rs
+++ b/cas-cli/src/hooks/handlers/session_budget.rs
@@ -56,6 +56,11 @@ pub(crate) enum DegradationPriority {
 /// passed this gate over the real limit.
 pub(crate) const SESSION_START_BUDGET_BYTES: usize = 9 * 1024;
 
+/// Minimum un-compacted payload headroom required by the self-test/doctor
+/// guard. A payload closer than this to the harness boundary is one small
+/// guidance edit away from invoking compaction.
+pub(crate) const SESSION_START_MIN_HEADROOM_BYTES: usize = 512;
+
 /// Separator between assembled segments (matches the pre-budget assembly).
 const SEP: &str = "\n";
 
@@ -302,6 +307,21 @@ impl SessionContextAssembler {
             .join(SEP)
     }
 
+    /// Measure the payload before any degradation is applied.
+    ///
+    /// This is the value that matters for headroom: `render()` can make an
+    /// over-budget payload fit by compacting it, but that is already a loss of
+    /// detail and should be visible to the regression test.
+    #[cfg(test)]
+    pub(crate) fn full_len(&self) -> usize {
+        self.segments
+            .iter()
+            .map(|segment| segment.full.as_str())
+            .collect::<Vec<_>>()
+            .join(SEP)
+            .len()
+    }
+
     /// Degradation order: lower-value segments first, then biggest saving,
     /// ties broken by assembly order.
     fn degradation_order(&self) -> Vec<usize> {
@@ -471,6 +491,64 @@ mod tests {
         assert!(out.contains("[SessionStart compacted: Static skills index]"));
         assert!(out.contains(&seg(80, 'a')), "ambient recall must survive");
         assert!(out.contains(&seg(80, 'i')), "factory inbox must survive");
+    }
+
+    /// Production-shape regression for cas-6a20: a supervisor guidance edit
+    /// that pushes the assembled payload over the aggregate budget must
+    /// compact a static listing before it touches ambient recall. The real
+    /// supervisor guidance is used so this fails when future edits consume
+    /// the remaining SessionStart headroom, while the surrounding sections
+    /// model the headings emitted by the production context builder.
+    #[test]
+    fn guidance_growth_compacts_static_listing_before_ambient_recall() {
+        let guidance_growth = "\nAdditional supervisor guidance retained for future policy edits."
+            .repeat(32);
+        let static_listing = (0..64)
+            .map(|i| format!("- skill-{i:02}: a representative static skill listing row\n"))
+            .collect::<String>();
+        let base = format!(
+            "## 📋 CAS Context\n**Session:** `7d3511aa-9cf5-44d8-921d-0289bd66fe0a`\n\n{}{}\n\n## Available Skills (64 skills, ~1.2k tk if expanded)\n{}",
+            crate::builtins::supervisor_guidance(),
+            guidance_growth,
+            static_listing,
+        );
+        let mut assembler = SessionContextAssembler::new(base);
+        let ambient = "[ambient recall v1 role=supervisor]\nCurrent release recovery audit receipts preserve operator intent\n"
+            .to_string();
+        assembler.append_degradable_with_priority(
+            "Ambient recall",
+            ambient.clone(),
+            "[ambient recall v1 role=supervisor] 1 evidence card; run `mcp__cas__search` for bodies"
+                .to_string(),
+            DegradationPriority::AmbientRecall,
+        );
+
+        let full_len = assembler.full_len();
+        assert!(
+            full_len > SESSION_START_BUDGET_BYTES,
+            "guidance-growth fixture must cross the {}B budget (full payload: {full_len}B)",
+            SESSION_START_BUDGET_BYTES
+        );
+
+        let payload = assembler.render();
+        assert!(
+            payload.len() <= SESSION_START_BUDGET_BYTES,
+            "compacted payload is {}B, over the {}B budget",
+            payload.len(),
+            SESSION_START_BUDGET_BYTES
+        );
+        assert!(
+            payload.contains("[SessionStart compacted: Available Skills"),
+            "static guidance listing must compact first: {payload}"
+        );
+        assert!(
+            payload.contains(&ambient),
+            "ambient recall must remain full after static guidance grows: {payload}"
+        );
+        assert!(
+            !payload.contains("skill-00: a representative static skill listing row"),
+            "static listing rows must not survive after the listing is compacted"
+        );
     }
 
     #[test]

--- a/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
+++ b/cas-cli/tests/snapshots/component_output_test__doctor_snapshot.snap
@@ -3,7 +3,7 @@ source: cas-cli/tests/component_output_test.rs
 assertion_line: 209
 expression: redacted
 ---
-[WARN] 3 warnings · 27 ok · [PROJECT] · [VERSION]
+[WARN] 3 warnings · 28 ok · [PROJECT] · [VERSION]
 ────────────────────────────────────────────────────────────────────────────────
 Host          [OK] registered project roots
   [WARN] host  host: [N] finding — see `cas doctor --host`
@@ -12,7 +12,7 @@ Indexes       [OK] legacy search index  [OK] symbol index  [OK] embedding drain 
   [WARN] search index        Index not found at [CAS_PATH] Will be created on first search; Run a search to build it
   [WARN] code history index  cannot check code history index: not a git repository: [TEMP_PATH] ([GIT_NOT_REPOSITORY])
 Cloud         [OK] supervisor relay  [OK] delivery retries  [OK] canonical id  [OK] cloud sync queue  [OK] cross-project rows
-Config        [OK] configuration  [OK] issue repositories  [OK] MCP stdio upstreams  [OK] MCP upstream reachability  [OK] sync target  [OK] mcp config
+Config        [OK] SessionStart budget  [OK] configuration  [OK] issue repositories  [OK] MCP stdio upstreams  [OK] MCP upstream reachability  [OK] sync target  [OK] mcp config
 Integrations  [OK] integrations
 
-27 ok · 3 warnings · 0 errors · [DURATION] · cas doctor --verbose for timings and full messages
+28 ok · 3 warnings · 0 errors · [DURATION] · cas doctor --verbose for timings and full messages

--- a/docs/design/cli/cas-doctor.brief.md
+++ b/docs/design/cli/cas-doctor.brief.md
@@ -3,10 +3,10 @@
 | Field | Sentence |
 | --- | --- |
 | First two lines | Whether the local store is healthy, how many findings need a hand, and which project and version this is about. |
-| Scannable | One line per healthy group with its marks; one row per finding under its group, with the mark, the name, and a repeat count when the same check fired per instance. |
+| Scannable | One line per healthy group with its marks; one row per finding under its group, including the `SessionStart budget` guard with its byte headroom. |
 | Readable | Each finding's cause (at most three lines) and its remedy under `→`; everything whole under `--verbose`. |
 | Machine output | `--json`: one array of `{name, status, group, message, remediation, duration_ms, phase}`; nothing else on stdout. |
-| Omitted | Per-check timings, the slow-phase table, and instances beyond the first of a repeated finding — all under `--verbose`. |
+| Omitted | Per-check timings, the slow-phase table, and instances beyond the first of a repeated finding — all under `--verbose`; detailed payload sections remain in the SessionStart references. |
 
 ## Rendering decisions
 
@@ -32,6 +32,11 @@ The MCP upstream reachability check is one grouped row: it reports the number pr
 reachable upstreams, and includes the bounded credential-free cause for each unavailable one;
 the same message is carried in the existing `--json` check object.
 
+The `SessionStart budget` row reports supervisor guidance bytes and remaining headroom below
+the protected 8,192-byte ceiling. It warns at less than 512 bytes of headroom and directs the
+operator to move detail into `cas-supervisor/references/`; its status and message are carried
+by the existing `--json` check object.
+
 ## Critique
 
 Before (build `eda3dfd1`): `terminal-qa: FAIL cas-doctor · 12 runs · 841 fail · 24 warn` — 788 contrast, 28 word-split, 24 overflow, 1 unicode-without-fallback.
@@ -55,3 +60,18 @@ this task.
 Task capture: `terminal-qa: PASS cas-doctor-fcba · 12 runs · 0 fail · 8 warn · 0 allowed · /home/pippenz/.cas/artifacts/cas-fcba/terminal-qa/cas-doctor/report.json`.
 The eight warnings are the existing 120-column word-split heuristics for temporary registered
 roots and the quarantine remedy; the new reachability row did not introduce a failure or overflow.
+
+SessionStart budget capture: `terminal-qa: PASS cas-doctor-budget · 12 runs · 0 fail · 4 warn · 0 allowed · /home/pippenz/.cas/artifacts/cas-6a20/terminal-qa/cas-doctor-budget/report.json`.
+The four warnings are the existing 120-column word-split heuristic on the quarantine remedy;
+the new `SessionStart budget` row is present in the 80-column capture and the JSON document,
+with no new failure or overflow.
+
+| Dimension | Score | Evidence |
+| --- | --- | --- |
+| Hierarchy | 5 | The first two lines give the warning count and the first group; the new budget status is a grouped Config row. |
+| Fit | 4 | The byte guard is one scan-friendly row and remains a typed JSON check rather than a separate output shape. |
+| Craft | 4 | The row names guidance bytes, headroom, and the protected ceiling in one line at 80 columns. |
+| Theme safety | 5 | The four palettes, `NO_COLOR`, and C-locale runs have no mechanical color or Unicode failures. |
+| Machine contract | 5 | The JSON run is one document and includes `name`, `status`, `message`, `phase`, and timing fields. |
+
+Scored by Codex on 2026-09-09; hierarchy, fit, and craft floors hold.


### PR DESCRIPTION
Replaces #782 (same delivery 0b2c6b1b plus one follow-up commit restoring the issue component registry keys that the guidance trim had collapsed; issue_intake_directive_test failed twice in the merge queue on #782).

SessionStart payload compaction chose sections by byte saving, so when supervisor guidance grew past the 9,216 B budget the ambient recall section was the first to be summarized and a supervisor launched with no recall. Now: sections carry a semantic compaction priority (static listings first; ambient recall and the factory inbox last), a compacted section leaves a one-line marker in the payload, a production-shape regression grows real supervisor guidance past the budget and asserts recall survives, supervisor guidance is trimmed by over 1 KB in all three flavors, and cas doctor gains a SessionStart budget row that fails under 512 B of headroom (intentional new snapshot row).

Proof: session_budget 12/12; doctor 133/133; supervisor guidance 5/5; doctor snapshot 2/2; skill guardrails + agent contract + flavor drift + issue_intake_directive_test 36/36; cli::factory::parity 6/6; terminal-qa PASS 12 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)