### PR TITLE
docs(release-notes): POSTED receipts for PRs #788-#792 and #794

### DIFF
--- a/docs/release-notes/2026-09-09-pairing-fixture-slack.md
+++ b/docs/release-notes/2026-09-09-pairing-fixture-slack.md
@@ -1,0 +1,29 @@
+# Slack draft — deterministic relay fixture for the invalid-invitation test (main merge, PR #792)
+
+Channel: #cas-internal. Deploy target: Live on production (main). Reaches installed hosts with the next runtime release.
+
+## User thread
+
+Top-level:
+Live on production — User — Was: one pairing test could fail a release check by racing its own throwaway server under load, blocking an unrelated change. Now: the test waits for its server to be ready and, if anything still goes wrong, says exactly which address refused.
+
+Reply:
+• Deterministic fixture — Was: the invalid-invitation pairing test started its throwaway server in a thread and sent the request straight away; on a busy CI shard the request could reach the port before the server was listening, and the failure only said "request was refused". Now: the test waits for the server to signal readiness, bounds the accept and read with deadlines, and any failure names the exact address and endpoint.
+• Scope — test code only; no pairing behavior changed. Fifty concurrent runs pass.
+
+## Dev thread
+
+Top-level:
+Live on production — Dev — Was: `hub_reverse_pairing::tests::invalid_invitation_reports_the_field_contract_and_sent_shape` bound a `TcpListener`, spawned `accept()` in a thread, and let the client race it; merge-group run 34369856376 got "request was refused". Now: readiness channel before the request, nonblocking accept with a 3 s deadline, 1 s read timeout, address-bearing panics and endpoint-bearing assertions; 50/50 under `xargs -P8` (PR #792).
+
+Reply:
+• Readiness handshake — Was: the client call raced the server thread's first `accept()`. Now: nonblocking listener, `sync_channel(1)` readiness signal, `ready_rx.recv()` before the request.
+• Bounded waits — Was: a hung accept or read hung the test. Now: 3 s accept deadline with 5 ms polling; 1 s read timeout.
+• Diagnostics — Was: bare `unwrap()` and `{error}` assertions. Now: every panic and assertion names the bound address or endpoint.
+
+Proof: `hub_reverse_pairing` 21/21; fifty concurrent invocations under `xargs -P8` all pass. Test-only change. PR #792.
+
+## POSTED
+Posted 2026-09-09 18:14Z via the MechaCassy hub to #cas-internal (C0B44GUKDK2):
+- User top-level ts 1788977646.259509 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788977646259509 (reply ts 1788977653.240639)
+- Dev top-level ts 1788977655.167029 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788977655167029 (reply ts 1788977668.600549)

--- a/docs/release-notes/2026-09-09-release-report-assembler-slack.md
+++ b/docs/release-notes/2026-09-09-release-report-assembler-slack.md
@@ -1,0 +1,32 @@
+# Slack draft — release report assembler fixes (main merge, PR #790)
+
+Channel: #cas-internal. Deploy target: Live on production (main). Reaches installed hosts with the next runtime release.
+
+## User thread
+
+Top-level:
+Live on production — User — Was: the new release-report command's first real run came out with placeholder "Was" lines, cut-off sentences, and a project named after a folder. Now: it reads your project settings from any checkout, keeps every changelog sentence whole, and tells the Was → Now story from your own release notes.
+
+Reply:
+• Settings found from any checkout — Was: run from a secondary checkout, the command could not find the project's issue tracker setting, so it reported no issues, no release, and a project named after the folder. Now: it resolves the project store the same way the rest of Cassy does and names the project from its settings.
+• Whole sentences — Was: a changelog entry that wrapped onto a second line was cut at the first line. Now: wrapped entries are joined before they are rendered.
+• Your release notes, not placeholders — Was: every article said "the prior behavior is not stated" and the user and developer sections were identical. Now: the Was → Now bullets from the release-notes draft fill the report, split into what a user sees and what a developer changed, with the changelog as fallback.
+• PDF without setup — Was: the PDF step stopped if the browser automation module was not installed locally. Now: it fetches a disposable copy and continues.
+
+## Dev thread
+
+Top-level:
+Live on production — Dev — Was: `cas release report` loaded config from `project_root/.cas` only, split changelog bullets per line, hard-coded a placeholder Was, fed both audience sections from the same entries, and exited when `require('playwright')` failed. Now: store detection via `find_cas_root_from`, joined bullets, draft Was/Now articles partitioned User/Dev, preserved inline-code headings, and a disposable Playwright install fallback (PR #790).
+
+Reply:
+• Config resolution — Was: `acquire_sources` read `project_root/.cas` directly, so a git worktree saw no `issues.repo` and named the project from the directory. Now: one `find_cas_root_from` lookup and `[project].canonical_id` for the name.
+• Changelog parser — Was: `parse_changelog_section` recorded each `- ` line alone. Now: continuation lines are joined into the bullet.
+• Article source — Was: `was_now_sections` used changelog entries with a hard-coded placeholder Was and fed both audience sections from the same selection. Now: the draft's Was/Now bullets become articles partitioned by thread, with per-section changelog fallback; inline-code headings keep the opening backtick.
+• PDF fallback — Was: `PDF_SCRIPT` exited on `require('playwright')` failure. Now: on MODULE_NOT_FOUND the command performs a disposable `npm install --no-save playwright` and retries.
+
+Proof: release_report unit 11/11; release_report_test 2/2 including a git-worktree fixture; terminal-qa PASS 12 runs; real v3.22.0 `--pdf` run, 5-page A4. Follow-up cas-ca80 in progress. PR #790.
+
+## POSTED
+Posted 2026-09-09 17:56Z via the MechaCassy hub to #cas-internal (C0B44GUKDK2):
+- User top-level ts 1788976548.834519 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788976548834519 (reply ts 1788976557.259729)
+- Dev top-level ts 1788976560.075769 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788976560075769 (reply ts 1788976573.004119)

--- a/docs/release-notes/2026-09-09-release-report-evidence-slack.md
+++ b/docs/release-notes/2026-09-09-release-report-evidence-slack.md
@@ -1,0 +1,32 @@
+# Slack draft — release report evidence: issues, publication, verdict, themes (main merge, PR #794)
+
+Channel: #cas-internal. Deploy target: Live on production (main). Reaches installed hosts with the next runtime release.
+
+## User thread
+
+Top-level:
+Live on production — User — Was: the generated release report could not see the issues a release closed, said the release was unpublished when it was live, and opened with a generic line. Now: it counts the closed issues, shows the publication time, opens with the release's own headline, and groups changes the way the release notes do.
+
+Reply:
+• Closed issues counted — Was: an issue named in the changelog or in the release pull request did not appear in the report's ledger or change map. Now: those references are collected, verified on GitHub, and counted under the matching theme.
+• Publication shown — Was: the report header said "publication evidence unavailable" even for a live release with a receipt. Now: it reads "Published <date> · <time> UTC" from the release or its receipt.
+• Headline as verdict — Was: the release notes' opening line became one more article. Now: that line is the report's verdict, capitalized and punctuated, and the two thread headers are not repeated as articles.
+• Themes from the notes — Was: the change map used a fixed list of generic surfaces. Now: it takes the release notes' own section labels, assigns each closed issue to the section that mentions it, and records the themes so a re-run gives the same map.
+
+## Dev thread
+
+Top-level:
+Live on production — Dev — Was: `cas release report` read only `closingIssuesReferences`, took the publication line from release metadata alone, rendered the draft's top-level as an article, and used the fixed `THEME_ORDER`. Now: PR body issue refs are extracted, `PUBLISHED_AT` from the receipt feeds the header, the draft punch becomes the normalized verdict, and themes derive from the draft's bold groups and persist in front matter (PR #794).
+
+Reply:
+• Issue discovery — Was: `collect_pr_issue_references` read `closingIssuesReferences` only. Now: PR body references are extracted too, merged with changelog references, verified through `gh issue list`, and assigned to the theme of the draft article that mentions them.
+• Publication header — Was: `publication_line` consulted release metadata only. Now: `PUBLISHED_AT` from `release-published.receipt` or the release object renders "Published <date> · <time> UTC".
+• Verdict and sections — Was: top-levels treated as articles, bold group labels discarded. Now: the User punch becomes the verdict (capitalized, terminated), both top-levels are skipped, sections use the draft's bold group labels.
+• Themes — Was: fixed `THEME_ORDER`. Now: derived from the draft's groups at assembly time and written into the front matter.
+
+Measured on v3.22.0 sources: Issues closed = 1 (#767 under Verification), themes Release / Memory / Verification / Factory, header 16:51 UTC. Proof: unit 13/13; release_report_test 2/2; terminal-qa PASS 12 runs. PR #794.
+
+## POSTED
+Posted 2026-09-09 18:24Z via the MechaCassy hub to #cas-internal (C0B44GUKDK2):
+- User top-level ts 1788978257.945319 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788978257945319 (reply ts 1788978270.103489)
+- Dev top-level ts 1788978272.562369 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788978272562369 (reply ts 1788978296.695599)

--- a/docs/release-notes/2026-09-09-scoped-proof-guardrails-slack.md
+++ b/docs/release-notes/2026-09-09-scoped-proof-guardrails-slack.md
@@ -1,0 +1,30 @@
+# Slack draft — scoped proof covers builtin guardrail tests (main merge, PR #789)
+
+Channel: #cas-internal. Deploy target: Live on production (main). Reaches installed hosts with the next runtime release.
+
+## User thread
+
+Top-level:
+Live on production — User — Was: a change to a built-in Cassy skill could pass its own checks and still fail a release check minutes later. Now: the proof a change must show before hand-off includes the guardrail tests that actually read that skill.
+
+Reply:
+• Guardrails travel with the skill — Was: editing a built-in skill or one of its reference pages only required the tests that mention the file by its source path, so size limits and required-phrase checks that read the installed copy were skipped, and twice today a release check or merge check caught what the hand-off proof had missed. Now: any built-in skill, reference, or agent edit must prove the cross-flavor, agent-contract, and skill-guardrail tests, plus every test that reads that file under either its source or installed name.
+• Lesson kept — Was: the release procedure had no record of this failure shape. Now: the release failure log names it, with a self-test so the entry cannot rot.
+• Budget hint where it is needed — Was: the compact supervisor playbook said nothing about its own 2 KB limit. Now: it tells an editor to split new guidance into a separate reference page.
+
+## Dev thread
+
+Top-level:
+Live on production — Dev — Was: `check-scoped-test-surface.sh` derived required targets only from changed `cas-cli/tests/*` and `cas-cli/src/*.rs`, so builtin skill/reference/agent paths were invisible to `--proof`. Now: builtin paths require drift, agent-contract, and skill-guardrail targets and discover more by grepping tests for the source path and the installed catalog spelling, failing closed on rg errors (PR #789).
+
+Reply:
+• Path-to-test mapping — Was: only changed `cas-cli/tests/**.rs` and `cas-cli/src/**.rs` produced required targets. Now: `is_builtin_skill_or_agent_path` adds `builtin_flavor_drift_test`, `agent_definition_contract_test`, and `factory_codex_skill_guardrails`, then `discover_builtin_test_targets` greps `cas-cli/tests` for the source path and for `builtin_catalog_path_for` (skills/<name>.md → skills/<name>/SKILL.md; references and agents pass through; codex/grok flavor dirs stripped).
+• Fail closed — Was: `rg -l -F -- "$path" cas-cli/tests --glob '*.rs' || true` passed `--glob` as a path after `--` and swallowed the exit-2 error. Now: `--glob` precedes `--`, and any rg exit other than 1 aborts the guard with the literal named.
+• Learn + self-tests — Was: no failure-log entry for "proof passed, guardrail failed in the gate". Now: `release-gate.sh --learn` entry in all three cas-cut-release mirrors with a self-test fixture; `test-run-scoped-tests.sh` gains cases for a reference edit and a supervisor-body-only edit.
+
+Proof: scoped-test self-test 28/28; release-gate self-test 75/75; Rust guardrail proof 34/34; terminal-qa PASS 11 runs. PR #789.
+
+## POSTED
+Posted 2026-09-09 17:45Z via the MechaCassy hub to #cas-internal (C0B44GUKDK2):
+- User top-level ts 1788975882.385779 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788975882385779 (reply ts 1788975890.006819)
+- Dev top-level ts 1788975892.362429 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788975892362429 (reply ts 1788975906.305659)

--- a/docs/release-notes/2026-09-09-supervisor-reference-slack.md
+++ b/docs/release-notes/2026-09-09-supervisor-reference-slack.md
@@ -1,0 +1,29 @@
+# Slack draft — supervisor guidance parked in a reference (main merge, PR #791)
+
+Channel: #cas-internal. Deploy target: Live on production (main). Reaches installed hosts with the next runtime release.
+
+## User thread
+
+Top-level:
+Live on production — User — Was: three pieces of coordinator guidance (how to report, who owns a release, where to file a bug) were cut from the built-in playbook to make room and survived only in a start-up prompt. Now: they live in a reference page the playbook points to, so they are read on demand and cannot be lost to a size trim again.
+
+Reply:
+• Guidance parked, not lost — Was: the reporting-style rules, the release-train ownership note, and the detailed bug-routing paragraph existed only in a session start-up prompt after the playbook trim. Now: they sit word-for-word in a reference page linked from the playbook's "On-demand references" line, in every harness flavor.
+• Room stays — Was: restoring the text in the playbook body would have eaten the headroom just recovered. Now: the body grows by one link, keeping over 2 KB of headroom under its limit, and the doctor budget row stays green.
+
+## Dev thread
+
+Top-level:
+Live on production — Dev — Was: the cas-6a20 trim dropped the Reporting style, Release train, and Cross-team routing sections from `cas-supervisor.md` in all three flavors. Now: `cas-supervisor/references/reporting-and-routing.md` carries them verbatim, registered in the Claude/Codex/Grok catalogs, with a breadcrumb in the body; bodies 5,861 / 5,859 / 5,856 B, doctor SessionStart budget 2,530 B headroom (PR #791).
+
+Reply:
+• Reference file — Was: no home for the trimmed text. Now: `skills/cas-supervisor/references/reporting-and-routing.md` (three byte-identical mirrors).
+• Catalog and breadcrumb — Was: a new reference is invisible to `cas update --sync` without registration. Now: `BuiltinFile` entries in all three catalogs; the body keeps the registry keys and the standing filing directive.
+• Ledger — `reference-history.json` regenerated from committed history in a separate commit.
+
+Proof: skill guardrails 10, flavor drift 17, agent contract 7, issue intake 2, factory parity 2, cli::factory::parity 6; `--proof builtins::tests` 92/92. PR #791.
+
+## POSTED
+Posted 2026-09-09 18:06Z via the MechaCassy hub to #cas-internal (C0B44GUKDK2):
+- User top-level ts 1788977160.516519 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788977160516519 (reply ts 1788977168.680019)
+- Dev top-level ts 1788977170.820409 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788977170820409 (reply ts 1788977182.336229)

--- a/docs/release-notes/2026-09-09-update-refresh-receipt-slack.md
+++ b/docs/release-notes/2026-09-09-update-refresh-receipt-slack.md
@@ -1,0 +1,29 @@
+# Slack draft — `cas update` keeps the post-swap refresh receipt (main merge, PR #788)
+
+Channel: #cas-internal. Deploy target: Live on production (main). Reaches installed hosts with the next runtime release.
+
+## User thread
+
+Top-level:
+Live on production — User — Was: after an update, Cassy could say the refresh outcome was unknown even though it had just printed which projects failed. Now: it keeps that receipt and tells you exactly which projects need attention and what to run.
+
+Reply:
+• Refresh receipt kept — Was: `cas update` swapped the binary, then reported "post-swap child exited without a refresh receipt; the refresh outcome is unknown" whenever any project's refresh failed, even though the per-project summary had scrolled past. Now: the refresh writes its receipt to a file the updater reads back, so the final message names the projects that did not refresh and the command to rerun.
+• Same detail in `--json` — Was: a JSON update run could lose the receipt when the child's output carried none. Now: the file receipt fills the gap and carries a `refresh_status` field.
+
+## Dev thread
+
+Top-level:
+Live on production — Dev — Was: the plain post-swap refresh child inherited stdio, so the parent had no receipt transport and mapped every non-zero exit to `refresh_failed_no_receipt`. Now: a hidden `--refresh-receipt <file>` side-channel carries the child's `project_refresh_receipt_json` (with `refresh_status`) back to the parent on both plain and JSON paths (PR #788).
+
+Reply:
+• Receipt transport — Was: `run_post_swap_refresh` used `command.status()` with inherited stdio for non-JSON updates, so the child's structured receipt never reached the parent. Now: `build_post_swap_command_with_receipt` passes `--refresh-receipt <tempfile>`; `refresh_all_projects` writes `project_refresh_receipt_json` there (new `refresh_status`); the parent reads it via `read_refresh_receipt` and renders `post_swap_refresh_failed_hint` with the failing projects.
+• JSON path — Was: only the last JSON document on stdout counted. Now: `parse_refresh_receipt(stdout).or_else(read_refresh_receipt(file))`.
+• Compatibility — children that predate the flag are still handled by the version probe; the parent side takes effect from the next update run by a binary that contains it.
+
+Tests: plain partial-receipt transport and guidance, receipt serialization to disk; JSON, spawn-failure, stale-version, and no-receipt paths unchanged (update module 95/95). Real built-binary run and terminal-qa PASS 12 runs. PR #788.
+
+## POSTED
+Posted 2026-09-09 17:33Z via the MechaCassy hub to #cas-internal (C0B44GUKDK2):
+- User top-level ts 1788975207.978089 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788975207978089 (reply ts 1788975214.339129)
+- Dev top-level ts 1788975216.567679 https://petra-stella.slack.com/archives/C0B44GUKDK2/p1788975216567679 (reply ts 1788975230.687449)


### PR DESCRIPTION
Slack drafts with POSTED receipts for six main merges announced this afternoon: cas update refresh receipt (#788), scoped proof guardrails (#789), release report assembler (#790), supervisor reference (#791), pairing fixture (#792), release report evidence (#794). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)