### PR TITLE
docs(supervisor): park the trimmed reporting and routing guidance in a reference (cas-6be1)

### DIFF
--- a/cas-cli/src/builtins.rs
+++ b/cas-cli/src/builtins.rs
@@ -223,6 +223,10 @@ pub const BUILTIN_SKILLS: &[BuiltinFile] = &[
         content: include_str!("builtins/skills/cas-supervisor/references/epic-flow-walk.md"),
     },
     BuiltinFile {
+        path: "skills/cas-supervisor/references/reporting-and-routing.md",
+        content: include_str!("builtins/skills/cas-supervisor/references/reporting-and-routing.md"),
+    },
+    BuiltinFile {
         path: "skills/cas-supervisor-checklist/SKILL.md",
         content: include_str!("builtins/skills/cas-supervisor-checklist.md"),
     },
@@ -781,6 +785,12 @@ pub const CODEX_BUILTIN_SKILLS: &[BuiltinFile] = &[
         content: include_str!("builtins/codex/skills/cas-supervisor/references/epic-flow-walk.md"),
     },
     BuiltinFile {
+        path: "skills/cas-supervisor/references/reporting-and-routing.md",
+        content: include_str!(
+            "builtins/codex/skills/cas-supervisor/references/reporting-and-routing.md"
+        ),
+    },
+    BuiltinFile {
         path: "skills/cas-codex-supervisor-checklist/SKILL.md",
         content: include_str!("builtins/codex/skills/cas-codex-supervisor-checklist.md"),
     },
@@ -1277,6 +1287,12 @@ pub const GROK_BUILTIN_SKILLS: &[BuiltinFile] = &[
     BuiltinFile {
         path: "skills/cas-supervisor/references/epic-flow-walk.md",
         content: include_str!("builtins/grok/skills/cas-supervisor/references/epic-flow-walk.md"),
+    },
+    BuiltinFile {
+        path: "skills/cas-supervisor/references/reporting-and-routing.md",
+        content: include_str!(
+            "builtins/grok/skills/cas-supervisor/references/reporting-and-routing.md"
+        ),
     },
     BuiltinFile {
         path: "skills/cas-supervisor/references/worker-recovery.md",

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor.md
@@ -54,7 +54,7 @@ Match controls via model-selection.md; see [reference.md](cas-supervisor/referen
 
 ## On-demand references
 
-Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured registry: `issues.repo` for this project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, `issues.components.cloud` for Cloud sync; if you hit a bug during operation, file a ticket in the matching repo before moving on.
+Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. See [reporting-and-routing.md](cas-supervisor/references/reporting-and-routing.md) for reporting style, release-train ownership, and cross-team routing. Route bugs through the configured registry: `issues.repo` for this project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, `issues.components.cloud` for Cloud sync; if you hit a bug during operation, file a ticket in the matching repo before moving on.
 For reminder discipline, read `cas-supervisor/references/reminders.md`; for epic driving, read `cas-supervisor/references/epic-driving.md`.
 
 ## Context budgeting

--- a/cas-cli/src/builtins/codex/skills/cas-supervisor/references/reporting-and-routing.md
+++ b/cas-cli/src/builtins/codex/skills/cas-supervisor/references/reporting-and-routing.md
@@ -1,0 +1,13 @@
+## Reporting style
+
+- **Facts, not narration.** Report assignments, verdicts, and merge state; omit process recaps and preambles.
+- **Brevity never trims evidence.** Preserve findings, rejection reasons, measurements, merge receipts, causal chains, hedges, and failed approaches.
+- **In the pane, shape beats compression.** Answer first; use bullets or a small table. Don't recap the message, restate the board, or close with a summary.
+
+## Release train
+
+Runtime releases use only skills/cas-cut-release/SKILL.md; it owns the mechanical gate, merge queue, publish receipt, Slack POSTED block, and host verification. The Slack transport is skills/mecha-cassy/SKILL.md — the default for every harness, so route a worker to it rather than taking its draft back by hand. Until worker proxy credentials are repaired, the `cas-cut-release` fallback lets the supervisor post through the direct configured MechaCassy MCP.
+
+## Cross-team routing
+
+Route every bug through the issue-repository registry: `issues.repo` for the current project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, and `issues.components.cloud` for Cloud sync/relay/pairing; inspect with `cas config get issues.repo` and the three `issues.components.*` keys. If you hit a bug during operation, file a ticket in the matching repo before moving on; `filing-cas-bugs` has the filing and receipt policy.

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor.md
@@ -54,7 +54,7 @@ Match controls via model-selection.md; see [reference.md](cas-supervisor/referen
 
 ## On-demand references
 
-Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured registry: `issues.repo` for this project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, `issues.components.cloud` for Cloud sync; if you hit a bug during operation, file a ticket in the matching repo before moving on.
+Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. See [reporting-and-routing.md](cas-supervisor/references/reporting-and-routing.md) for reporting style, release-train ownership, and cross-team routing. Route bugs through the configured registry: `issues.repo` for this project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, `issues.components.cloud` for Cloud sync; if you hit a bug during operation, file a ticket in the matching repo before moving on.
 For reminder discipline, read `cas-supervisor/references/reminders.md`; for epic driving, read `cas-supervisor/references/epic-driving.md`.
 
 ## Context budgeting

--- a/cas-cli/src/builtins/grok/skills/cas-supervisor/references/reporting-and-routing.md
+++ b/cas-cli/src/builtins/grok/skills/cas-supervisor/references/reporting-and-routing.md
@@ -1,0 +1,13 @@
+## Reporting style
+
+- **Facts, not narration.** Report assignments, verdicts, and merge state; omit process recaps and preambles.
+- **Brevity never trims evidence.** Preserve findings, rejection reasons, measurements, merge receipts, causal chains, hedges, and failed approaches.
+- **In the pane, shape beats compression.** Answer first; use bullets or a small table. Don't recap the message, restate the board, or close with a summary.
+
+## Release train
+
+Runtime releases use only skills/cas-cut-release/SKILL.md; it owns the mechanical gate, merge queue, publish receipt, Slack POSTED block, and host verification. The Slack transport is skills/mecha-cassy/SKILL.md — the default for every harness, so route a worker to it rather than taking its draft back by hand. Until worker proxy credentials are repaired, the `cas-cut-release` fallback lets the supervisor post through the direct configured MechaCassy MCP.
+
+## Cross-team routing
+
+Route every bug through the issue-repository registry: `issues.repo` for the current project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, and `issues.components.cloud` for Cloud sync/relay/pairing; inspect with `cas config get issues.repo` and the three `issues.components.*` keys. If you hit a bug during operation, file a ticket in the matching repo before moving on; `filing-cas-bugs` has the filing and receipt policy.

--- a/cas-cli/src/builtins/reference-history.json
+++ b/cas-cli/src/builtins/reference-history.json
@@ -516,6 +516,9 @@
       "cb5b8c9b8472acd2ee8383b508828fe6cd466be5936baeb9b0e89066801db898",
       "f847fd0dc15bc47004edb86b16e5e7697bb44a4a2db93f42612270a687fa8df1"
     ],
+    "skills/cas-supervisor/references/reporting-and-routing.md": [
+      "6742840251a359a2bd884278df0ce3ba4dfe0df814e2e95a9a510d6d4d3a826e"
+    ],
     "skills/cas-supervisor/references/worker-recovery.md": [
       "186194057b9818062d7cf5e6a7eae9bcea8914505b95f984d55818044b11cd8d",
       "19d95bda0116d1acb754aa8703989379b9a6afbe5680cebe49453ff6180b903b",

--- a/cas-cli/src/builtins/skills/cas-supervisor.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor.md
@@ -54,7 +54,7 @@ Match controls via model-selection.md; see [reference.md](cas-supervisor/referen
 
 ## On-demand references
 
-Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. Route bugs through the configured registry: `issues.repo` for this project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, `issues.components.cloud` for Cloud sync; if you hit a bug during operation, file a ticket in the matching repo before moving on.
+Report facts with evidence and use the focused files in `cas-supervisor/references/` for workflow, release, merge, recovery, and issue-filing details. See [reporting-and-routing.md](cas-supervisor/references/reporting-and-routing.md) for reporting style, release-train ownership, and cross-team routing. Route bugs through the configured registry: `issues.repo` for this project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, `issues.components.cloud` for Cloud sync; if you hit a bug during operation, file a ticket in the matching repo before moving on.
 For reminder discipline, read `cas-supervisor/references/reminders.md`; for epic driving, read `cas-supervisor/references/epic-driving.md`.
 
 ## Context budgeting

--- a/cas-cli/src/builtins/skills/cas-supervisor/references/reporting-and-routing.md
+++ b/cas-cli/src/builtins/skills/cas-supervisor/references/reporting-and-routing.md
@@ -1,0 +1,13 @@
+## Reporting style
+
+- **Facts, not narration.** Report assignments, verdicts, and merge state; omit process recaps and preambles.
+- **Brevity never trims evidence.** Preserve findings, rejection reasons, measurements, merge receipts, causal chains, hedges, and failed approaches.
+- **In the pane, shape beats compression.** Answer first; use bullets or a small table. Don't recap the message, restate the board, or close with a summary.
+
+## Release train
+
+Runtime releases use only skills/cas-cut-release/SKILL.md; it owns the mechanical gate, merge queue, publish receipt, Slack POSTED block, and host verification. The Slack transport is skills/mecha-cassy/SKILL.md — the default for every harness, so route a worker to it rather than taking its draft back by hand. Until worker proxy credentials are repaired, the `cas-cut-release` fallback lets the supervisor post through the direct configured MechaCassy MCP.
+
+## Cross-team routing
+
+Route every bug through the issue-repository registry: `issues.repo` for the current project, `issues.components.cassy` for Cassy runtime/hooks/MCP, `issues.components.mecha_cassy` for the Slack hub, and `issues.components.cloud` for Cloud sync/relay/pairing; inspect with `cas config get issues.repo` and the three `issues.components.*` keys. If you hit a bug during operation, file a ticket in the matching repo before moving on; `filing-cas-bugs` has the filing and receipt policy.


### PR DESCRIPTION
The cas-6a20 budget trim removed the Reporting style, Release train, and Cross-team routing paragraphs from the supervisor skill body. They now live verbatim in cas-supervisor/references/reporting-and-routing.md in all three harness flavors, registered in the builtin catalogs, with a breadcrumb in the On-demand references section; the body keeps the issue registry keys and the standing filing directive. Bodies 5,861 / 5,859 / 5,856 B (2,331+ B under the 8,192 B protected ceiling); doctor SessionStart budget row ok with 2,530 B headroom. Ledger regenerated after the commit.

Proof: skill guardrails 10, flavor drift 17, agent contract 7, issue_intake_directive 2, factory parity 2, cli::factory::parity 6; --proof builtins::tests 92/92 with committed-diff coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)