### PR TITLE
fix(factory): close gate requires origin reachability; worktree-only git guard; spawn refresh refuses unpublished parent (cas-93e8)

### DIFF
--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -169,9 +169,12 @@ pub fn handle_pre_tool_use(
                     ));
                 }
                 if looks_like_git_write_op(cmd) {
-                    if let Some(deny_msg) =
-                        check_worker_git_commit_scope_for_command(&input.cwd, cmd)
+                    if let Some((target, deny_msg)) =
+                        worker_git_scope_violation_for_command(&input.cwd, cmd)
                     {
+                        if let Some(root) = cas_root {
+                            log_factory_git_scope_rejection(root, input, &target, cmd);
+                        }
                         return Ok(HookOutput::with_pre_tool_permission("deny", &deny_msg));
                     }
                 }
@@ -941,9 +944,9 @@ fn direct_test_invocation_without_receipt(words: &[String]) -> bool {
 
 // ── Worker commit guard helpers (cas-bea2, LAYER 1) ───────────────────────
 //
-// Detects `git commit` / `git merge` Bash commands from factory workers
-// and denies them when HEAD is on a protected branch OR (for isolated
-// workers) the cwd is outside the assigned worktree (CAS_CLONE_PATH).
+// Detects history-changing Git commands from factory workers and denies them
+// when HEAD is on a protected branch OR the effective cwd/git-dir/work-tree
+// is outside the assigned worktree (CAS_CLONE_PATH).
 //
 // Fires for ALL factory workers (CAS_AGENT_ROLE=worker && CAS_FACTORY_MODE),
 // whether or not they have an isolated worktree (CAS_CLONE_PATH). This
@@ -977,42 +980,33 @@ pub(crate) fn is_worker_commit_allowed_branch(branch: &str) -> bool {
     !matches!(b, "main" | "master" | "staging" | "")
 }
 
-/// Return true if `cmd` looks like a `git commit`, `git merge`, or `git push`
-/// invocation.
+/// Return true if `cmd` looks like a history-changing Git invocation.
 ///
 /// Matches common forms:
 /// - `git commit -m "msg"`
 /// - `git -C /some/path commit`
 /// - `git merge main`
+/// - `git rebase main`
+/// - `git reset --hard HEAD~1`
+/// - `git checkout feature/my-worker`
+/// - `git add -A`
 /// - `git push origin HEAD:refs/heads/factory/my-worker`
 /// - Commands with env-var prefixes like `GIT_AUTHOR_NAME=... git commit`
 ///
 /// Intentionally conservative: false-negatives (missed commands) are safe
 /// because LAYER 2 (pre-commit hook) is the hard floor.
 pub(crate) fn looks_like_git_write_op(cmd: &str) -> bool {
-    // Find the first occurrence of "git" as a word boundary
-    let mut rest = cmd;
-    loop {
-        let pos = match rest.find("git") {
-            Some(p) => p,
-            None => return false,
-        };
-        // Ensure "git" is not a substring of another word (e.g. "config")
-        let before_ok = pos == 0 || !rest.as_bytes()[pos - 1].is_ascii_alphanumeric();
-        let after_idx = pos + 3;
-        let after_ok =
-            after_idx >= rest.len() || !rest.as_bytes()[after_idx].is_ascii_alphanumeric();
-        if before_ok && after_ok {
-            let after_git = &rest[after_idx..];
-            // After "git" there may be flags like -C /path before the subcommand
-            // We look for a guarded write as a word anywhere after "git".
-            return after_git
-                .split_whitespace()
-                .any(|tok| matches!(tok, "commit" | "merge" | "push"));
-        }
-        // Not a word boundary — advance past this occurrence
-        rest = &rest[pos + 1..];
-    }
+    super::attribution::split_shell_statements(cmd)
+        .into_iter()
+        .any(|words| {
+            let Some(git_index) = words
+                .iter()
+                .position(|word| word == "git" || word.ends_with("/git"))
+            else {
+                return false;
+            };
+            git_history_write_operation(&words[git_index + 1..]).is_some()
+        })
 }
 
 /// Return true when a shell command invokes `git push origin`.
@@ -1107,7 +1101,10 @@ impl GitCommandTarget {
     }
 
     fn path_for_scope(&self) -> &std::path::Path {
-        self.work_tree.as_deref().unwrap_or(&self.cwd)
+        self.work_tree
+            .as_deref()
+            .or(self.git_dir.as_deref())
+            .unwrap_or(&self.cwd)
     }
 }
 
@@ -1120,14 +1117,59 @@ fn resolve_git_option_path(base: &std::path::Path, value: &str) -> std::path::Pa
     }
 }
 
-/// Extract every git write invocation's repository target from a shell command.
-/// Git's `-C`, `--git-dir`, and `--work-tree` options are parsed before the
-/// write subcommand so a linked worktree is checked instead of the hook's cwd.
+fn git_history_write_operation(git_words: &[String]) -> Option<usize> {
+    let operation_index = git_words.iter().position(|word| {
+        matches!(
+            word.as_str(),
+            "commit" | "merge" | "push" | "rebase" | "reset" | "checkout" | "add"
+        )
+    })?;
+    let operation = git_words.get(operation_index)?.as_str();
+    let args = &git_words[operation_index + 1..];
+    let is_write = match operation {
+        "commit" | "merge" | "push" | "rebase" => true,
+        "reset" => args.iter().any(|arg| arg == "--hard" || arg == "-H"),
+        "checkout" => args.iter().any(|arg| !arg.starts_with('-')),
+        "add" => args.iter().any(|arg| arg == "-A" || arg == "--all"),
+        _ => false,
+    };
+    is_write.then_some(operation_index)
+}
+
+/// Resolve the small subset of shell variable forms used in worker guidance
+/// before applying the worktree containment check. Unknown variables remain
+/// literal, which fails closed if they would resolve outside the worktree.
+fn resolve_worker_cd_path(base: &std::path::Path, value: &str) -> std::path::PathBuf {
+    let value = match value {
+        "$CAS_CLONE_PATH" | "${CAS_CLONE_PATH}" => {
+            std::env::var_os("CAS_CLONE_PATH").map_or_else(|| value.to_string(), |v| v.to_string_lossy().into_owned())
+        }
+        _ => value.to_string(),
+    };
+    resolve_git_option_path(base, &value)
+}
+
+/// Extract every history-changing git invocation's repository target from a
+/// shell command. Git's `-C`, `--git-dir`, and `--work-tree` options are
+/// parsed before the operation so a linked worktree is checked instead of the
+/// hook's cwd. Explicit `cd` statements are carried forward across `&&`, `;`,
+/// and `|` statements because the hook receives the whole shell command.
 fn git_write_targets(cwd: &str, command: &str) -> Vec<GitCommandTarget> {
     let default_target = GitCommandTarget::from_cwd(cwd);
     let mut targets = Vec::new();
+    let mut shell_cwd = default_target.cwd.clone();
 
     for words in super::attribution::split_shell_statements(command) {
+        if words.first().is_some_and(|word| word == "cd") {
+            if let Some(path) = words.get(1).filter(|path| path.as_str() != "--") {
+                shell_cwd = resolve_worker_cd_path(&shell_cwd, path);
+            } else if words.get(1).is_some_and(|path| path == "--") {
+                if let Some(path) = words.get(2) {
+                    shell_cwd = resolve_worker_cd_path(&shell_cwd, path);
+                }
+            }
+            continue;
+        }
         let Some(git_index) = words
             .iter()
             .position(|word| word == "git" || word.ends_with("/git"))
@@ -1135,14 +1177,12 @@ fn git_write_targets(cwd: &str, command: &str) -> Vec<GitCommandTarget> {
             continue;
         };
         let git_words = &words[git_index + 1..];
-        let Some(write_index) = git_words
-            .iter()
-            .position(|word| matches!(word.as_str(), "commit" | "merge" | "push"))
-        else {
+        let Some(write_index) = git_history_write_operation(git_words) else {
             continue;
         };
 
         let mut target = default_target.clone();
+        target.cwd = shell_cwd.clone();
         let mut index = 0;
         while index < write_index {
             let word = &git_words[index];
@@ -1219,12 +1259,21 @@ fn get_branch_at_git_target(target: &GitCommandTarget) -> Option<String> {
 }
 
 fn check_worker_git_commit_scope_for_command(cwd: &str, command: &str) -> Option<String> {
-    git_write_targets(cwd, command)
-        .into_iter()
-        .find_map(|target| check_worker_git_commit_scope_at_target(&target))
+    worker_git_scope_violation_for_command(cwd, command).map(|(_, message)| message)
 }
 
-/// Check whether a factory worker's `git commit` / `git merge` / `git push`
+fn worker_git_scope_violation_for_command(
+    cwd: &str,
+    command: &str,
+) -> Option<(GitCommandTarget, String)> {
+    git_write_targets(cwd, command)
+        .into_iter()
+        .find_map(|target| {
+            check_worker_git_commit_scope_at_target(&target).map(|message| (target, message))
+        })
+}
+
+/// Check whether a factory worker's history-changing Git operation
 /// should be denied.
 ///
 /// Returns `Some(denial_message)` when:
@@ -1253,14 +1302,21 @@ fn check_worker_git_commit_scope_at_target(target: &GitCommandTarget) -> Option<
         .map(|s| !s.is_empty())
         .unwrap_or(false);
 
-    // DENY: isolated worker's cwd is outside the assigned worktree.
-    // Only applicable when CAS_CLONE_PATH is set.
+    // DENY: a history-changing command's effective cwd/git-dir/work-tree is
+    // outside the assigned worktree. This applies to every factory worker
+    // with a registered CAS_CLONE_PATH, including commands that first `cd`
+    // into the primary checkout. Do not rely on string prefixes: sibling
+    // paths such as `/worktree-sibling` are outside `/worktree`.
     if is_isolated {
         let clone_path = clone_path.as_deref().unwrap();
         let cwd_path = std::path::Path::new(&cwd);
         let worktree_path = std::path::Path::new(clone_path);
 
-        if !cwd_path.starts_with(worktree_path) {
+        let inside_worktree = canonicalize_for_containment(cwd_path)
+            .zip(canonicalize_for_containment(worktree_path))
+            .is_some_and(|(cwd, worktree)| cwd.starts_with(worktree));
+
+        if !inside_worktree {
             let worker_name =
                 std::env::var("CAS_AGENT_NAME").unwrap_or_else(|_| "<worker-name>".to_string());
             return Some(format!(
@@ -2157,6 +2213,69 @@ fn log_factory_workspace_rejection(
             ("evaluated_path", violation.evaluated_path.as_str()),
             ("resolved_path", resolved_path.as_str()),
             ("matched_rule", violation.matched_rule),
+            ("payload_bytes", payload_bytes.as_str()),
+        ],
+    );
+}
+
+/// Persist a refusal for a history-changing Git command that targeted a
+/// path outside the worker's assigned worktree. Keep the command itself out
+/// of the event: Bash payloads may contain credentials or other secrets, but
+/// the operation and evaluated path are enough to audit the refusal.
+fn log_factory_git_scope_rejection(
+    cas_root: &Path,
+    input: &HookInput,
+    target: &GitCommandTarget,
+    command: &str,
+) {
+    let tool = input.tool_name.as_deref().unwrap_or("unknown");
+    let payload_bytes = input
+        .tool_input
+        .as_ref()
+        .and_then(|value| serde_json::to_vec(value).ok())
+        .map(|payload| payload.len().to_string())
+        .unwrap_or_else(|| "0".to_string());
+    let operation_tokens = command
+        .split_whitespace()
+        .map(|word| word.trim_matches(|ch: char| "'\"`;&|".contains(ch)))
+        .collect::<Vec<_>>();
+    let operation_index = operation_tokens.iter().position(|word| {
+        matches!(
+            *word,
+            "commit" | "merge" | "push" | "rebase" | "reset" | "checkout" | "add"
+        )
+    });
+    let operation = operation_index
+        .map(|index| {
+            let operation = operation_tokens[index];
+            if matches!(operation, "reset" | "add") {
+                operation_tokens
+                    .get(index + 1)
+                    .filter(|flag| {
+                        (operation == "reset" && **flag == "--hard")
+                            || (operation == "add" && **flag == "-A")
+                    })
+                    .map_or(operation, |_| {
+                        if operation == "reset" {
+                            "reset --hard"
+                        } else {
+                            "add -A"
+                        }
+                    })
+            } else {
+                operation
+            }
+        })
+        .unwrap_or("unknown");
+    let evaluated_path = target.path_for_scope().display().to_string();
+    let _ = crate::hooks::handlers::session_hygiene::append_factory_session_event(
+        cas_root,
+        "workspace_contract_git_rejection",
+        &[
+            ("tool", tool),
+            ("evaluated_path", evaluated_path.as_str()),
+            ("matched_rule", "history-changing git outside worker worktree"),
+            ("git_operation", operation),
             ("payload_bytes", payload_bytes.as_str()),
         ],
     );
@@ -3140,6 +3259,26 @@ mod worker_commit_guard_tests {
         assert!(!looks_like_git_write_op("digitalocean config commit"));
     }
 
+    /// cas-93e8: history-changing Git commands must all enter the worker
+    /// worktree guard, including commands that were previously invisible to
+    /// the commit/merge/push matcher.
+    #[test]
+    fn history_changing_git_commands_are_guarded_cas_93e8() {
+        for command in [
+            "git commit -m work",
+            "git merge main",
+            "git rebase main",
+            "git reset --hard HEAD~1",
+            "git checkout main",
+            "git add -A",
+        ] {
+            assert!(
+                looks_like_git_write_op(command),
+                "history-changing command must be recognized: {command}"
+            );
+        }
+    }
+
     // ── is_worker_commit_allowed_branch tests (cas-7e7b denylist) ──────────
 
     #[test]
@@ -3605,6 +3744,87 @@ mod worker_commit_guard_tests {
         assert!(
             result.is_none(),
             "expected allow on factory/worker1 branch, got: {result:?}"
+        );
+    }
+
+    /// cas-93e8: a `cd` in the same shell command changes the repository
+    /// targeted by every following Git history mutation. The hook cwd alone
+    /// is not sufficient because a worker can leave its worktree with
+    /// `cd /primary/checkout && git commit`.
+    #[test]
+    fn explicit_cd_outside_worker_worktree_is_denied_for_history_writes_cas_93e8() {
+        let parent = tempfile::tempdir().unwrap();
+        let worktree = parent.path().join("worker");
+        let outside = parent.path().join("primary");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let worktree_path = worktree.to_string_lossy().to_string();
+        let outside_path = outside.to_string_lossy().to_string();
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_CLONE_PATH", Some(worktree_path.as_str())),
+            ("CAS_AGENT_NAME", Some("worker")),
+        ]);
+
+        for operation in [
+            "git commit -m work",
+            "git merge main",
+            "git rebase main",
+            "git reset --hard HEAD~1",
+            "git checkout main",
+            "git add -A",
+        ] {
+            let command = format!("cd '{outside_path}' && {operation}");
+            let message = check_worker_git_commit_scope_for_command(&worktree_path, &command)
+                .unwrap_or_else(|| panic!("outside-worktree operation must be denied: {command}"));
+            assert!(
+                message.contains("outside your assigned worktree"),
+                "refusal must identify the workspace boundary: {message}"
+            );
+        }
+    }
+
+    /// cas-93e8: an outside-worktree history mutation is denied through the
+    /// real PreToolUse handler and leaves an auditable workspace-contract
+    /// rejection event.
+    #[test]
+    fn outside_worktree_history_write_is_logged_by_pre_tool_cas_93e8() {
+        let cas_root = tempfile::tempdir().unwrap();
+        let parent = tempfile::tempdir().unwrap();
+        let worktree = parent.path().join("worker");
+        let outside = parent.path().join("primary");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let worktree_path = worktree.to_string_lossy().to_string();
+        let outside_path = outside.to_string_lossy().to_string();
+        let _env = TestEnvGuard::with_optional_vars(&[
+            ("CAS_AGENT_ROLE", Some("worker")),
+            ("CAS_FACTORY_MODE", Some("1")),
+            ("CAS_CLONE_PATH", Some(worktree_path.as_str())),
+            ("CAS_AGENT_NAME", Some("worker")),
+            ("CAS_FACTORY_SESSION", Some("cas-93e8-pre-tool")),
+        ]);
+
+        let input = hook_git_write_input(
+            &worktree_path,
+            &format!("cd '{outside_path}' && git reset --hard HEAD~1"),
+        );
+        let output = handle_pre_tool_use(&input, Some(cas_root.path())).expect("handler ok");
+        let value = serde_json::to_value(output).unwrap();
+        assert_eq!(
+            value["hookSpecificOutput"]["permissionDecision"], "deny",
+            "outside-worktree history mutation must be denied: {value}"
+        );
+
+        let log_path = cas_root.path().join(format!(
+            "logs/factory-session-{}.log",
+            chrono::Utc::now().format("%Y-%m-%d")
+        ));
+        let log = std::fs::read_to_string(log_path).expect("git workspace refusal log");
+        assert!(
+            log.contains("workspace_contract_git_rejection")
+                && log.contains(&outside_path)
+                && log.contains("reset --hard"),
+            "git workspace refusal must be durable and identify the operation/path: {log}"
         );
     }
 

--- a/cas-cli/src/mcp/tools/core/task/lifecycle.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle.rs
@@ -1166,7 +1166,9 @@ impl CasCore {
                 "[{timestamp}] Decision: resume from awaiting_merge for merge recovery. \
                  {parked_branch} was flagged with a merge conflict or its conflict \
                  preflight could not be evaluated, so the task is back in_progress for \
-                 the assigned worker to inspect and resolve directly."
+                 the assigned worker to inspect from inside the worker worktree. Rebase \
+                 {parked_branch} onto the current integration target tip, push the \
+                 rebased factory branch, and re-park it with merge_request=true."
             );
             task.notes = if task.notes.is_empty() {
                 audit

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -6828,8 +6828,9 @@ fn enrich_merge_required_with_conflict_check(
              merge attempt will fail here. Conflicting file(s): {}.\n\n\
              Alternative: the assigned worker can \
              `mcp__cas__task action=start id={task_id}` (now permitted from \
-             `awaiting_merge`) to resolve the conflict directly on their \
-             factory branch and re-close.",
+             `awaiting_merge`) to inspect from inside their worker worktree, \
+             rebase the factory branch onto the current integration target tip, \
+             push, and re-park it with merge_request=true before re-closing.",
             conflict_paths.join(", ")
         )
     } else if let Some(error) = check_error {
@@ -6839,8 +6840,10 @@ fn enrich_merge_required_with_conflict_check(
              into {parent_branch}. Git conflict preflight failed: {error}.\n\n\
              To avoid stranding the task in `awaiting_merge`, Cassy marks this \
              park as reopen-eligible. The assigned worker can \
-             `mcp__cas__task action=start id={task_id}` to inspect or resolve \
-             the branch, then re-close."
+             `mcp__cas__task action=start id={task_id}` to inspect from inside \
+             the worker worktree, rebase the factory branch onto the current \
+             integration target tip, push, and re-park it with \
+             merge_request=true before re-closing."
         )
     } else {
         message
@@ -7094,7 +7097,38 @@ pub(crate) fn run_factory_branch_merge_gate_with_attribution(
         _ => None,
     };
     let commit_ish = trusted_anchor.unwrap_or(factory_branch.as_str());
-    let stranded = count_unmerged_factory_commits(repo_path, commit_ish, parent_branch);
+    let origin_parent_branch = format!("origin/{parent_branch}");
+    let mut origin_fetch_attempted = false;
+    let mut stranded = count_unmerged_factory_commits(repo_path, commit_ish, parent_branch);
+    let mut local_only_trunk_target = false;
+    if stranded == 0 {
+        // A local trunk ref is not shared integration evidence. Refresh and
+        // consult origin before accepting the local zero; otherwise a worker
+        // who committed on the primary checkout can merge into local `main`
+        // and close successfully while origin/main remains untouched.
+        origin_fetch_attempted = fetch_parent_branch_best_effort(repo_path, parent_branch);
+        let local_epic_merge = parent_branch.starts_with("epic/");
+        let origin_required = !local_epic_merge && origin_remote_configured(repo_path);
+        let origin_proves_delivery = git_ref_exists(repo_path, &origin_parent_branch)
+            && matches!(
+                known_unmerged_factory_commits(repo_path, commit_ish, &origin_parent_branch),
+                KnownUnmergedCount::KnownZero
+            );
+        if origin_required && !origin_proves_delivery {
+            // Keep the existing local-only epic exception and local-only
+            // repositories, but force a normal remote-backed trunk through
+            // the rejection path when origin cannot prove the delivery.
+            local_only_trunk_target = true;
+            stranded = match known_unmerged_factory_commits(
+                repo_path,
+                commit_ish,
+                &origin_parent_branch,
+            ) {
+                KnownUnmergedCount::KnownPositive(count) => count.max(1),
+                KnownUnmergedCount::KnownZero | KnownUnmergedCount::Unknown => 1,
+            };
+        }
+    }
     if stranded == 0 {
         if let Some(recorded_anchor) = trusted_anchor {
             // The local parent ref may be stale immediately after the
@@ -7146,8 +7180,9 @@ pub(crate) fn run_factory_branch_merge_gate_with_attribution(
     // origin Git state masquerade as integration. Missing origin ref
     // simply skips this block (no rescue); KnownPositive and Unknown
     // fall through to Reject.
-    let origin_fetch_attempted = fetch_parent_branch_best_effort(repo_path, parent_branch);
-    let origin_parent_branch = format!("origin/{parent_branch}");
+    if !origin_fetch_attempted {
+        origin_fetch_attempted = fetch_parent_branch_best_effort(repo_path, parent_branch);
+    }
     if git_ref_exists(repo_path, &origin_parent_branch)
         && matches!(
             known_unmerged_factory_commits(repo_path, commit_ish, &origin_parent_branch),
@@ -7178,8 +7213,11 @@ pub(crate) fn run_factory_branch_merge_gate_with_attribution(
     // this branch's stranded work. Unknowable git state keeps the local
     // measurement (fail closed), and a partially-merged branch now reports the
     // real remainder instead of stale-base arithmetic.
-    let remote_aware_stranded =
-        count_unmerged_against_targets(repo_path, commit_ish, parent_branch);
+    let remote_aware_stranded = if local_only_trunk_target {
+        None
+    } else {
+        count_unmerged_against_targets(repo_path, commit_ish, parent_branch)
+    };
     if remote_aware_stranded == Some(0) {
         if let Some(recorded_anchor) = trusted_anchor {
             let anchor = delivery_content_anchor_at_close(
@@ -8125,6 +8163,18 @@ pub(crate) fn fetch_parent_branch_best_effort(
             Err(_) => return true,
         }
     }
+}
+
+/// Return whether this checkout has an `origin` remote whose target refs are
+/// the shared integration authority. A repository with no origin remains a
+/// supported local-only development repository; a configured origin with no
+/// matching target ref must not let a local trunk ref masquerade as landed.
+fn origin_remote_configured(repo_path: &std::path::Path) -> bool {
+    std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(repo_path)
+        .output()
+        .is_ok_and(|output| output.status.success())
 }
 
 /// cas-cf64 (P3, option-injection hardening): `true` when `name` is safe to
@@ -19501,6 +19551,67 @@ mod merge_state_gate_tests {
         assert!(
             matches!(out, MergeStateGateOutcome::Reject(_)),
             "origin KnownPositive must reject, got {out:?}"
+        );
+    }
+
+    /// cas-93e8: a worker commit that is reachable only from the local target
+    /// branch must not satisfy the close gate. The local target can be ahead
+    /// because a worker committed in the primary checkout during merge
+    /// recovery; only origin/<target> is shared integration evidence for a
+    /// normal trunk target.
+    #[test]
+    fn local_only_trunk_merge_does_not_satisfy_close_gate_cas_93e8() {
+        let bare = tempfile::tempdir().unwrap();
+        let bare_status = std::process::Command::new("git")
+            .args(["init", "-q", "--bare"])
+            .current_dir(bare.path())
+            .status()
+            .expect("git init --bare");
+        assert!(bare_status.success());
+
+        let dir = init_factory_repo("worker");
+        let p = dir.path();
+        git(
+            p,
+            &["remote", "add", "origin", bare.path().to_str().unwrap()],
+        );
+        // Establish origin/main at the pre-delivery tip.
+        git(p, &["push", "-q", "origin", "main"]);
+
+        std::fs::write(p.join("local-only.rs"), "// only on local main\n").unwrap();
+        git(p, &["add", "local-only.rs"]);
+        git(p, &["commit", "-q", "-m", "worker delivery"]);
+        let worker_tip = rev_parse(p, "factory/worker");
+
+        // Simulate the unsafe recovery: merge the worker into local main but
+        // leave origin/main at the old tip.
+        git(p, &["checkout", "-q", "main"]);
+        git(
+            p,
+            &["merge", "-q", "--no-ff", "factory/worker", "-m", "local merge"],
+        );
+        let local_main_tip = rev_parse(p, "main");
+        assert!(
+            git_commit_is_ancestor(p, &worker_tip, "main"),
+            "precondition: worker tip must be reachable from local main"
+        );
+        assert!(
+            !git_commit_is_ancestor(p, &worker_tip, "origin/main"),
+            "precondition: worker tip must not be reachable from origin/main"
+        );
+        assert_ne!(
+            local_main_tip,
+            rev_parse(p, "origin/main"),
+            "precondition: local main must be ahead of origin/main"
+        );
+        git(p, &["checkout", "-q", "factory/worker"]);
+
+        let task = worker_task("worker");
+        let req = base_req(&task.id);
+        let out = run_factory_branch_merge_gate(&task, &req, "main", p);
+        assert!(
+            matches!(out, MergeStateGateOutcome::Reject(_)),
+            "local-only trunk integration must reject until origin/main carries the work, got {out:?}"
         );
     }
 }

--- a/cas-cli/src/mcp/tools/core/task/query.rs
+++ b/cas-cli/src/mcp/tools/core/task/query.rs
@@ -140,7 +140,9 @@ impl CasCore {
                     "⚠️  MERGE CONFLICT / REWORK REQUIRED — this task is NOT complete. \
                      The parked branch is conflicted or its conflict preflight could \
                      not be evaluated; the assigned worker can `task start` it to \
-                     inspect and resolve the branch directly.\n",
+                     inspect from inside the worker worktree, rebase the parked \
+                     factory branch onto the current integration target tip, push, \
+                     and re-park with merge_request=true.\n",
                 );
             } else {
                 output.push_str(

--- a/cas-cli/src/mcp/tools/core/task/repo_context.rs
+++ b/cas-cli/src/mcp/tools/core/task/repo_context.rs
@@ -1922,6 +1922,11 @@ mod tests {
                     "factory/worker",
                 ],
             );
+            // The declared target repository has an origin remote, so its
+            // already-landed target tip must be represented by origin/master
+            // as well as the local master branch. Without this remote-tracking
+            // ref, the close gate must (correctly) reject local-only evidence.
+            git(&repo_b, &["update-ref", "refs/remotes/origin/master", "master"]);
 
             let target = declare_work_target(
                 &repo_a.join(".cas"),

--- a/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
+++ b/cas-cli/src/ui/factory/app/render_and_ops/epic_workers.rs
@@ -927,11 +927,12 @@ fn checkout_ref_for_spawn_base(
 /// merely checking out the parent commit) keeps the new worker, later syncs,
 /// and the next spawning supervisor on the same integration history.
 ///
-/// The parent is resolved from its fresher local/`origin/` ref before the
-/// relationship is tested. This keeps the refresh decision aligned with
-/// [`stale_spawn_base_notice`], which also treats a fetched remote parent as
-/// current evidence. A genuinely split epic/parent history is refused: a
-/// worker must not be cut from a base known to omit target history.
+/// The parent is resolved from `origin/<parent>` whenever that shared ref is
+/// available before the relationship is tested. A local parent that is ahead
+/// of origin is refused rather than treated as authoritative: a worker must
+/// not be cut from an unpublished operator commit. A genuinely split
+/// epic/parent history is also refused because the worker must not inherit a
+/// base known to omit target history.
 fn fast_forward_epic_base_from_parent(
     repo_root: &std::path::Path,
     epic_branch: &str,
@@ -1094,10 +1095,11 @@ fn epic_base_refresh_refusal(error: &str) -> String {
     )
 }
 
-/// Choose the current parent ref without silently picking one side of a
-/// local/remote split. A fetched remote that strictly contains the local ref
-/// is the freshest safe parent; an ahead local ref remains authoritative until
-/// pushed; a true split must be reconciled before a worker can inherit it.
+/// Choose the shared parent ref without silently picking an unpublished local
+/// side of a local/remote split. A fetched remote that strictly contains the
+/// local ref is the freshest safe parent; an equal remote is authoritative;
+/// an ahead local ref and a true split must be reconciled before a worker can
+/// inherit either one.
 fn freshest_nondivergent_ref(repo_root: &std::path::Path, branch: &str) -> Result<String, String> {
     if branch.starts_with("origin/") {
         return Ok(branch.to_string());
@@ -1133,7 +1135,11 @@ fn freshest_nondivergent_ref(repo_root: &std::path::Path, branch: &str) -> Resul
         .status()
         .map_err(|error| format!("could not compare parent '{remote}' to '{branch}': {error}"))?;
     if remote_is_ancestor.success() {
-        return Ok(branch.to_string());
+        return Err(format!(
+            "local parent '{branch}' ({}) is ahead of shared '{remote}' ({}); refusing to advance an epic base from an unpublished local parent",
+            &local_sha[..local_sha.len().min(8)],
+            &remote_sha[..remote_sha.len().min(8)],
+        ));
     }
 
     Err(format!(
@@ -4397,6 +4403,61 @@ mod spawn_base_tests {
             "current support playbook",
             "a no-code worker must receive the current playbook from the refreshed parent"
         );
+    }
+
+    /// cas-93e8: spawn-time epic refresh must not promote a worker or operator
+    /// commit that exists only on the local parent branch. Origin is the
+    /// shared parent authority whenever that remote-tracking ref exists.
+    #[test]
+    fn epic_base_refresh_refuses_local_parent_ahead_of_origin_cas_93e8() {
+        let tmp = TempDir::new().unwrap();
+        let origin = tmp.path().join("origin");
+        std::fs::create_dir(&origin).unwrap();
+        init_repo(&origin);
+        Command::new("git")
+            .args(["branch", "epic/behind", "main"])
+            .current_dir(&origin)
+            .output()
+            .unwrap();
+
+        let repo = tmp.path().join("repo");
+        Command::new("git")
+            .args([
+                "clone",
+                "-q",
+                origin.to_str().unwrap(),
+                repo.to_str().unwrap(),
+            ])
+            .output()
+            .expect("git clone");
+        Command::new("git")
+            .args(["config", "user.email", "test@cas.test"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Cassy Test"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["branch", "epic/behind", "origin/epic/behind"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+
+        let remote_parent_tip = head_sha(&origin, "main");
+        commit(&repo, "operator-only.txt", "unpublished local parent work");
+        let local_parent_tip = head_sha(&repo, "main");
+        let epic_tip = head_sha(&repo, "epic/behind");
+        assert_ne!(local_parent_tip, remote_parent_tip);
+
+        let error = fast_forward_epic_base_from_parent(&repo, "epic/behind", "main")
+            .expect_err("an unpublished local parent must refuse epic refresh");
+        assert!(error.contains("ahead of shared 'origin/main'"), "{error}");
+        assert!(error.contains("unpublished local parent"), "{error}");
+        assert_eq!(head_sha(&repo, "epic/behind"), epic_tip);
+        assert_eq!(head_sha(&origin, "epic/behind"), epic_tip);
     }
 
     #[test]

--- a/cas-cli/tests/factory_mcp_ops_test.rs
+++ b/cas-cli/tests/factory_mcp_ops_test.rs
@@ -7096,6 +7096,24 @@ async fn test_a844_worker_can_start_awaiting_merge_task() {
         after.notes
     );
     assert!(
+        after.notes.contains("inside the worker worktree")
+            && after
+                .notes
+                .to_lowercase()
+                .contains("rebase factory/swift-fox")
+            && after.notes.contains("current integration target tip")
+            && after.notes.contains("push")
+            && after.notes.contains("re-park")
+            && after.notes.contains("merge_request=true"),
+        "merge recovery must prescribe worktree-only rebase, push, and re-park: {}",
+        after.notes
+    );
+    assert!(
+        !after.notes.contains("resolve directly"),
+        "merge recovery must not direct workers to resolve against the target checkout: {}",
+        after.notes
+    );
+    assert!(
         after.deliverables.factory_branch_anchor.is_none(),
         "conflict rework must invalidate the parked anchor"
     );

--- a/cas-cli/tests/task_update_work_target_close_test.rs
+++ b/cas-cli/tests/task_update_work_target_close_test.rs
@@ -153,6 +153,10 @@ async fn combined_work_target_update_and_close_uses_the_updated_branch() {
     run_git(&repo.root, &["commit", "-m", "worker change"]);
     run_git(&repo.root, &["checkout", "main"]);
     run_git(&repo.root, &["merge", "--ff-only", "factory/alice"]);
+    run_git(
+        &repo.root,
+        &["update-ref", "refs/remotes/origin/main", "main"],
+    );
 
     let cas_root = init_cas_dir(&repo.root).expect("initialize CAS");
     std::fs::write(

--- a/cas-cli/tests/worktree_surface_test.rs
+++ b/cas-cli/tests/worktree_surface_test.rs
@@ -1475,6 +1475,10 @@ async fn update_to_closed_rejects_unmerged_task_without_mutation_then_closes_aft
     );
 
     run_git(&["merge", "--no-ff", "factory/frontend"], &repo_b.root);
+    run_git(
+        &["update-ref", "refs/remotes/origin/main", "main"],
+        &repo_b.root,
+    );
     core.cas_task_update(Parameters(close_update_request(task.id.clone())))
         .await
         .expect("merged update-to-closed must use frontend context");


### PR DESCRIPTION
Was: a worker could commit on the primary checkout's local main during merge recovery, the light-depth close accepted it because the merge-state guard read the local target, and spawn-time epic refresh promoted that unpublished commit to origin/epic and every new worker.
Now: a normal trunk target is only satisfied by origin/<target> reachability (epic and no-origin repos keep their local path); the awaiting_merge recovery text tells the worker to rebase inside its worktree, push and re-park; the PreToolUse guard denies history-changing git (commit/merge/rebase/push/reset --hard/checkout <ref>/add -A) outside the worker worktree, following explicit cd, and logs a workspace_contract_git_rejection event; epic base refresh refuses a local parent ahead of origin.
Proof: cas_93e8 5/5, worker_commit_guard 50/50, merge_state_gate 73/73, spawn_base 45/45, factory_mcp_ops test_a844 1/1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)