### PR TITLE
fix(update): preserve plain post-swap refresh receipts (cas-a461)

### DIFF
--- a/cas-cli/src/cli/update.rs
+++ b/cas-cli/src/cli/update.rs
@@ -204,6 +204,10 @@ pub struct UpdateArgs {
     /// Version replaced by the post-swap invocation.
     #[arg(long = "from", hide = true, requires = "post_swap")]
     pub from: Option<String>,
+
+    /// File where a post-swap refresh writes its machine-readable receipt.
+    #[arg(long = "refresh-receipt", hide = true, requires = "post_swap")]
+    pub refresh_receipt: Option<PathBuf>,
 }
 
 pub fn execute(args: &UpdateArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow::Result<()> {
@@ -992,6 +996,11 @@ fn refresh_all_projects(
 
     let failed_count = receipts.iter().filter(|receipt| receipt.failed()).count()
         + usize::from(user_level.failed());
+    let receipt =
+        project_refresh_receipt_json(&receipts, &user_level, &discovery.skipped_unregistered);
+    if let Some(path) = &args.refresh_receipt {
+        write_refresh_receipt(path, &receipt)?;
+    }
     if failed_count > 0 {
         anyhow::bail!(
             "one or more projects were not fully refreshed; see the per-project phase summary above"
@@ -1346,6 +1355,13 @@ fn project_refresh_receipt_json(
         // receipt from the pre-update image is what made an operator's first
         // `cas update` look converged when it was not.
         "refresh_binary_version": env!("CARGO_PKG_VERSION"),
+        "refresh_status": if receipts.iter().any(|receipt| receipt.failed())
+            || user_level.failed()
+        {
+            "refresh_failed"
+        } else {
+            "complete"
+        },
         "projects": projects,
         "user_level_store": {
             "store": user_level_store_root(),
@@ -1362,6 +1378,13 @@ fn project_refresh_receipt_json(
             }))
             .collect::<Vec<_>>(),
     })
+}
+
+fn write_refresh_receipt(path: &Path, receipt: &serde_json::Value) -> anyhow::Result<()> {
+    let bytes = serde_json::to_vec(receipt).context("could not encode refresh receipt")?;
+    std::fs::write(path, bytes)
+        .with_context(|| format!("could not write refresh receipt {}", path.display()))?;
+    Ok(())
 }
 
 fn print_project_refresh_summary(
@@ -2834,11 +2857,24 @@ fn build_post_swap_command(
     previous_version: &str,
     json: bool,
 ) -> std::process::Command {
+    build_post_swap_command_with_receipt(installed_binary, previous_version, json, None)
+}
+
+fn build_post_swap_command_with_receipt(
+    installed_binary: &Path,
+    previous_version: &str,
+    json: bool,
+    receipt_path: Option<&Path>,
+) -> std::process::Command {
     let mut command = std::process::Command::new(installed_binary);
     command.args(["update", "--post-swap", "--from"]);
     command.arg(previous_version);
     if json {
         command.arg("--json");
+    }
+    if let Some(receipt_path) = receipt_path {
+        command.args(["--refresh-receipt"]);
+        command.arg(receipt_path);
     }
     command
 }
@@ -2861,7 +2897,15 @@ fn run_post_swap_refresh(
     installed_version: &str,
     json: bool,
 ) -> anyhow::Result<serde_json::Value> {
-    let mut command = build_post_swap_command(installed_binary, previous_version, json);
+    let receipt_file = tempfile::NamedTempFile::new()
+        .context("could not create a post-swap refresh receipt file")?;
+    let receipt_path = receipt_file.path().to_owned();
+    let mut command = build_post_swap_command_with_receipt(
+        installed_binary,
+        previous_version,
+        json,
+        Some(&receipt_path),
+    );
     let rerun_hint = post_swap_rerun_hint(installed_version, installed_binary);
 
     if !json {
@@ -2878,24 +2922,51 @@ fn run_post_swap_refresh(
             }
         };
         if !status.success() {
-            let message = post_swap_refresh_unreported_hint(installed_version, status, "");
+            let child_receipt = read_refresh_receipt(&receipt_path);
+            let Some(child_receipt) = child_receipt else {
+                let message = post_swap_refresh_unreported_hint(installed_version, status, "");
+                return Err(PostSwapRefreshFailure::new(
+                    refresh_failed_without_receipt(
+                        installed_version,
+                        "refresh_failed_no_receipt",
+                        &message,
+                    ),
+                    message,
+                )
+                .into());
+            };
+            verify_refresh_binary_version(
+                child_receipt
+                    .get("refresh_binary_version")
+                    .and_then(|v| v.as_str()),
+                installed_version,
+                installed_binary,
+            )?;
+            let message =
+                post_swap_refresh_failed_hint(installed_version, status, "", Some(&child_receipt));
             return Err(PostSwapRefreshFailure::new(
-                refresh_failed_without_receipt(
-                    installed_version,
-                    "refresh_failed_no_receipt",
-                    &message,
-                ),
+                refresh_failed_receipt(installed_version, child_receipt, status, "", &message),
                 message,
             )
             .into());
         }
-        // The child inherited stdio, so there is no receipt to read the
-        // version out of; ask the same path what it is instead.
-        verify_refresh_binary_version(
-            reported_binary_version(installed_binary).as_deref(),
-            installed_version,
-            installed_binary,
-        )?;
+        // The child inherited stdio, so use its side-channel receipt when
+        // available; retain the version probe for older installed children.
+        if let Some(child_receipt) = read_refresh_receipt(&receipt_path) {
+            verify_refresh_binary_version(
+                child_receipt
+                    .get("refresh_binary_version")
+                    .and_then(|v| v.as_str()),
+                installed_version,
+                installed_binary,
+            )?;
+        } else {
+            verify_refresh_binary_version(
+                reported_binary_version(installed_binary).as_deref(),
+                installed_version,
+                installed_binary,
+            )?;
+        }
         return Ok(serde_json::Value::Null);
     }
 
@@ -2913,7 +2984,9 @@ fn run_post_swap_refresh(
     let stdout = String::from_utf8_lossy(&output.stdout);
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let Some(child_receipt) = parse_refresh_receipt(&stdout) else {
+        let Some(child_receipt) =
+            parse_refresh_receipt(&stdout).or_else(|| read_refresh_receipt(&receipt_path))
+        else {
             let message =
                 post_swap_refresh_unreported_hint(installed_version, output.status, stderr.trim());
             return Err(PostSwapRefreshFailure::new(
@@ -2933,8 +3006,12 @@ fn run_post_swap_refresh(
             installed_version,
             installed_binary,
         )?;
-        let message =
-            post_swap_refresh_failed_hint(installed_version, output.status, stderr.trim());
+        let message = post_swap_refresh_failed_hint(
+            installed_version,
+            output.status,
+            stderr.trim(),
+            Some(&child_receipt),
+        );
         let receipt = refresh_failed_receipt(
             installed_version,
             child_receipt,
@@ -2946,14 +3023,18 @@ fn run_post_swap_refresh(
     }
     // The child may print progress lines before its receipt; the receipt is
     // the last JSON document on stdout.
-    let receipt = parse_refresh_receipt(&stdout).ok_or_else(|| {
-        anyhow::anyhow!(
-            "{rerun_hint} (its output carried no JSON receipt: {})",
-            stdout.trim()
-        )
-    })?;
+    let receipt = parse_refresh_receipt(&stdout)
+        .or_else(|| read_refresh_receipt(&receipt_path))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{rerun_hint} (its output carried no JSON receipt: {})",
+                stdout.trim()
+            )
+        })?;
     verify_refresh_binary_version(
-        receipt.get("refresh_binary_version").and_then(|v| v.as_str()),
+        receipt
+            .get("refresh_binary_version")
+            .and_then(|v| v.as_str()),
         installed_version,
         installed_binary,
     )?;
@@ -2970,21 +3051,72 @@ fn parse_refresh_receipt(stdout: &str) -> Option<serde_json::Value> {
         .filter(|receipt| receipt.is_object() && receipt.get("refresh_binary_version").is_some())
 }
 
+fn read_refresh_receipt(path: &Path) -> Option<serde_json::Value> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(contents.trim())
+        .ok()
+        .filter(|receipt: &serde_json::Value| {
+            receipt.is_object() && receipt.get("refresh_binary_version").is_some()
+        })
+}
+
 fn post_swap_refresh_failed_hint(
     installed_version: &str,
     status: std::process::ExitStatus,
     stderr: &str,
+    receipt: Option<&serde_json::Value>,
 ) -> String {
     let stderr = stderr.trim();
+    let failure_details = receipt.and_then(refresh_failure_details);
+    let diagnosis = failure_details.map_or_else(
+        || {
+            "inspect the per-project refresh results and resolve the reported failures before rerunning `cas update --all-projects`".to_owned()
+        },
+        |details| {
+            format!(
+                "failed project(s): {details}; resolve the reported project/cloud errors before rerunning `cas update --all-projects`"
+            )
+        },
+    );
     if stderr.is_empty() {
         format!(
-            "binary updated to {installed_version}; post-swap refresh ran and failed (exit status {status}); inspect the per-project refresh results and resolve the reported failures before rerunning `cas update --all-projects`"
+            "binary updated to {installed_version}; post-swap refresh ran and failed (exit status {status}); {diagnosis}"
         )
     } else {
         format!(
-            "binary updated to {installed_version}; post-swap refresh ran and failed (exit status {status}): {stderr}; inspect the per-project refresh results and resolve the reported failures before rerunning `cas update --all-projects`"
+            "binary updated to {installed_version}; post-swap refresh ran and failed (exit status {status}): {stderr}; {diagnosis}"
         )
     }
+}
+
+fn refresh_failure_details(receipt: &serde_json::Value) -> Option<String> {
+    let projects = receipt.get("projects")?.as_array()?;
+    let mut failures = Vec::new();
+    for project in projects {
+        let Some(name) = project.get("project").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        let phases = [
+            ("migration", project.get("migration")),
+            ("search_index", project.get("search_index")),
+            ("skills", project.get("skills")),
+            ("membership", project.get("membership")),
+            ("cloud_sync", project.get("cloud_sync")),
+        ];
+        let failed_phases = phases
+            .into_iter()
+            .filter_map(|(phase, value)| {
+                let detail = value?.as_str()?;
+                detail
+                    .starts_with("FAILED:")
+                    .then(|| format!("{phase}: {detail}"))
+            })
+            .collect::<Vec<_>>();
+        if !failed_phases.is_empty() {
+            failures.push(format!("{name} ({})", failed_phases.join(", ")));
+        }
+    }
+    (!failures.is_empty()).then(|| failures.join("; "))
 }
 
 fn post_swap_refresh_unreported_hint(

--- a/cas-cli/src/cli/update_tests/tests.rs
+++ b/cas-cli/src/cli/update_tests/tests.rs
@@ -501,6 +501,7 @@ fn post_swap_mode_is_a_terminal_update_path() {
         register: None,
         post_swap: true,
         from: Some("3.7.7".to_owned()),
+        refresh_receipt: None,
     };
     let cli = Cli {
         json: true,
@@ -636,6 +637,44 @@ fn post_swap_refresh_failure_preserves_the_child_receipt_and_failed_project() {
 
 #[cfg(unix)]
 #[test]
+fn plain_post_swap_refresh_failure_preserves_the_child_receipt_and_failed_project() {
+    let temp_dir = tempfile::tempdir().expect("create post-swap test directory");
+    let installed_binary = temp_dir.path().join("cas-failed-plain-refresh");
+    write_stub_binary(
+        &installed_binary,
+        "#!/bin/sh
+receipt=''
+while [ \"$#\" -gt 0 ]; do
+  if [ \"$1\" = \"--refresh-receipt\" ]; then receipt=\"$2\"; shift 2; else shift; fi
+done
+printf '%s' '{\"refresh_binary_version\":\"9.9.9-stub\",\"projects\":[{\"project\":\"/tmp/failed-project\",\"cloud_sync\":\"FAILED: cloud sync: project registration missing\"}],\"user_level_store\":{\"status\":\"ok\"}}' > \"$receipt\"
+exit 1
+",
+    );
+
+    let error = run_post_swap_refresh(&installed_binary, "3.15.1", "9.9.9-stub", false)
+        .expect_err("a failed plain child refresh must preserve its receipt");
+    let failure = error
+        .downcast_ref::<PostSwapRefreshFailure>()
+        .expect("a child refresh failure should preserve structured failure data");
+    let receipt = failure
+        .receipt
+        .as_ref()
+        .expect("the child receipt should be retained");
+
+    assert_eq!(receipt["binary_updated"], true);
+    assert_eq!(receipt["refresh_binary_version"], "9.9.9-stub");
+    assert_eq!(receipt["refresh_status"], "refresh_failed");
+    assert_eq!(receipt["projects"][0]["project"], "/tmp/failed-project");
+    assert!(
+        failure.to_string().contains("/tmp/failed-project")
+            && failure.to_string().contains("cas update --all-projects"),
+        "plain guidance must name the failed project and remedy: {failure}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn post_swap_refresh_failure_without_a_receipt_is_not_reported_as_skipped() {
     let temp_dir = tempfile::tempdir().expect("create post-swap test directory");
     let installed_binary = temp_dir.path().join("cas-no-receipt");
@@ -671,6 +710,37 @@ fn refresh_receipt_names_the_binary_that_ran_it() {
         receipt["refresh_binary_version"],
         env!("CARGO_PKG_VERSION"),
         "every refresh receipt must name the binary version that produced it: {receipt}"
+    );
+}
+
+#[test]
+fn refresh_receipt_records_partial_failure_before_refresh_returns_error() {
+    let temp_dir = tempfile::tempdir().expect("create refresh receipt directory");
+    let path = temp_dir.path().join("refresh.json");
+    let receipts = vec![ProjectRefreshReceipt {
+        project: PathBuf::from("/tmp/failed-project"),
+        unregistered: false,
+        migration: ProjectPhase::Ok("migration".to_owned()),
+        search_index: ProjectPhase::Ok("no stray root".to_owned()),
+        skills: ProjectPhase::Ok("skills".to_owned()),
+        membership: ProjectPhase::Ok("membership".to_owned()),
+        cloud: ProjectPhase::Failed("cloud sync: project registration missing".to_owned()),
+        details: String::new(),
+        phase_details: Vec::new(),
+    }];
+    let receipt =
+        project_refresh_receipt_json(&receipts, &ProjectPhase::Ok("up to date".to_owned()), &[]);
+
+    assert_eq!(receipt["refresh_status"], "refresh_failed");
+    write_refresh_receipt(&path, &receipt).expect("partial refresh receipt should be writable");
+    let written = read_refresh_receipt(&path).expect("partial refresh receipt should be readable");
+    assert_eq!(written["refresh_binary_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(written["projects"][0]["project"], "/tmp/failed-project");
+    assert!(
+        written["projects"][0]["cloud_sync"]
+            .as_str()
+            .expect("cloud phase summary")
+            .starts_with("FAILED:")
     );
 }
 
@@ -812,6 +882,7 @@ fn update_test_args() -> UpdateArgs {
         register: None,
         post_swap: false,
         from: None,
+        refresh_receipt: None,
     }
 }
 

--- a/docs/design/cli/cas-update.brief.md
+++ b/docs/design/cli/cas-update.brief.md
@@ -14,6 +14,9 @@
   `⚠ update available · 3.17.2 → 3.18.0`, then `Binary` and `Schema` rows, then one remedy.
 - The refresh banner became a verdict line: `✓ complete`, `⚠ N not refreshed`, or
   `✗ N projects failed`, with the unchanged count grammar as its detail.
+- A failed post-swap refresh names each failing project and its failed phase, then gives one
+  copyable remedy (`cas update --all-projects`); the old "outcome is unknown" wording remains
+  only when the child truly produced no receipt.
 - The `Current version: / Latest version:` pairs, each in accent colour, are gone; versions
   are plain text in the row.
 
@@ -23,10 +26,13 @@ Before (build `eda3dfd1`): `terminal-qa: FAIL cas-update-check · 12 runs · 33 
 
 After: `terminal-qa: PASS cas-update-check · 12 runs · 0 fail · 0 warn · 0 allowed · docs/design/cli/captures/after/cas-update-check/report.md`
 
+Post-swap failure review: `terminal-qa: PASS cas-update · 12 runs · 0 fail · 0 warn · 0 allowed · /home/pippenz/.cas/artifacts/cas-a461/terminal-qa/report.json`; the plain-mode
+failure test keeps the first line actionable by naming the failed project and the one rerun command.
+
 | Dimension | Score | Evidence |
 | --- | --- | --- |
-| Hierarchy | 5 | verdict first; the remedy is the only line after the rows |
-| Fit | 4 | two rows for a two-fact answer; the refresh table still carries a free-text note column |
-| Craft | 4 | fixed label column; `→` between versions reads as a change |
+| Hierarchy | 5 | verdict first; post-swap failures name the project before the one rerun command |
+| Fit | 4 | two rows for a two-fact answer; partial failures retain structured project evidence |
+| Craft | 4 | fixed label column; failure guidance uses one copyable remedy |
 | Theme safety | 5 | marks only; four palettes pass |
 | Machine contract | 5 | `--check --json` is one object |


### PR DESCRIPTION
On this host both 3.21.0 and 3.22.0 updates ended with "post-swap child exited with status 1 without a refresh receipt; the refresh outcome is unknown" although the child had printed a per-project summary. The plain (non-JSON) parent launched the child with inherited stdio, so it had no receipt transport and routed every non-zero exit to the unknown-outcome hint.

Now the parent passes a hidden `--refresh-receipt <file>` to the post-swap child; the child writes its machine-readable receipt (with a `refresh_status` field) to that file before exiting, the parent reads it on failure and names the failing projects and remedy, the JSON path falls back to the file when stdout carries no receipt, and the version probe is kept for older children. Tests: plain partial-receipt transport and guidance, receipt serialization to disk; existing JSON, spawn-failure, stale-version, and no-receipt paths stay green (update module 95/95). Real built-binary run and terminal-qa PASS (12 runs) under the cas-a461 artifacts directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)