### PR TITLE
docs: record verified release and source announcements

### DIFF
--- a/docs/release-notes/2026-09-11-coordination-contracts-slack.md
+++ b/docs/release-notes/2026-09-11-coordination-contracts-slack.md
@@ -1,10 +1,10 @@
 # Coordination contracts — main-merge announcement draft
 
-Draft only. Publish after the reviewed PR lands on main. These four message bodies describe source on main; they make no installed-runtime or deployment claim.
+Posted source-merge announcement. The reviewed changes are on main and included in published Cassy v3.25.4. These four bodies remain a separate source announcement and make no installed-host claim.
 
 Channel: #cas-internal (`C0B44GUKDK2`). Order: User top-level → User reply → Dev top-level → Dev reply. Each reply belongs to the immediately preceding top-level message.
 
-Review basis: assembled branch at `8f7181e4`, compared with its incorporated main baseline. Recheck against the final merged diff, including the pending prompt correction, before publication. Scoped test receipts support the changes; assembled integration approval remains pending.
+Review basis: PR853 landed on main at `5640e6b4` from reviewed assembly `8f6d0b63`, including the final prompt correction. The assembled gate passed 9,392 workspace tests and 2 doctests. Published v3.25.4 source `875e353b` contains these changes.
 
 ## 1. User top-level
 
@@ -24,7 +24,7 @@ Was: recovery instructions could point to commands your coding tool couldn't run
 
 • *Clearer status boundaries* — Was: an empty report could look like there was no work anywhere. → Now: it names the current session and distinguishes entries in other sessions.
 
-Availability: these changes are in the source on main. Installed copies require a later runtime release containing them.
+Availability: these changes are on main and included in published Cassy v3.25.4. Older installations need updating to receive them.
 ```
 
 ## 3. Dev top-level
@@ -49,5 +49,16 @@ Was: recovery templates assumed a tool namespace. → Now: caller and registered
 
 • *Explicit status scope* — Was: full, summary and empty status responses left their session boundary implicit. → Now: they report the session and counts inside and outside it, partitioning by session before name deduplication. These are registered-entry counts, not process-liveness claims.
 
-Availability: source on main only. No runtime version or deployment is announced here.
+Availability: this source-on-main change set is included in published Cassy v3.25.4. This source announcement does not claim any host was updated.
 ```
+
+## POSTED
+
+- **Posted at (UTC):** `2026-09-11T18:14:57.905212+00:00`
+- **Channel:** `#cas-internal` (`C0B44GUKDK2`)
+- **User top-level:** `message_id=1789150465.818649` · `thread_id=1789150465.818649` · <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789150465818649>
+- **User reply:** `message_id=1789150483.335439` · `thread_id=1789150465.818649` · <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789150483335439?thread_ts=1789150465.818649&cid=C0B44GUKDK2>
+- **Dev top-level:** `message_id=1789150491.380109` · `thread_id=1789150491.380109` · <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789150491380109>
+- **Dev reply:** `message_id=1789150497.805649` · `thread_id=1789150491.380109` · <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789150497805649?thread_ts=1789150491.380109&cid=C0B44GUKDK2>
+
+Transport: authenticated MechaCassy hub/bot. Four source-announcement messages only; runtime/report publication has its separate receipts. Approved pre-publication draft SHA-256: `7d4b03de6749144270145db57fa5e253bca41bf488021bfaaf12c64cb631e185`. No host update is claimed.

--- a/docs/release-notes/2026-09-11-v3.25.4-slack.md
+++ b/docs/release-notes/2026-09-11-v3.25.4-slack.md
@@ -2,19 +2,17 @@
 
 Channel: #cas-internal (C0B44GUKDK2). Transport: MechaCassy hub/bot only.
 
-**Status: Runtime published; announcement unposted.** Version 3.25.4 was
+**Status: Runtime published; announcement and report posted.** Version 3.25.4 was
 published at 2026-09-11T17:07:51Z from commit
 `875e353b39da01a9576c0e3e35b555a5845c4f20`. Both published downloads passed
 SHA-256 verification. The source-bound Release and hosted install-proof
 workflows succeeded. Local host refresh remains held pending operator direction;
-no local update or report-upload integrity is claimed.
+the uploaded report was independently verified against the committed PDF bytes.
 
 Report sources and offline artifacts: [Markdown](../release-reports/v3.25.4.md),
 [concept brief](../release-reports/v3.25.4.brief.md),
 [standalone HTML](../release-reports/v3.25.4.html),
-[PDF](../release-reports/v3.25.4.pdf). Local report QA passed (four light/dark views, all 29 articles, seven-page A4 and Letter PDFs); these documentation
-artifacts still require the protected-main follow-up before their public links
-are used. Actual report uploads and Slack POSTED receipts remain unavailable.
+[PDF](../release-reports/v3.25.4.pdf). Local report QA passed (four light/dark views, all 29 articles, seven-page A4 and Letter PDFs); the standalone HTML is linked at its immutable protected-main commit, and the exact PDF upload has passed independent readback.
 
 ## User thread
 
@@ -129,19 +127,53 @@ Tag-workflow creation 17:04:26Z to published 17:07:51Z took 205 seconds; full-ga
 green 16:23:45Z to published took 2,646 seconds (44m 06s). These are different
 endpoints, neither measures local installation or Slack delivery.
 
-After report QA and the protected documentation follow-up, publish the User
-parent and its single reply, then the Dev parent and its single reply through
-MechaCassy only. Preserve each returned ID and permalink. With both parent IDs
-available, attach the exact PDF to the User thread and link the HTML from the
-Dev thread. Require independent PDF download, source-hash equality, decode,
-page count and thread binding, plus independent HTML link-destination
-verification. The report adapter's local-hash receipt alone does not establish
-uploaded-byte integrity (GH856 remains unfixed). Preserve partial receipts and
-never repost an uncertain write. Hosted install proof does not establish local
-host refresh or the manual consumer-Mac Gatekeeper GUI/SIP checks. No 3.25.4
-Slack POSTED or new report-upload receipt exists yet.
+The User parent and its single reply, then the Dev parent and its single reply,
+were published through MechaCassy only. The exact PDF is attached to the User
+thread and the immutable HTML is linked from the Dev thread. Independent PDF
+download, source-hash equality, decode, page count and thread binding passed,
+alongside independent HTML byte and link-destination verification. The report
+adapter's local-hash receipt alone does not establish uploaded-byte integrity
+(GH856 remains unfixed); the strict readback proof below does. Hosted install
+proof does not establish local host refresh or the manual consumer-Mac
+Gatekeeper GUI/SIP checks.
 
 The existing v3.25.3 draft contains its own four returned POSTED receipts; they
 remain evidence for that earlier release only. The separate
 `2026-09-11-coordination-contracts-slack.md` source-on-main draft is unposted and
-does not establish runtime publication.
+has separate POSTED receipts; those receipts do not establish runtime
+publication for this release.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`). UTC posting timestamps derived from the
+returned Slack message IDs: User top `2026-09-11T18:05:31.968049Z`, User reply
+`2026-09-11T18:05:52.045219Z`, Dev top `2026-09-11T18:06:03.490699Z`, Dev reply
+`2026-09-11T18:06:15.676939Z`, PDF upload `2026-09-11T18:11:13.143469Z`, and
+HTML-link reply `2026-09-11T18:12:26.550649Z`.
+
+The four runtime announcement messages were posted through the authenticated
+MechaCassy hub to `#cas-internal` in order on 2026-09-11:
+
+- User top-level — `1789149931.968049` — <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789149931968049>
+- User reply — `1789149952.045219` — <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789149952045219?thread_ts=1789149931.968049&cid=C0B44GUKDK2>
+- Dev top-level — `1789149963.490699` — <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789149963490699>
+- Dev reply — `1789149975.676939` — <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789149975676939?thread_ts=1789149963.490699&cid=C0B44GUKDK2>
+
+The four returned announcement receipts are preserved under
+`/home/pippenz/.cas/artifacts/cas-9061b/`, alongside the PDF upload and HTML-link
+receipts. The PDF upload returned file `F0C1BK16NAD`, message
+`1789150273.143469`, and permalink
+<https://petra-stella.slack.com/files/U0BUKC4FB60/F0C1BK16NAD/v3.25.4.pdf>;
+the HTML-link reply returned message `1789150346.550649` and permalink
+<https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789150346550649?thread_ts=1789149963.490699&cid=C0B44GUKDK2>.
+
+The strict readback verifier passed with `F0C1BK16NAD` bound to User parent
+`1789149931.968049`: 130752 bytes, SHA-256
+`82f5b381c0d902b07b1747d2f5ff731bf270c7e7e1c59ae0bd5dcb37508170f7`, and seven
+decoded PDF pages. The immutable HTML URL binds commit
+`d6d760f51edc87f033f1dd8544075db49186dcdf`; fetched bytes match SHA-256
+`b1e89dbb9da14ff11761cfb65f2838a114d1d807e609b7784f0b0ccf203e9d52`, and all
+32 href destinations are unchanged. Canonical report receipt and proof logs
+are under
+`/home/pippenz/.cas/artifacts/release/v3.25.4-release-3.25.4-prepare/` and
+`/home/pippenz/.cas/artifacts/cas-9061b/`.

--- a/docs/release-notes/2026-09-11-v3.25.4-slack.md
+++ b/docs/release-notes/2026-09-11-v3.25.4-slack.md
@@ -139,7 +139,7 @@ Gatekeeper GUI/SIP checks.
 
 The existing v3.25.3 draft contains its own four returned POSTED receipts; they
 remain evidence for that earlier release only. The separate
-`2026-09-11-coordination-contracts-slack.md` source-on-main draft is unposted and
+`2026-09-11-coordination-contracts-slack.md` source-on-main draft
 has separate POSTED receipts; those receipts do not establish runtime
 publication for this release.
 


### PR DESCRIPTION
## Summary

Record actual MechaCassy-only publication receipts in two existing announcement drafts. Runtime and source-change announcements are posted, with all reply bindings and ordered writes verified. The PDF attachment and immutable HTML link have independent remote integrity evidence.

## Evidence

- Source receipt delivery adac8d9e: exact fast CI34632366102/job103372019035 passed.
- Runtime receipt delivery fbcc274d: exact fast CI34633061634/job103374321962 passed; corrected obsolete unposted wording and explicit UTC/channel identity.
- Eight announcement messages plus PDF upload and HTML-link reply returned genuine ok:true receipts. Drafts preserve approved fenced bodies and returned IDs/permalinks.
- New uploaded PDF F0C1BK16NAD:130752 bytes, seven decoded pages, correct User parent, SHA25682f5b381c0d902b07b1747d2f5ff731bf270c7e7e1c59ae0bd5dcb37508170f7 identical to source.
- Fetched immutable HTML at d6d760f5:38866 bytes,32href destinations unchanged, SHA256b1e89dbb9da14ff11761cfb65f2838a114d1d807e609b7784f0b0ccf203e9d52 identical to committed source.
- Clean two-Markdown-file diff; no report bytes, runtime, version, ledger, tag or release asset changes. Required protected checks/queue apply; no bypass.

## Boundaries

This records completed announcements; it does not publish new messages or a new runtime. Local host update remains held. The upload helper argument-limit bug is tracked separately in Richards-LLC/mecha-cassy#11; successful direct hub upload is not a helper-fix claim. Original local failure stderr/exit retained; intermediate checker-log overwrite limitation is recorded in task evidence.