### PR TITLE
docs: record v3.25.5 announcement receipts

### DIFF
--- a/docs/release-notes/2026-09-11-v3.25.5-slack.md
+++ b/docs/release-notes/2026-09-11-v3.25.5-slack.md
@@ -2,9 +2,14 @@
 
 Channel: #cas-internal (C0B44GUKDK2). Transport: MechaCassy hub/bot only.
 
-**Status:** Draft. Do not post until the tagged GitHub workflow publishes both
-assets and `release-published-receipt.sh --write-draft` has replaced both
-checksum placeholders below.
+**Status: Runtime published; announcement posted.** Version 3.25.5 was
+published at 2026-09-11T22:36:34Z from commit
+`5645951e12e7def931a041ef44f2e8e486320576` (tag pushed 22:33:02Z, 212 s
+tag-to-published). Both published downloads passed SHA-256 verification;
+release workflow 34654490839 and install-path proof 34654751344 succeeded.
+Both release hosts (prowl, soundwave) refreshed to 3.25.5 with their hub
+Tailscale URL preserved. No release report (PDF/HTML) was produced for this
+hotfix release.
 
 ## User thread
 
@@ -29,8 +34,8 @@ Was: pairing a Mac to Cassy Cloud could fail for days after an update. → Now: 
 • *Doctor knows* — Was: a loopback-only hub looked healthy. → Now: `cas doctor` and `cas hub status` warn when Tailscale is signed in but the hub is not published.
 
 Install: use `cas update`, or download v3.25.5 from https://github.com/Richards-LLC/cassy/releases/tag/v3.25.5
-Linux x86_64 SHA-256: `{{LINUX_SHA256}}`
-macOS ARM64 SHA-256: `{{MACOS_SHA256}}`
+Linux x86_64 SHA-256: `f38c0021c727cb53a59582181e1350daf1c7140383f4b055d85843d716157173`
+macOS ARM64 SHA-256: `fdfafc12744f6b0b426473f81bd56f13676f53269d240c6c4adcab4d575cab3d`
 ```
 
 ## Dev thread
@@ -55,9 +60,9 @@ Was: the hub's Tailscale lookup was PATH-only and a Serve failure on relaunch wa
 
 • *Signed-in loopback warning* — Was: doctor treated a loopback fallback as OK unless supervised. → Now: a bounded `tailscale status --json` probe classifies signed-in-but-unpublished as WARN in doctor and status.
 
-Validation: {{VALIDATION_SUMMARY}}
-Published Linux archive: `cas-x86_64-unknown-linux-gnu.tar.gz`, SHA-256 `{{LINUX_SHA256}}`
-Published macOS archive: `cas-aarch64-apple-darwin.tar.gz`, SHA-256 `{{MACOS_SHA256}}`
+Validation: Full release gate 20/20 rows in 9m28s; 9,402 workspace passes (2 leaky, 113 archive skips), 2 doctests passed / 25 ignored. Merge-queue Fast Validation and macOS Check green; published downloads verified; hosted Linux/macOS install proof passed. Both release hosts refreshed to 3.25.5 with their hub Tailscale URL preserved through the update.
+Published Linux archive: `cas-x86_64-unknown-linux-gnu.tar.gz`, SHA-256 `f38c0021c727cb53a59582181e1350daf1c7140383f4b055d85843d716157173`
+Published macOS archive: `cas-aarch64-apple-darwin.tar.gz`, SHA-256 `fdfafc12744f6b0b426473f81bd56f13676f53269d240c6c4adcab4d575cab3d`
 ```
 
 ## Posting sequence
@@ -74,11 +79,14 @@ Published macOS archive: `cas-aarch64-apple-darwin.tar.gz`, SHA-256 `{{MACOS_SHA
 
 ## POSTED
 
-Channel: `#cas-internal` (`C0B44GUKDK2`).
+Channel: `#cas-internal` (`C0B44GUKDK2`). Posted through the authenticated
+MechaCassy hub (one-shot JSON-RPC client from soundwave) on 2026-09-11.
 
-| Message | UTC timestamp | Permalink |
+| Message | UTC timestamp | Receipt |
 | --- | --- | --- |
-| User top-level |  |  |
-| User reply (Was → Now) |  |  |
-| Dev top-level |  |  |
-| Dev reply (Was → Now) |  |  |
+| User top-level | `2026-09-11T22:44:21Z` | `message_id=1789166661.256809` · <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789166661256809> |
+| User reply (Was → Now) | `2026-09-11T22:44:22Z` | `message_id=1789166662.739409` · <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789166662739409?thread_ts=1789166661.256809&cid=C0B44GUKDK2> |
+| Dev top-level | `2026-09-11T22:44:24Z` | `message_id=1789166664.198339` · <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789166664198339> |
+| Dev reply (Was → Now) | `2026-09-11T22:44:25Z` | `message_id=1789166665.674419` · <https://petra-stella.slack.com/archives/C0B44GUKDK2/p1789166665674419?thread_ts=1789166664.198339&cid=C0B44GUKDK2> |
+
+Canonical receipts: `/home/pippenz/.cas/artifacts/release/v3.25.5-release-3.25.5-prepare/{slack-post-receipts.json,release-published.receipt,release-latency.receipt,release-workflow.json,install-proof-workflow-34654751344.json}`.


### PR DESCRIPTION
Records the v3.25.5 publication and Slack receipts in the release draft. Docs-only; no runtime change.