### PR TITLE
hooks: enforce the factory workspace-contract write guard even without a resolved cas root (cas-5ed1)

### DIFF
--- a/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
+++ b/cas-cli/src/hooks/handlers/handlers_events/pre_tool.rs
@@ -200,6 +200,40 @@ pub fn handle_pre_tool_use(
     }
 
     // ========================================================================
+    // FACTORY WORKSPACE CONTRACT — ROOT-INDEPENDENT FALLBACK
+    //
+    // Filesystem auto-approval must remain available when Cassy cannot resolve
+    // a root for the hook invocation, but it must not bypass the workspace
+    // contract. The normal guard below can read the registered checkout and
+    // configured roots from Cassy's stores; this fallback uses the bootstrap
+    // `CAS_CLONE_PATH` binding and the default artifacts root so an isolated
+    // worker cannot write into the primary checkout on the cas_root=None path.
+    // ========================================================================
+    if cas_root.is_none() && is_factory_agent {
+        let worktree_root = std::env::var_os("CAS_CLONE_PATH")
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from);
+        if let Some(violation) = factory_write_violation(
+            input,
+            &None,
+            None,
+            crate::harness_policy::is_supervisor(input),
+            worktree_root.as_deref(),
+        ) {
+            return Ok(HookOutput::with_pre_tool_permission(
+                "deny",
+                &factory_workspace_contract_denial(
+                    input,
+                    &violation,
+                    None,
+                    None,
+                    worktree_root.as_deref(),
+                ),
+            ));
+        }
+    }
+
+    // ========================================================================
     // FACTORY AUTO-APPROVE — HOISTED ABOVE cas_root check (cas-7f33)
     //
     // The factory filesystem auto-approve also runs below, AFTER all
@@ -272,21 +306,15 @@ pub fn handle_pre_tool_use(
             crate::harness_policy::is_supervisor(input),
             registered_worktree.as_deref(),
         ) {
-            let path = &violation.resolved_path;
             log_factory_workspace_rejection(cas_root, input, &violation);
-            let artifacts =
-                crate::config::resolved_factory_artifacts_root(artifacts_root.as_deref());
-            let scratch = scratch_root
-                .as_deref()
-                .map(|root| format!(" or `{root}/...` for ephemeral scratch output"))
-                .unwrap_or_default();
             return Ok(HookOutput::with_pre_tool_permission(
                 "deny",
-                &format!(
-                    "🚫 FACTORY WORKSPACE CONTRACT: file creation outside the worktree, durable artifacts root, configured scratch root, or harness exceptions is blocked: {}. Use your worktree, `{}/<task-id>/` for durable proof{}; only this session's harness scratchpad is sanctioned for ephemeral notes. Bare /tmp and stray $HOME files are not sanctioned.",
-                    path.display(),
-                    artifacts.display(),
-                    scratch
+                &factory_workspace_contract_denial(
+                    input,
+                    &violation,
+                    artifacts_root.as_deref(),
+                    scratch_root.as_deref(),
+                    registered_worktree.as_deref(),
                 ),
             ));
         }
@@ -2233,6 +2261,32 @@ fn log_factory_workspace_rejection(
             ("payload_bytes", payload_bytes.as_str()),
         ],
     );
+}
+
+fn factory_workspace_contract_denial(
+    input: &HookInput,
+    violation: &FactoryWriteViolation,
+    configured_artifacts_root: Option<&str>,
+    configured_scratch_root: Option<&str>,
+    worktree_root: Option<&std::path::Path>,
+) -> String {
+    let artifacts = crate::config::resolved_factory_artifacts_root(configured_artifacts_root)
+        .display()
+        .to_string();
+    let scratch = configured_scratch_root
+        .filter(|root| !root.trim().is_empty())
+        .map(|root| format!(" or `{root}/...` for ephemeral scratch output"))
+        .unwrap_or_default();
+    let worktree = worktree_root
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| std::path::PathBuf::from(&input.cwd));
+    format!(
+        "🚫 FACTORY WORKSPACE CONTRACT: file creation outside the assigned worktree, durable artifacts root, configured scratch root, or harness exceptions is blocked: {}. Assigned worktree: `{}`. Use your worktree, `{}/<task-id>/` for durable proof{}; only this session's harness scratchpad is sanctioned for ephemeral notes. Bare /tmp and stray $HOME files are not sanctioned.",
+        violation.resolved_path.display(),
+        worktree.display(),
+        artifacts,
+        scratch,
+    )
 }
 
 /// Persist a refusal for a history-changing Git command that targeted a

--- a/cas-cli/src/hooks/handlers/handlers_tests/factory_auto_approve.rs
+++ b/cas-cli/src/hooks/handlers/handlers_tests/factory_auto_approve.rs
@@ -404,6 +404,74 @@ fn worker_edit_is_auto_approved_without_cas_root() {
 }
 
 #[test]
+fn worker_write_outside_registered_worktree_is_denied_without_cas_root() {
+    let _g = super::env_lock();
+    let _role = set_role_env(Some("worker"));
+    let worktree = tempfile::tempdir().expect("worktree");
+    let primary = tempfile::tempdir().expect("primary checkout");
+    let _clone = set_env_var("CAS_CLONE_PATH", worktree.path().as_os_str());
+    let target = primary.path().join("scripts/draft.sh");
+    let input = HookInput {
+        session_id: "test-session".into(),
+        cwd: worktree.path().to_string_lossy().into_owned(),
+        hook_event_name: "PreToolUse".into(),
+        tool_name: Some("Write".into()),
+        tool_input: Some(serde_json::json!({
+            "file_path": target,
+            "content": "draft",
+        })),
+        ..HookInput::default()
+    };
+
+    let out = handle_pre_tool_use(&input, None).expect("handler ok");
+    let reason = deny_reason(&out).expect("writes outside the worker worktree must be denied");
+    assert!(reason.contains("WORKSPACE CONTRACT"), "{reason}");
+    assert!(
+        reason.contains(worktree.path().to_string_lossy().as_ref()),
+        "{reason}"
+    );
+}
+
+#[test]
+fn worker_shell_writes_outside_registered_worktree_are_denied_without_cas_root() {
+    let _g = super::env_lock();
+    let _role = set_role_env(Some("worker"));
+    let _factory = set_env_var("CAS_FACTORY_MODE", std::ffi::OsStr::new("1"));
+    let worktree = tempfile::tempdir().expect("worktree");
+    let primary = tempfile::tempdir().expect("primary checkout");
+    let _clone = set_env_var("CAS_CLONE_PATH", worktree.path().as_os_str());
+
+    for (command, filename) in [
+        ("echo draft >", "redirect.sh"),
+        ("printf draft >>", "append.sh"),
+        ("tee", "tee.sh"),
+        ("cp source", "copy.sh"),
+        ("mv source", "move.sh"),
+    ] {
+        let target = primary.path().join(filename);
+        let command = format!("{command} {}", target.display());
+        let input = HookInput {
+            session_id: "test-session".into(),
+            cwd: worktree.path().to_string_lossy().into_owned(),
+            hook_event_name: "PreToolUse".into(),
+            tool_name: Some("Bash".into()),
+            tool_input: Some(serde_json::json!({"command": command})),
+            ..HookInput::default()
+        };
+
+        let out = handle_pre_tool_use(&input, None).expect("handler ok");
+        let reason = deny_reason(&out).unwrap_or_else(|| {
+            panic!("shell write must be denied: {command}");
+        });
+        assert!(reason.contains("WORKSPACE CONTRACT"), "{reason}");
+        assert!(
+            reason.contains(worktree.path().to_string_lossy().as_ref()),
+            "{reason}"
+        );
+    }
+}
+
+#[test]
 fn solo_user_write_without_cas_root_is_not_auto_approved() {
     // When CAS_AGENT_ROLE is unset AND cas_root is None, we must still
     // fall through to Claude Code's normal flow — the bypass is strictly


### PR DESCRIPTION
Was: with cas_root=None the PreToolUse filesystem auto-approve ran before the workspace-contract check, so a factory worker could write files into the supervisor's primary checkout (a stray test-script draft blocked a local fast-forward today).
Now: Write/Edit/NotebookEdit and shell write targets are checked against the assigned worktree (CAS_CLONE_PATH) and artifacts root before any auto-approval; denial names the assigned worktree. factory_auto_approve 27/27, workspace_contract_tests 21/21, hook_schema 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)