### PR TITLE
Release 3.25.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [3.25.5] - 2026-09-11
+
+### Fixed
+
+- Commander pairing on macOS no longer fails after `cas update` when the Tailscale app is installed without a PATH CLI. The hub resolves the app-bundle CLI at `/Applications/Tailscale.app/Contents/MacOS/Tailscale` (or `~/Applications`), invokes it by its real path, and records the resolved path.
+- `cas update` keeps a previously published hub public URL: a failed Tailscale Serve republication is reported as a hub transport error in the update banner and JSON receipt while the project refresh still completes, instead of a silent loopback fallback or an aborted update.
+- `cas hub authorize` names the actual transport cause (which Tailscale CLI locations were checked) and prescribes `cas hub restart --tailscale-serve`; the previous `service uninstall` advice is gone from authorize, readiness and status remedies.
+- `cas doctor` and `cas hub status` warn when the hub is loopback-only while Tailscale is signed in on the host.
+
 ## [3.25.4] - 2026-09-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cas"
-version = "3.25.4"
+version = "3.25.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cas-core"
-version = "3.25.4"
+version = "3.25.5"
 dependencies = [
  "cas-store",
  "cas-types",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "cas-mcp"
-version = "3.25.4"
+version = "3.25.5"
 dependencies = [
  "cas-core",
  "cas-store",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "cas-search"
-version = "3.25.4"
+version = "3.25.5"
 dependencies = [
  "anyhow",
  "cas-code",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "cas-store"
-version = "3.25.4"
+version = "3.25.5"
 dependencies = [
  "anyhow",
  "blake3",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "cas-types"
-version = "3.25.4"
+version = "3.25.5"
 dependencies = [
  "chrono",
  "glob",

--- a/cas-cli/Cargo.toml
+++ b/cas-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas"
-version = "3.25.4"
+version = "3.25.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Coding Agent System - unified tasks, memory, rules, and skills for AI agents"

--- a/cas-cli/src/cli/doctor.rs
+++ b/cas-cli/src/cli/doctor.rs
@@ -735,6 +735,8 @@ fn host_hub_transport_check() -> Check {
         name,
         if report.is_failure() {
             CheckStatus::Error
+        } else if report.is_signed_in_loopback_warning() {
+            CheckStatus::Warning
         } else {
             CheckStatus::Ok
         },

--- a/cas-cli/src/cli/hub.rs
+++ b/cas-cli/src/cli/hub.rs
@@ -313,7 +313,7 @@ impl HubTransportReport {
             ),
             None,
             None,
-            "Run `cas hub service uninstall && cas hub start --tailscale-serve` from an interactive shell to publish the pairing route.".to_owned(),
+            "Run `cas hub restart --tailscale-serve` to republish the pairing route without removing hub supervision.".to_owned(),
         )
     }
 
@@ -326,12 +326,26 @@ impl HubTransportReport {
             .starts_with("hub is supervised but not publishable")
     }
 
+    pub(crate) fn is_signed_in_loopback_warning(&self) -> bool {
+        self.message
+            .starts_with("hub is loopback-only while Tailscale is signed in")
+            || self
+                .message
+                .starts_with("hub is loopback-only; Tailscale is signed in")
+    }
+
     pub(crate) fn message_with_remedy(&self) -> String {
         match &self.remedy {
             Some(remedy) => format!("{}; {remedy}", self.message),
             None => self.message.clone(),
         }
     }
+}
+
+fn update_transport_error(warning: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "cas update: Tailscale Serve publication failed: {warning}; hub remains loopback-only; run `cas hub restart --tailscale-serve`"
+    )
 }
 
 fn default_hub_command() -> HubCommands {
@@ -1082,11 +1096,18 @@ fn start_with_output_resolved(
                         .map(str::to_owned)
                         .unwrap_or_else(|| format!("http://{}:{}", record.bind, record.port));
                     println!("Cassy hub started at {endpoint} (pid {})", record.pid);
-                    if let Some(warning) = &record.transport_warning {
+                    if launch_origin != HubLaunchOrigin::Update
+                        && let Some(warning) = &record.transport_warning
+                    {
                         eprintln!(
                             "Tailscale Serve unavailable: {warning}; local hub remains healthy"
                         );
                     }
+                }
+                if launch_origin == HubLaunchOrigin::Update
+                    && let Some(warning) = record.transport_warning.as_deref()
+                {
+                    return Err(update_transport_error(warning));
                 }
                 return Ok(());
             }
@@ -1675,6 +1696,10 @@ fn status(cli: &Cli) -> Result<()> {
 
 fn render_transport_status(report: &HubTransportReport) -> String {
     if !report.is_failure() {
+        if report.is_signed_in_loopback_warning() {
+            return "Tailscale Serve: WARN - Tailscale is signed in; hub remains loopback-only"
+                .to_owned();
+        }
         if report
             .message
             .starts_with("hub is loopback-only; Tailscale Serve publication")
@@ -1862,7 +1887,7 @@ pub(crate) fn restart_stale_hub(binary_version: &str, cli: &Cli) -> Result<bool>
     };
     // A stale-version restart is a relaunch: if a concurrent command already
     // produced a hub on the new binary, that is the outcome this wanted.
-    if let StopOutcome::AlreadySatisfied(_) = stop_with_output(
+    if let StopOutcome::AlreadySatisfied(record) = stop_with_output(
         cli,
         !cli.json,
         Some(RelaunchIntent {
@@ -1872,6 +1897,11 @@ pub(crate) fn restart_stale_hub(binary_version: &str, cli: &Cli) -> Result<bool>
         }),
         false,
     )? {
+        if spec.tailscale_serve
+            && let Some(warning) = record.transport_warning.as_deref()
+        {
+            return Err(update_transport_error(warning));
+        }
         return Ok(true);
     }
     start_with_output_from(
@@ -2006,9 +2036,19 @@ pub(crate) fn hub_transport_report(
             if record.is_some_and(|record| record.launched_by.as_deref() == Some("service")) {
                 return HubTransportReport::supervised_unavailable(warning);
             }
+            if manager.is_logged_in().unwrap_or(false) {
+                return HubTransportReport::ok(format!(
+                    "hub is loopback-only; Tailscale is signed in but Serve publication failed: {warning}; run `cas hub restart --tailscale-serve` to publish the route"
+                ));
+            }
             return HubTransportReport::ok(format!(
                 "hub is loopback-only; Tailscale Serve publication was unavailable: {warning}"
             ));
+        }
+        if live && manager.is_logged_in().unwrap_or(false) {
+            return HubTransportReport::ok(
+                "hub is loopback-only while Tailscale is signed in; run `cas hub restart --tailscale-serve` to publish the route",
+            );
         }
         return HubTransportReport::ok(
             "hub is loopback-only; no CAS-created Tailscale Serve route is recorded",
@@ -2198,11 +2238,22 @@ mod tests {
             .remedy
             .as_deref()
             .is_some_and(|remedy| remedy.contains(
-                "cas hub service uninstall && cas hub start --tailscale-serve"
+                "cas hub restart --tailscale-serve"
             )));
         assert_eq!(
             render_transport_status(&report),
-            "Tailscale Serve: FAIL - supervised hub is not publishable\n  remedy: Run `cas hub service uninstall && cas hub start --tailscale-serve` from an interactive shell to publish the pairing route."
+            "Tailscale Serve: FAIL - supervised hub is not publishable\n  remedy: Run `cas hub restart --tailscale-serve` to republish the pairing route without removing hub supervision."
+        );
+    }
+
+    #[test]
+    fn transport_status_renders_signed_in_loopback_warning() {
+        let report = HubTransportReport::ok(
+            "hub is loopback-only while Tailscale is signed in; run `cas hub restart --tailscale-serve` to publish the route",
+        );
+        assert_eq!(
+            render_transport_status(&report),
+            "Tailscale Serve: WARN - Tailscale is signed in; hub remains loopback-only"
         );
     }
 
@@ -2455,5 +2506,30 @@ mod tests {
                 .is_none(),
             "matching hub version must not trigger update restart"
         );
+    }
+
+    #[test]
+    fn update_restart_spec_preserves_a_legacy_public_url_record() {
+        let mut stale = record("3.4.1", 4310, None);
+        stale.public_url = Some("https://hub.example/".to_owned());
+        let spec = restart_spec_for_record(&stale, "3.7.7")
+            .unwrap()
+            .expect("a stale hub with a public URL must be restarted");
+
+        assert!(spec.tailscale_serve);
+        assert_eq!(spec.tailscale_port, 443);
+    }
+
+    #[test]
+    fn update_transport_failure_is_explicit_and_keeps_working_recovery() {
+        let error = update_transport_error(
+            "tailscale CLI is unavailable; looked for `tailscale` on PATH and app locations",
+        )
+        .to_string();
+        assert!(error.starts_with("cas update: Tailscale Serve publication failed"));
+        assert!(error.contains("tailscale CLI is unavailable"));
+        assert!(error.contains("looked for"));
+        assert!(error.contains("cas hub restart --tailscale-serve"));
+        assert!(!error.contains("service uninstall"));
     }
 }

--- a/cas-cli/src/cli/hub.rs
+++ b/cas-cli/src/cli/hub.rs
@@ -342,10 +342,40 @@ impl HubTransportReport {
     }
 }
 
-fn update_transport_error(warning: &str) -> anyhow::Error {
-    anyhow::anyhow!(
+#[derive(Debug)]
+struct UpdateTransportError {
+    message: String,
+}
+
+impl std::fmt::Display for UpdateTransportError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for UpdateTransportError {}
+
+fn update_transport_error_message(warning: &str) -> String {
+    format!(
         "cas update: Tailscale Serve publication failed: {warning}; hub remains loopback-only; run `cas hub restart --tailscale-serve`"
     )
+}
+
+fn update_transport_error(warning: &str) -> anyhow::Error {
+    anyhow::Error::new(UpdateTransportError {
+        message: update_transport_error_message(warning),
+    })
+}
+
+fn update_transport_error_message_from(error: &anyhow::Error) -> Option<String> {
+    error
+        .downcast_ref::<UpdateTransportError>()
+        .map(|error| error.message.clone())
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct HubRestartOutcome {
+    pub(crate) transport_error: Option<String>,
 }
 
 fn default_hub_command() -> HubCommands {
@@ -1862,16 +1892,19 @@ fn stop_with_output(
 /// Restart a live hub left behind by an older Cassy binary. This is called by
 /// `cas update` after the replacement version is known; a missing, dead, or
 /// already-current hub is intentionally a no-op.
-pub(crate) fn restart_stale_hub(binary_version: &str, cli: &Cli) -> Result<bool> {
+pub(crate) fn restart_stale_hub(
+    binary_version: &str,
+    cli: &Cli,
+) -> Result<HubRestartOutcome> {
     let paths = HubRuntimePaths::default_for_user()?;
     let Ok(record) = paths.read_process_record() else {
-        return Ok(false);
+        return Ok(HubRestartOutcome::default());
     };
     if !record_is_live(&record) {
-        return Ok(false);
+        return Ok(HubRestartOutcome::default());
     }
     let Some(spec) = restart_spec_for_record(&record, binary_version)? else {
-        return Ok(false);
+        return Ok(HubRestartOutcome::default());
     };
 
     if !cli.json {
@@ -1900,19 +1933,31 @@ pub(crate) fn restart_stale_hub(binary_version: &str, cli: &Cli) -> Result<bool>
         if spec.tailscale_serve
             && let Some(warning) = record.transport_warning.as_deref()
         {
-            return Err(update_transport_error(warning));
+            return Ok(HubRestartOutcome {
+                transport_error: Some(update_transport_error_message(warning)),
+            });
         }
-        return Ok(true);
+        return Ok(HubRestartOutcome::default());
     }
-    start_with_output_from(
+    match start_with_output_from(
         &args,
         cli,
         spec.tailscale_serve,
         spec.tailscale_port,
         !cli.json,
         HubLaunchOrigin::Update,
-    )?;
-    Ok(true)
+    ) {
+        Ok(()) => Ok(HubRestartOutcome::default()),
+        Err(error) => {
+            if let Some(message) = update_transport_error_message_from(&error) {
+                Ok(HubRestartOutcome {
+                    transport_error: Some(message),
+                })
+            } else {
+                Err(error)
+            }
+        }
+    }
 }
 
 fn process_is_running(pid: u32) -> bool {

--- a/cas-cli/src/cli/hub_reverse_pairing.rs
+++ b/cas-cli/src/cli/hub_reverse_pairing.rs
@@ -512,9 +512,17 @@ fn resolve_hub_url(
         .or(record.public_url.as_deref())
         .or(configured_hub_url)
         .or(remembered_hub_url.as_deref())
-        .context(
-            "hub is running without a public URL; run `cas hub service uninstall && cas hub start --tailscale-serve` from an interactive shell, then retry authorization",
-        )?;
+        .ok_or_else(|| {
+            if let Some(warning) = record.transport_warning.as_deref() {
+                anyhow::anyhow!(
+                    "hub is running without a public URL because Tailscale Serve failed: {warning}; run `cas hub restart --tailscale-serve`, then retry authorization"
+                )
+            } else {
+                anyhow::anyhow!(
+                    "hub is running without a public URL; run `cas hub restart --tailscale-serve`, then retry authorization"
+                )
+            }
+        })?;
     let parsed = validate_hub_url(url)?;
     Ok(parsed.origin().ascii_serialization())
 }
@@ -557,11 +565,11 @@ fn verify_public_hub_ready(hub_url: &str) -> Result<()> {
 fn public_hub_readiness_error(hub_url: &str, status: Option<u16>) -> anyhow::Error {
     if status == Some(502) {
         anyhow::anyhow!(
-            "hub public URL {hub_url} route exists but the backend is gone (HTTP 502); the pairing code remains unclaimed and no invitation was created. Run `cas hub service uninstall && cas hub start --tailscale-serve`, then retry authorization"
+            "hub public URL {hub_url} route exists but the backend is gone (HTTP 502); the pairing code remains unclaimed and no invitation was created. Run `cas hub restart --tailscale-serve`, then retry authorization"
         )
     } else {
         anyhow::anyhow!(
-            "hub public URL {hub_url} is not reachable from this machine; the pairing code remains unclaimed and no invitation was created. Run `cas hub service uninstall && cas hub start --tailscale-serve`, then retry authorization"
+            "hub public URL {hub_url} is not reachable from this machine; the pairing code remains unclaimed and no invitation was created. Run `cas hub restart --tailscale-serve`, then retry authorization"
         )
     }
 }
@@ -1123,8 +1131,29 @@ mod tests {
 
         let error = resolve_hub_url(&paths, None, None).unwrap_err().to_string();
         assert!(error.contains("hub is running without a public URL"));
-        assert!(error.contains("cas hub service uninstall && cas hub start --tailscale-serve"));
+        assert!(error.contains("cas hub restart --tailscale-serve"));
         assert!(!error.contains("cas hub --tailscale-serve start"));
+        health.join().unwrap();
+    }
+
+    #[test]
+    fn running_hub_without_public_origin_preserves_transport_failure_cause() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = HubRuntimePaths::new(temp.path().join("hub"));
+        let (port, health) = serve_ready_health_checks(1);
+        write_live_record(&paths, port, None);
+        let mut record = paths.read_process_record().unwrap();
+        record.transport_warning = Some(
+            "tailscale CLI is unavailable; looked for `tailscale` on PATH and app locations"
+                .to_owned(),
+        );
+        paths.write_process_record(&record).unwrap();
+
+        let error = resolve_hub_url(&paths, None, None).unwrap_err().to_string();
+        assert!(error.contains("tailscale CLI is unavailable"), "{error}");
+        assert!(error.contains("looked for"), "{error}");
+        assert!(error.contains("cas hub restart --tailscale-serve"), "{error}");
+        assert!(!error.contains("service uninstall"), "{error}");
         health.join().unwrap();
     }
 
@@ -1404,7 +1433,7 @@ mod tests {
                 .to_string();
 
         assert!(error.contains("not reachable from this machine"), "{error}");
-        assert!(error.contains("cas hub service uninstall && cas hub start --tailscale-serve"), "{error}");
+        assert!(error.contains("cas hub restart --tailscale-serve"), "{error}");
         assert!(relay.claims.lock().unwrap().is_empty());
         assert!(relay.completed_invitation_urls.lock().unwrap().is_empty());
 

--- a/cas-cli/src/cli/update.rs
+++ b/cas-cli/src/cli/update.rs
@@ -232,12 +232,12 @@ pub fn execute(args: &UpdateArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
     if args.all_projects {
         let mut steps = UpdateStepTracker::new(1, !cli.json);
         let report = steps.run("Refreshing all local Cassy projects", || {
-            refresh_all_projects(args, cli, cas_root)
+            refresh_all_projects(args, cli, cas_root, None)
         })?;
         if !cli.json {
             let mut out = io::stdout();
             let mut fmt = Formatter::stdout(&mut out, ActiveTheme::default());
-            print_update_banner_with_formatter(&mut fmt, &report)?;
+            print_update_banner_with_formatter(&mut fmt, &report, None)?;
         }
         return Ok(());
     }
@@ -273,10 +273,10 @@ pub fn execute(args: &UpdateArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
 
     // Full update: binary + every local project's migration/sync/cloud state.
     let mut steps = UpdateStepTracker::new(2, !cli.json);
-    let outcome = steps.run("Updating Cassy binary", || {
+    let (outcome, hub_restart) = steps.run("Updating Cassy binary", || {
         let outcome = perform_update(args, current_version, cli)?;
-        super::hub::restart_stale_hub(&outcome.version, cli)?;
-        Ok(outcome)
+        let hub_restart = super::hub::restart_stale_hub(&outcome.version, cli)?;
+        Ok((outcome, hub_restart))
     })?;
     if !cli.json {
         let mut out = io::stdout();
@@ -292,7 +292,12 @@ pub fn execute(args: &UpdateArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
         if cli.json {
             println!(
                 "{}",
-                combined_update_receipt(&outcome.version, outcome.updated, Some(&refresh))
+                combined_update_receipt(
+                    &outcome.version,
+                    outcome.updated,
+                    Some(&refresh),
+                    hub_restart.transport_error.as_deref(),
+                )
             );
         }
         return Ok(());
@@ -301,12 +306,19 @@ pub fn execute(args: &UpdateArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
     if cli.json {
         println!(
             "{}",
-            combined_update_receipt(&outcome.version, outcome.updated, None)
+            combined_update_receipt(
+                &outcome.version,
+                outcome.updated,
+                None,
+                hub_restart.transport_error.as_deref(),
+            )
         );
     }
 
-    let report = steps.run("Refreshing all local Cassy projects", || {
-        refresh_all_projects(args, cli, cas_root)
+    let (report, hub_transport_error) = refresh_after_hub_restart(hub_restart, |error| {
+        steps.run("Refreshing all local Cassy projects", || {
+            refresh_all_projects(args, cli, cas_root, error)
+        })
     })?;
 
     if !cli.json {
@@ -314,7 +326,7 @@ pub fn execute(args: &UpdateArgs, cli: &Cli, cas_root: Option<&Path>) -> anyhow:
         let theme = ActiveTheme::default();
         let mut fmt = Formatter::stdout(&mut out, theme);
         fmt.newline()?;
-        print_update_banner_with_formatter(&mut fmt, &report)?;
+        print_update_banner_with_formatter(&mut fmt, &report, hub_transport_error.as_deref())?;
     }
 
     Ok(())
@@ -331,6 +343,7 @@ fn combined_update_receipt(
     version: &str,
     updated: bool,
     refresh: Option<&serde_json::Value>,
+    hub_transport_error: Option<&str>,
 ) -> serde_json::Value {
     let mut receipt = serde_json::json!({
         "binary_updated": updated,
@@ -341,7 +354,22 @@ fn combined_update_receipt(
             target.insert(key.clone(), value.clone());
         }
     }
+    if let Some(error) = hub_transport_error {
+        receipt["hub_transport"] = serde_json::json!({
+            "status": "error",
+            "message": error,
+        });
+    }
     receipt
+}
+
+fn refresh_after_hub_restart<T>(
+    hub_restart: super::hub::HubRestartOutcome,
+    refresh: impl FnOnce(Option<&str>) -> anyhow::Result<T>,
+) -> anyhow::Result<(T, Option<String>)> {
+    let transport_error = hub_restart.transport_error;
+    let refreshed = refresh(transport_error.as_deref())?;
+    Ok((refreshed, transport_error))
 }
 
 /// Add an existing project to the host registry.
@@ -814,6 +842,7 @@ fn update_banner_text(report: &RefreshReport) -> String {
 fn print_update_banner_with_formatter(
     fmt: &mut Formatter<'_>,
     report: &RefreshReport,
+    hub_transport_error: Option<&str>,
 ) -> io::Result<()> {
     let (verdict, word) = if report.failed_count > 0 {
         (
@@ -832,7 +861,11 @@ fn print_update_banner_with_formatter(
     } else {
         (Verdict::Ok, "complete".to_string())
     };
-    fmt.verdict(verdict, &word, &update_banner_text(report))
+    fmt.verdict(verdict, &word, &update_banner_text(report))?;
+    if let Some(error) = hub_transport_error {
+        fmt.verdict(Verdict::Error, "hub transport", error)?;
+    }
+    Ok(())
 }
 
 fn capture_phase<T>(enabled: bool, operation: impl FnOnce() -> T) -> (T, String) {
@@ -921,6 +954,7 @@ fn refresh_all_projects(
     args: &UpdateArgs,
     cli: &Cli,
     current_cas_root: Option<&Path>,
+    hub_transport_error: Option<&str>,
 ) -> anyhow::Result<RefreshReport> {
     let started_at = Instant::now();
     let discovery = discover_local_projects(current_cas_root);
@@ -992,12 +1026,17 @@ fn refresh_all_projects(
         &user_details,
         &discovery.skipped_unregistered,
         cli,
+        hub_transport_error,
     );
 
     let failed_count = receipts.iter().filter(|receipt| receipt.failed()).count()
         + usize::from(user_level.failed());
-    let receipt =
-        project_refresh_receipt_json(&receipts, &user_level, &discovery.skipped_unregistered);
+    let receipt = project_refresh_receipt_json(
+        &receipts,
+        &user_level,
+        &discovery.skipped_unregistered,
+        hub_transport_error,
+    );
     if let Some(path) = &args.refresh_receipt {
         write_refresh_receipt(path, &receipt)?;
     }
@@ -1334,6 +1373,7 @@ fn project_refresh_receipt_json(
     receipts: &[ProjectRefreshReceipt],
     user_level: &ProjectPhase,
     skipped_unregistered: &[SkippedProject],
+    hub_transport_error: Option<&str>,
 ) -> serde_json::Value {
     let projects = receipts
         .iter()
@@ -1350,7 +1390,7 @@ fn project_refresh_receipt_json(
             })
         })
         .collect::<Vec<_>>();
-    serde_json::json!({
+    let mut receipt = serde_json::json!({
         // cas-91ba: name the binary that actually performed this refresh. A
         // receipt from the pre-update image is what made an operator's first
         // `cas update` look converged when it was not.
@@ -1377,7 +1417,14 @@ fn project_refresh_receipt_json(
                 "reason": skip.reason,
             }))
             .collect::<Vec<_>>(),
-    })
+    });
+    if let Some(error) = hub_transport_error {
+        receipt["hub_transport"] = serde_json::json!({
+            "status": "error",
+            "message": error,
+        });
+    }
+    receipt
 }
 
 fn write_refresh_receipt(path: &Path, receipt: &serde_json::Value) -> anyhow::Result<()> {
@@ -1393,11 +1440,17 @@ fn print_project_refresh_summary(
     user_details: &str,
     skipped_unregistered: &[SkippedProject],
     cli: &Cli,
+    hub_transport_error: Option<&str>,
 ) {
     if cli.json {
         println!(
             "{}",
-            project_refresh_receipt_json(receipts, user_level, skipped_unregistered)
+            project_refresh_receipt_json(
+                receipts,
+                user_level,
+                skipped_unregistered,
+                hub_transport_error,
+            )
         );
         return;
     }
@@ -2840,14 +2893,16 @@ fn execute_post_swap(args: &UpdateArgs, cli: &Cli, current_version: &str) -> any
         .ok_or_else(|| anyhow::anyhow!("post-swap mode requires --from"))?;
     // The hub goes first so it picks up the new binary immediately rather than
     // waiting behind a full refresh.
-    super::hub::restart_stale_hub(current_version, cli)?;
+    let hub_restart = super::hub::restart_stale_hub(current_version, cli)?;
 
     // These are the phases that must not run in the pre-update image.
-    let report = refresh_all_projects(args, cli, None)?;
+    let (report, hub_transport_error) = refresh_after_hub_restart(hub_restart, |error| {
+        refresh_all_projects(args, cli, None, error)
+    })?;
     if !cli.json {
         let mut out = io::stdout();
         let mut fmt = Formatter::stdout(&mut out, ActiveTheme::default());
-        print_update_banner_with_formatter(&mut fmt, &report)?;
+        print_update_banner_with_formatter(&mut fmt, &report, hub_transport_error.as_deref())?;
     }
     Ok(())
 }

--- a/cas-cli/src/cli/update_tests/tests.rs
+++ b/cas-cli/src/cli/update_tests/tests.rs
@@ -1,4 +1,5 @@
 use crate::cli::update::*;
+use crate::cli::hub::HubRestartOutcome;
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -390,6 +391,7 @@ fn refresh_receipt_names_each_skipped_project_and_why_it_was_not_refreshed() {
             project: PathBuf::from("/tmp/container-copy"),
             reason: "its .cas has no [project] canonical_id pin and no git origin remote".to_string(),
         }],
+        None,
     );
 
     assert_eq!(receipt["skipped_unregistered"][0]["project"], "/tmp/container-copy");
@@ -704,7 +706,7 @@ fn post_swap_refresh_failure_without_a_receipt_is_not_reported_as_skipped() {
 
 #[test]
 fn refresh_receipt_names_the_binary_that_ran_it() {
-    let receipt = project_refresh_receipt_json(&[], &ProjectPhase::Ok(String::new()), &[]);
+    let receipt = project_refresh_receipt_json(&[], &ProjectPhase::Ok(String::new()), &[], None);
 
     assert_eq!(
         receipt["refresh_binary_version"],
@@ -728,8 +730,12 @@ fn refresh_receipt_records_partial_failure_before_refresh_returns_error() {
         details: String::new(),
         phase_details: Vec::new(),
     }];
-    let receipt =
-        project_refresh_receipt_json(&receipts, &ProjectPhase::Ok("up to date".to_owned()), &[]);
+    let receipt = project_refresh_receipt_json(
+        &receipts,
+        &ProjectPhase::Ok("up to date".to_owned()),
+        &[],
+        None,
+    );
 
     assert_eq!(receipt["refresh_status"], "refresh_failed");
     write_refresh_receipt(&path, &receipt).expect("partial refresh receipt should be writable");
@@ -752,7 +758,7 @@ fn combined_receipt_merges_the_installed_binary_refresh_into_one_document() {
         "user_level_store": {"status": "ok"},
     });
 
-    let combined = combined_update_receipt("3.15.2", true, Some(&refresh));
+    let combined = combined_update_receipt("3.15.2", true, Some(&refresh), None);
     assert_eq!(combined["binary_updated"], true);
     assert_eq!(combined["version"], "3.15.2");
     assert_eq!(
@@ -762,9 +768,56 @@ fn combined_receipt_merges_the_installed_binary_refresh_into_one_document() {
     assert!(combined["user_level_store"].is_object(), "{combined}");
 
     // No swap: no refresh receipt to merge, and no stale version claimed.
-    let solo = combined_update_receipt("3.15.2", false, None);
+    let solo = combined_update_receipt("3.15.2", false, None, None);
     assert_eq!(solo["binary_updated"], false);
     assert!(solo.get("refresh_binary_version").is_none(), "{solo}");
+}
+
+#[test]
+fn failed_serve_publication_still_refreshes_projects_and_reports_update_error() {
+    let transport_error = "cas update: Tailscale Serve publication failed: tailscale CLI is unavailable; hub remains loopback-only; run `cas hub restart --tailscale-serve`";
+    let mut refreshed = false;
+    let (refresh, reported_error) = refresh_after_hub_restart(
+        HubRestartOutcome {
+            transport_error: Some(transport_error.to_owned()),
+        },
+        |error| {
+            assert_eq!(error, Some(transport_error));
+            refreshed = true;
+            Ok::<_, anyhow::Error>(serde_json::json!({"projects": ["refreshed"]}))
+        },
+    )
+    .expect("a transport warning must not prevent refresh");
+
+    assert!(refreshed, "project refresh must continue after Serve failure");
+    let receipt = combined_update_receipt(
+        "3.15.2",
+        false,
+        Some(&refresh),
+        reported_error.as_deref(),
+    );
+    assert_eq!(receipt["hub_transport"]["status"], "error");
+    assert_eq!(receipt["hub_transport"]["message"], transport_error);
+    let refresh_receipt = project_refresh_receipt_json(
+        &[],
+        &ProjectPhase::Ok("up to date".to_owned()),
+        &[],
+        reported_error.as_deref(),
+    );
+    assert_eq!(refresh_receipt["hub_transport"]["status"], "error");
+    assert_eq!(refresh_receipt["hub_transport"]["message"], transport_error);
+
+    let report = RefreshReport {
+        project_count: 1,
+        failed_count: 0,
+        skipped_unregistered: 0,
+        elapsed: std::time::Duration::from_millis(5),
+    };
+    let banner = render_plain_at(160, |fmt| {
+        print_update_banner_with_formatter(fmt, &report, Some(transport_error))
+    });
+    assert!(banner.contains("[ERROR] hub transport"), "{banner}");
+    assert!(banner.contains("cas hub restart --tailscale-serve"), "{banner}");
 }
 
 #[cfg(unix)]
@@ -1076,7 +1129,7 @@ fn refresh_banner_is_a_verdict_line_with_the_count_grammar_as_detail() {
         skipped_unregistered: 0,
         elapsed: std::time::Duration::from_millis(1200),
     };
-    let banner = render_plain_at(80, |fmt| print_update_banner_with_formatter(fmt, &report));
+    let banner = render_plain_at(80, |fmt| print_update_banner_with_formatter(fmt, &report, None));
     assert!(
         banner.starts_with(&format!(
             "[OK] complete · Cassy {} · 2 projects refreshed · 0 failed",
@@ -1091,7 +1144,8 @@ fn refresh_banner_is_a_verdict_line_with_the_count_grammar_as_detail() {
         skipped_unregistered: 2,
         elapsed: std::time::Duration::from_secs(4),
     };
-    let banner = render_plain_at(80, |fmt| print_update_banner_with_formatter(fmt, &failed));
+    let banner =
+        render_plain_at(80, |fmt| print_update_banner_with_formatter(fmt, &failed, None));
     assert!(banner.starts_with("[ERROR] 1 project failed · "), "{banner}");
     assert!(banner.contains("2 unregistered store(s) not refreshed"), "{banner}");
 }

--- a/cas-cli/src/hub/tailscale.rs
+++ b/cas-cli/src/hub/tailscale.rs
@@ -266,6 +266,19 @@ impl TailscaleServeManager {
         self.run_json(&["status".into(), "--json".into()])
     }
 
+    /// Return whether Tailscale reports a signed-in local node.
+    ///
+    /// This uses the same bounded `status --json` probe as Serve setup, so a
+    /// missing or wedged CLI cannot make doctor hang.
+    pub fn is_logged_in(&self) -> Result<bool> {
+        let status = self.status()?;
+        Ok(status
+            .get("Self")
+            .and_then(|value| value.get("DNSName"))
+            .and_then(Value::as_str)
+            .is_some_and(|name| valid_dns_name(name.trim_end_matches('.'))))
+    }
+
     fn serve_status(&self) -> Result<Value> {
         self.run_json(&["serve".into(), "status".into(), "--json".into()])
     }
@@ -288,9 +301,7 @@ impl TailscaleServeManager {
         )
         .map_err(|error| match error {
             BoundedCommandError::TimedOut => anyhow::anyhow!("tailscale command timed out"),
-            BoundedCommandError::Io => anyhow::anyhow!(
-                "tailscale CLI is unavailable (install Tailscale and sign in first)"
-            ),
+            BoundedCommandError::Io => anyhow::anyhow!(tailscale_unavailable_message()),
         })?;
         anyhow::ensure!(
             output.status.success(),
@@ -316,10 +327,57 @@ fn tailscale_executable() -> OsString {
 }
 
 fn select_tailscale_executable(path_cli: Option<PathBuf>) -> OsString {
+    select_tailscale_executable_with_app(path_cli, macos_tailscale_app_executable())
+}
+
+fn select_tailscale_executable_with_app(
+    path_cli: Option<PathBuf>,
+    macos_app_cli: Option<PathBuf>,
+) -> OsString {
     if let Some(path) = path_cli {
         return path.into_os_string();
     }
+    if let Some(path) = macos_app_cli {
+        // Invoke the real app-bundle path. A symlink to this binary makes the
+        // Swift bundle check report an unknown bundle identifier.
+        return path.into_os_string();
+    }
     OsString::from("tailscale")
+}
+
+#[cfg(target_os = "macos")]
+fn macos_tailscale_app_executable() -> Option<PathBuf> {
+    let mut candidates = vec![PathBuf::from(MACOS_TAILSCALE_APP_CLI)];
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join("Applications/Tailscale.app/Contents/MacOS/Tailscale"));
+    }
+    candidates.into_iter().find(|candidate| candidate.is_file())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn macos_tailscale_app_executable() -> Option<PathBuf> {
+    None
+}
+
+const MACOS_TAILSCALE_APP_CLI: &str = "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
+
+#[cfg(target_os = "macos")]
+fn tailscale_unavailable_message() -> String {
+    let user_app = dirs::home_dir()
+        .map(|home| {
+            home.join("Applications/Tailscale.app/Contents/MacOS/Tailscale")
+                .display()
+                .to_string()
+        })
+        .unwrap_or_else(|| "~/Applications/Tailscale.app/Contents/MacOS/Tailscale".to_owned());
+    format!(
+        "tailscale CLI is unavailable; looked for `tailscale` on PATH, `{MACOS_TAILSCALE_APP_CLI}`, and `{user_app}`; install Tailscale and sign in first"
+    )
+}
+
+#[cfg(not(target_os = "macos"))]
+fn tailscale_unavailable_message() -> String {
+    "tailscale CLI is unavailable; looked for `tailscale` on PATH; install Tailscale and sign in first".to_owned()
 }
 
 fn executable_on_path(name: &str) -> Option<PathBuf> {
@@ -444,7 +502,29 @@ mod tests {
 
     #[test]
     fn no_cli_keeps_existing_unavailable_command() {
-        assert_eq!(select_tailscale_executable(None), OsString::from("tailscale"));
+        assert_eq!(
+            select_tailscale_executable_with_app(None, None),
+            OsString::from("tailscale")
+        );
+    }
+
+    #[test]
+    fn macos_app_cli_is_used_when_path_cli_is_missing() {
+        let app_cli = PathBuf::from("/Applications/Tailscale.app/Contents/MacOS/Tailscale");
+        assert_eq!(
+            select_tailscale_executable_with_app(None, Some(app_cli.clone())),
+            app_cli.into_os_string()
+        );
+    }
+
+    #[test]
+    fn path_cli_wins_over_macos_app_cli() {
+        let path_cli = PathBuf::from("/opt/homebrew/bin/tailscale");
+        let app_cli = PathBuf::from("/Applications/Tailscale.app/Contents/MacOS/Tailscale");
+        assert_eq!(
+            select_tailscale_executable_with_app(Some(path_cli.clone()), Some(app_cli)),
+            path_cli.into_os_string()
+        );
     }
 
     #[test]
@@ -485,6 +565,7 @@ mod tests {
         assert!(!second.created_by_cas);
         assert_eq!(first.public_url, "https://node.tail.ts.net/");
         assert!(manager.disable_owned().unwrap().is_some());
+        assert!(manager.is_logged_in().unwrap());
 
         let calls = fs::read_to_string(calls).unwrap();
         assert_eq!(calls.matches("serve --bg").count(), 1);

--- a/crates/cas-core/Cargo.toml
+++ b/crates/cas-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-core"
-version = "3.25.4"
+version = "3.25.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Core business logic for CAS"

--- a/crates/cas-mcp/Cargo.toml
+++ b/crates/cas-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-mcp"
-version = "3.25.4"
+version = "3.25.5"
 edition = "2024"
 rust-version = "1.88"
 description = "MCP server for CAS"

--- a/crates/cas-search/Cargo.toml
+++ b/crates/cas-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-search"
-version = "3.25.4"
+version = "3.25.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Search infrastructure for CAS: BM25, semantic vectors, and hybrid search"

--- a/crates/cas-store/Cargo.toml
+++ b/crates/cas-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-store"
-version = "3.25.4"
+version = "3.25.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Storage layer for CAS (Coding Agent System)"

--- a/crates/cas-types/Cargo.toml
+++ b/crates/cas-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-types"
-version = "3.25.4"
+version = "3.25.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Core types for CAS (Coding Agent System)"

--- a/docs/design/cli/cas-hub-transport.brief.md
+++ b/docs/design/cli/cas-hub-transport.brief.md
@@ -34,6 +34,27 @@ terminal-qa: PASS cas-doctor-hub-transport · 12 runs · 0 fail · 0 warn · 0 a
 
 Scored by the worker on 2026-09-08; floor holds.
 
+### macOS app-bundle fallback and signed-in loopback warning
+
+When the PATH CLI is absent on macOS, the transport probe invokes the full
+Tailscale app-bundle binary and the status/doctor surfaces retain one compact
+warning with `cas hub restart --tailscale-serve`. Update-origin relaunches now
+surface Serve publication failure as an error while retaining the underlying
+cause. The Prowl real-build capture is recorded at
+`/Users/pippenz/.cas/artifacts/cas-5722/terminal-qa-hub-status/report.json`.
+
+terminal-qa: PASS cas-5722-hub-status · 12 runs · 0 fail · 0 warn · 0 allowed · `/Users/pippenz/.cas/artifacts/cas-5722/terminal-qa-hub-status/report.json`
+
+| Dimension | Score | Evidence |
+| --- | --- | --- |
+| Hierarchy | 4 | Status keeps the hub verdict first and places the signed-in loopback warning immediately below it. |
+| Fit | 4 | The warning is one compact transport row; JSON remains one document. |
+| Craft | 4 | The cause and one copyable restart command use the existing transport grammar. |
+| Theme safety | 5 | The terminal gate passes dark, light, Solarized, `NO_COLOR`, and C-locale runs. |
+| Machine contract | 5 | The JSON capture is one document and the diagnostic banner stays on stderr. |
+
+Scored by the worker on 2026-09-11; floor holds.
+
 ### Wedged-holder recovery rendering
 
 terminal-qa: PASS cas-be89-hub-status · 12 runs · 0 fail · 0 warn · 0 allowed · /home/pippenz/.cas/artifacts/cas-be89/terminal-qa/report.json

--- a/docs/design/cli/hub-pairing.brief.md
+++ b/docs/design/cli/hub-pairing.brief.md
@@ -19,3 +19,25 @@
 | Width/locale | 3/4 | `terminal-qa: PASS cas-hub-authorize-help-120 · 5 runs · 0 fail · 0 warn · 0 allowed` (`/home/pippenz/.cas/artifacts/cas-3fb7/terminal-qa-help120/report.json`). The service dry-run still has a long absolute `ExecStart` line at 80 columns and an em dash under `LC_ALL=C`; retained as a documented pre-existing presentation finding. |
 
 The CLI surface gate is a real-build terminal capture. Full launchd execution and a successful Cloud pairing need a supervised macOS/Cloud environment, so those paths are covered by deterministic unit/integration tests and the bounded isolated-home matrix rather than claimed as locally exercised.
+
+### Update recovery and Tailscale cause preservation
+
+`cas hub authorize` now keeps the persisted Tailscale Serve failure in its
+error, names where the CLI was sought when the macOS app fallback is missing,
+and offers `cas hub restart --tailscale-serve` without telling an actively
+supervised hub to uninstall its service. Real-build captures and the honest
+demo ledger are under `/Users/pippenz/.cas/artifacts/cas-5722/`.
+
+terminal-qa: PASS cas-5722-authorize-cause · 11 runs · 0 fail · 0 warn · 0 allowed · `/Users/pippenz/.cas/artifacts/cas-5722/terminal-qa-authorize-cause/report.json`
+
+| Criterion | Score | Evidence / follow-up |
+| --- | ---: | --- |
+| First two lines | 4/4 | The error names the missing public URL first and gives one restart command. |
+| Scannable | 4/4 | The Tailscale failure cause is retained without launchd internals. |
+| Readable | 4/4 | The macOS fallback search locations and restart remedy are explicit. |
+| Machine output | 4/4 | JSON success remains one document; failure diagnostics remain on stderr. |
+| Width/locale | 4/4 | Terminal QA passes the human error across its width, palette, pipe, and locale matrix. |
+
+Scored by the worker on 2026-09-11; floor holds. The demo happy path was not
+exercised because no valid Commander code was available; deterministic relay
+tests cover invitation delivery.

--- a/docs/release-notes/2026-09-11-v3.25.5-slack.md
+++ b/docs/release-notes/2026-09-11-v3.25.5-slack.md
@@ -1,0 +1,84 @@
+# Slack draft — Cassy v3.25.5 runtime release
+
+Channel: #cas-internal (C0B44GUKDK2). Transport: MechaCassy hub/bot only.
+
+**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
+assets and `release-published-receipt.sh --write-draft` has replaced both
+checksum placeholders below.
+
+## User thread
+
+**Top-level:**
+
+```text
+*Live on production — User — Cassy v3.25.5*
+Was: pairing a Mac to Cassy Cloud could fail for days after an update. → Now: the Mac finds its Tailscale app on its own and pairing completes.
+```
+
+**Only reply:**
+
+```text
+*Pairing your Mac*
+
+• *Tailscale found automatically* — Was: with only the Tailscale app installed, the hub came back from an update without a public address and every pairing code was wasted. → Now: Cassy uses the app's own command line, and the hub keeps its address across updates.
+
+• *Honest error, working fix* — Was: the pairing error told you to uninstall the hub service, which did not help. → Now: it says what was actually missing and gives the one command that fixes it.
+
+• *Update finishes anyway* — Was: a hub address problem could stop an update partway. → Now: the update completes and shows the hub address problem as a clear error line.
+
+• *Doctor knows* — Was: a loopback-only hub looked healthy. → Now: `cas doctor` and `cas hub status` warn when Tailscale is signed in but the hub is not published.
+
+Install: use `cas update`, or download v3.25.5 from https://github.com/Richards-LLC/cassy/releases/tag/v3.25.5
+Linux x86_64 SHA-256: `{{LINUX_SHA256}}`
+macOS ARM64 SHA-256: `{{MACOS_SHA256}}`
+```
+
+## Dev thread
+
+**Top-level:**
+
+```text
+*Live on production — Dev — Cassy v3.25.5*
+Was: the hub's Tailscale lookup was PATH-only and a Serve failure on relaunch was a silent warning. → Now: macOS app-bundle fallback, preserved Serve intent across update, and a typed transport error surfaced without aborting the refresh.
+```
+
+**Only reply:**
+
+```text
+*Hub transport*
+
+• *App-bundle CLI resolution* — Was: the Tailscale executable lookup returned the PATH hit or the bare name. → Now: on macOS it falls back to `/Applications/Tailscale.app/Contents/MacOS/Tailscale` and the `~/Applications` copy, invoked by real path because a symlink trips the Swift bundle-identifier check; the hub record stores the resolved path.
+
+• *Update relaunch keeps Serve* — Was: a stale-hub relaunch from `cas update` swallowed a Serve failure as a stderr warning. → Now: the relaunch returns a structured outcome whose typed transport error is rendered as an ERROR row in the banner and as `hub_transport` in the JSON receipt, and both update call sites continue into the project refresh.
+
+• *Cause-preserving authorize* — Was: hub URL resolution and readiness errors prescribed a service uninstall plus start. → Now: they carry the record's transport warning, including which locations were searched, and prescribe `cas hub restart --tailscale-serve`.
+
+• *Signed-in loopback warning* — Was: doctor treated a loopback fallback as OK unless supervised. → Now: a bounded `tailscale status --json` probe classifies signed-in-but-unpublished as WARN in doctor and status.
+
+Validation: {{VALIDATION_SUMMARY}}
+Published Linux archive: `cas-x86_64-unknown-linux-gnu.tar.gz`, SHA-256 `{{LINUX_SHA256}}`
+Published macOS archive: `cas-aarch64-apple-darwin.tar.gz`, SHA-256 `{{MACOS_SHA256}}`
+```
+
+## Posting sequence
+
+1. Replace the narrative placeholders after the release PR is merged.
+2. Tag the fetched `origin/main` landing and run
+   `./scripts/release.sh --publish-tag`. A bare `release.sh` is a local audit
+   and does not touch the remote.
+3. Run `release-published-receipt.sh --write-draft` against this draft. It
+   downloads and hashes both published assets before replacing every digest
+   placeholder; never type a digest from a local audit archive.
+4. Post the User top-level and its only reply, then the Dev top-level and its
+   only reply; append the receipt below.
+
+## POSTED
+
+Channel: `#cas-internal` (`C0B44GUKDK2`).
+
+| Message | UTC timestamp | Permalink |
+| --- | --- | --- |
+| User top-level |  |  |
+| User reply (Was → Now) |  |  |
+| Dev top-level |  |  |
+| Dev reply (Was → Now) |  |  |


### PR DESCRIPTION
Cassy 3.25.5 fixes Commander pairing on macOS after `cas update` when the Tailscale app is installed without a PATH CLI, keeps a published hub URL across update relaunches, and makes the pairing error name its real cause with a remediation that works.

- Resolve the Tailscale CLI from the macOS app bundle (`/Applications/Tailscale.app/Contents/MacOS/Tailscale`, then `~/Applications`) when `tailscale` is not on PATH, invoke it by real path, and record the resolved path in the hub record.
- Return a structured outcome from the stale-hub relaunch: a failed Tailscale Serve republication becomes a typed hub transport error rendered as an ERROR row in the `cas update` banner and as `hub_transport` in the JSON receipt, while both update call sites continue into the project refresh.
- Preserve the transport cause in `cas hub authorize`, readiness and status errors, and prescribe `cas hub restart --tailscale-serve` instead of `service uninstall`.
- Warn in `cas doctor` and `cas hub status` when the hub is loopback-only while Tailscale is signed in.
- Bump all six release crates and Cargo.lock to 3.25.5, add the dated changelog section and the four-body runtime announcement draft, and regenerate the builtin reference ledger as the last prep step.

Fixes cas-5722.

Validation

- Exact-source full release gate: **PASS**, all **20/20 rows**, on `b4ab3ef2184c0dd14b5b557fb66928d37073f2fd`. `gate.done` is `0`; `gate.full.sha` names that same source. Run interval: **2026-09-11T21:45:55Z–2026-09-11T21:55:23Z** (9m28s).
- Workspace nextest coverage: **9389 archive passes (2 leaky, 113 skipped) + 13 in-tree snapshot-complement passes = 9402 passes**, 0 failures.
- Doctests: **2 passed, 0 failed, 25 ignored**.
- The full gate also passed workspace test compilation, macOS target checking, Hub asset drift and visual QA, snapshot portability, builtin projections, version/changelog alignment, procedure checks and final working-tree cleanliness. macOS checking is not published-asset installation proof.
- Lane admission: `factory/crisp-heron-16` at `ef72a7a5` had a green push-triggered Scoped Validation (factory/PR) job (CI run 34650452936, job 103431123233). Worker scoped proof 55/55 passed; three pre-existing failures in the wider hub filter were reproduced on unmodified origin/main and are unrelated.
- Durable full-gate evidence: `/home/pippenz/.cas/artifacts/release/v3.25.5-release-3.25.5-prepare/{gate.log,gate.done,gate.full.sha}` and `rows/20260911T214555Z-370728/{timing.tsv,archive-mode.log,nextest.log,doctests.log}`.
- Required protected PR/merge-queue checks: **PENDING**. The local full gate does not establish protected-main landing or queue success.

Known limitations

- The launchd hub service unit sets no PATH; the app-bundle fallback in the binary is what makes a reboot-started hub find the CLI. Existing hosts pick this up on their next `cas update`.

Publication: **PENDING**. No 3.25.5 tag, published assets, installation, report delivery or Slack receipt is claimed.
