### PR TITLE
fix(close-gate): credit worker merge-resolution content (GH #840)

### DIFF
--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -19093,6 +19093,128 @@ mod merge_state_gate_tests {
         );
     }
 
+    /// GH #840: a worker's own conflict-resolution merge can intentionally
+    /// replace the hunks from an earlier task commit before the final worker
+    /// tip is merged. That merge resolution is task content, not a dropped
+    /// delivery, even though the original non-merge commit's exact patch no
+    /// longer applies to the target tree.
+    #[test]
+    fn worker_merge_resolution_supersedes_earlier_content_without_drop_gh_840() {
+        let dir = init_factory_repo("worker");
+        let p = dir.path();
+
+        std::fs::write(
+            p.join("conversation-history.ts"),
+            "export type MessageReceipt = { id: string };\n",
+        )
+        .unwrap();
+        git(p, &["add", "conversation-history.ts"]);
+        git(
+            p,
+            &[
+                "commit",
+                "-q",
+                "-m",
+                "feat(cas-test1): add conversation history",
+            ],
+        );
+
+        // The integration target independently adds the same path, forcing
+        // the worker's target-sync merge to carry an explicit resolution.
+        git(p, &["checkout", "-q", "main"]);
+        std::fs::write(
+            p.join("conversation-history.ts"),
+            "export type MessageReceipt = { source: string };\n",
+        )
+        .unwrap();
+        git(p, &["add", "conversation-history.ts"]);
+        git(
+            p,
+            &["commit", "-q", "-m", "feat: advance integration history"],
+        );
+        git(p, &["checkout", "-q", "factory/worker"]);
+        let merge = git_command(
+            p,
+            &[
+                "merge",
+                "--no-ff",
+                "main",
+                "-m",
+                "Merge branch 'main' into factory/worker",
+            ],
+        )
+        .status()
+        .expect("start worker target-sync merge");
+        assert!(!merge.success(), "fixture must produce a merge conflict");
+        std::fs::write(
+            p.join("conversation-history.ts"),
+            "export type MessageQueued = { id: string };\n",
+        )
+        .unwrap();
+        git(p, &["add", "conversation-history.ts"]);
+        git(
+            p,
+            &[
+                "commit",
+                "-q",
+                "-m",
+                "Merge branch 'main' into factory/worker",
+            ],
+        );
+
+        // Keep a later ordinary task commit in the same worker branch, then
+        // merge another target-only change to make the recorded anchor a
+        // merge tip, matching the delivery shape from GH #840.
+        std::fs::write(p.join("follow-up.rs"), "pub fn follow_up() {}\n").unwrap();
+        git(p, &["add", "follow-up.rs"]);
+        git(
+            p,
+            &["commit", "-q", "-m", "fix(cas-test1): add follow-up"],
+        );
+        git(p, &["checkout", "-q", "main"]);
+        std::fs::write(p.join("target-only.rs"), "// target-only\n").unwrap();
+        git(p, &["add", "target-only.rs"]);
+        git(p, &["commit", "-q", "-m", "chore: advance target again"]);
+        git(p, &["checkout", "-q", "factory/worker"]);
+        git(
+            p,
+            &[
+                "merge",
+                "-q",
+                "--no-ff",
+                "main",
+                "-m",
+                "Merge branch 'main' into factory/worker",
+            ],
+        );
+        let worker_tip = rev_parse_local(p, "HEAD");
+
+        git(p, &["checkout", "-q", "main"]);
+        git(
+            p,
+            &[
+                "merge",
+                "-q",
+                "--no-ff",
+                "factory/worker",
+                "-m",
+                "merge worker delivery",
+            ],
+        );
+
+        let mut task = worker_task("worker");
+        task.status = TaskStatus::AwaitingMerge;
+        task.deliverables.factory_branch_anchor = Some(worker_tip);
+        let req = base_req(&task.id);
+        assert!(
+            matches!(
+                run_factory_branch_merge_gate(&task, &req, "main", p),
+                MergeStateGateOutcome::Proceed
+            ),
+            "a worker-owned merge resolution must count as delivered task content"
+        );
+    }
+
     /// A target-sync merge with no task-attributed content must remain
     /// fail-closed; the presence of a merge commit alone is not delivery.
     #[test]

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops.rs
@@ -19171,6 +19171,7 @@ mod merge_state_gate_tests {
             p,
             &["commit", "-q", "-m", "fix(cas-test1): add follow-up"],
         );
+        let later_content = rev_parse_local(p, "HEAD");
         git(p, &["checkout", "-q", "main"]);
         std::fs::write(p.join("target-only.rs"), "// target-only\n").unwrap();
         git(p, &["add", "target-only.rs"]);
@@ -19213,6 +19214,25 @@ mod merge_state_gate_tests {
             ),
             "a worker-owned merge resolution must count as delivered task content"
         );
+
+        // A validated receipt may name that later content commit directly;
+        // the merge-tip proof must honor it as the delivery boundary too.
+        let receipt_window = window_at(0, "GH #840 receipt regression");
+        let mut receipt_req = base_req(&task.id);
+        receipt_req.commit_receipt = Some(later_content.clone());
+        assert!(matches!(
+            run_factory_branch_merge_gate_with_attribution(
+                &task,
+                &receipt_req,
+                "main",
+                p,
+                TaskCommitAttribution {
+                    receipt: Some(&later_content),
+                    window: Some(&receipt_window),
+                },
+            ),
+            MergeStateGateOutcome::Proceed
+        ));
     }
 
     /// A target-sync merge with no task-attributed content must remain

--- a/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops/task_attribution.rs
+++ b/cas-cli/src/mcp/tools/core/task/lifecycle/close_ops/task_attribution.rs
@@ -1,6 +1,7 @@
 //! Shared task delivery attribution for close gates and their receipt display.
 use super::*;
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
 
@@ -337,6 +338,11 @@ pub(super) fn merge_tip_content_presence(
         return None;
     }
 
+    // GH #840: a worker-owned merge can replace an earlier task hunk before
+    // the final merge tip is integrated. When the tip and target agree on a
+    // delivered path, preserve that final tree effect instead of requiring
+    // the original non-merge patch to remain byte-for-byte applicable.
+    let merge_tip_paths = merge_tip_tree_effect_paths(repo, &target, merge_tip, &commits)?;
     let mut present_paths = Vec::new();
     let mut superseded_paths = Vec::new();
     let mut superseding_commits = Vec::new();
@@ -352,7 +358,13 @@ pub(super) fn merge_tip_content_presence(
                 append_unique(&mut superseding_commits, commits);
             }
             DeliveryContentPresence::Dropped { paths } => {
-                append_unique(&mut dropped_paths, paths);
+                append_unique(
+                    &mut dropped_paths,
+                    paths
+                        .into_iter()
+                        .filter(|path| !merge_tip_paths.contains(path))
+                        .collect(),
+                );
             }
             DeliveryContentPresence::Unknown { reason } => {
                 unknown_reason.get_or_insert(reason);
@@ -388,6 +400,64 @@ fn append_unique(values: &mut Vec<String>, additions: Vec<String>) {
         if !values.contains(&value) {
             values.push(value);
         }
+    }
+}
+
+/// Paths whose final merge-tip tree effect is the task delivery, even when an
+/// earlier non-merge task commit's exact patch no longer applies.
+///
+/// A worker can resolve a target-sync merge on top of an earlier task commit,
+/// replacing its hunk while retaining the intended path. The old attribution
+/// check only inspected each non-merge commit against the target and therefore
+/// reported that earlier hunk as dropped. Compare the merge tip to the
+/// authoritative target per delivered path, but require the merge tip to
+/// differ from at least one task commit's first parent. That last predicate
+/// preserves the genuinely-empty/reverted-delivery rejection.
+fn merge_tip_tree_effect_paths(
+    repo: &Path,
+    target: &str,
+    merge_tip: &str,
+    commits: &[String],
+) -> Option<HashSet<String>> {
+    let mut paths = HashSet::new();
+    for commit in commits {
+        let parent_ref = format!("{commit}^1");
+        let parent = git_text(repo, &["rev-parse", &parent_ref])?;
+        let changed = git_text(
+            repo,
+            &["diff", "--name-only", "--no-renames", &parent, commit, "--"],
+        )?;
+        for path in changed.lines().filter(|path| !path.is_empty()) {
+            let anchor_path = format!("{merge_tip}:{path}");
+            let anchor_exists = Command::new("git")
+                .args(["cat-file", "-e", &anchor_path])
+                .current_dir(repo)
+                .status()
+                .ok()?
+                .success();
+            if !anchor_exists {
+                continue;
+            }
+            let anchor_matches_target = git_diff_is_empty(repo, merge_tip, target, path)?;
+            let anchor_differs_from_parent = !git_diff_is_empty(repo, &parent, merge_tip, path)?;
+            if anchor_matches_target && anchor_differs_from_parent {
+                paths.insert(path.to_string());
+            }
+        }
+    }
+    Some(paths)
+}
+
+fn git_diff_is_empty(repo: &Path, left: &str, right: &str, path: &str) -> Option<bool> {
+    let status = Command::new("git")
+        .args(["diff", "--quiet", "--no-renames", left, right, "--", path])
+        .current_dir(repo)
+        .status()
+        .ok()?;
+    match status.code() {
+        Some(0) => Some(true),
+        Some(1) => Some(false),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
Close gate reported DELIVERY CONTENT DROPPED when a worker's own conflict-resolution merge superseded an earlier task commit's hunks. Per-path final-tree attribution now credits a delivered path when the merge tip matches the target and differs from the task commit's parent; empty and reverted deliveries still reject.

Fixes #840

Proof: scoped close_ops 336 passed; task_attribution 7 passed; GH #819 merge-tip 3/3 and GH #324 dropped-content 1/1 regressions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)