### PR TITLE
fix(skills): did-you-mean on unknown skills, ~/.local/bin on agent PATH, doctor duplicate-skill check (cas-d019)

### DIFF
--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -451,6 +451,115 @@ fn scan_user_skill_dirs(
     strays
 }
 
+/// One skill name present in more than one user-level skills directory with
+/// differing `SKILL.md` content (GH #810, cas-d019). Identical copies are not
+/// reported: they are the normal projected state. Divergent ones mean an agent
+/// reads a different contract depending on which account directory it runs
+/// under, and only one of them is the file `cas update` keeps current.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DivergentUserSkill {
+    name: String,
+    canonical: PathBuf,
+    others: Vec<PathBuf>,
+}
+
+/// The directory that owns a user skill when copies disagree: the Claude
+/// user scope (`~/.claude/skills`, or `CLAUDE_CONFIG_DIR` when set).
+fn canonical_user_skills_dir() -> Option<PathBuf> {
+    if let Some(configured) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        return Some(PathBuf::from(configured).join("skills"));
+    }
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".claude").join("skills"))
+}
+
+/// Group `SKILL.md` files by skill name across `dirs` (canonical-path
+/// deduplicated like [`scan_user_skill_dirs`]) and keep the names whose
+/// copies differ. The canonical copy is the one under `canonical_dir` when
+/// present, else the lexically first path.
+fn find_divergent_user_skills(dirs: &[PathBuf], canonical_dir: &Path) -> Vec<DivergentUserSkill> {
+    let mut by_name: std::collections::BTreeMap<String, Vec<(PathBuf, String)>> =
+        std::collections::BTreeMap::new();
+    let mut seen = std::collections::HashSet::new();
+    for dir in dirs {
+        let Ok(entries) = fs::read_dir(dir) else { continue };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let skill_file = path.join("SKILL.md");
+            if !path.is_dir() || !skill_file.is_file() {
+                continue;
+            }
+            let canonical = skill_file.canonicalize().unwrap_or_else(|_| skill_file.clone());
+            if !seen.insert(canonical) {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else { continue };
+            let Ok(content) = fs::read_to_string(&skill_file) else { continue };
+            by_name.entry(name.to_string()).or_default().push((skill_file, content));
+        }
+    }
+    by_name
+        .into_iter()
+        .filter_map(|(name, mut copies)| {
+            if copies.len() < 2 || copies.iter().all(|(_, body)| *body == copies[0].1) {
+                return None;
+            }
+            copies.sort_by(|a, b| a.0.cmp(&b.0));
+            let canonical_index = copies
+                .iter()
+                .position(|(path, _)| path.starts_with(canonical_dir))
+                .unwrap_or(0);
+            let (canonical, canonical_body) = copies.remove(canonical_index);
+            Some(DivergentUserSkill {
+                name,
+                canonical,
+                // Only the copies that actually disagree with the canonical
+                // file are named; identical projections are fine where they are.
+                others: copies
+                    .into_iter()
+                    .filter(|(_, body)| *body != canonical_body)
+                    .map(|(path, _)| path)
+                    .collect(),
+            })
+        })
+        .collect()
+}
+
+fn divergent_user_skills_check(divergent: &[DivergentUserSkill]) -> Check {
+    if divergent.is_empty() {
+        return Check::new(
+            "duplicate skills",
+            CheckStatus::Ok,
+            "no user-level skill has divergent copies across account directories",
+        );
+    }
+    let detail = divergent
+        .iter()
+        .map(|entry| {
+            format!(
+                "{} (canonical {}; differs: {})",
+                entry.name,
+                entry.canonical.display(),
+                entry
+                    .others
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    Check::new(
+        "duplicate skills",
+        CheckStatus::Warning,
+        format!(
+            "{} skill(s) exist in more than one skills directory with different content: {detail}. \
+             Keep the canonical copy (~/.claude/skills) and delete or symlink the others",
+            divergent.len()
+        ),
+    )
+}
+
 /// Every user-level skills directory this machine might carry.
 ///
 /// `cas update --user` writes into `~/.claude`, `~/.codex` and `~/.grok`, and
@@ -537,9 +646,16 @@ fn host_checks(current: Option<&Path>) -> Vec<Check> {
     #[cfg(not(feature = "mcp-proxy"))]
     checks.push(Check::new("host proxy", CheckStatus::Ok, "proxy integration unavailable in this build"));
     checks.extend(registered_project_root_checks(current.unwrap_or_else(|| Path::new(""))));
-    let mut skills = stray_user_skills_check(&scan_user_skill_dirs(&user_skill_scan_targets()));
+    let targets = user_skill_scan_targets();
+    let mut skills = stray_user_skills_check(&scan_user_skill_dirs(&targets));
     skills.name = "host user skills".into();
     checks.push(skills);
+    if let Some(canonical) = canonical_user_skills_dir() {
+        let dirs: Vec<PathBuf> = targets.iter().map(|(dir, _)| dir.clone()).collect();
+        let mut duplicates = divergent_user_skills_check(&find_divergent_user_skills(&dirs, &canonical));
+        duplicates.name = "host duplicate skills".into();
+        checks.push(duplicates);
+    }
     checks
 }
 
@@ -6832,6 +6948,43 @@ mod tests {
 
     fn claude_names() -> std::collections::HashSet<String> {
         catalog_skill_names(crate::builtins::BUILTIN_SKILLS)
+    }
+
+    /// GH #810 (cas-d019): the same skill name in two account directories is
+    /// only a finding when the bodies differ, and the Claude user scope is
+    /// named as the copy to keep.
+    #[test]
+    fn divergent_duplicate_user_skills_are_flagged_with_the_canonical_copy() {
+        let home = TempDir::new().unwrap();
+        let claude = home.path().join(".claude").join("skills");
+        let alt = home.path().join(".claude-alt").join("skills");
+        let codex = home.path().join(".codex").join("skills");
+        let body = "---\nname: exa-search\n---\n\nRun `exa-search \"query\"`.\n";
+        let canonical = write_skill(&claude, "exa-search", body);
+        write_skill(&codex, "exa-search", body);
+        let drifted = write_skill(&alt, "exa-search", "---\nname: exa-search\n---\n\nOld text.\n");
+        write_skill(&claude, "cas-worker", "same");
+        write_skill(&alt, "cas-worker", "same");
+
+        let dirs = vec![alt.clone(), claude.clone(), codex.clone()];
+        let divergent = find_divergent_user_skills(&dirs, &claude);
+        assert_eq!(
+            divergent,
+            vec![DivergentUserSkill {
+                name: "exa-search".to_string(),
+                canonical,
+                others: vec![drifted],
+            }]
+        );
+        let check = divergent_user_skills_check(&divergent);
+        assert!(matches!(check.status, CheckStatus::Warning));
+        assert!(check.message.contains("exa-search"), "{}", check.message);
+        assert!(check.message.contains(".claude-alt"), "{}", check.message);
+        assert!(check.message.contains("canonical"), "{}", check.message);
+
+        let identical = find_divergent_user_skills(&[claude.clone(), codex], &claude);
+        assert!(identical.is_empty(), "identical copies are not findings");
+        assert!(matches!(divergent_user_skills_check(&identical).status, CheckStatus::Ok));
     }
 
     fn write_skill(dir: &Path, name: &str, body: &str) -> PathBuf {

--- a/cas-cli/src/mcp/tools/core/skills.rs
+++ b/cas-cli/src/mcp/tools/core/skills.rs
@@ -37,6 +37,41 @@ impl CasCore {
 
     /// Show skill details
     /// Checks database first, then falls back to .claude/skills/ files
+    /// "Skill not found: X. Did you mean: y?" (GH #810). Candidates are every
+    /// name an agent could legitimately have meant: stored skills (name and
+    /// id), the project's `.claude/skills` directories, and the builtin
+    /// catalog.
+    fn unknown_skill_message(&self, query: &str, skill_store: &dyn cas_store::SkillStore) -> String {
+        let mut candidates: Vec<String> = Vec::new();
+        if let Ok(skills) = skill_store.list(None) {
+            for skill in skills {
+                candidates.push(skill.name);
+                candidates.push(skill.id);
+            }
+        }
+        let project_root = self.cas_root.parent().unwrap_or(&self.cas_root);
+        if let Ok(entries) = std::fs::read_dir(project_root.join(".claude").join("skills")) {
+            for entry in entries.flatten() {
+                if entry.path().join("SKILL.md").is_file()
+                    && let Some(name) = entry.file_name().to_str()
+                {
+                    candidates.push(name.to_owned());
+                }
+            }
+        }
+        candidates.extend(
+            crate::builtins::BUILTIN_SKILLS
+                .iter()
+                .filter_map(|file| file.path.strip_prefix("skills/"))
+                .filter_map(|rest| rest.split('/').next())
+                .map(str::to_owned),
+        );
+        crate::sync::skill_suggest::unknown_skill_message(
+            query,
+            candidates.iter().map(String::as_str),
+        )
+    }
+
     pub async fn cas_skill_show(
         &self,
         Parameters(req): Parameters<IdRequest>,
@@ -56,7 +91,7 @@ impl CasCore {
                     Ok(None) => {
                         return Err(McpError {
                             code: ErrorCode::INVALID_PARAMS,
-                            message: Cow::from(format!("Skill not found: {}", req.id)),
+                            message: Cow::from(self.unknown_skill_message(&req.id, skill_store.as_ref())),
                             data: None,
                         });
                     }
@@ -331,7 +366,12 @@ impl CasCore {
 
         let mut skill = skill_store.get(&req.id).map_err(|e| McpError {
             code: ErrorCode::INVALID_PARAMS,
-            message: Cow::from(format!("Skill not found: {e}")),
+            message: Cow::from(match e {
+                cas_store::StoreError::NotFound(_) => {
+                    self.unknown_skill_message(&req.id, skill_store.as_ref())
+                }
+                other => format!("Skill not found: {other}"),
+            }),
             data: None,
         })?;
 

--- a/cas-cli/src/sync/mod.rs
+++ b/cas-cli/src/sync/mod.rs
@@ -35,6 +35,7 @@
 
 // #![allow(dead_code)] // Check unused // API for sync functionality
 
+pub mod skill_suggest;
 pub mod skills;
 
 pub use skills::{SkillSyncer, create_planning_skill, generate_planning_skill};

--- a/cas-cli/src/sync/skill_suggest.rs
+++ b/cas-cli/src/sync/skill_suggest.rs
@@ -1,0 +1,147 @@
+//! Nearest-match suggestions for unknown skill names (GH #810, cas-d019).
+//!
+//! An operator says "ExaSearchSkill"; the skill is `exa-search`. The old
+//! answer was a bare "not found", which cost a directory listing per session.
+//! Matching is case- and separator-insensitive with a trailing `skill`
+//! stripped, then a small Levenshtein bound over the listed names.
+
+/// Normalise a skill name for comparison: lowercase, drop `-`/`_`/spaces,
+/// and drop a trailing `skill` (people say "the exa search skill").
+pub fn normalize_skill_name(name: &str) -> String {
+    let compact: String = name
+        .chars()
+        .filter(|ch| !matches!(ch, '-' | '_' | ' ' | '.'))
+        .flat_map(char::to_lowercase)
+        .collect();
+    compact
+        .strip_suffix("skill")
+        .filter(|rest| !rest.is_empty())
+        .map(str::to_owned)
+        .unwrap_or(compact)
+}
+
+/// Classic Levenshtein distance over chars.
+pub fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut previous: Vec<usize> = (0..=b.len()).collect();
+    let mut current = vec![0; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        current[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let substitution = previous[j] + usize::from(ca != cb);
+            current[j + 1] = (previous[j + 1] + 1).min(current[j] + 1).min(substitution);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+    previous[b.len()]
+}
+
+/// Candidates worth naming for `query`, best first, at most three.
+///
+/// Exact normalised matches win outright; otherwise a candidate qualifies when
+/// its normalised form is within `max(2, len/4)` edits of the query, or one
+/// contains the other (so "search" finds `exa-search`). Duplicates collapse.
+pub fn suggest_skill_names<'a, I>(query: &str, candidates: I) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let wanted = normalize_skill_name(query);
+    if wanted.is_empty() {
+        return Vec::new();
+    }
+    let bound = (wanted.chars().count() / 4).max(2);
+    let mut scored: Vec<(usize, String)> = Vec::new();
+    for candidate in candidates {
+        let candidate = candidate.trim();
+        if candidate.is_empty() || scored.iter().any(|(_, seen)| seen == candidate) {
+            continue;
+        }
+        let normal = normalize_skill_name(candidate);
+        let score = if normal == wanted {
+            0
+        } else if normal.contains(&wanted) || wanted.contains(&normal) {
+            1
+        } else {
+            let distance = levenshtein(&wanted, &normal);
+            if distance > bound {
+                continue;
+            }
+            distance + 1
+        };
+        scored.push((score, candidate.to_owned()));
+    }
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    scored.into_iter().take(3).map(|(_, name)| name).collect()
+}
+
+/// The full "not found" sentence, with the suggestion clause only when there
+/// is one: `Skill not found: ExaSearchSkill. Did you mean: exa-search?`
+pub fn unknown_skill_message<'a, I>(query: &str, candidates: I) -> String
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let suggestions = suggest_skill_names(query, candidates);
+    if suggestions.is_empty() {
+        format!("Skill not found: {query}")
+    } else {
+        format!(
+            "Skill not found: {query}. Did you mean: {}?",
+            suggestions.join(", ")
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CATALOG: [&str; 6] = [
+        "exa-search",
+        "cas-search",
+        "cas-worker",
+        "cas-supervisor",
+        "release-notes",
+        "mecha-cassy",
+    ];
+
+    #[test]
+    fn camel_case_with_skill_suffix_finds_the_kebab_name() {
+        assert_eq!(
+            unknown_skill_message("ExaSearchSkill", CATALOG),
+            "Skill not found: ExaSearchSkill. Did you mean: exa-search?"
+        );
+        assert_eq!(suggest_skill_names("exa_search", CATALOG), ["exa-search"]);
+        assert_eq!(suggest_skill_names("Exa Search", CATALOG), ["exa-search"]);
+    }
+
+    #[test]
+    fn small_typos_and_substrings_still_suggest() {
+        assert_eq!(suggest_skill_names("exa-serch", CATALOG), ["exa-search"]);
+        assert_eq!(
+            suggest_skill_names("search", CATALOG),
+            ["cas-search", "exa-search"]
+        );
+        assert_eq!(
+            suggest_skill_names("releasenotes", CATALOG),
+            ["release-notes"]
+        );
+    }
+
+    #[test]
+    fn far_names_get_no_suggestion_and_message_stays_bare() {
+        assert!(suggest_skill_names("kubernetes", CATALOG).is_empty());
+        assert_eq!(
+            unknown_skill_message("kubernetes", CATALOG),
+            "Skill not found: kubernetes"
+        );
+        assert!(suggest_skill_names("", CATALOG).is_empty());
+    }
+
+    #[test]
+    fn levenshtein_is_the_textbook_distance() {
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("same", "same"), 0);
+    }
+}

--- a/crates/cas-pty/src/pty.rs
+++ b/crates/cas-pty/src/pty.rs
@@ -1028,6 +1028,7 @@ impl PtyConfig {
         // (cas-4513 Claude Code JS crash-screen symptom). Emitted only
         // for role="worker"; supervisor stays uncapped.
         push_worker_cargo_env(&mut env, role);
+        push_local_bin_path_env(&mut env);
         // cas-eb39: share dependency compilation across isolated worktrees
         // without serializing their Cargo target directories.
         push_worker_build_cache_env(&mut env, role);
@@ -1216,6 +1217,7 @@ impl PtyConfig {
 
         // cas-0bf4: see equivalent comment in `claude()`.
         push_worker_cargo_env(&mut env, role);
+        push_local_bin_path_env(&mut env);
         // cas-eb39: see equivalent comment in `claude()`.
         push_worker_build_cache_env(&mut env, role);
         // cas-3522 follow-on: see equivalent comment in `claude()`.
@@ -1334,6 +1336,7 @@ impl PtyConfig {
         }
         push_factory_worker_metadata_env(&mut env, role, factory_worker_cli, model, effort);
         push_worker_cargo_env(&mut env, role);
+        push_local_bin_path_env(&mut env);
         push_worker_build_cache_env(&mut env, role);
         push_worker_zig_env(&mut env, role, cas_root);
 
@@ -1530,6 +1533,7 @@ impl PtyConfig {
 
         // cas-0bf4: see equivalent comment in `claude()`.
         push_worker_cargo_env(&mut env, role);
+        push_local_bin_path_env(&mut env);
         // cas-eb39: see equivalent comment in `claude()`.
         push_worker_build_cache_env(&mut env, role);
         // cas-3522 follow-on: see equivalent comment in `claude()`.
@@ -1801,6 +1805,39 @@ fn cas_binary_on_path() -> bool {
         let candidate = dir.join("cas");
         candidate.is_file()
     })
+}
+
+/// Keep `~/.local/bin` on the spawned agent's `PATH` (GH #810, cas-d019).
+///
+/// Skill CLIs such as `exa-search` install there, and their docs promise "no
+/// further setup". A daemon started from a non-login shell inherits a `PATH`
+/// without it, so every worker paid an `export PATH=...` per session. Only
+/// prepends when the directory exists and is not already listed.
+fn push_local_bin_path_env(env: &mut Vec<(String, String)>) {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    push_local_bin_path_env_with(env, &home, std::env::var_os("PATH"));
+}
+
+fn push_local_bin_path_env_with(
+    env: &mut Vec<(String, String)>,
+    home: &std::path::Path,
+    current: Option<std::ffi::OsString>,
+) {
+    let local_bin = home.join(".local").join("bin");
+    if !local_bin.is_dir() {
+        return;
+    }
+    let current = current.unwrap_or_default();
+    if std::env::split_paths(&current).any(|dir| dir == local_bin) {
+        return;
+    }
+    let mut paths = vec![local_bin];
+    paths.extend(std::env::split_paths(&current));
+    if let Ok(joined) = std::env::join_paths(paths) {
+        env.push(("PATH".to_string(), joined.to_string_lossy().into_owned()));
+    }
 }
 
 /// Push the `CARGO_BUILD_JOBS` env entry into `env` when `role == "worker"`.
@@ -3648,6 +3685,41 @@ mod tests {
             .position(|a| a == "--effort")
             .expect("--effort must be present when Some(effort) is given");
         assert_eq!(config.args[idx + 1], "medium");
+    }
+
+    /// GH #810 (cas-d019): a spawn whose inherited PATH lacks `~/.local/bin`
+    /// gets it prepended; one that already has it is left alone.
+    #[test]
+    fn local_bin_is_prepended_to_path_only_when_missing() {
+        let root = std::env::temp_dir().join(format!("cas-pty-localbin-{}", std::process::id()));
+        let home = root.join("home");
+        let local_bin = home.join(".local").join("bin");
+        std::fs::create_dir_all(&local_bin).unwrap();
+        let bare = root.join("bare");
+        std::fs::create_dir_all(&bare).unwrap();
+        let mut env = Vec::new();
+        push_local_bin_path_env_with(&mut env, &home, Some("/usr/bin:/bin".into()));
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].0, "PATH");
+        assert!(
+            env[0].1.starts_with(&format!("{}:", local_bin.display())),
+            "{}",
+            env[0].1
+        );
+        assert!(env[0].1.ends_with("/usr/bin:/bin"));
+
+        let mut already = Vec::new();
+        push_local_bin_path_env_with(
+            &mut already,
+            &home,
+            Some(format!("/usr/bin:{}", local_bin.display()).into()),
+        );
+        assert!(already.is_empty(), "present PATH entry must not be duplicated");
+
+        let mut missing = Vec::new();
+        push_local_bin_path_env_with(&mut missing, &bare, Some("/usr/bin".into()));
+        assert!(missing.is_empty(), "no ~/.local/bin means no PATH override");
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// cas-556a: `max` passes through to Codex unchanged as


### PR DESCRIPTION
## Summary
- `mcp__cas__skill show/use` on an unknown name now answers `Skill not found: ExaSearchSkill. Did you mean: exa-search?` — case/separator-insensitive match with a bounded Levenshtein over stored skills, project `.claude/skills` and the builtin catalog.
- Spawned factory agents get `~/.local/bin` prepended to `PATH` when the inherited `PATH` lacks it (and the directory exists), so skill CLIs like `exa-search` run with no manual export.
- `cas doctor --host` gains a `duplicate skills` row: warns when a skill name has divergent `SKILL.md` copies across account directories and names the canonical `~/.claude/skills` copy; identical projections stay silent.

Fixes #810

## Tests
`sync::skill_suggest` 4 · `cli::doctor::tests` 104 · cas-pty `local_bin` 1 + `test_pty_config` 49

Task: cas-d019

🤖 Generated with [Claude Code](https://claude.com/claude-code)