### PR TITLE
Release 3.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.25.3] - 2026-09-11
+
+### Fixed
+- The `Scoped Validation (fast)` CI tier no longer requires ripgrep on the
+  runner: the proof-surface script falls back to `git grep` (#836).
+- The director's stalled-supervisor relay distinguishes a merged delivery whose
+  close is blocked from an unmerged one, posts the close rejection once, and
+  stops repeating the merge demand (#835).
+
 ## [3.25.2] - 2026-09-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.25.2"
+version = "3.25.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.25.2"
+version = "3.25.3"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.25.2"
+version = "3.25.3"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.25.2"
+version = "3.25.3"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.25.2"
+version = "3.25.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.25.2"
+version = "3.25.3"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.25.2"
+version = "3.25.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/cas-cli/Makefile
+++ b/cas-cli/Makefile
@@ -228,6 +228,7 @@ test-ci-tiers:
 	cd .. && ./scripts/test-cas-install.sh
 	cd .. && ./scripts/test-check-release-migration-snapshots.sh
 	cd .. && ./scripts/test-check-scoped-snapshot-tests.sh
+	cd .. && ./scripts/test-check-scoped-test-surface.sh
 
 # Type check
 check:

--- a/cas-cli/src/ui/factory/app/mod.rs
+++ b/cas-cli/src/ui/factory/app/mod.rs
@@ -7,14 +7,16 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime};
 
 use cas_mux::{Mux, PaneKind};
+use cas_store::TaskStore;
 use chrono::{DateTime, Utc};
 use ratatui::layout::Rect;
 
 use super::director::{
     DiffLine, DirectorData, DirectorEvent, DirectorEventDetector, DirectorStores,
-    MergeAlertFreshness, PanelAreas, Prompt, SidecarFocus, ViewMode, check_merge_alert_freshness,
-    generate_prompt_at, prompt_is_still_deliverable, revalidate_event_for_delivery_with_context,
-    revalidate_event_for_delivery_with_focus, supervisor_actionable_state,
+    MergeAlertFreshness, MergedCloseBlockedTask, PanelAreas, Prompt, SidecarFocus, ViewMode,
+    check_merge_alert_freshness, generate_prompt_at, prompt_is_still_deliverable,
+    revalidate_event_for_delivery_with_context, revalidate_event_for_delivery_with_focus,
+    supervisor_actionable_state_with_merge_classifier,
 };
 use crate::store::open_prompt_queue_store;
 use crate::types::Worktree;
@@ -87,6 +89,24 @@ pub use cas_factory::{AutoPromptConfig, EpicState, FactoryConfig};
 pub use sidecar_and_selection::{
     ClickAction, ClientGeometryMode, GrokEscAction, ScrollAction, sgr_left_click_bytes,
 };
+
+fn git_is_ancestor(repo_root: &Path, ancestor: &str, descendant: &str) -> bool {
+    std::process::Command::new("git")
+        .args(["merge-base", "--is-ancestor", ancestor, descendant])
+        .current_dir(repo_root)
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn last_close_rejection_reason(notes: &str) -> Option<String> {
+    const MARKER: &str = "Close rejected: ";
+    const END: &str = ". Task parked as awaiting_merge";
+    notes.lines().rev().find_map(|line| {
+        let reason = line.split_once(MARKER)?.1.split_once(END)?.0.trim();
+        (!reason.is_empty()).then(|| reason.to_string())
+    })
+}
 
 /// Booting state for a worker that is being spawned (after prepare, before finish)
 #[derive(Debug, Clone)]
@@ -1165,6 +1185,50 @@ impl FactoryApp {
         self.cas_dir.parent().unwrap_or(&self.cas_dir).to_path_buf()
     }
 
+    /// Return merged-close-blocked evidence for a parked task only when its
+    /// task-specific delivery anchor is already reachable from the resolved
+    /// target. Missing task/Git evidence is deliberately treated as unknown,
+    /// preserving the existing merge demand rather than inventing a merged
+    /// verdict.
+    fn classify_merged_close_blocked_task(
+        &self,
+        task: &crate::ui::factory::director::TaskSummary,
+        factory_branch: &str,
+        target_branch: &str,
+        _factory_tip: Option<&str>,
+        repo_root: &Path,
+    ) -> Option<MergedCloseBlockedTask> {
+        let target_tip = crate::mcp::tools::core::task::lifecycle::close_ops::resolve_branch_sha(
+            repo_root,
+            target_branch,
+        )?;
+        let stores = self.director_stores.as_ref()?;
+        let parked = stores.task_store.get(&task.id).ok()?;
+        let anchor = parked
+            .deliverables
+            .factory_branch_anchor
+            .as_deref()
+            .map(str::trim)
+            .filter(|anchor| !anchor.is_empty())?;
+        let anchor_sha =
+            crate::mcp::tools::core::task::lifecycle::close_ops::resolve_branch_sha(
+                repo_root, anchor,
+            )?;
+        if !git_is_ancestor(repo_root, &anchor_sha, &target_tip) {
+            return None;
+        }
+
+        Some(MergedCloseBlockedTask {
+            task_id: task.id.clone(),
+            factory_branch: factory_branch.to_string(),
+            anchor: anchor.to_string(),
+            target_branch: target_branch.to_string(),
+            target_tip,
+            close_rejection: last_close_rejection_reason(&parked.notes)
+                .unwrap_or_else(|| "MERGE REQUIRED".to_string()),
+        })
+    }
+
     /// Refresh Cassy data from stores and detect state changes
     ///
     /// Returns the detected events. Prompt generation happens later, at
@@ -1277,7 +1341,7 @@ impl FactoryApp {
         let now = Utc::now();
         let held_workers = worker_holds_from_session_metadata_named(session).unwrap_or_default();
         let repo_root = self.delivery_repo_root();
-        let actionable = supervisor_actionable_state(
+        let actionable = supervisor_actionable_state_with_merge_classifier(
             &self.unfiltered_director_data,
             self.epic_state.epic_id().or(self.current_epic_id.as_deref()),
             &self.supervisor_name,
@@ -1288,6 +1352,15 @@ impl FactoryApp {
                 crate::mcp::tools::core::task::lifecycle::close_ops::resolve_branch_sha(
                     &repo_root,
                     branch,
+                )
+            },
+            |task, factory_branch, target_branch, factory_tip| {
+                self.classify_merged_close_blocked_task(
+                    task,
+                    factory_branch,
+                    target_branch,
+                    factory_tip,
+                    &repo_root,
                 )
             },
         );
@@ -1359,7 +1432,7 @@ impl FactoryApp {
         }
         let held_workers = worker_holds_from_session_metadata_named(session).unwrap_or_default();
         let repo_root = self.delivery_repo_root();
-        supervisor_actionable_state(
+        supervisor_actionable_state_with_merge_classifier(
             data,
             self.epic_state.epic_id().or(self.current_epic_id.as_deref()),
             &self.supervisor_name,
@@ -1370,6 +1443,15 @@ impl FactoryApp {
                 crate::mcp::tools::core::task::lifecycle::close_ops::resolve_branch_sha(
                     &repo_root,
                     branch,
+                )
+            },
+            |task, factory_branch, target_branch, factory_tip| {
+                self.classify_merged_close_blocked_task(
+                    task,
+                    factory_branch,
+                    target_branch,
+                    factory_tip,
+                    &repo_root,
                 )
             },
         )

--- a/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
+++ b/cas-cli/src/ui/factory/daemon/runtime/lifecycle.rs
@@ -13,6 +13,62 @@ fn enqueue_worker_attention_relay(
         actionable_idle_secs,
     } = event
     {
+        if let Some(stable_key) = next_step.merged_close_blocked_relay_key() {
+            let stable_key = merged_close_blocked_status_key(cas_dir, next_step)
+                .map(|status_key| format!("{stable_key}:status:{status_key}"))
+                .unwrap_or(stable_key);
+            let task_id = match next_step {
+                crate::ui::factory::director::SupervisorActionableState::MergeCloseBlocked {
+                    tasks,
+                } if tasks.len() == 1 => Some(tasks[0].task_id.as_str()),
+                crate::ui::factory::director::SupervisorActionableState::MergeQueue {
+                    merged_close_blocked: tasks,
+                    ..
+                } if tasks.len() == 1 => Some(tasks[0].task_id.as_str()),
+                _ => None,
+            };
+            let detail = format!(
+                "Supervisor actionable-idle for {}m. {}",
+                actionable_idle_secs / 60,
+                next_step.next_step_text()
+            );
+            let merged = enqueue_worker_attention_relay_detail_with_key(
+                cas_dir,
+                "merged_close_blocked",
+                "supervisor",
+                task_id,
+                Some(*actionable_idle_secs),
+                &detail,
+                occurrence,
+                Some(&stable_key),
+            );
+
+            // A mixed queue still needs the old genuinely-unmerged merge
+            // demand. Its occurrence-based key preserves the prior refire
+            // behavior, while the merged task remains stable-key deduped.
+            if let Some(unmerged) = next_step.unmerged_merge_state() {
+                let unmerged_detail = format!(
+                    "Supervisor actionable-idle for {}m. {}",
+                    actionable_idle_secs / 60,
+                    unmerged.next_step_text()
+                );
+                let unmerged_outcome = enqueue_worker_attention_relay_detail(
+                    cas_dir,
+                    "supervisor_stalled",
+                    "supervisor",
+                    None,
+                    Some(*actionable_idle_secs),
+                    &unmerged_detail,
+                    occurrence,
+                );
+                return if matches!(merged, WorkerAttentionRelayOutcome::Pending) {
+                    unmerged_outcome
+                } else {
+                    merged
+                };
+            }
+            return merged;
+        }
         let detail = format!(
             "Supervisor actionable-idle for {}m. {}",
             actionable_idle_secs / 60,
@@ -62,6 +118,40 @@ fn enqueue_worker_attention_relay(
         &detail,
         &format!("{kind}:{worker}:{}", task_id.unwrap_or("")),
     )
+}
+
+/// Add the task-store's update identity to a merged-close-blocked relay key.
+/// The actionable enum only contains AwaitingMerge tasks, so the persisted
+/// status/update pair is the status-cycle boundary that permits a new relay
+/// after a task leaves and later re-enters that state. Missing store evidence
+/// preserves the base anchor/target-tip dedupe key.
+fn merged_close_blocked_status_key(
+    cas_dir: &std::path::Path,
+    next_step: &crate::ui::factory::director::SupervisorActionableState,
+) -> Option<String> {
+    let tasks = match next_step {
+        crate::ui::factory::director::SupervisorActionableState::MergeCloseBlocked { tasks }
+        | crate::ui::factory::director::SupervisorActionableState::MergeQueue {
+            merged_close_blocked: tasks,
+            ..
+        } => tasks,
+        _ => return None,
+    };
+    let store = crate::store::open_task_store(cas_dir).ok()?;
+    let mut generations = tasks
+        .iter()
+        .map(|task| {
+            let current = store.get(&task.task_id).ok()?;
+            Some(format!(
+                "{}:{}:{}",
+                task.task_id,
+                current.status,
+                current.updated_at.to_rfc3339()
+            ))
+        })
+        .collect::<Option<Vec<_>>>()?;
+    generations.sort();
+    Some(generations.join("|"))
 }
 
 /// Persist one confirmed worker stoppage through the same durable supervisor
@@ -574,6 +664,65 @@ mod worker_attention_tests {
                 && row.prompt.contains("limited-codex")
                 && row.prompt.contains("terminal unavailable state")
         }));
+    }
+
+    #[test]
+    fn merged_close_blocked_supervisor_stall_relays_once_without_repeat_merge_demand() {
+        let _env = crate::test_support::TestEnvGuard::with_vars(&[(
+            "CAS_FACTORY_SESSION",
+            "merged-close-blocked-test",
+        )]);
+        let temp = tempfile::TempDir::new().unwrap();
+        let cas_dir = crate::store::init_cas_dir(temp.path()).unwrap();
+        register_supervisor(&cas_dir, "merged-close-blocked-test");
+        let next_step = crate::ui::factory::director::SupervisorActionableState::MergeCloseBlocked {
+            tasks: vec![crate::ui::factory::director::MergedCloseBlockedTask {
+                task_id: "cas-merged".to_string(),
+                factory_branch: "factory/gold-fox".to_string(),
+                anchor: "anchor-sha".to_string(),
+                target_branch: "epic/cas-epic".to_string(),
+                target_tip: "target-tip".to_string(),
+                close_rejection: "ZERO-COMMIT after merged delivery".to_string(),
+            }],
+        };
+        let first = enqueue_worker_attention_relay(
+            &cas_dir,
+            &crate::ui::factory::director::DirectorEvent::SupervisorStalled {
+                next_step: next_step.clone(),
+                occurrence: "2026-09-11T02:40:00Z".to_string(),
+                actionable_idle_secs: 600,
+            },
+        );
+        let replay = enqueue_worker_attention_relay(
+            &cas_dir,
+            &crate::ui::factory::director::DirectorEvent::SupervisorStalled {
+                next_step,
+                occurrence: "2026-09-11T02:50:00Z".to_string(),
+                actionable_idle_secs: 1200,
+            },
+        );
+        assert!(matches!(
+            first,
+            WorkerAttentionRelayOutcome::Persisted { .. }
+        ));
+        assert!(matches!(
+            replay,
+            WorkerAttentionRelayOutcome::Persisted { .. }
+        ));
+
+        let queue = crate::store::open_prompt_queue_store(&cas_dir).unwrap();
+        let rows = queue.peek_all(10).unwrap();
+        assert_eq!(rows.len(), 1, "the merged close block is stable-deduped");
+        assert!(rows[0].prompt.contains("kind=\"merged_close_blocked\""));
+        assert!(rows[0]
+            .prompt
+            .contains("ZERO-COMMIT after merged delivery"));
+        assert!(rows[0]
+            .prompt
+            .contains("task action=close id=cas-merged"));
+        assert!(!rows[0]
+            .prompt
+            .contains("merge the ready delivery branch(es)"));
     }
 
     /// cas-d9a8: the fail-safe for supervisor traffic that is not wake-shaped.

--- a/cas-cli/src/ui/factory/director/events.rs
+++ b/cas-cli/src/ui/factory/director/events.rs
@@ -24,6 +24,19 @@ pub enum SupervisorActionableState {
         /// `(task id, delivery branch, live tip)` in deterministic task order.
         branches: Vec<(String, String, String)>,
     },
+    /// Delivery is already reachable from its target, but the task remains
+    /// parked because the close gate rejected it. This is a different
+    /// supervisor action from merging a genuinely unmerged factory branch.
+    MergeCloseBlocked {
+        tasks: Vec<MergedCloseBlockedTask>,
+    },
+    /// A stalled epic has both genuinely unmerged deliveries and deliveries
+    /// that are already merged but still blocked at close. Keep both facts in
+    /// one actionable state so neither class is hidden by the other.
+    MergeQueue {
+        branches: Vec<(String, String, String)>,
+        merged_close_blocked: Vec<MergedCloseBlockedTask>,
+    },
     AssignReadyWork {
         task_ids: Vec<String>,
         idle_workers: Vec<String>,
@@ -47,6 +60,24 @@ impl SupervisorActionableState {
                     "Drive to the exit: merge the ready delivery branch(es) into the focused epic now:\n{rows}"
                 )
             }
+            Self::MergeCloseBlocked { tasks } => format!(
+                "Drive to the exit: delivery is already merged, but close is blocked; do not merge the factory branch again:\n{}",
+                render_merged_close_blocked(tasks)
+            ),
+            Self::MergeQueue {
+                branches,
+                merged_close_blocked,
+            } => {
+                let unmerged = Self::MergeBranches {
+                    branches: branches.clone(),
+                }
+                .next_step_text();
+                let merged = format!(
+                    "Delivery already merged but close is blocked; do not merge those factory branches again:\n{}",
+                    render_merged_close_blocked(merged_close_blocked)
+                );
+                format!("{unmerged}\n{merged}")
+            }
             Self::AssignReadyWork {
                 task_ids,
                 idle_workers,
@@ -62,6 +93,94 @@ impl SupervisorActionableState {
     }
 }
 
+/// Evidence for a parked task whose recorded delivery anchor is already on
+/// the resolved merge target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MergedCloseBlockedTask {
+    pub task_id: String,
+    pub factory_branch: String,
+    pub anchor: String,
+    pub target_branch: String,
+    pub target_tip: String,
+    pub close_rejection: String,
+}
+
+fn render_merged_close_blocked(tasks: &[MergedCloseBlockedTask]) -> String {
+    tasks
+        .iter()
+        .map(|task| {
+            format!(
+                "- {}: {} anchor {} is already reachable from {} @ {}. Last close rejection: {}. Suggested close: `mcp__cs__task action=close id={}` (or supervisor `mcp__cs__task action=close id={} supervisor_override=true reason=\"merged delivery verified; close rejection: {}\"`).",
+                task.task_id,
+                task.factory_branch,
+                task.anchor,
+                task.target_branch,
+                task.target_tip,
+                task.close_rejection,
+                task.task_id,
+                task.task_id,
+                task.close_rejection,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn merged_close_blocked_key(tasks: &[MergedCloseBlockedTask]) -> String {
+    tasks
+        .iter()
+        .map(|task| {
+            format!(
+                "{}:{}:{}:{}",
+                task.task_id, task.anchor, task.target_branch, task.target_tip
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+impl SupervisorActionableState {
+    /// Stable dedupe key for merged-but-close-blocked relay rows. The key
+    /// intentionally changes only when the task identity/anchor, target ref,
+    /// or target tip changes; a repeated supervisor-stall sample must not
+    /// manufacture another close demand for the same merged delivery.
+    pub(crate) fn merged_close_blocked_relay_key(&self) -> Option<String> {
+        let tasks = match self {
+            Self::MergeCloseBlocked { tasks } | Self::MergeQueue {
+                merged_close_blocked: tasks,
+                ..
+            } if !tasks.is_empty() => tasks,
+            _ => return None,
+        };
+        Some(format!("merged-close-blocked:{}", merged_close_blocked_key(tasks)))
+    }
+
+    /// Render only the genuinely unmerged portion of a mixed merge queue.
+    pub(crate) fn unmerged_merge_state(&self) -> Option<Self> {
+        match self {
+            Self::MergeQueue { branches, .. } if !branches.is_empty() => {
+                Some(Self::MergeBranches {
+                    branches: branches.clone(),
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Resolve the branch a child task delivers into. A task-level WorkTarget
+/// wins; otherwise the parent epic's branch is the legacy target.
+fn merge_target_for_task(data: &DirectorData, task: &TaskSummary) -> Option<String> {
+    task.branch.clone().or_else(|| {
+        task.epic.as_ref().and_then(|epic_id| {
+            data.epic_tasks
+                .iter()
+                .find(|epic| epic.id == *epic_id)
+                .and_then(|epic| epic.branch.clone())
+        })
+    })
+}
+
 /// Persistable per-factory-session accounting for supervisor stalls.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SupervisorStallTracker {
@@ -74,6 +193,11 @@ pub struct SupervisorStallTracker {
     /// Last wake accepted for delivery in this session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_wake_at: Option<DateTime<Utc>>,
+    /// Stable merged-delivery state most recently delivered. A changed anchor
+    /// or target tip must wake immediately, while an unchanged merged
+    /// delivery must not refire the same close demand every ten minutes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_merged_close_blocked_key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -116,10 +240,28 @@ impl SupervisorStallTracker {
             .last_wake_at
             .map(|last| (now - last).num_seconds() >= SUPERVISOR_STALL_REFIRE_SECS)
             .unwrap_or(true);
-        let wake = if condition_true && refire_due {
+        let merged_key = actionable.as_ref().and_then(|action| {
+            matches!(action, SupervisorActionableState::MergeCloseBlocked { .. })
+                .then(|| action.merged_close_blocked_relay_key())
+                .flatten()
+        });
+        let merged_state_repeated = merged_key.as_ref().is_some_and(|key| {
+            self.last_merged_close_blocked_key.as_ref() == Some(key)
+        });
+        let wake = if condition_true
+            && if merged_key.is_some() {
+                !merged_state_repeated
+            } else {
+                refire_due
+            }
+        {
             self.last_wake_at = Some(now);
+            self.last_merged_close_blocked_key = merged_key;
             actionable
         } else {
+            if !condition_true || merged_key.is_none() {
+                self.last_merged_close_blocked_key = None;
+            }
             None
         };
 
@@ -151,7 +293,38 @@ pub(crate) fn supervisor_actionable_state(
     held_workers: &HashSet<String>,
     now: DateTime<Utc>,
     idle_after_secs: u64,
+    resolve_branch_tip: impl FnMut(&str) -> Option<String>,
+) -> Option<SupervisorActionableState> {
+    supervisor_actionable_state_with_merge_classifier(
+        data,
+        focused_epic_id,
+        supervisor_name,
+        held_workers,
+        now,
+        idle_after_secs,
+        resolve_branch_tip,
+        |_, _, _, _| None,
+    )
+}
+
+/// Compute the supervisor's next action while allowing production to classify
+/// a parked delivery against live Git and task-store evidence. The plain
+/// [`supervisor_actionable_state`] wrapper preserves the pure legacy behavior
+/// used by display/unit callers that do not have a repository-backed checker.
+pub(crate) fn supervisor_actionable_state_with_merge_classifier(
+    data: &DirectorData,
+    focused_epic_id: Option<&str>,
+    supervisor_name: &str,
+    held_workers: &HashSet<String>,
+    now: DateTime<Utc>,
+    idle_after_secs: u64,
     mut resolve_branch_tip: impl FnMut(&str) -> Option<String>,
+    mut classify_merged_close_blocked: impl FnMut(
+        &TaskSummary,
+        &str,
+        &str,
+        Option<&str>,
+    ) -> Option<MergedCloseBlockedTask>,
 ) -> Option<SupervisorActionableState> {
     let epic_id = focused_epic_id?;
     let epic_is_open = data.epic_tasks.iter().any(|epic| {
@@ -165,29 +338,58 @@ pub(crate) fn supervisor_actionable_state(
         return None;
     }
 
-    let mut mergeable = data
-        .in_progress_tasks
-        .iter()
-        .filter(|task| {
-            task.epic.as_deref() == Some(epic_id) && task.status == TaskStatus::AwaitingMerge
-        })
-        .filter_map(|task| {
-            let assignee = task.assignee.as_deref()?;
-            let worker = data
-                .agent_id_to_name
-                .get(assignee)
-                .map(String::as_str)
-                .unwrap_or(assignee);
-            let branch = format!("factory/{worker}");
-            let tip = resolve_branch_tip(&branch).unwrap_or_else(|| "tip-unresolved".to_string());
-            Some((task.id.clone(), branch, tip))
-        })
-        .collect::<Vec<_>>();
+    let mut mergeable = Vec::new();
+    let mut merged_close_blocked = Vec::new();
+    for task in data.in_progress_tasks.iter().filter(|task| {
+        task.epic.as_deref() == Some(epic_id) && task.status == TaskStatus::AwaitingMerge
+    }) {
+        let Some(assignee) = task.assignee.as_deref() else {
+            continue;
+        };
+        let worker = data
+            .agent_id_to_name
+            .get(assignee)
+            .map(String::as_str)
+            .unwrap_or(assignee);
+        let branch = format!("factory/{worker}");
+        let tip = resolve_branch_tip(&branch);
+        if let Some(target) = merge_target_for_task(data, task)
+            && let Some(merged) = classify_merged_close_blocked(
+                task,
+                &branch,
+                &target,
+                tip.as_deref(),
+            )
+        {
+            merged_close_blocked.push(merged);
+            continue;
+        }
+        mergeable.push((
+            task.id.clone(),
+            branch,
+            tip.unwrap_or_else(|| "tip-unresolved".to_string()),
+        ));
+    }
     mergeable.sort_by(|left, right| left.0.cmp(&right.0));
-    if !mergeable.is_empty() {
-        return Some(SupervisorActionableState::MergeBranches {
-            branches: mergeable,
-        });
+    merged_close_blocked.sort_by(|left, right| left.task_id.cmp(&right.task_id));
+    match (mergeable.is_empty(), merged_close_blocked.is_empty()) {
+        (false, false) => {
+            return Some(SupervisorActionableState::MergeQueue {
+                branches: mergeable,
+                merged_close_blocked,
+            });
+        }
+        (true, false) => {
+            return Some(SupervisorActionableState::MergeCloseBlocked {
+                tasks: merged_close_blocked,
+            });
+        }
+        (false, true) => {
+            return Some(SupervisorActionableState::MergeBranches {
+                branches: mergeable,
+            });
+        }
+        (true, true) => {}
     }
 
     let active_children = data

--- a/cas-cli/src/ui/factory/director/mod.rs
+++ b/cas-cli/src/ui/factory/director/mod.rs
@@ -21,14 +21,17 @@ pub(crate) mod tasks;
 
 pub use data::{AgentSummary, DirectorData, DirectorStores, TaskSummary};
 pub(crate) use events::pick_best_open_branch_epic;
-pub use events::{DirectorEvent, DirectorEventDetector, SupervisorStallTracker};
+pub use events::{
+    DirectorEvent, DirectorEventDetector, SupervisorActionableState, SupervisorStallTracker,
+};
 // cas-893c: shared idle-confidence gate, reused by the daemon's delivery-time
 // idle-nudge decision (queue_and_events.rs) so the "is this worker really
 // idle, not just between turns" heuristic has one definition.
 pub(crate) use events::{
-    effective_stall_threshold_secs, supervisor_actionable_state, FRESH_HEARTBEAT_SECS,
-    RECENT_ACTIVITY_SECS,
+    effective_stall_threshold_secs, supervisor_actionable_state_with_merge_classifier,
+    FRESH_HEARTBEAT_SECS, RECENT_ACTIVITY_SECS,
 };
+pub(crate) use events::MergedCloseBlockedTask;
 pub use panel::PanelRegistry;
 pub use prompts::{
     check_merge_alert_freshness, check_merge_alert_freshness_for_task, compute_gated_task_ids,

--- a/cas-cli/src/ui/factory/director/supervisor_stall_tests.rs
+++ b/cas-cli/src/ui/factory/director/supervisor_stall_tests.rs
@@ -1,6 +1,7 @@
 use super::data::{AgentSummary, DirectorData, TaskSummary};
 use super::events::{
-    SupervisorActionableState, SupervisorStallTracker, supervisor_actionable_state,
+    MergedCloseBlockedTask, SupervisorActionableState, SupervisorStallTracker,
+    supervisor_actionable_state, supervisor_actionable_state_with_merge_classifier,
 };
 use cas_types::{AgentStatus, Priority, TaskStatus, TaskType};
 use chrono::{Duration, TimeZone, Utc};
@@ -104,6 +105,52 @@ fn awaiting_merge_names_task_branch_and_live_tip() {
             )],
         })
     );
+}
+
+#[test]
+fn merged_delivery_is_classified_as_close_blocked_with_rejection_and_reclose() {
+    let now = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+    let mut snapshot = data();
+    snapshot.in_progress_tasks.push(task(
+        "cas-merged",
+        TaskStatus::AwaitingMerge,
+        Some("gold-fox"),
+        Some("cas-epic"),
+    ));
+
+    let state = supervisor_actionable_state_with_merge_classifier(
+        &snapshot,
+        Some("cas-epic"),
+        "supervisor",
+        &HashSet::new(),
+        now,
+        600,
+        |branch| (branch == "factory/gold-fox").then(|| "factory-tip".to_string()),
+        |task, factory_branch, target_branch, factory_tip| {
+            assert_eq!(task.id, "cas-merged");
+            assert_eq!(factory_branch, "factory/gold-fox");
+            assert_eq!(target_branch, "epic/cas-epic");
+            assert_eq!(factory_tip, Some("factory-tip"));
+            Some(MergedCloseBlockedTask {
+                task_id: task.id.clone(),
+                factory_branch: factory_branch.to_string(),
+                anchor: "anchor-sha".to_string(),
+                target_branch: target_branch.to_string(),
+                target_tip: "target-tip".to_string(),
+                close_rejection: "ZERO-COMMIT after merged delivery".to_string(),
+            })
+        },
+    );
+
+    let Some(SupervisorActionableState::MergeCloseBlocked { tasks }) = state else {
+        panic!("merged delivery must be classified separately: {state:?}");
+    };
+    assert_eq!(tasks.len(), 1);
+    let rendered = SupervisorActionableState::MergeCloseBlocked { tasks }.next_step_text();
+    assert!(rendered.contains("already merged"));
+    assert!(rendered.contains("ZERO-COMMIT after merged delivery"));
+    assert!(rendered.contains("task action=close id=cas-merged"));
+    assert!(!rendered.contains("merge the ready delivery branch(es)"));
 }
 
 #[test]
@@ -248,4 +295,57 @@ fn stall_gate_fires_once_per_ten_minutes_and_accumulates_actionable_idle_time() 
         600,
     );
     assert_eq!(cleared.actionable_idle_secs, 720);
+}
+
+#[test]
+fn merged_close_blocked_stall_wakes_for_changed_delivery_without_refiring_same_state() {
+    let start = Utc.with_ymd_and_hms(2026, 9, 5, 12, 0, 0).unwrap();
+    let merged = |target_tip: &str| SupervisorActionableState::MergeCloseBlocked {
+        tasks: vec![MergedCloseBlockedTask {
+            task_id: "cas-merged".into(),
+            factory_branch: "factory/gold-fox".into(),
+            anchor: "anchor-sha".into(),
+            target_branch: "epic/cas-epic".into(),
+            target_tip: target_tip.into(),
+            close_rejection: "already merged".into(),
+        }],
+    };
+    let mut tracker = SupervisorStallTracker::default();
+
+    assert!(
+        tracker
+            .observe(
+                Some(merged("target-a")),
+                Some(start - Duration::seconds(600)),
+                false,
+                start,
+                600,
+            )
+            .wake
+            .is_some()
+    );
+    assert!(
+        tracker
+            .observe(
+                Some(merged("target-a")),
+                Some(start - Duration::seconds(1_200)),
+                false,
+                start + Duration::seconds(600),
+                600,
+            )
+            .wake
+            .is_none()
+    );
+    assert!(
+        tracker
+            .observe(
+                Some(merged("target-b")),
+                Some(start - Duration::seconds(1_201)),
+                false,
+                start + Duration::seconds(601),
+                600,
+            )
+            .wake
+            .is_some()
+    );
 }

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.25.2"
+version = "3.25.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.25.2"
+version = "3.25.3"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.25.2"
+version = "3.25.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.25.2"
+version = "3.25.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.25.2"
+version = "3.25.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/release-notes/2026-09-11-v3.25.3-slack.md
+++ b/docs/release-notes/2026-09-11-v3.25.3-slack.md
@@ -1,0 +1,53 @@
+# Slack draft — Cassy v3.25.3 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2)
+
+**Status:** Draft. Do not post until the tagged workflow publishes both
+archives, the published receipt replaces both checksum placeholders, and the
+release report receipt is complete.
+
+## User thread
+
+**Top-level:**
+
+```text
+*Live on production — User — Cassy v3.25.3*
+Was: small changes were failing their quick check for a missing tool, and finished work kept getting flagged as unmerged. Now: the quick check runs everywhere and finished work is reported once, correctly.
+```
+
+**Reply (Was → Now):**
+
+```text
+*Checks and notices*
+
+• *Quick check works everywhere* — Was: the fast validation for small changes failed on every push because the build machine lacked a search tool. Now: it uses what the machine has and passes on clean changes.
+
+• *One notice, not thirteen* — Was: a finished change that was already merged kept being reported as "not merged" every few minutes. Now: it is reported once, with the actual reason it cannot close yet.
+
+Install: use `cas update` after publication, or download the v3.25.3 Linux x86_64 archive (SHA-256 `{{LINUX_SHA256}}`) or macOS ARM64 archive (SHA-256 `{{MACOS_SHA256}}`) from the GitHub release.
+```
+
+## Dev thread
+
+**Top-level:**
+
+```text
+*Live on production — Dev — Cassy v3.25.3*
+Was: check-scoped-test-surface.sh required rg and the director re-relayed merged-but-close-blocked deliveries every stall tick. Now: a git-grep fallback and a merged_close_blocked classification with dedupe.
+```
+
+**Reply (Was → Now):**
+
+```text
+*CI*
+
+• *Fast tier without ripgrep (#836)* — Was: `Scoped Validation (fast)` exited 2 with `rg exit 127` on GitHub-hosted runners, so every small factory push went red. Now: the proof-surface script resolves one grep backend (rg if present, else `git grep -n` over tracked files) with a self-test that masks rg; the release gate's rg-free archive mode still passes.
+
+*Factory*
+
+• *Merged, close blocked (#835)* — Was: `events.rs` rendered every AwaitingMerge child as a merge demand and the stall tracker refired unchanged state every 10 minutes. Now: when the parked anchor is an ancestor of the live target tip the task is classified `merged_close_blocked`; the relay carries the last close-rejection note and close guidance, is keyed by task/anchor/target tip, and repeats only when that key changes.
+
+Validation: `cargo metadata --locked`, the full release gate, published asset receipt, and release report receipt are required before posting.
+
+Install: `cas-x86_64-unknown-linux-gnu.tar.gz` (SHA-256 `{{LINUX_SHA256}}`) and `cas-aarch64-apple-darwin.tar.gz` (SHA-256 `{{MACOS_SHA256}}`) will be published by CI.
+```

--- a/scripts/check-scoped-test-surface.sh
+++ b/scripts/check-scoped-test-surface.sh
@@ -42,6 +42,52 @@ repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
 }
 cd "$repo_root"
 
+# GitHub-hosted runners do not guarantee ripgrep. Resolve the search backend
+# once, then keep every test-surface search on either rg or tracked git files.
+if command -v rg >/dev/null 2>&1; then
+    grep_backend=rg
+else
+    grep_backend=git
+fi
+tracked_rust_test_paths=('cas-cli/tests/*.rs' 'cas-cli/tests/**/*.rs')
+
+run_test_path_search() {
+    local mode="$1"
+    shift
+    case "${grep_backend}:${mode}" in
+        rg:regex)
+            rg -l --glob '*.rs' "$@" -- cas-cli/tests
+            ;;
+        rg:fixed)
+            rg -l -F --glob '*.rs' -- "$1" cas-cli/tests
+            ;;
+        git:regex)
+            git grep -n -E "$@" -- "${tracked_rust_test_paths[@]}"
+            ;;
+        git:fixed)
+            git grep -n -F -e "$1" -- "${tracked_rust_test_paths[@]}"
+            ;;
+        *)
+            return 2
+            ;;
+    esac
+}
+
+search_test_paths() {
+    local mode="$1" matches search_status
+    shift
+    if matches="$(run_test_path_search "$mode" "$@")"; then
+        [[ -n "$matches" ]] || return 0
+        if [[ "$grep_backend" == git ]]; then
+            matches="$(sed -E 's/:[0-9]+:.*$//' <<<"$matches")"
+        fi
+        printf '%s\n' "$matches" | sort -u
+    else
+        search_status=$?
+        return "$search_status"
+    fi
+}
+
 if [[ -z "$base_ref" ]]; then
     if git rev-parse --verify --quiet origin/main >/dev/null; then
         base_ref="origin/main"
@@ -186,7 +232,7 @@ source_public_symbols_for() {
 
 discover_source_integration_targets() {
     local source_path="$1" source_file module_path test_path symbol symbol_filter
-    local matched_paths rg_status
+    local matched_paths search_status
     local -a symbol_patterns=()
     source_file="$repo_root/$source_path"
     [[ -f "$source_file" ]] || return 0
@@ -209,17 +255,17 @@ discover_source_integration_targets() {
     # reference (not as arbitrary target-name text). Search the test tree once
     # for each evidence class; per-symbol/per-file subprocesses made a large
     # close diff needlessly expensive.
-    if matched_paths="$(rg -l --glob '*.rs' \
+    if matched_paths="$(search_test_paths regex \
         -e "^[[:space:]]*(pub[[:space:]]+)?use[[:space:]].*${module_path}([[:space:];:{]|$)" \
         -e "^[[:space:]]*[^/].*${module_path}" \
         -e "^[[:space:]]*[^/].*(include_str!|include_bytes!|Path|read_to_string).*${source_path}" \
-        -- cas-cli/tests 2>/dev/null)"; then
+        2>/dev/null)"; then
         :
     else
-        rg_status=$?
-        if [[ "$rg_status" -ne 1 ]]; then
-            printf 'SCOPED PROOF SURFACE: source path discovery failed for %s (rg exit %s).\n' \
-                "$source_path" "$rg_status" >&2
+        search_status=$?
+        if [[ "$search_status" -ne 1 ]]; then
+            printf 'SCOPED PROOF SURFACE: source path discovery failed for %s (%s exit %s).\n' \
+                "$source_path" "$grep_backend" "$search_status" >&2
             exit 2
         fi
         matched_paths=''
@@ -234,13 +280,13 @@ discover_source_integration_targets() {
     # -> `test_worker_status_*`). Match only test declarations, so comments
     # and fixture strings cannot claim a target.
     if [[ ${#symbol_patterns[@]} -gt 0 ]]; then
-        if matched_paths="$(rg -l --glob '*.rs' "${symbol_patterns[@]}" -- cas-cli/tests 2>/dev/null)"; then
+        if matched_paths="$(search_test_paths regex "${symbol_patterns[@]}" 2>/dev/null)"; then
             :
         else
-            rg_status=$?
-            if [[ "$rg_status" -ne 1 ]]; then
-                printf 'SCOPED PROOF SURFACE: source symbol discovery failed for %s (rg exit %s).\n' \
-                    "$source_path" "$rg_status" >&2
+            search_status=$?
+            if [[ "$search_status" -ne 1 ]]; then
+                printf 'SCOPED PROOF SURFACE: source symbol discovery failed for %s (%s exit %s).\n' \
+                    "$source_path" "$grep_backend" "$search_status" >&2
                 exit 2
             fi
             matched_paths=''
@@ -277,16 +323,16 @@ builtin_relative_path_for() {
 }
 
 discover_builtin_test_targets() {
-    local literal="$1" test_paths test_path target rg_status
-    if test_paths="$(rg -l -F --glob '*.rs' -- "$literal" cas-cli/tests)"; then
+    local literal="$1" test_paths test_path target search_status
+    if test_paths="$(search_test_paths fixed "$literal" 2>/dev/null)"; then
         :
     else
-        rg_status=$?
-        if [[ "$rg_status" -eq 1 ]]; then
+        search_status=$?
+        if [[ "$search_status" -eq 1 ]]; then
             test_paths=''
         else
-            printf 'SCOPED PROOF SURFACE: builtin path discovery failed for %s (rg exit %s).\n' \
-                "$literal" "$rg_status" >&2
+            printf 'SCOPED PROOF SURFACE: builtin path discovery failed for %s (%s exit %s).\n' \
+                "$literal" "$grep_backend" "$search_status" >&2
             exit 2
         fi
     fi

--- a/scripts/test-check-scoped-test-surface.sh
+++ b/scripts/test-check-scoped-test-surface.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Self-test for check-scoped-test-surface.sh, including its no-rg fallback.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+checker="$script_dir/check-scoped-test-surface.sh"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+repo="$tmpdir/repo"
+mkdir -p \
+    "$repo/cas-cli/src/builtins/skills/demo" \
+    "$repo/cas-cli/tests" \
+    "$repo/scripts"
+cp "$checker" "$repo/scripts/check-scoped-test-surface.sh"
+chmod +x "$repo/scripts/check-scoped-test-surface.sh"
+
+printf '%s\n' 'pub fn factory_widget() {}' >"$repo/cas-cli/src/widget.rs"
+printf '%s\n' 'baseline skill' >"$repo/cas-cli/src/builtins/skills/demo/SKILL.md"
+printf '%s\n' \
+    'use widget::factory_widget;' \
+    'fn test_factory_widget() {}' \
+    'cas-cli/src/builtins/skills/demo/SKILL.md' \
+    'skills/demo/SKILL.md' >"$repo/cas-cli/tests/widget_test.rs"
+printf '%s\n' 'builtin flavor contract' >"$repo/cas-cli/tests/builtin_flavor_drift_test.rs"
+printf '%s\n' 'agent definition contract' >"$repo/cas-cli/tests/agent_definition_contract_test.rs"
+printf '%s\n' 'factory codex guardrail' >"$repo/cas-cli/tests/factory_codex_skill_guardrails.rs"
+printf '%s\n' \
+    'cas-cli/src/builtins/skills/demo/SKILL.md' \
+    'skills/demo/SKILL.md' >"$repo/cas-cli/tests/builtin_demo_test.rs"
+
+git -C "$repo" init -q -b main
+git -C "$repo" config user.email scoped-surface@example.test
+git -C "$repo" config user.name scoped-surface-test
+git -C "$repo" add .
+git -C "$repo" commit -qm baseline
+git -C "$repo" checkout -qb changed-surface
+printf '%s\n' '// changed source surface' >>"$repo/cas-cli/src/widget.rs"
+printf '%s\n' 'changed skill' >>"$repo/cas-cli/src/builtins/skills/demo/SKILL.md"
+git -C "$repo" add .
+git -C "$repo" commit -qm 'change scoped surfaces'
+
+with_rg_output="$(
+    cd "$repo"
+    bash ./scripts/check-scoped-test-surface.sh --resolve-targets --base main --
+)"
+
+# Build an isolated PATH containing every command used by the checker except
+# rg. This masks both /usr/bin/rg and /bin/rg on hosts that ship either one.
+no_rg_bin="$tmpdir/no-rg-bin"
+mkdir -p "$no_rg_bin"
+for command in bash git sed basename sort grep; do
+    ln -s "$(command -v "$command")" "$no_rg_bin/$command"
+done
+without_rg_output="$(
+    cd "$repo"
+    PATH="$no_rg_bin" bash ./scripts/check-scoped-test-surface.sh \
+        --resolve-targets --base main --
+)"
+
+[[ "$without_rg_output" == "$with_rg_output" ]]
+for expected in \
+    '--lib widget' \
+    '--test widget_test' \
+    '--test builtin_demo_test' \
+    '--test builtin_flavor_drift_test' \
+    '--test agent_definition_contract_test' \
+    '--test factory_codex_skill_guardrails'; do
+    grep -qF -- "$expected" <<<"$without_rg_output"
+done
+
+printf 'ok   no-rg backend preserves scoped target mapping\n'
+printf 'PASS: scoped test surface backend verified.\n'

--- a/scripts/test-ci-test-tiers.sh
+++ b/scripts/test-ci-test-tiers.sh
@@ -16,6 +16,8 @@ real_store_guard="$repo_root/scripts/check-real-store-untouched.sh"
 migration_guard="$repo_root/scripts/check-release-migration-snapshots.sh"
 snapshot_router="$repo_root/scripts/check-scoped-snapshot-tests.sh"
 snapshot_router_test="$repo_root/scripts/test-check-scoped-snapshot-tests.sh"
+scoped_surface="$repo_root/scripts/check-scoped-test-surface.sh"
+scoped_surface_test="$repo_root/scripts/test-check-scoped-test-surface.sh"
 watchdog="$repo_root/.github/workflows/merge-queue-watchdog.yml"
 watchdog_script="$repo_root/scripts/cancel-stale-merge-group-runs.sh"
 runner_unit="$repo_root/ops/systemd/cassy-actions-runner.service"
@@ -503,6 +505,23 @@ else
 fi
 require_text "$(<"$makefile")" 'test-check-scoped-snapshot-tests.sh' \
     'test-ci-tiers runs the snapshot router self-test'
+
+if [[ -x "$scoped_surface" ]]; then
+    printf 'ok   scoped test surface checker is executable\n'
+    pass=$((pass + 1))
+else
+    printf 'FAIL scoped test surface checker must be executable\n'
+    fail=$((fail + 1))
+fi
+if [[ -x "$scoped_surface_test" ]]; then
+    printf 'ok   scoped test surface checker has an executable self-test\n'
+    pass=$((pass + 1))
+else
+    printf 'FAIL scoped test surface checker has no executable self-test\n'
+    fail=$((fail + 1))
+fi
+require_text "$(<"$makefile")" 'test-check-scoped-test-surface.sh' \
+    'test-ci-tiers runs the scoped test surface self-test'
 
 # Removing the factory push trigger in the name of dedupe would leave the
 # supervisor's `git merge --no-ff` integration path — which never opens a pull


### PR DESCRIPTION
## Cassy v3.25.3

Post-3.25.2 fixes (epic cas-d5bd) on top of main 9f671db6:

- `Scoped Validation (fast)` CI tier works without ripgrep: the proof-surface script falls back to `git grep` (#836).
- Director stalled-supervisor relay classifies merged-but-close-blocked deliveries, posts the close rejection once, and stops repeating the merge demand (#835).

Fixes #835
Fixes #836

Gate: `RELEASE GATE PASSED` on fd25cd55 (run dir `v3.25.3-release-train-assembly`, 20/20 rows). Assembly sweep 9338/9338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
