### PR TITLE
docs(release-notes): v3.22.0 POSTED receipts and report links

### DIFF
--- a/docs/release-notes/2026-09-09-v3.22.0-slack.md
+++ b/docs/release-notes/2026-09-09-v3.22.0-slack.md
@@ -2,7 +2,7 @@
 
 Channel: #cas-internal (C0B44GUKDK2)
 
-Status: Draft. Do not post until the tagged GitHub workflow publishes both assets and `release-published-receipt.sh --write-draft` has replaced both checksum placeholders below.
+Status: POSTED (see the POSTED block at the end).
 
 User top-level
 
@@ -30,7 +30,9 @@ User reply
 
 • *Honest start-up line* — Was: a Codex helper's start-up line claimed a Claude account folder. Now: it names the tool and account folder actually in use.
 
-Install: update with `cas update`, or download the Linux x86_64 archive (`{{LINUX_SHA256}}`) or macOS ARM64 archive (`{{MACOS_SHA256}}`) from the Cassy v3.22.0 release.
+Report: the v3.22.0 release report (PDF and HTML) is attached below in this thread.
+
+Install: update with `cas update`, or download the Linux x86_64 archive (`6a0e7b36a21ebb1458fdcd6d10e2c7c374a3deb0963e69fdbb7ba9399b27249c`) or macOS ARM64 archive (`77ae01610d2093193e9847ee56b98b484b3a63c61ed969bcbcc4b42d542485c5`) from the Cassy v3.22.0 release.
 ```
 
 Dev top-level
@@ -61,11 +63,19 @@ Dev reply
 
 • *Spawn audit* — Was: the PTY audit always printed a Claude account directory. Now: it names the launched CLI, model, effort, and `CLAUDE_CONFIG_DIR`/`CODEX_HOME` source, with a routing regression (PR #780).
 
-Validation: full release gate on the exact candidate tip; merge queue validates the synthetic tree.
+Validation: full release gate green on candidate e91c0397 (run 2; run 1 caught a runtime checkout read in the new command, fixed on the assembled tree); merge queue validated the synthetic tree (PR #785, run 34375930966). Tag-to-published 174 s; green-to-published 2,535 s. Honest note: the shipped command's first real run on this release did not produce a usable report (worktree config lookup, wrapped changelog lines, placeholder Was lines, duplicated sections, Playwright resolution); the attached report was produced with the skill, and the fixes are in progress.
 
-Install: `cas-x86_64-unknown-linux-gnu.tar.gz` (`{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (`{{MACOS_SHA256}}`), published by CI for Linux and macOS.
+Install: `cas-x86_64-unknown-linux-gnu.tar.gz` (`6a0e7b36a21ebb1458fdcd6d10e2c7c374a3deb0963e69fdbb7ba9399b27249c`) and `cas-aarch64-apple-darwin.tar.gz` (`77ae01610d2093193e9847ee56b98b484b3a63c61ed969bcbcc4b42d542485c5`), published by CI for Linux and macOS.
 ```
 
 ## POSTED
 
-(pending)
+Posted 2026-09-09 17:13Z via the MechaCassy hub (mecha_post) to #cas-internal (C0B44GUKDK2), after `release-published-receipt.sh v3.22.0 --write-draft` replaced both digests (PUBLISHED_AT=2026-09-09T16:51:40Z) and the v3.22.0 report (cas-1bda, PR #786) was produced with the cas-release-report skill:
+
+- User top-level ts 1788973969.737149 — https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788973969737149
+- User reply ts 1788973985.292609 (thread of the user top-level)
+- Dev top-level ts 1788973988.246869 — https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788973988246869
+- Dev reply ts 1788974005.197849 (thread of the dev top-level; the validation line names both gate runs, the latencies, and the honest note about the shipped command's first run)
+- Report files posted 17:13Z in the user thread via the claude.ai Slack MCP: PDF F0C0P67H2PL https://petra-stella.slack.com/files/U076KKG4DGU/F0C0P67H2PL/cassy-v3.22.0-release-report.pdf ; HTML F0C1HHU2LGG https://petra-stella.slack.com/files/U076KKG4DGU/F0C1HHU2LGG/cassy-v3.22.0-release-report.html
+- Release-report receipt (train `--report` contract): ~/.cas/artifacts/release/v3.22.0-epic-b36e-merge/release-report.receipt, verified by `--status`.
+- Host verification: `cas update --yes` refresh_binary_version=3.22.0; `cas --version` = 3.22.0 (c2db094); hub 3.22.0 (the post-swap child exited without a refresh receipt on both host updates today: cas-a461). Receipts: release-workflow.json run 34379061737; install-path-proof.json run 34379360263 (Linux + macOS success); release-published.receipt; release-latency.receipt; host-update.json.


### PR DESCRIPTION
Records the Slack POSTED receipts for the Cassy v3.22.0 announcement (user and dev threads, report PDF/HTML file links), the published asset digests, the release-report receipt reference, and host verification. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)